### PR TITLE
Bug #2283. Classement PdC obligatoire non enregistrable (IE8 et Chrome)

### DIFF
--- a/war-core/src/main/webapp/util/javaScript/silverpeas-pdc.js
+++ b/war-core/src/main/webapp/util/javaScript/silverpeas-pdc.js
@@ -737,7 +737,8 @@
         $('<img>', {
           src: settings.edition.mandatoryIcon,
           alt: settings.edition.mandatoryLegend, 
-          width: '5px'
+          width: '5px',
+          height: '5px'
         }).appendTo(currentAxisDiv.append(' '));
       }
       if (anAxis.invariant) {
@@ -745,7 +746,8 @@
         $('<img>', {
           src: settings.edition.invariantIcon, 
           alt: settings.edition.invariantLegend,
-          width: '10px'
+          width: '10px',
+          height: '10px'
         }).appendTo(currentAxisDiv);
       }
     });
@@ -772,7 +774,8 @@
         legende.append($('<img>', {
           src: settings.edition.mandatoryIcon, 
           alt: settings.edition.mandatoryLegend,
-          width: '5px'
+          width: '5px',
+          height: '5px'
         })).append($('<span>').html('&nbsp;:' + settings.edition.mandatoryLegend + ' '));
       }
       if (hasInvariantAxis) {
@@ -780,7 +783,8 @@
           $('<img>', {
             src: settings.edition.invariantIcon, 
             alt: settings.edition.invariantLegend,
-            width: '10px'
+            width: '10px',
+            height: '10px'
           })).
         append($('<span>').html('&nbsp;:' + settings.edition.invariantLegend));
       }

--- a/war-core/src/main/webapp/util/styleSheets/globalSP_SilverpeasV5-IE.css
+++ b/war-core/src/main/webapp/util/styleSheets/globalSP_SilverpeasV5-IE.css
@@ -48,3 +48,7 @@
 #gef-progressMessage img {
 	margin-bottom: 25px;
 }
+
+.pdc_position img {
+    width: 12px;
+}


### PR DESCRIPTION
Bug #2283. Replace the onClick event processing on the option HTML element (representing a value of an axis) by the onChange event processing on the select HTML element. The later is supported by all web browsers instead of the former.

WARNING: don't forget to integrate also the branch bug-2283 in Silverpeas Components.
