### PR TITLE
Bug #2938 Previously the selection of several values for an axis in orde...

### DIFF
--- a/war-core/src/main/webapp/util/javaScript/silverpeas-pdc-widgets.js
+++ b/war-core/src/main/webapp/util/javaScript/silverpeas-pdc-widgets.js
@@ -959,7 +959,7 @@ function removePosition( position, positions ) {
   }
   
   function duplicateAxis( $axisDiv, settings, selectedValues, axis) {
-    //$('.another-value').remove();
+    $axisDiv.children('.another-value').remove();
     renderAxis($axisDiv, settings, selectedValues, axis);
   }
   


### PR DESCRIPTION
...r to generate several different positions was only possible for one axis (the multi-valuation for other axis were then disactivated). Now it is possible to select several values for several axis when positionning a contribution onto the PdC or when defined a predefined classification for contents in a given category. So the users has to be cautious when using these evolution
