### PR TITLE
Feature #3180 : handle expired password for Active Directory domain

### DIFF
--- a/config-core/src/main/config/properties/com/silverpeas/authentication/multilang/authentication_en.properties
+++ b/config-core/src/main/config/properties/com/silverpeas/authentication/multilang/authentication_en.properties
@@ -54,5 +54,6 @@ authentication.password.length = (at least * characters)
 authentication.password.length.alert = Your password must contain at least * characters
 authentication.password.different = The answer and confirmation are not the same
 authentication.password.aboutToExpire = Your password is about to expire. It is strongly recommended to change it as soon as possible.
+authentication.password.expired = Your password has expired. You must change it to access the application.
 authentication.password.change = Change password
 authentication.password.remindMeLater = Remind me later

--- a/config-core/src/main/config/properties/com/silverpeas/authentication/multilang/authentication_fr.properties
+++ b/config-core/src/main/config/properties/com/silverpeas/authentication/multilang/authentication_fr.properties
@@ -54,5 +54,6 @@ authentication.password.length = (* caract\u00E8res minimum)
 authentication.password.length.alert = Votre mot de passe doit comporter au moins * caract\u00E8res
 authentication.password.different = Le mot de passe et sa confirmation ne sont pas identiques
 authentication.password.aboutToExpire = Votre mot de passe arrive bient\u00F4t \u00E0 expiration. Il est conseill\u00E9 de le changer dans les plus brefs d\u00E9lais.
+authentication.password.expired = Votre mot de passe a expir\u00E9. Vous devez le changer pour pouvoir acc\u00E9der \u00E0 l'application.
 authentication.password.change = Changer le mot de passe
 authentication.password.remindMeLater = Me le rappeler plus tard

--- a/config-core/src/main/config/properties/com/silverpeas/authentication/settings/passwordExpiration.properties
+++ b/config-core/src/main/config/properties/com/silverpeas/authentication/settings/passwordExpiration.properties
@@ -31,3 +31,5 @@ notificationType=POPUP
 
 # password Change page URL : admin/jsp/passwordAboutToExpire.jsp
 passwordChangeURL=/defaultPasswordAboutToExpire.jsp
+
+passwordExpiredURL=/defaultPasswordExpired.jsp

--- a/config-core/src/main/config/properties/com/stratelia/silverpeas/authentication/autDomainMSAD.properties
+++ b/config-core/src/main/config/properties/com/stratelia/silverpeas/authentication/autDomainMSAD.properties
@@ -27,6 +27,8 @@
 # Fallback type : could be one of the following values : none, ifNotRejected, always
 fallbackType=always
 
+allowPasswordChange=false
+
 # Authentication servers
 # Available types are : com.stratelia.silverpeas.authentication.AuthenticationNT, com.stratelia.silverpeas.authentication.AuthenticationSQL and com.stratelia.silverpeas.authentication.AuthenticationLDAP
 
@@ -40,5 +42,9 @@ autServer0.LDAPAccessLogin=CN=bob,CN=Users,DC=TOTO,DC=BOB
 autServer0.LDAPAccessPasswd=bob
 autServer0.LDAPUserBaseDN=OU=Utilisateurs,OU=testSynchro,DC=toto,DC=bob
 autServer0.LDAPUserLoginFieldName=sAMAccountName
+#Connection must be secured if you plan to change passwords
 autServer0.LDAPSecured=false
 autServer0.LDAPSecuredPort=636
+autServer0.LDAPPwdLastSetFieldName=pwdLastSet
+autServer0.LDAPPwdLastSetFieldFormat=nanoseconds
+autServer0.MustAlertPasswordExpiration=false

--- a/lib-core/src/main/java/com/stratelia/silverpeas/authentication/AuthenticationPasswordExpired.java
+++ b/lib-core/src/main/java/com/stratelia/silverpeas/authentication/AuthenticationPasswordExpired.java
@@ -1,0 +1,9 @@
+package com.stratelia.silverpeas.authentication;
+
+import com.stratelia.webactiv.util.exception.SilverpeasException;
+
+public class AuthenticationPasswordExpired extends AuthenticationException {
+  public AuthenticationPasswordExpired(String extraParams) {
+    super(null, SilverpeasException.ERROR, "authentication.EX_PASSWORD_EXPIRED", extraParams);
+  }
+}

