### PR TITLE
Support #2977 SQL scripts for the migration of the PdC

### DIFF
--- a/config-core/src/main/config/dbRepository/data/mssql/pdc-contribution.xml
+++ b/config-core/src/main/config/dbRepository/data/mssql/pdc-contribution.xml
@@ -27,60 +27,66 @@
 
 <contribution product="pdc">
 
-    <requirement>
-    </requirement>
+  <requirement>
+  </requirement>
 
-    <current version="006">
-        <create_table>
-            <file name="mssql\pdc\006\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-        </create_table>
-        <create_constraint>
-            <file name="mssql\pdc\006\create_constraint.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-        </create_constraint>
-        <create_index>
-            <file name="mssql\pdc\006\create_index.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-        </create_index>
-        <drop_table>
-            <file name="mssql\pdc\006\drop_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-        </drop_table>
-        <drop_constraint>
-            <file name="mssql\pdc\006\drop_constraint.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-        </drop_constraint>
-        <drop_index>
-            <file name="mssql\pdc\006\drop_index.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-        </drop_index>
-    </current>
+  <current version="007">
+    <create_table>
+      <file name="mssql\pdc\006\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_table>
+    <create_constraint>
+      <file name="mssql\pdc\006\create_constraint.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_constraint>
+    <create_index>
+      <file name="mssql\pdc\006\create_index.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_index>
+    <drop_table>
+      <file name="mssql\pdc\006\drop_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </drop_table>
+    <drop_constraint>
+      <file name="mssql\pdc\006\drop_constraint.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </drop_constraint>
+    <drop_index>
+      <file name="mssql\pdc\006\drop_index.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </drop_index>
+  </current>
+    
+  <upgrade version="006">
+    <create_table>
+      <file name="IdGenerationWithUniqueId.jar" type="javalib" classname="org.silverpeas.migration.pdc.IdGenerationByUsingUniqueId" methodname="migrate"/>
+    </create_table>
+  </upgrade>
 
-    <upgrade version="005">
-       <create_table>
-            <file name="mssql\pdc\up005\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-       </create_table>
-	   <create_constraint>
-            <file name="mssql\pdc\up005\create_constraint.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-        </create_constraint>
-        <create_index>
-            <file name="mssql\pdc\up005\create_index.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-        </create_index>
-    </upgrade>
+  <upgrade version="005">
+    <create_table>
+      <file name="mssql\pdc\up005\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_table>
+    <create_constraint>
+      <file name="mssql\pdc\up005\create_constraint.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_constraint>
+    <create_index>
+      <file name="mssql\pdc\up005\create_index.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_index>
+  </upgrade>
 
-	<upgrade version="004">
-       <create_table>
-            <file name="mssql\pdc\up004\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-       </create_table>
-	   <create_constraint>
-            <file name="mssql\pdc\up004\create_constraint.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-        </create_constraint>
-    </upgrade>
+  <upgrade version="004">
+    <create_table>
+      <file name="mssql\pdc\up004\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_table>
+    <create_constraint>
+      <file name="mssql\pdc\up004\create_constraint.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_constraint>
+  </upgrade>
 
-	<upgrade version="003">
-       <create_table>
-            <file name="mssql\pdc\up003\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-       </create_table>
-    </upgrade>
+  <upgrade version="003">
+    <create_table>
+      <file name="mssql\pdc\up003\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_table>
+  </upgrade>
 
-    <upgrade version="002">
-       <create_table>
-            <file name="mssql\pdc\up002\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-       </create_table>
-    </upgrade>
+  <upgrade version="002">
+    <create_table>
+      <file name="mssql\pdc\up002\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_table>
+  </upgrade>
 </contribution>

--- a/config-core/src/main/config/dbRepository/data/oracle/pdc-contribution.xml
+++ b/config-core/src/main/config/dbRepository/data/oracle/pdc-contribution.xml
@@ -27,60 +27,66 @@
 
 <contribution product="pdc">
 
-    <requirement>
-    </requirement>
+  <requirement>
+  </requirement>
 
-    <current version="006">
-        <create_table>
-            <file name="oracle\pdc\006\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-        </create_table>
-        <create_constraint>
-            <file name="oracle\pdc\006\create_constraint.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-        </create_constraint>
-        <create_index>
-            <file name="oracle\pdc\006\create_index.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-        </create_index>
-        <drop_table>
-            <file name="oracle\pdc\006\drop_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-        </drop_table>
-        <drop_constraint>
-            <file name="oracle\pdc\006\drop_constraint.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-        </drop_constraint>
-        <drop_index>
-            <file name="oracle\pdc\006\drop_index.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-        </drop_index>
-    </current>
+  <current version="007">
+    <create_table>
+      <file name="oracle\pdc\007\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_table>
+    <create_constraint>
+      <file name="oracle\pdc\007\create_constraint.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_constraint>
+    <create_index>
+      <file name="oracle\pdc\007\create_index.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_index>
+    <drop_table>
+      <file name="oracle\pdc\007\drop_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </drop_table>
+    <drop_constraint>
+      <file name="oracle\pdc\007\drop_constraint.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </drop_constraint>
+    <drop_index>
+      <file name="oracle\pdc\007\drop_index.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </drop_index>
+  </current>
+    
+  <upgrade version="006">
+    <create_table>
+      <file name="IdGenerationWithUniqueId.jar" type="javalib" classname="org.silverpeas.migration.pdc.IdGenerationByUsingUniqueId" methodname="migrate"/>
+    </create_table>
+  </upgrade>
 
-    <upgrade version="005">
-       <create_table>
-            <file name="oracle\pdc\up005\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-       </create_table>
-	   <create_constraint>
-            <file name="oracle\pdc\up005\create_constraint.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-        </create_constraint>
-        <create_index>
-            <file name="oracle\pdc\up005\create_index.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-        </create_index>
-    </upgrade>
+  <upgrade version="005">
+    <create_table>
+      <file name="oracle\pdc\up005\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_table>
+    <create_constraint>
+      <file name="oracle\pdc\up005\create_constraint.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_constraint>
+    <create_index>
+      <file name="oracle\pdc\up005\create_index.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_index>
+  </upgrade>
 
-	<upgrade version="004">
-       <create_table>
-            <file name="oracle\pdc\up004\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-       </create_table>
-	   <create_constraint>
-            <file name="oracle\pdc\up004\create_constraint.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-        </create_constraint>
-    </upgrade>
+  <upgrade version="004">
+    <create_table>
+      <file name="oracle\pdc\up004\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_table>
+    <create_constraint>
+      <file name="oracle\pdc\up004\create_constraint.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_constraint>
+  </upgrade>
 
-    <upgrade version="003">
-       <create_table>
-            <file name="oracle\pdc\up003\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-       </create_table>
-    </upgrade>
+  <upgrade version="003">
+    <create_table>
+      <file name="oracle\pdc\up003\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_table>
+  </upgrade>
 
-	 <upgrade version="002">
-       <create_table>
-            <file name="oracle\pdc\up002\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-       </create_table>
-    </upgrade>
+  <upgrade version="002">
+    <create_table>
+      <file name="oracle\pdc\up002\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_table>
+  </upgrade>
 </contribution>

--- a/config-core/src/main/config/dbRepository/data/postgres/pdc-contribution.xml
+++ b/config-core/src/main/config/dbRepository/data/postgres/pdc-contribution.xml
@@ -27,60 +27,66 @@
 
 <contribution product="pdc">
 
-    <requirement>
-    </requirement>
+  <requirement>
+  </requirement>
 
