### PR TITLE
Dependency on mockito-core instead of mockito-all

### DIFF
--- a/test-core/pom.xml
+++ b/test-core/pom.xml
@@ -72,7 +72,7 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
+      <artifactId>mockito-core</artifactId>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/ws-test-core/pom.xml
+++ b/ws-test-core/pom.xml
@@ -81,7 +81,7 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
+      <artifactId>mockito-core</artifactId>
       <scope>compile</scope>
     </dependency>
      <dependency>


### PR DESCRIPTION
Fixing conflicts between mockito-all 1.8.5 and hamcrest 1.2
