### PR TITLE
fix bug #1789 : Champs fichiers inaccessibles dans les contenus de publication saisis grace à un formulaire XML

### DIFF
--- a/lib-core/src/main/java/com/stratelia/webactiv/util/attachment/control/AttachmentController.java
+++ b/lib-core/src/main/java/com/stratelia/webactiv/util/attachment/control/AttachmentController.java
@@ -609,7 +609,10 @@ public class AttachmentController {
     try {
       AttachmentDetail attachDetail = attachmentBm.
           getAttachmentByPrimaryKey(pk);
-      deleteAttachment(attachDetail, invokeCallback);
+      if(attachDetail != null) {
+        //l'attachment existe bien toujours en base
+        deleteAttachment(attachDetail, invokeCallback);
+      }
 
     } catch (Exception fe) {
       throw new AttachmentRuntimeException(


### PR DESCRIPTION
Corrrige le problème #1847 (lié #1789) remonté par Unifaf : à la mise à jour des fichiers d'un modèle de contenu formulaire XML (contenant n champs wysiwyg et n champs fichier), une incohérence était engendrée -> disparition du fichier attaché dans la base (table sb_attachment_attachment) mais référence à ce fichier toujours présent dans la table sb_formtemplate_textfield ce qui entrainait à la demande de mise à jour du fichier une exception de suppression d'attachment impossible car inexistant.

Anomalie contournée en n'appelant pas la suppression du fichier attaché dans la base dans le cas où celui-ci est inexistant.