-    <current version="006">
-        <create_table>
-            <file name="postgres\pdc\006\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-        </create_table>
-        <create_constraint>
-            <file name="postgres\pdc\006\create_constraint.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-        </create_constraint>
-        <create_index>
-            <file name="postgres\pdc\006\create_index.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-        </create_index>
-        <drop_table>
-            <file name="postgres\pdc\006\drop_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-        </drop_table>
-        <drop_constraint>
-            <file name="postgres\pdc\006\drop_constraint.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-        </drop_constraint>
-        <drop_index>
-            <file name="postgres\pdc\006\drop_index.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-        </drop_index>
-    </current>
-
-    <upgrade version="005">
-       <create_table>
-            <file name="postgres\pdc\up005\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-       </create_table>
-	   <create_constraint>
-            <file name="postgres\pdc\up005\create_constraint.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-        </create_constraint>
-        <create_index>
-            <file name="postgres\pdc\up005\create_index.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-        </create_index>
-    </upgrade>
+  <current version="007">
+    <create_table>
+      <file name="postgres\pdc\006\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_table>
+    <create_constraint>
+      <file name="postgres\pdc\006\create_constraint.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_constraint>
+    <create_index>
+      <file name="postgres\pdc\006\create_index.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_index>
+    <drop_table>
+      <file name="postgres\pdc\006\drop_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </drop_table>
+    <drop_constraint>
+      <file name="postgres\pdc\006\drop_constraint.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </drop_constraint>
+    <drop_index>
+      <file name="postgres\pdc\006\drop_index.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </drop_index>
+  </current>
     
-    <upgrade version="004">
-       <create_table>
-            <file name="postgres\pdc\up004\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-       </create_table>
-	   <create_constraint>
-            <file name="postgres\pdc\up004\create_constraint.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-        </create_constraint>
-    </upgrade>
+  <upgrade version="006">
+    <create_table>
+      <file name="IdGenerationWithUniqueId.jar" type="javalib" classname="org.silverpeas.migration.pdc.IdGenerationByUsingUniqueId" methodname="migrate"/>
+    </create_table>
+  </upgrade>
 
-	<upgrade version="003">
-       <create_table>
-            <file name="postgres\pdc\up003\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-       </create_table>
-    </upgrade>
+  <upgrade version="005">
+    <create_table>
+      <file name="postgres\pdc\up005\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_table>
+    <create_constraint>
+      <file name="postgres\pdc\up005\create_constraint.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_constraint>
+    <create_index>
+      <file name="postgres\pdc\up005\create_index.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_index>
+  </upgrade>
+    
+  <upgrade version="004">
+    <create_table>
+      <file name="postgres\pdc\up004\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_table>
+    <create_constraint>
+      <file name="postgres\pdc\up004\create_constraint.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_constraint>
+  </upgrade>
 
-	<upgrade version="002">
-       <create_table>
-            <file name="postgres\pdc\up002\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-       </create_table>
-    </upgrade>
+  <upgrade version="003">
+    <create_table>
+      <file name="postgres\pdc\up003\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_table>
+  </upgrade>
+
+  <upgrade version="002">
+    <create_table>
+      <file name="postgres\pdc\up002\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_table>
+  </upgrade>
 </contribution>

--- a/config-core/src/main/config/dbRepository/mssql/pdc/007/create_constraint.sql
+++ b/config-core/src/main/config/dbRepository/mssql/pdc/007/create_constraint.sql
@@ -1,0 +1,56 @@
+ALTER TABLE SB_Pdc_Axis ADD 
+	 CONSTRAINT PK_Pdc_Axis PRIMARY KEY  CLUSTERED 
+	(
+		id
+	)
+;
+
+ALTER TABLE SB_Pdc_Utilization ADD 
+	 CONSTRAINT PK_Pdc_Utilization PRIMARY KEY  CLUSTERED 
+	(
+		id
+	)
+;
+
+ALTER TABLE SB_Pdc_AxisI18N ADD 
+	 CONSTRAINT PK_Pdc_AxisI18N PRIMARY KEY  CLUSTERED 
+	(
+		id
+	)
+;
+
+ALTER TABLE SB_Pdc_User_Rights 
+ADD CONSTRAINT FK_Pdc_User_Rights_1 FOREIGN KEY (axisId) REFERENCES SB_Pdc_Axis(id)
+;
+
+ALTER TABLE SB_Pdc_User_Rights 
+ADD CONSTRAINT FK_Pdc_User_Rights_2 FOREIGN KEY (userId) REFERENCES ST_User(id)
+;
+
+ALTER TABLE SB_Pdc_Group_Rights 
+ADD CONSTRAINT FK_Pdc_Group_Rights_1 FOREIGN KEY (axisId) REFERENCES SB_Pdc_Axis(id)
+;
+
+ALTER TABLE SB_Pdc_Group_Rights 
+ADD CONSTRAINT FK_Pdc_Group_Rights_2 FOREIGN KEY (groupId) REFERENCES ST_Group(id)
+;
+
+alter table PdcClassification_PdcPosition 
+  add constraint FK_PdcClassification_PdcPosition_PositionId
+  foreign key (positions_id) 
+  references PdcPosition;
+
+alter table PdcClassification_PdcPosition 
+  add constraint FK_PdcClassification_PdcPosition_PositionId_PdcClassificationId
+  foreign key (PdcClassification_id) 
+  references PdcClassification;
+
+alter table PdcPosition_PdcAxisValue 
+  add constraint FK_PdcPosition_PdcAxisValue_AxisValuesId
+  foreign key (axisValues_valueId, axisValues_axisId) 
+  references PdcAxisValue;
+
+alter table PdcPosition_PdcAxisValue 
+  add constraint FK_PdcPosition_PdcAxisValue_PdcPositionId
+  foreign key (PdcPosition_id) 
+  references PdcPosition;

--- a/config-core/src/main/config/dbRepository/mssql/pdc/007/create_index.sql
+++ b/config-core/src/main/config/dbRepository/mssql/pdc/007/create_index.sql
@@ -1,0 +1,10 @@
+CREATE INDEX IN_SB_Pdc_Axis_1 ON SB_Pdc_Axis(AxisType);
+
+CREATE INDEX IN_SB_Pdc_Utilization_1 ON SB_Pdc_Utilization(baseValue);
+CREATE INDEX IN_SB_Pdc_Utilization_2 ON SB_Pdc_Utilization(instanceId);
+
+create index IDX_PdcClassification_InstanceId on PdcClassification(instanceId);
+create index IDX_PdcClassification_ContentId on PdcClassification(contentId);
+
+
+

--- a/config-core/src/main/config/dbRepository/mssql/pdc/007/create_table.sql
+++ b/config-core/src/main/config/dbRepository/mssql/pdc/007/create_table.sql
@@ -1,0 +1,84 @@
+CREATE TABLE SB_Pdc_Axis
+(
+	id			int		NOT NULL ,
+	RootId			int		NOT NULL ,
+	Name			varchar (255)	NOT NULL ,
+	AxisType		char(1)		NOT NULL ,
+	AxisOrder		int		NOT NULL ,
+	creationDate		varchar (10)	NULL ,
+	creatorId		varchar (255)	NULL,
+	description             varchar (1000)  NULL,
+	lang			char(2)		NULL
+)
+;
+
+CREATE TABLE SB_Pdc_Utilization
+(
+	id			int		NOT NULL ,
+	instanceId		varchar (100)	NOT NULL ,
+	axisId			int		NOT NULL ,
+	baseValue		int		NOT NULL ,
+	mandatory		int		NOT NULL ,
+	variant			int		NOT NULL
+)
+;
+
+CREATE TABLE SB_Pdc_AxisI18N
+(
+	id			int		NOT NULL ,
+	AxisId			int		NOT NULL ,
+	lang			char(2)		NOT NULL ,
+	Name			varchar (255)	NOT NULL ,
+	description             varchar (1000)  NULL
+)
+;
+
+CREATE TABLE SB_Pdc_User_Rights
+(
+	axisId	int	NOT NULL,
+	valueId	int	NOT NULL,
+	userId	int	NOT NULL
+)
+;
+
+CREATE TABLE SB_Pdc_Group_Rights
+(
+	axisId	int	NOT NULL,
+	valueId	int	NOT NULL,
+	groupId	int	NOT NULL
+)
+;
+
+create table PdcAxisValue (
+  valueId numeric(19,0) not null,
+  axisId numeric(19,0) not null,
+  primary key (valueId, axisId)
+);
+
+create table PdcClassification (
+  id numeric(19,0) identity not null,
+  contentId varchar(255) null,
+  instanceId varchar(255) not null,
+  modifiable tinyint not null,
+  nodeId varchar(255) null,
+  primary key (id)
+);
+
+create table PdcClassification_PdcPosition (
+  PdcClassification_id numeric(19,0) not null,
+  positions_id numeric(19,0) not null,
+  primary key (PdcClassification_id, positions_id),
+  unique (positions_id)
+);
+
+create table PdcPosition (
+  id numeric(19,0) identity not null,
+  primary key (id)
+);
+
+create table PdcPosition_PdcAxisValue (
+  PdcPosition_id numeric(19,0) not null,
+  axisValues_valueId numeric(19,0) not null,
+  axisValues_axisId numeric(19,0) not null,
+  primary key (PdcPosition_id, axisValues_valueId, axisValues_axisId)
+);

