### PR TITLE
According to the cookies specifications, cookie values cannot have some s

### DIFF
--- a/war-core/src/main/java/com/silverpeas/authentication/AuthenticationServlet.java
+++ b/war-core/src/main/java/com/silverpeas/authentication/AuthenticationServlet.java
@@ -30,6 +30,8 @@ import com.stratelia.silverpeas.silvertrace.SilverTrace;
 import com.stratelia.silverpeas.util.SilverpeasSettings;
 import com.stratelia.webactiv.util.ResourceLocator;
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 import javax.servlet.ServletException;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServlet;
@@ -254,7 +256,12 @@ public class AuthenticationServlet extends HttpServlet {
    */
   private void writeCookie(HttpServletResponse response, String name,
       String value, int duration) {
-    Cookie cookie = new Cookie(name, value);
+    Cookie cookie;
+    try {
+      cookie = new Cookie(name, URLEncoder.encode(value, "UTF-8"));
+    } catch (UnsupportedEncodingException ex) {
+      cookie = new Cookie(name, value);
+    }
     cookie.setMaxAge(duration); // Duration in s
     cookie.setPath("/");
     response.addCookie(cookie);


### PR DESCRIPTION
According to the cookies specifications, cookie values cannot have some specific characters like whitespace, brackets and parentheses, equals signs, commas, double quotes, slashes, question marks, at signs, colons, and semicolons. Cookie values can be either a token or a (double) quoted-string. The cookie management in J2EE/JEE supports both Version 0 and Version 1 (RFC 2109 superseded by RFC 2965) of the cookie specification.