--- a/lib-core/src/main/java/com/stratelia/silverpeas/authentication/LoginPasswordAuthentication.java
+++ b/lib-core/src/main/java/com/stratelia/silverpeas/authentication/LoginPasswordAuthentication.java
@@ -79,6 +79,7 @@ public class LoginPasswordAuthentication {
   static final protected String m_UserDomainColumnName;
 
   static protected int m_AutoInc = 1;
+  public static final String ERROR_PWD_EXPIRED = "Error_PwdExpired";
 
   static {
     ResourceLocator propFile = new ResourceLocator(
@@ -207,12 +208,6 @@ public class LoginPasswordAuthentication {
 
       AuthenticationServer authenticationServer = getAuthenticationServer(m_Connection, domainId);
 
-      // Authentification test
-      authenticationServer.authenticate(login, password, request);
-
-      // Generate a random key and store it in database
-      String key = getAuthenticationKey(login, domainId);
-
       if (request != null) {
         // Store information about password change capabilities in HTTP session
         HttpSession session = request.getSession();
@@ -220,9 +215,15 @@ public class LoginPasswordAuthentication {
             (authenticationServer.isPasswordChangeAllowed()) ? "yes" : "no");
       }
 
+      // Authentification test
+      authenticationServer.authenticate(login, password, request);
+
+      // Generate a random key and store it in database
+      String key = getAuthenticationKey(login, domainId);
+
       return key;
     } catch (AuthenticationException ex) {
-      SilverTrace.warn("authentication",
+      SilverTrace.error("authentication",
           "LoginPasswordAuthentication.authenticate()",
           "authentication.EX_USER_REJECTED", "DomainId=" + domainId + ";User="
               + login, ex);
@@ -239,6 +240,8 @@ public class LoginPasswordAuthentication {
         errorCause = "Error_2";
       } else if (ex instanceof AuthenticationPwdNotAvailException) {
         errorCause = "Error_5";
+      } else if (ex instanceof AuthenticationPasswordExpired) {
+        errorCause = ERROR_PWD_EXPIRED;
       }
       return errorCause;
     } finally {

--- a/war-core/src/main/webapp/defaultPasswordExpired.jsp
+++ b/war-core/src/main/webapp/defaultPasswordExpired.jsp
@@ -1,0 +1,131 @@
+<%--
+
+    Copyright (C) 2000 - 2011 Silverpeas
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    As a special exception to the terms and conditions of version 3.0 of
+    the GPL, you may redistribute this Program in connection with Free/Libre
+    Open Source Software ("FLOSS") applications as described in Silverpeas's
+    FLOSS exception.  You should have received a copy of the text describing
+    the FLOSS exception, and it is also available here:
+    "http://repository.silverpeas.com/legal/licensing"
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+--%>
+<%@page import="com.stratelia.webactiv.util.viewGenerator.html.GraphicElementFactory"%>
+<%@page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+        "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<%@page import="com.stratelia.webactiv.beans.admin.UserDetail"%>
+<%@page import="com.silverpeas.jobDomainPeas.JobDomainSettings"%>
+<%@page import="com.stratelia.silverpeas.peasCore.MainSessionController"%>
+<%@ include file="headLog.jsp"%>
+
+<%
+int minLengthPassword = JobDomainSettings.m_MinLengthPwd;
+ResourceLocator authenticationBundle = new ResourceLocator("com.silverpeas.authentication.multilang.authentication", "");
+%>
+
+<html xmlns="http://www.w3.org/1999/xhtml">
+	<head>
+		<title><%=generalMultilang.getString("GML.popupTitle")%></title>
+		<link REL="SHORTCUT ICON" HREF="<%=request.getContextPath()%>/util/icons/favicon.ico">
+		<link type="text/css" rel="stylesheet" href="<%=styleSheet%>" />
+		<!--[if lt IE 8]>
+			<style>
+			input{
+				background-color:#FAFAFA;
+				border:1px solid #DAD9D9;
+				width:448px;
+				text-align:left;
+			    margin-left:-10px;
+			    height:26px;
+			    line-height:24px;
+			    padding:0px 60px;
+			    display:block;
+			    padding:0px;
+			}
+			</style>
+		<![endif]-->
+		<script type="text/javascript" src="<%=m_context%>/passwordValidator.js"></script>
+	    <script type="text/javascript">
+
+		function checkPassword() {
+			var form = document.getElementById("changePwdForm");
+			var newPassword = form.newPassword.value;
+			var passed = validatePassword(newPassword, {
+				length:   [4, Infinity],
+				combined: 0
+			});
+	    	if (newPassword != form.confirmPassword.value) {
+	    		alert("<%=authenticationBundle.getString("authentication.password.different") %>");
+		    	return false;
+	    	}
+	    	else if (passed == false) {
+		    	alert("Votre mot de passe doit comporter au moins huit caractères et être composé d'une combinaison de trois types de caractères (à choisir entre minuscules, majuscules, chiffres et signes spéciaux). ");
+		    	return false;
+	    	}
+	    	else {
+			    form.submit();
+	    	}
+	    }
+
+	    </script>
+	</head>
+
+<body>
+	<form id="changePwdForm" action="<%=m_context%>/CredentialsServlet/ChangeExpiredPassword" method="post">
+        <div id="top"></div> <!-- Background foncé -->
+        <div class="page"> <!-- Centrage horizontal des éléments (960px) -->
+            <div class="titre"><%=authenticationBundle.getString("authentication.logon.title") %></div>
+            <div id="backgroundBig"> <!-- image de fond du formulaire -->
+                <div class="cadre">
+                    <div id="header">
+                        <img src="<%=logo%>" class="logo" />
+                        <p class="information"><%=authenticationBundle.getString("authentication.password.expired") %><br/>
+								<%
+									String message = (String) request.getAttribute("message");
+									if (message != null) {
+								%>
+									( <%=message%> )<br/>
+								<%
+									}
+								%></p>
+                        <div class="clear"></div>
+                    </div>
+					<p><label><span><%=authenticationBundle.getString("authentication.password.old") %></span><input type="password" name="oldPassword" id="oldPassword"/></label></p>
+					<p><label><span><%=authenticationBundle.getString("authentication.password.new") %> <%=authenticationBundle.getStringWithParam("authentication.password.length", Integer.toString(minLengthPassword)) %></span><input type="password" name="newPassword" id="newPassword"/></label></p>
+					<p><label><span><%=authenticationBundle.getString("authentication.password.confirm") %></span><input type="password" name="confirmPassword" id="confirmPassword"/></label></p>
+                    <input type="hidden" name="login" value="${param.login}" />
+                    <input type="hidden" name="domainId" value="${param.domainId}" />
+					<br/>
+					<p>
+						<table cellspacing="0" width="100%">
+						<tbody>
+						<tr>
+							<td style="background-image: url('images/bt-left.png'); width: 31px; height: 31px">&nbsp;</td>
+							<td style="background-image: url('images/bt-bg.png'); background-repeat: repeat-x;"><a href="#" class="submit" onclick="checkPassword();"><%=authenticationBundle.getString("authentication.password.change") %></a></td>
+							<td style="background-image: url('images/bt-right.png');width: 16px; height: 31px">&nbsp;</td>
+						</tr>
+						</tbody>
+						</table>
+					</p>
+                </div>
+            </div>
+        </div>
+      </form>
+
+	</body>
+</html>

--- a/web-core/src/main/java/com/silverpeas/authentication/AuthenticationServlet.java
+++ b/web-core/src/main/java/com/silverpeas/authentication/AuthenticationServlet.java
@@ -25,8 +25,10 @@ package com.silverpeas.authentication;
 
 
 import com.silverpeas.util.StringUtil;
+import com.stratelia.silverpeas.authentication.Authentication;
 import com.stratelia.silverpeas.authentication.EncryptionFactory;
 import com.stratelia.silverpeas.authentication.LoginPasswordAuthentication;
+import com.stratelia.silverpeas.notificationManager.NotificationManagerException;
 import com.stratelia.silverpeas.peasCore.URLManager;
 import com.stratelia.silverpeas.silvertrace.SilverTrace;
 import com.stratelia.webactiv.util.ResourceLocator;
@@ -111,13 +113,21 @@ public class AuthenticationServlet extends HttpServlet {
     if (identificationParameters.isCasMode()) {
       url = "/admin/jsp/casAuthenticationError.jsp";
     } else {
-      String errorCode;
       if("Error_1".equals(authenticationKey)) {
-        errorCode = INCORRECT_LOGIN_PWD;
-      }else {
-        errorCode = TECHNICAL_ISSUE;
+        url = "/Login.jsp?ErrorCode=" + INCORRECT_LOGIN_PWD;
       }
-      url = "/Login.jsp?ErrorCode=" + errorCode;
+      else if(LoginPasswordAuthentication.ERROR_PWD_EXPIRED.equals(authenticationKey)){
+          String allowPasswordChange = (String) session.getAttribute(Authentication.PASSWORD_CHANGE_ALLOWED);
+          if(StringUtil.getBooleanValue(allowPasswordChange)){
+            ResourceLocator settings = new ResourceLocator("com.silverpeas.authentication.settings.passwordExpiration", "");
+            url = settings.getString("passwordExpiredURL")+"?login="+identificationParameters.getLogin()+"&domainId="+sDomainId;
+          } else {
+            url = "/Login.jsp?ErrorCode=" + LoginPasswordAuthentication.ERROR_PWD_EXPIRED;
+          }
+      }
+      else {
+        url = "/Login.jsp?ErrorCode=" + TECHNICAL_ISSUE;
+      }
     }
     response.sendRedirect(response.encodeRedirectURL(URLManager.getFullApplicationURL(request) + url));
   }

--- a/web-core/src/main/java/com/stratelia/webactiv/servlets/CredentialsServlet.java
+++ b/web-core/src/main/java/com/stratelia/webactiv/servlets/CredentialsServlet.java
@@ -20,29 +20,17 @@
  */
 package com.stratelia.webactiv.servlets;
 
-import com.stratelia.webactiv.servlets.credentials.ChangePasswordHandler;
-import com.stratelia.webactiv.servlets.credentials.ChangeQuestionHandler;
-import com.stratelia.webactiv.servlets.credentials.EffectiveChangePasswordBeforeExpirationHandler;
-import com.stratelia.webactiv.servlets.credentials.EffectiveChangePasswordHandler;
-import com.stratelia.webactiv.servlets.credentials.ForcePasswordChangeHandler;
-import com.stratelia.webactiv.servlets.credentials.ForgotPasswordHandler;
-import com.stratelia.webactiv.servlets.credentials.FunctionHandler;
-import com.stratelia.webactiv.servlets.credentials.LoginQuestionHandler;
-import com.stratelia.webactiv.servlets.credentials.ResetLoginPasswordHandler;
-import com.stratelia.webactiv.servlets.credentials.ResetPasswordHandler;
-import com.stratelia.webactiv.servlets.credentials.SendMessageHandler;
-import com.stratelia.webactiv.servlets.credentials.ValidationAnswerHandler;
-import com.stratelia.webactiv.servlets.credentials.ValidationQuestionHandler;
+import com.stratelia.webactiv.servlets.credentials.*;
 
 import javax.servlet.RequestDispatcher;
 import javax.servlet.ServletException;
+import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-import javax.servlet.http.Cookie;
 
 /**
  * Controller tier for credential management (called by MandatoryQuestionChecker)
@@ -72,6 +60,7 @@ public class CredentialsServlet extends HttpServlet {
     handlers.put("LoginQuestion", new LoginQuestionHandler());
     handlers.put("ValidateAnswer", new ValidationAnswerHandler());
     handlers.put("ChangePassword", new ChangePasswordHandler());
+    handlers.put("ChangeExpiredPassword", new ChangeExpiredPasswordHandler());
     // Password reset management
     handlers.put("ForgotPassword", new ForgotPasswordHandler());
     handlers.put("ResetPassword", new ResetPasswordHandler());

--- a/web-core/src/main/java/com/stratelia/webactiv/servlets/credentials/ChangeExpiredPasswordHandler.java
+++ b/web-core/src/main/java/com/stratelia/webactiv/servlets/credentials/ChangeExpiredPasswordHandler.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (C) 2000 - 2011 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "http://repository.silverpeas.com/legal/licensing"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.stratelia.webactiv.servlets.credentials;
+
+import com.stratelia.silverpeas.authentication.AuthenticationException;
+import com.stratelia.silverpeas.authentication.LoginPasswordAuthentication;
+import com.stratelia.silverpeas.silvertrace.SilverTrace;
+import com.stratelia.webactiv.util.ResourceLocator;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * Navigation case : user asks to change his expired password.
+ * @author ndupont
+ */
+public class ChangeExpiredPasswordHandler extends FunctionHandler {
+
+  @Override
+  public String doAction(HttpServletRequest request) {
+    String login = request.getParameter("login");
+    String domainId = request.getParameter("domainId");
+    String oldPassword = request.getParameter("oldPassword");
+    String newPassword = request.getParameter("newPassword");
+    try {
+      // Change password.
+      LoginPasswordAuthentication auth = new LoginPasswordAuthentication();
+      auth.changePassword(login, oldPassword, newPassword, domainId);
+      return "/AuthenticationServlet?Login=" + login + "&Password=" + newPassword
+          + "&DomainId=" + domainId;
+    } catch (AuthenticationException e) {
+        // Error : go back to page
+      SilverTrace.error("peasCore", "ChangeExpiredPasswordHandler.doAction()",
+          "peasCore.EX_CANNOT_CHANGE_PWD", "login=" + login,e);
+      request.setAttribute("message", getM_Multilang().getString("badCredentials"));
+      ResourceLocator settings = new ResourceLocator("com.silverpeas.authentication.settings.passwordExpiration", "");
+      return settings.getString("passwordExpiredURL")+"?login="+login+"&domainId="+domainId;
+    }
+  }
+}


### PR DESCRIPTION
Handle expired password on authentication on Active Directory domain
Throw exception when trying to change password on an Active Directory with a non-secure connection
Fix default properties for MS Active Directory domain authentication