--- a/config-core/src/main/config/dbRepository/mssql/pdc/007/drop_constraint.sql
+++ b/config-core/src/main/config/dbRepository/mssql/pdc/007/drop_constraint.sql
@@ -1,0 +1,8 @@
+ALTER TABLE SB_Pdc_Axis		DROP CONSTRAINT PK_Pdc_Axis;
+ALTER TABLE SB_Pdc_Utilization	DROP CONSTRAINT PK_Pdc_Utilization;
+ALTER TABLE SB_Pdc_AxisI18N	DROP CONSTRAINT PK_Pdc_AxisI18N;
+
+alter table PdcPosition_PdcAxisValue drop FK_PdcPosition_PdcAxisValue_AxisValuesId;
+alter table PdcPosition_PdcAxisValue drop FK_PdcPosition_PdcAxisValue_PdcPositionId;
+alter table PdcClassification_PdcPosition drop constraint FK_PdcClassification_PdcPosition_PositionId;
+alter table PdcClassification_PdcPosition drop constraint FK_PdcClassification_PdcPosition_PositionId_PdcClassificationId;

--- a/config-core/src/main/config/dbRepository/mssql/pdc/007/drop_index.sql
+++ b/config-core/src/main/config/dbRepository/mssql/pdc/007/drop_index.sql
@@ -1,0 +1,7 @@
+DROP INDEX SB_Pdc_Axis.IN_SB_Pdc_Axis_1;
+
+DROP INDEX SB_Pdc_Utilization.IN_SB_Pdc_Utilization_1;
+DROP INDEX SB_Pdc_Utilization.IN_SB_Pdc_Utilization_2;
+
+drop index IDX_PdcClassification_InstanceId;
+drop index IDX_PdcClassification_ContentId;

--- a/config-core/src/main/config/dbRepository/mssql/pdc/007/drop_table.sql
+++ b/config-core/src/main/config/dbRepository/mssql/pdc/007/drop_table.sql
@@ -1,0 +1,11 @@
+drop table SB_Pdc_Axis;
+drop table SB_Pdc_Utilization;
+drop table SB_Pdc_AxisI18N;
+drop table SB_Pdc_User_Rights;
+drop table SB_Pdc_Group_Rights;
+
+drop table PdcPosition_PdcAxisValue;
+drop table PdcClassification_PdcPosition;
+drop table PdcClassification;
+drop table PdcPosition;
+drop table PdcAxisValue;

--- a/config-core/src/main/config/dbRepository/oracle/pdc/007/create_constraint.sql
+++ b/config-core/src/main/config/dbRepository/oracle/pdc/007/create_constraint.sql
@@ -1,0 +1,57 @@
+ALTER TABLE SB_Pdc_Axis ADD 
+	 CONSTRAINT PK_Pdc_Axis PRIMARY KEY   
+	(
+		id
+	)
+;
+
+ALTER TABLE SB_Pdc_Utilization ADD 
+	 CONSTRAINT PK_Pdc_Utilization PRIMARY KEY   
+	(
+		id
+	)
+;
+
+ALTER TABLE SB_Pdc_AxisI18N ADD 
+	 CONSTRAINT PK_Pdc_AxisI18N PRIMARY KEY   
+	(
+		id
+	)
+;
+
+ALTER TABLE SB_Pdc_User_Rights 
+ADD CONSTRAINT FK_Pdc_User_Rights_1 FOREIGN KEY (axisId) REFERENCES SB_Pdc_Axis(id)
+;
+
+ALTER TABLE SB_Pdc_User_Rights 
+ADD CONSTRAINT FK_Pdc_User_Rights_2 FOREIGN KEY (userId) REFERENCES ST_User(id)
+;
+
+ALTER TABLE SB_Pdc_Group_Rights 
+ADD CONSTRAINT FK_Pdc_Group_Rights_1 FOREIGN KEY (axisId) REFERENCES SB_Pdc_Axis(id)
+;
+
+ALTER TABLE SB_Pdc_Group_Rights 
+ADD CONSTRAINT FK_Pdc_Group_Rights_2 FOREIGN KEY (groupId) REFERENCES ST_Group(id)
+;
+
+alter table PdcClassification_PdcPosition 
+  add constraint FK_PdcClass_PdcPos_1
+  foreign key (positions_id) 
+  references PdcPosition;
+
+alter table PdcClassification_PdcPosition 
+  add constraint FK_PdcClass_PdcPos_2
+  foreign key (PdcClassification_id) 
+  references PdcClassification;
+
+alter table PdcPosition_PdcAxisValue 
+  add constraint FK_PdcAxisValue_1
+  foreign key (axisValues_valueId, axisValues_axisId) 
+  references PdcAxisValue;
+
+alter table PdcPosition_PdcAxisValue 
+  add constraint FK_PdcAxisValue_2
+  foreign key (PdcPosition_id) 
+  references PdcPosition;
+  

--- a/config-core/src/main/config/dbRepository/oracle/pdc/007/create_index.sql
+++ b/config-core/src/main/config/dbRepository/oracle/pdc/007/create_index.sql
@@ -1,0 +1,10 @@
+CREATE INDEX IN_SB_Pdc_Axis_1 ON SB_Pdc_Axis(AxisType);
+
+CREATE INDEX IN_SB_Pdc_Utilization_1 ON SB_Pdc_Utilization(baseValue);
+CREATE INDEX IN_SB_Pdc_Utilization_2 ON SB_Pdc_Utilization(instanceId);
+
+create index IDX_PdcClass_InstanceId on PdcClassification(instanceId);
+create index IDX_PdcClass_ContentId on PdcClassification(contentId);
+
+
+

--- a/config-core/src/main/config/dbRepository/oracle/pdc/007/create_table.sql
+++ b/config-core/src/main/config/dbRepository/oracle/pdc/007/create_table.sql
@@ -1,0 +1,84 @@
+CREATE TABLE SB_Pdc_Axis
+(
+	id			int		NOT NULL ,
+	RootId			int		NOT NULL ,
+	Name			varchar (255)	NOT NULL ,
+	AxisType		char(1)		NOT NULL ,
+	AxisOrder		int		NOT NULL ,
+	creationDate		varchar (10)	NULL ,
+	creatorId		varchar (255)	NULL,
+	description             varchar (1000)  NULL,
+	lang			char(2)		NULL
+)
+;
+
+CREATE TABLE SB_Pdc_Utilization
+(
+	id			int		NOT NULL ,
+	instanceId		varchar (100)	NOT NULL ,
+	axisId			int		NOT NULL ,
+	baseValue		int		NOT NULL ,
+	mandatory		int		NOT NULL ,
+	variant			int		NOT NULL
+)
+;
+
+CREATE TABLE SB_Pdc_AxisI18N
+(
+	id			int		NOT NULL ,
+	AxisId			int		NOT NULL ,
+	lang			char(2)		NOT NULL ,
+	Name			varchar (255)	NOT NULL ,
+	description             varchar (1000)  NULL
+)
+;
+
+CREATE TABLE SB_Pdc_User_Rights
+(
+	axisId	int	NOT NULL,
+	valueId	int	NOT NULL,
+	userId	int	NOT NULL
+)
+;
+
+CREATE TABLE SB_Pdc_Group_Rights
+(
+	axisId	int	NOT NULL,
+	valueId	int	NOT NULL,
+	groupId	int	NOT NULL
+)
+;
+
+create table PdcAxisValue (
+  valueId number(19,0) not null,
+  axisId number(19,0) not null,
+  primary key (valueId, axisId)
+);
+
+create table PdcClassification (
+  id number(19,0) not null,
+  contentId varchar2(255),
+  instanceId varchar2(255) not null,
+  modifiable number(1,0) not null,
+  nodeId varchar2(255),
+  primary key (id)
+);
+
+create table PdcClassification_PdcPosition (
+  PdcClassification_id number(19,0) not null,
+  positions_id number(19,0) not null,
+  primary key (PdcClassification_id, positions_id),
+  unique (positions_id)
+ );
+
+create table PdcPosition (
+  id number(19,0) not null,
+  primary key (id)
+);
+
+create table PdcPosition_PdcAxisValue (
+  PdcPosition_id number(19,0) not null,
+  axisValues_valueId number(19,0) not null,
+  axisValues_axisId number(19,0) not null,
+  primary key (PdcPosition_id, axisValues_valueId, axisValues_axisId)
+);

