### PR TITLE
Bug #1867. Fix the URL syntax of the castor mapping file used in export

### DIFF
--- a/web-core/src/main/java/com/silverpeas/importExport/control/ImportExport.java
+++ b/web-core/src/main/java/com/silverpeas/importExport/control/ImportExport.java
@@ -99,6 +99,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.net.URL;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -146,10 +147,11 @@ public class ImportExport {
     try {
       String mappingDir = settings.getString("mappingDir");
       String mappingFileName = settings.getString("importExportMapping");
-      File mappingFile = new File(mappingDir, mappingFileName);
-
+      if (!mappingDir.endsWith("/")) {
+        mappingDir += "/";
+      }
       // Load mapping and instantiate a Marshaller
-      mapping.loadMapping(mappingFile.getPath());
+      mapping.loadMapping(new URL(mappingDir + mappingFileName));
 
       writer = new OutputStreamWriter(new FileOutputStream(xmlToExportPath), Charsets.UTF_8);
       Marshaller mar = new Marshaller(writer);


### PR DESCRIPTION
With JBoss 6, the URL of resources should be well formated, otherwise an exception is thrown and the resource cannot be accessed by the bean. In the process of publication export, the castor XML parser is used to build an XML file defining the publications to export. In order to generate a such XML file, a castor mapping file is used but its URL isn't well formated in Windows as it contains '\' character! The fix consists to explicitly build an URL from the path of the XML mapping file.