--- a/config-core/src/main/config/dbRepository/oracle/pdc/007/drop_constraint.sql
+++ b/config-core/src/main/config/dbRepository/oracle/pdc/007/drop_constraint.sql
@@ -1,0 +1,8 @@
+ALTER TABLE SB_Pdc_Axis		DROP CONSTRAINT PK_Pdc_Axis;
+ALTER TABLE SB_Pdc_Utilization	DROP CONSTRAINT PK_Pdc_Utilization;
+ALTER TABLE SB_Pdc_AxisI18N	DROP CONSTRAINT PK_Pdc_AxisI18N;
+
+alter table PdcPosition_PdcAxisValue drop FK_PdcAxisValue_1;
+alter table PdcPosition_PdcAxisValue drop FK_PdcAxisValue_2;
+alter table PdcClassification_PdcPosition drop constraint FK_PdcClass_PdcPos_1;
+alter table PdcClassification_PdcPosition drop constraint FK_PdcClass_PdcPos_2;

--- a/config-core/src/main/config/dbRepository/oracle/pdc/007/drop_index.sql
+++ b/config-core/src/main/config/dbRepository/oracle/pdc/007/drop_index.sql
@@ -1,0 +1,7 @@
+DROP INDEX IN_SB_Pdc_Axis_1;
+
+DROP INDEX IN_SB_Pdc_Utilization_1;
+DROP INDEX IN_SB_Pdc_Utilization_2;
+
+drop index IDX_PdcClassification_InstanceId;
+drop index IDX_PdcClassification_ContentId;

--- a/config-core/src/main/config/dbRepository/oracle/pdc/007/drop_table.sql
+++ b/config-core/src/main/config/dbRepository/oracle/pdc/007/drop_table.sql
@@ -1,0 +1,11 @@
+drop table SB_Pdc_Axis;
+drop table SB_Pdc_Utilization;
+drop table SB_Pdc_AxisI18N;
+drop table SB_Pdc_User_Rights;
+drop table SB_Pdc_Group_Rights;
+
+drop table PdcPosition_PdcAxisValue;
+drop table PdcClassification_PdcPosition;
+drop table PdcClassification;
+drop table PdcPosition;
+drop table PdcAxisValue;

--- a/config-core/src/main/config/dbRepository/postgres/pdc/007/create_constraint.sql
+++ b/config-core/src/main/config/dbRepository/postgres/pdc/007/create_constraint.sql
@@ -1,0 +1,56 @@
+ALTER TABLE SB_Pdc_Axis ADD 
+	 CONSTRAINT PK_Pdc_Axis PRIMARY KEY   
+	(
+		id
+	)
+;
+
+ALTER TABLE SB_Pdc_Utilization ADD 
+	 CONSTRAINT PK_Pdc_Utilization PRIMARY KEY   
+	(
+		id
+	)
+;
+
+ALTER TABLE SB_Pdc_AxisI18N ADD 
+	 CONSTRAINT PK_Pdc_AxisI18N PRIMARY KEY   
+	(
+		id
+	)
+;
+
+ALTER TABLE SB_Pdc_User_Rights 
+ADD CONSTRAINT FK_Pdc_User_Rights_1 FOREIGN KEY (axisId) REFERENCES SB_Pdc_Axis(id)
+;
+
+ALTER TABLE SB_Pdc_User_Rights 
+ADD CONSTRAINT FK_Pdc_User_Rights_2 FOREIGN KEY (userId) REFERENCES ST_User(id)
+;
+
+ALTER TABLE SB_Pdc_Group_Rights 
+ADD CONSTRAINT FK_Pdc_Group_Rights_1 FOREIGN KEY (axisId) REFERENCES SB_Pdc_Axis(id)
+;
+
+ALTER TABLE SB_Pdc_Group_Rights 
+ADD CONSTRAINT FK_Pdc_Group_Rights_2 FOREIGN KEY (groupId) REFERENCES ST_Group(id)
+;
+
+alter table PdcClassification_PdcPosition 
+  add constraint FK_PdcClassification_PdcPosition_PositionId
+  foreign key (positions_id) 
+  references PdcPosition;
+
+alter table PdcClassification_PdcPosition 
+  add constraint FK_PdcClassification_PdcPosition_PositionId_PdcClassificationId
+  foreign key (PdcClassification_id) 
+  references PdcClassification;
+
+alter table PdcPosition_PdcAxisValue 
+  add constraint FK_PdcPosition_PdcAxisValue_PdcAxisValueId
+  foreign key (axisValues_valueId, axisValues_axisId) 
+  references PdcAxisValue;
+
+alter table PdcPosition_PdcAxisValue 
+  add constraint FK_PdcPosition_PdcAxisValue_PdcPositionId
+  foreign key (PdcPosition_id) 
+  references PdcPosition;

--- a/config-core/src/main/config/dbRepository/postgres/pdc/007/create_index.sql
+++ b/config-core/src/main/config/dbRepository/postgres/pdc/007/create_index.sql
@@ -1,0 +1,12 @@
+CREATE INDEX IN_SB_Pdc_Axis_1 ON SB_Pdc_Axis(AxisType);
+
+CREATE INDEX IN_SB_Pdc_Utilization_1 ON SB_Pdc_Utilization(baseValue);
+CREATE INDEX IN_SB_Pdc_Utilization_2 ON SB_Pdc_Utilization(instanceId);
+
+create index IDX_PdcClassification_InstanceId on PdcClassification(instanceId);
+create index IDX_PdcClassification_ContentId on PdcClassification(contentId);
+
+
+
+
+

--- a/config-core/src/main/config/dbRepository/postgres/pdc/007/create_table.sql
+++ b/config-core/src/main/config/dbRepository/postgres/pdc/007/create_table.sql
@@ -1,0 +1,83 @@
+CREATE TABLE SB_Pdc_Axis
+(
+	id			int		NOT NULL ,
+	RootId			int		NOT NULL ,
+	Name			varchar (255)	NOT NULL ,
+	AxisType		char(1)		NOT NULL ,
+	AxisOrder		int		NOT NULL ,
+	creationDate		varchar (10)	NULL ,
+	creatorId		varchar (255)	NULL,
+	description             varchar (1000)  NULL,
+	lang			char(2)		NULL
+)
+;
+
+CREATE TABLE SB_Pdc_Utilization
+(
+	id			int		NOT NULL ,
+	instanceId		varchar (100)	NOT NULL ,
+	axisId			int		NOT NULL ,
+	baseValue		int		NOT NULL ,
+	mandatory		int		NOT NULL ,
+	variant			int		NOT NULL
+)
+;
+
+CREATE TABLE SB_Pdc_AxisI18N
+(
+	id			int		NOT NULL ,
+	AxisId			int		NOT NULL ,
+	lang			char(2)		NOT NULL ,
+	Name			varchar (255)	NOT NULL ,
+	description             varchar (1000)  NULL
+)
+;
+
+CREATE TABLE SB_Pdc_User_Rights
+(
+	axisId	int	NOT NULL,
+	valueId	int	NOT NULL,
+	userId	int	NOT NULL
+)
+;
+
+CREATE TABLE SB_Pdc_Group_Rights
+(
+	axisId	int	NOT NULL,
+	valueId	int	NOT NULL,
+	groupId	int	NOT NULL
+)
+;
+create table PdcAxisValue (
+  valueId int8 not null,
+  axisId int8 not null,
+  primary key (valueId, axisId)
+);
+
+create table PdcClassification (
+  id int8 not null,
+  contentId varchar(255),
+  instanceId varchar(255) not null,
+  modifiable bool not null,
+  nodeId varchar(255),
+  primary key (id)
+);
+
+create table PdcClassification_PdcPosition (
+  PdcClassification_id int8 not null,
+  positions_id int8 not null,
+  primary key (PdcClassification_id, positions_id),
+  unique (positions_id)
+);
+
+create table PdcPosition (
+  id int8 not null,
+  primary key (id)
+);
+
+create table PdcPosition_PdcAxisValue (
+  PdcPosition_id int8 not null,
+  axisValues_valueId int8 not null,
+  axisValues_axisId bigint not null,
+  primary key (PdcPosition_id, axisValues_valueId, axisValues_axisId)
+);

--- a/config-core/src/main/config/dbRepository/postgres/pdc/007/drop_constraint.sql
+++ b/config-core/src/main/config/dbRepository/postgres/pdc/007/drop_constraint.sql
@@ -1,0 +1,8 @@
+ALTER TABLE SB_Pdc_Axis		DROP CONSTRAINT PK_Pdc_Axis;
+ALTER TABLE SB_Pdc_Utilization	DROP CONSTRAINT PK_Pdc_Utilization;
+ALTER TABLE SB_Pdc_AxisI18N	DROP CONSTRAINT PK_Pdc_AxisI18N;
+
+alter table PdcPosition_PdcAxisValue drop FK_PdcPosition_PdcAxisValue_AxisValuesId;
+alter table PdcPosition_PdcAxisValue drop FK_PdcPosition_PdcAxisValue_PdcPositionId;
+alter table PdcClassification_PdcPosition drop constraint FK_PdcClassification_PdcPosition_PositionId;
+alter table PdcClassification_PdcPosition drop constraint FK_PdcClassification_PdcPosition_PositionId_PdcClassificationId;

--- a/config-core/src/main/config/dbRepository/postgres/pdc/007/drop_index.sql
+++ b/config-core/src/main/config/dbRepository/postgres/pdc/007/drop_index.sql
@@ -1,0 +1,7 @@
+DROP INDEX IN_SB_Pdc_Axis_1;
+
+DROP INDEX IN_SB_Pdc_Utilization_1;
+DROP INDEX IN_SB_Pdc_Utilization_2;
+
+drop index IDX_PdcClassification_InstanceId;
+drop index IDX_PdcClassification_ContentId;

--- a/config-core/src/main/config/dbRepository/postgres/pdc/007/drop_table.sql
+++ b/config-core/src/main/config/dbRepository/postgres/pdc/007/drop_table.sql
@@ -1,0 +1,11 @@
+drop table SB_Pdc_Axis;
+drop table SB_Pdc_Utilization;
+drop table SB_Pdc_AxisI18N;
+drop table SB_Pdc_User_Rights;
+drop table SB_Pdc_Group_Rights;
+
+drop table PdcPosition_PdcAxisValue;
+drop table PdcClassification_PdcPosition;
+drop table PdcClassification;
+drop table PdcPosition;
+drop table PdcAxisValue;

--- a/ejb-core/pdc/src/main/java/com/silverpeas/pdc/dao/PdcAxisValueRepository.java
+++ b/ejb-core/pdc/src/main/java/com/silverpeas/pdc/dao/PdcAxisValueRepository.java
@@ -27,16 +27,19 @@ import com.silverpeas.pdc.model.PdcAxisValue;
 import com.silverpeas.pdc.model.PdcAxisValuePk;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 /**
  * DAO that handles the persistence of PdcAxisValue beans.
  */
-public interface PdcAxisValueDAO extends JpaRepository<PdcAxisValue, PdcAxisValuePk> {
+public interface PdcAxisValueRepository extends JpaRepository<PdcAxisValue, PdcAxisValuePk> {
   
   /**
    * Finds all the values of the specified PdC's axis.
    * @param axisId the unique identifier of the axis.
    * @return a list of the values of the specified axis.
    */
-  List<PdcAxisValue> findByAxisId(Long axisId);
+  @Query("from PdcAxisValue where axisId = :axisId")
+  List<PdcAxisValue> findByAxisId(@Param("axisId") Long axisId);
 }

--- a/ejb-core/pdc/src/main/java/com/silverpeas/pdc/dao/PdcClassificationRepository.java
+++ b/ejb-core/pdc/src/main/java/com/silverpeas/pdc/dao/PdcClassificationRepository.java
@@ -27,37 +27,50 @@ import com.silverpeas.pdc.model.PdcAxisValue;
 import com.silverpeas.pdc.model.PdcClassification;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 /**
  * DAO that handles the persistence of PdcClassification beans.
  */
-public interface PdcClassificationDAO extends JpaRepository<PdcClassification, Long> {
+public interface PdcClassificationRepository extends JpaRepository<PdcClassification, Long> {
 
   /**
    * Finds the predefined classification on the PdC that is set for the whole specified component
    * instance.
+   *
    * @param instanceId the unique identifier of the component instance.
    * @return the predefined classification that is set to the component instance, or null if no
    * predefined classification was set for the component instance.
    */
-  PdcClassification findPredefinedClassificationByComponentInstanceId(String instanceId);
-  
+  @Query(
+  "from PdcClassification where instanceId=:instanceId and contentId is null and nodeId is null")
+  PdcClassification findPredefinedClassificationByComponentInstanceId(
+          @Param("instanceId") String instanceId);
+
   /**
    * Finds the predefined classification on the PdC that is set for the contents in the specified
    * node of the specified component instance.
+   *
    * @param nodeId the unique identifier of the node.
    * @param instanceId the unique identifier of the component instance to which the node belongs.
-   * @return either the predefined classification associated with the node or null if no predefined 
+   * @return either the predefined classification associated with the node or null if no predefined
    * classification exists for that node.
    */
-  PdcClassification findPredefinedClassificationByNodeId(String nodeId, String instanceId);
-  
+  @Query(
+  "from PdcClassification where instanceId=:instanceId and contentId is null and nodeId=:nodeId)")
+  PdcClassification findPredefinedClassificationByNodeId(@Param("nodeId") String nodeId, @Param(
+          "instanceId") String instanceId);
+
   /**
    * Finds all classifications on the PdC that have at least one position with the one or more of
    * the specified axis values. If no such values exist, then an empty list is returned.
+   *
    * @param values a list of PdC's axis values.
    * @return a list of classifications having at least one of the specified values or an empty list.
    */
-  List<PdcClassification> findClassificationsByPdcAxisValues(final List<PdcAxisValue> values);
-  
+  @Query(
+  "select distinct c from PdcClassification c join c.positions p join p.axisValues v where v in :values")
+  List<PdcClassification> findClassificationsByPdcAxisValues(
+          @Param("values") final List<PdcAxisValue> values);
 }

--- a/ejb-core/pdc/src/main/java/com/silverpeas/pdc/model/PdcAxisValue.java
+++ b/ejb-core/pdc/src/main/java/com/silverpeas/pdc/model/PdcAxisValue.java
@@ -25,24 +25,13 @@ package com.silverpeas.pdc.model;
 
 import com.silverpeas.pdc.PdcServiceFactory;
 import com.stratelia.silverpeas.pdc.control.PdcBm;
-import com.stratelia.silverpeas.pdc.model.AxisHeader;
-import com.stratelia.silverpeas.pdc.model.ClassifyValue;
-import com.stratelia.silverpeas.pdc.model.PdcException;
-import com.stratelia.silverpeas.pdc.model.PdcRuntimeException;
-import com.stratelia.silverpeas.pdc.model.UsedAxis;
-import com.stratelia.silverpeas.pdc.model.Value;
+import com.stratelia.silverpeas.pdc.model.*;
 import com.stratelia.silverpeas.treeManager.model.TreeNode;
 import com.stratelia.webactiv.util.exception.SilverpeasException;
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import javax.persistence.EmbeddedId;
 import javax.persistence.Entity;
-import javax.persistence.NamedQueries;
-import javax.persistence.NamedQuery;
 import javax.persistence.Transient;
 
 /**
@@ -60,9 +49,6 @@ import javax.persistence.Transient;
  */
 @Entity
 //@IdClass(PdcAxisValuePk.class) : https://jira.springsource.org/browse/DATAJPA-50
-@NamedQueries({
-  @NamedQuery(name = "PdcAxisValue.findByAxisId", query = "from PdcAxisValue where axisId = ?1")
-})
 public class PdcAxisValue implements Serializable, Cloneable {
 
   private static final long serialVersionUID = 2345886411781136417L;

--- a/ejb-core/pdc/src/main/java/com/silverpeas/pdc/model/PdcAxisValuePk.java
+++ b/ejb-core/pdc/src/main/java/com/silverpeas/pdc/model/PdcAxisValuePk.java
@@ -24,7 +24,6 @@
 package com.silverpeas.pdc.model;
 
 import java.io.Serializable;
-import javax.persistence.Id;
 
 /**
  * The composite primary key used to store values of PdC's axis.

--- a/ejb-core/pdc/src/main/java/com/silverpeas/pdc/model/PdcClassification.java
+++ b/ejb-core/pdc/src/main/java/com/silverpeas/pdc/model/PdcClassification.java
@@ -23,55 +23,34 @@
  */
 package com.silverpeas.pdc.model;
 
+import static com.silverpeas.util.StringUtil.isDefined;
 import com.stratelia.silverpeas.pdc.model.ClassifyPosition;
 import com.stratelia.silverpeas.pdc.model.PdcException;
 import com.stratelia.silverpeas.pdc.model.PdcRuntimeException;
 import com.stratelia.webactiv.util.exception.SilverpeasException;
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import javax.persistence.CascadeType;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.FetchType;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.NamedQueries;
-import javax.persistence.NamedQuery;
-import javax.persistence.OneToMany;
+import java.util.*;
+import javax.persistence.*;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
-import static com.silverpeas.util.StringUtil.isDefined;
 
 /**
  * A classification of a content in Silverpeas on the classification plan (named PdC).
- * 
+ *
  * A classification of a content is made up of one or more positions on the axis of the PdC. Each
- * position consists of one or several values on some PdC's axis. A classification cannot have two or
- * more identical positions; each of them must be unique. 
- * 
+ * position consists of one or several values on some PdC's axis. A classification cannot have two
+ * or more identical positions; each of them must be unique.
+ *
  * It can also represent, for a Silverpeas component instance or for a node in a component instance,
  * a predefined classification with which any published contents can be classified on the PdC. In
  * this case, the contentId attribute is null.
- * 
+ *
  * A classification can be or not modifiable; by default, a predefined classification, that is used
- * to classify new contents, is not modifiable whereas a classification of a content can be modified.
+ * to classify new contents, is not modifiable whereas a classification of a content can be
+ * modified.
  */
 @Entity
-@NamedQueries({
-  @NamedQuery(name = "PdcClassification.findPredefinedClassificationByComponentInstanceId",
-  query = "from PdcClassification where instanceId=?1 and contentId is null and nodeId is null"),
-  @NamedQuery(name = "PdcClassification.findPredefinedClassificationByNodeId",
-  query = "from PdcClassification where instanceId=?2 and contentId is null and nodeId=?1)"),
-  @NamedQuery(name = "PdcClassification.findClassificationsByPdcAxisValues",
-  query =
-  "select distinct c from PdcClassification c join c.positions p join p.axisValues v where v in ?1")
-})
 public class PdcClassification implements Serializable, Cloneable {
 
   /**
@@ -80,7 +59,9 @@ public class PdcClassification implements Serializable, Cloneable {
   public static final PdcClassification NONE_CLASSIFICATION = new PdcClassification();
   private static final long serialVersionUID = 4032206628783381447L;
   @Id
-  @GeneratedValue(strategy = GenerationType.AUTO)
+  @TableGenerator(name = "UNIQUE_ID_GEN", table = "uniqueId", pkColumnName = "tablename",
+  valueColumnName = "maxId", pkColumnValue = "PdcClassification", allocationSize = 1)
+  @GeneratedValue(strategy = GenerationType.TABLE, generator = "UNIQUE_ID_GEN")
   private Long id;
   @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
   @NotNull
@@ -97,9 +78,9 @@ public class PdcClassification implements Serializable, Cloneable {
 
   /**
    * Creates an empty predefined classification for the contents that will published in the
-   * specified component instance.
-   * By default, a predefined classification isn't modifiable and servs to classify automatically 
-   * new contents published in the specied component instance.
+   * specified component instance. By default, a predefined classification isn't modifiable and
+   * servs to classify automatically new contents published in the specied component instance.
+   *
    * @param instanceId the unique identifier of the component instance to which the predefined
    * classification will be attached.
    * @return an empty predefined classification.
@@ -110,8 +91,8 @@ public class PdcClassification implements Serializable, Cloneable {
 
   /**
    * Creates an empty classification on the PdC of the specified content published in the specified
-   * component instance.
-   * By default, the classification of a content can be updated.
+   * component instance. By default, the classification of a content can be updated.
+   *
    * @param contentId the unique identifier of the content to classify.
    * @param inComponentInstanceId the unique identifier of the component instance in which the
    * content is published.
@@ -124,8 +105,9 @@ public class PdcClassification implements Serializable, Cloneable {
   }
 
   /**
-   * Gets the positions on the PdC's axis with which the content is classified.
-   * Positions on the PdC can be added or removed with the returned set.
+   * Gets the positions on the PdC's axis with which the content is classified. Positions on the PdC
+   * can be added or removed with the returned set.
+   *
    * @return a set of positions of this classification.
    */
   public Set<PdcPosition> getPositions() {
@@ -134,6 +116,7 @@ public class PdcClassification implements Serializable, Cloneable {
 
   /**
    * Is this classification empty?
+   *
    * @return true if this classification is an empty one, false otherwise.
    */
   public boolean isEmpty() {
@@ -142,6 +125,7 @@ public class PdcClassification implements Serializable, Cloneable {
 
   /**
    * Is the PdC classifications generated from this template can be changed?
+   *
    * @return false if the content have to be automatically classified, true if the classifications
    * from this template should serv as a proposition of classification.
    */
@@ -151,6 +135,7 @@ public class PdcClassification implements Serializable, Cloneable {
 
   /**
    * Sets this PdC classification as modifiable.
+   *
    * @return itself.
    */
   public PdcClassification modifiable() {
@@ -160,6 +145,7 @@ public class PdcClassification implements Serializable, Cloneable {
 
   /**
    * Sets this PdC classification as unmodifiable.
+   *
    * @return itself.
    */
   public PdcClassification unmodifiable() {
@@ -206,10 +192,11 @@ public class PdcClassification implements Serializable, Cloneable {
   /**
    * Is this classification on the PdC is a predefined one to classify any new contents in the given
    * node or for the given whole component instance?
-   * 
+   *
    * If this classification serves as a template for classifying the contents in a whole component
-   * instance or in a node, then true is returned.
-   * If this classification is the one of a given content, then false is returned.
+   * instance or in a node, then true is returned. If this classification is the one of a given
+   * content, then false is returned.
+   *
    * @return true if this classification is a predefined one, false otherwise.
    */
   public boolean isPredefined() {
@@ -219,14 +206,14 @@ public class PdcClassification implements Serializable, Cloneable {
   /**
    * Is this classification on the PdC is a predefined one for the contents published in the given
    * whole component instance?
-   * 
+   *
    * If this classification serves as a template for classifying the contents in a whole component
-   * instance, then true is returned.
-   * If this classification is a predefined one dedicated to classify only the content in a given
-   * node, then false is returned.
-   * If this classification is the one of a given content, then false is returned.
-   * @return true if this classification is a predefined one for the whole component instance,
-   * false otherwise.
+   * instance, then true is returned. If this classification is a predefined one dedicated to
+   * classify only the content in a given node, then false is returned. If this classification is
+   * the one of a given content, then false is returned.
+   *
+   * @return true if this classification is a predefined one for the whole component instance, false
+   * otherwise.
    */
   public boolean isPredefinedForTheWholeComponentInstance() {
     return isPredefined() && nodeId == null;
@@ -235,12 +222,12 @@ public class PdcClassification implements Serializable, Cloneable {
   /**
    * Is this classification on the PdC is a predefined one for the contents published in a given
    * node?
-   * 
+   *
    * If this classification serves to classify the contents published in a single node of the
-   * component instance, then true is returned.
-   * If this classification is the one of a given content, then false is returned.
-   * If this classification is the predefined one for the whole component instance, then false
-   * is returned.
+   * component instance, then true is returned. If this classification is the one of a given
+   * content, then false is returned. If this classification is the predefined one for the whole
+   * component instance, then false is returned.
+   *
    * @return true if this classification is a predefined one for a given node, false otherwise.
    */
   public boolean isPredefinedForANode() {
@@ -250,16 +237,14 @@ public class PdcClassification implements Serializable, Cloneable {
   /**
    * Updates this classification by removing from its positions the specified values because they
    * will be deleted from the PdC's axis.
-   * 
+   *
    * This method is invoked at axis value deletion. Accordingly, it performs an update of this
-   * classification by applying the following algorithm for each deleted value:
-   * <ul>
-   * <li>The value is a base one of the axis: the value is removed from any positions of the
-   * classification. If a position is empty (it has no values) it is then deleted (the classification
-   * can be then found empty).</li>
-   * <li>The value is a leaf in its value hierarchical tree: the value is replaced by its mother
-   * value in any positions of this classification.</li>
-   * </ul>
+   * classification by applying the following algorithm for each deleted value: <ul> <li>The value
+   * is a base one of the axis: the value is removed from any positions of the classification. If a
+   * position is empty (it has no values) it is then deleted (the classification can be then found
+   * empty).</li> <li>The value is a leaf in its value hierarchical tree: the value is replaced by
+   * its mother value in any positions of this classification.</li> </ul>
+   *
    * @param deletedValues the values that are removed from a PdC's axis.
    */
   public void updateForPdcAxisValuesDeletion(final List<PdcAxisValue> deletedValues) {
@@ -295,6 +280,7 @@ public class PdcClassification implements Serializable, Cloneable {
 
   /**
    * Sets the positions on the PdC for this classification.
+   *
    * @param thePositions the position to set in this classification.
    * @return itself.
    */
@@ -306,6 +292,7 @@ public class PdcClassification implements Serializable, Cloneable {
 
   /**
    * Adds the specified position on the PdC in this classification.
+   *
    * @param aPosition a position on the PdC to add in this classification.
    * @return itself.
    */
@@ -319,12 +306,12 @@ public class PdcClassification implements Serializable, Cloneable {
   }
 
   /**
-   * Gets the unique identifier of this classification on the PdC.
-   * The identifier is set when the classification is persisted over the Silverpeas runtime. If the
-   * content this classification is about were at a time unclassified, then the identifier of the 
-   * classification isn't expected to be not the one of the previous classification as they are
-   * considered distinct objects (the previous classification was removed from the persistence
-   * context in Silverpeas).
+   * Gets the unique identifier of this classification on the PdC. The identifier is set when the
+   * classification is persisted over the Silverpeas runtime. If the content this classification is
+   * about were at a time unclassified, then the identifier of the classification isn't expected to
+   * be not the one of the previous classification as they are considered distinct objects (the
+   * previous classification was removed from the persistence context in Silverpeas).
+   *
    * @return the classification unique identifier.
    */
   public Long getId() {
@@ -357,6 +344,7 @@ public class PdcClassification implements Serializable, Cloneable {
   /**
    * Gets the positions on the PdC of this classification in the form of ClassifyPosition instances.
    * This method is for compatibility with the old way to manage the classification.
+   *
    * @return a list of ClassifyPosition instances, each of them representing a position on the PdC.
    */
   public List<ClassifyPosition> getClassifyPositions() {

--- a/ejb-core/pdc/src/main/java/com/silverpeas/pdc/model/PdcPosition.java
+++ b/ejb-core/pdc/src/main/java/com/silverpeas/pdc/model/PdcPosition.java
@@ -23,6 +23,7 @@
  */
 package com.silverpeas.pdc.model;
 
+import static com.silverpeas.util.StringUtil.isDefined;
 import com.stratelia.silverpeas.pdc.model.ClassifyPosition;
 import com.stratelia.silverpeas.pdc.model.ClassifyValue;
 import com.stratelia.silverpeas.pdc.model.PdcException;
@@ -31,16 +32,10 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
-import javax.persistence.Entity;
-import javax.persistence.FetchType;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.OneToMany;
+import javax.persistence.*;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
-import static com.silverpeas.util.StringUtil.*;
 
 /**
  * A position of a content on some axis of the classification plan (named PdC). The positions of 
@@ -62,7 +57,9 @@ public class PdcPosition implements Serializable, Cloneable {
   private static final long serialVersionUID = 665144316569539208L;
   
   @Id
-  @GeneratedValue(strategy = GenerationType.AUTO)
+  @TableGenerator(name = "UNIQUE_ID_GEN", table = "uniqueId", pkColumnName = "tablename",
+  valueColumnName = "maxId", pkColumnValue = "PdcPosition", allocationSize = 1)
+  @GeneratedValue(strategy = GenerationType.TABLE, generator = "UNIQUE_ID_GEN")
   private Long id;
   @OneToMany(fetch = FetchType.EAGER)
   @NotNull

--- a/ejb-core/pdc/src/test/java/com/silverpeas/pdc/dao/PdcAxisValueDAOTest.java
+++ b/ejb-core/pdc/src/test/java/com/silverpeas/pdc/dao/PdcAxisValueDAOTest.java
@@ -55,7 +55,7 @@ import static com.silverpeas.pdc.matchers.PdcAxisValueMatcher.*;
 public class PdcAxisValueDAOTest {
 
   @Inject
-  private PdcAxisValueDAO dao;
+  private PdcAxisValueRepository dao;
   @Inject
   private DataSource dataSource;
 

--- a/ejb-core/pdc/src/test/java/com/silverpeas/pdc/dao/PdcClassificationDAOTest.java
+++ b/ejb-core/pdc/src/test/java/com/silverpeas/pdc/dao/PdcClassificationDAOTest.java
@@ -60,7 +60,7 @@ import static com.silverpeas.pdc.model.PdcModelHelper.*;
 public class PdcClassificationDAOTest {
 
   @Inject
-  private PdcClassificationDAO dao;
+  private PdcClassificationRepository dao;
   @Inject
   private DataSource dataSource;
   @Inject

--- a/ejb-core/pdc/src/test/java/com/silverpeas/pdc/service/PdcClassificationServiceTest.java
+++ b/ejb-core/pdc/src/test/java/com/silverpeas/pdc/service/PdcClassificationServiceTest.java
@@ -34,7 +34,7 @@ import org.dbunit.operation.DatabaseOperation;
 import java.util.Set;
 import java.util.List;
 import com.silverpeas.pdc.TestResources;
-import com.silverpeas.pdc.dao.PdcClassificationDAO;
+import com.silverpeas.pdc.dao.PdcClassificationRepository;
 import com.silverpeas.pdc.model.PdcAxisValue;
 import org.junit.runner.RunWith;
 import org.springframework.test.context.ContextConfiguration;
@@ -69,7 +69,7 @@ public class PdcClassificationServiceTest {
   @Inject
   private DataSource dataSource;
   @Inject
-  PdcClassificationDAO dao;
+  PdcClassificationRepository dao;
 
   public PdcClassificationServiceTest() {
   }

--- a/ejb-core/pdc/src/test/resources/com/silverpeas/pdc/dao/create-database.sql
+++ b/ejb-core/pdc/src/test/resources/com/silverpeas/pdc/dao/create-database.sql
@@ -1,3 +1,7 @@
+CREATE TABLE UniqueId (
+	maxId int NOT NULL ,
+	tableName varchar(100) NOT NULL
+);
 
     create table PdcAxisValue (
         axisId bigint not null,

--- a/ejb-core/pdc/src/test/resources/com/silverpeas/pdc/dao/pdc-dataset.xml
+++ b/ejb-core/pdc/src/test/resources/com/silverpeas/pdc/dao/pdc-dataset.xml
@@ -73,4 +73,6 @@
   <PdcPosition_PdcAxisValue PdcPosition_id="5" axisValues_valueId="0" axisValues_axisId="1" />
   <PdcPosition_PdcAxisValue PdcPosition_id="5" axisValues_valueId="4" axisValues_axisId="2" />
   
+  <uniqueId maxId="5" tablename="PdcClassification"/>
+  <uniqueId maxId="6" tablename="PdcPosition"/>
 </dataset>

--- a/web-core/src/test/java/com/silverpeas/pdc/web/PdcTestResources.java
+++ b/web-core/src/test/java/com/silverpeas/pdc/web/PdcTestResources.java
@@ -23,33 +23,34 @@
  */
 package com.silverpeas.pdc.web;
 
-import com.silverpeas.pdc.dao.PdcClassificationDAO;
-import java.util.ArrayList;
-import com.stratelia.webactiv.util.node.model.NodeDetail;
-import com.stratelia.webactiv.util.node.model.NodePK;
+import com.silverpeas.pdc.dao.PdcClassificationRepository;
 import com.silverpeas.pdc.model.PdcClassification;
 import com.silverpeas.pdc.service.PdcClassificationService;
-import javax.inject.Named;
-import java.util.List;
-import com.silverpeas.pdc.web.mock.PdcBmMock;
+import static com.silverpeas.pdc.web.PdcClassificationEntity.*;
+import static com.silverpeas.pdc.web.TestConstants.*;
+import static com.silverpeas.pdc.web.UserThesaurusHolder.forUser;
 import com.silverpeas.pdc.web.mock.ContentManagerMock;
+import com.silverpeas.pdc.web.mock.PdcBmMock;
 import com.silverpeas.personalization.UserPreferences;
 import com.silverpeas.rest.TestResources;
 import com.silverpeas.thesaurus.ThesaurusException;
 import com.silverpeas.thesaurus.control.ThesaurusManager;
+import static com.silverpeas.util.StringUtil.isDefined;
 import com.stratelia.silverpeas.contentManager.ContentManager;
 import com.stratelia.silverpeas.pdc.control.PdcBm;
 import com.stratelia.webactiv.beans.admin.UserDetail;
 import com.stratelia.webactiv.util.node.control.NodeBm;
+import com.stratelia.webactiv.util.node.model.NodeDetail;
+import com.stratelia.webactiv.util.node.model.NodePK;
 import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
+import javax.inject.Named;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import org.springframework.test.util.ReflectionTestUtils;
-import static org.mockito.Mockito.*;
-import static com.silverpeas.pdc.web.TestConstants.*;
-import static com.silverpeas.pdc.web.PdcClassificationEntity.*;
-import static com.silverpeas.pdc.web.UserThesaurusHolder.*;
-import static com.silverpeas.util.StringUtil.isDefined;
 
 /**
  * Resources required by the unit tests on the PdC web resources.
@@ -73,7 +74,7 @@ public class PdcTestResources extends TestResources {
   @Inject
   ContentManagerMock contentManager;
   @Inject
-  PdcClassificationDAO classificationDAO;
+  PdcClassificationRepository classificationRepository;
   @Inject
   PdcClassificationService classificationService;
   private NodeBm nodeBmMock = mock(NodeBm.class);
@@ -121,23 +122,23 @@ public class PdcTestResources extends TestResources {
   }
 
   public void savePredefined(final PdcClassification classification) {
-    classificationDAO.saveAndFlush(classification);
+    classificationRepository.saveAndFlush(classification);
   }
   
   public PdcClassification getPredefinedClassification(String nodeId, String componentId) {
     if (isDefined(nodeId)) {
-      return classificationDAO.findPredefinedClassificationByNodeId(nodeId, componentId);
+      return classificationRepository.findPredefinedClassificationByNodeId(nodeId, componentId);
     } else {
-      return classificationDAO.findPredefinedClassificationByComponentInstanceId(componentId);
+      return classificationRepository.findPredefinedClassificationByComponentInstanceId(componentId);
     }
   }
 
   public void getPredefinedPdcClassificationForWholeComponent() {
-    classificationDAO.findPredefinedClassificationByComponentInstanceId(COMPONENT_INSTANCE_ID);
+    classificationRepository.findPredefinedClassificationByComponentInstanceId(COMPONENT_INSTANCE_ID);
   }
 
   public void getPredefinedPdcClassificationForNode() {
-    classificationDAO.findPredefinedClassificationByNodeId(NODE_ID, COMPONENT_INSTANCE_ID);
+    classificationRepository.findPredefinedClassificationByNodeId(NODE_ID, COMPONENT_INSTANCE_ID);
   }
 
   /**

--- a/web-core/src/test/java/com/silverpeas/pdc/web/mock/PdcAxisValueRepositoryMock.java
+++ b/web-core/src/test/java/com/silverpeas/pdc/web/mock/PdcAxisValueRepositoryMock.java
@@ -24,7 +24,7 @@
 package com.silverpeas.pdc.web.mock;
 
 import com.google.common.collect.Lists;
-import com.silverpeas.pdc.dao.PdcAxisValueDAO;
+import com.silverpeas.pdc.dao.PdcAxisValueRepository;
 import com.silverpeas.pdc.model.PdcAxisValue;
 import com.silverpeas.pdc.model.PdcAxisValuePk;
 import java.util.List;
@@ -37,8 +37,8 @@ import org.springframework.data.domain.Sort;
 /**
  * Mock the PdcAxisValueDAO for tests.
  */
-@Named("pdcAxisValueDAO")
-public class PdcAxisValueDAOMock implements PdcAxisValueDAO {
+@Named("pdcAxisValueRepository")
+public class PdcAxisValueRepositoryMock implements PdcAxisValueRepository {
 
   @Override
   public PdcAxisValue save(PdcAxisValue t) {

--- a/web-core/src/test/java/com/silverpeas/pdc/web/mock/PdcClassificationRepositoryMock.java
+++ b/web-core/src/test/java/com/silverpeas/pdc/web/mock/PdcClassificationRepositoryMock.java
@@ -23,9 +23,10 @@
  */
 package com.silverpeas.pdc.web.mock;
 
-import com.silverpeas.pdc.dao.PdcClassificationDAO;
+import com.silverpeas.pdc.dao.PdcClassificationRepository;
 import com.silverpeas.pdc.model.PdcAxisValue;
 import com.silverpeas.pdc.model.PdcClassification;
+import static com.silverpeas.pdc.model.PdcClassificationHelper.*;
 import com.silverpeas.pdc.model.PdcPosition;
 import com.silverpeas.pdc.web.IdGenerator;
 import java.util.ArrayList;
@@ -41,13 +42,11 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 
-import static com.silverpeas.pdc.model.PdcClassificationHelper.*;
-
 /**
  * Mock of the PdcClassification service bean
  */
-@Named("pdcClassificationDAO")
-public class PdcClassificationDAOMock implements PdcClassificationDAO {
+@Named("pdcClassificationRepository")
+public class PdcClassificationRepositoryMock implements PdcClassificationRepository {
 
   private Map<Long, PdcClassification> classifications =
           new ConcurrentHashMap<Long, PdcClassification>();


### PR DESCRIPTION
Don't forget to merge also the branch support-2799 of the DB-Builder project. It contains the migration Java code for the PdC component so that its table can take profit of the UniqueId table for the automatique identifier generation
