### PR TITLE
Registers with Jersey the Jackson and Silverpeas mappers + support of Bean Validation

### DIFF
--- a/war-core/src/main/webapp/WEB-INF/web.xml
+++ b/war-core/src/main/webapp/WEB-INF/web.xml
@@ -122,6 +122,11 @@
             <param-name>com.sun.jersey.api.json.POJOMappingFeature</param-name>
             <param-value>true</param-value>
         </init-param>
+        <init-param>
+            <description>Packages in which are defined both REST resources and mapper providers not managed by Spring</description>
+            <param-name>com.sun.jersey.config.property.packages</param-name>
+            <param-value>org.codehaus.jackson.jaxrs;com.silverpeas.web.mappers</param-value>
+        </init-param>
     </servlet>
     <servlet>
         <servlet-name>AuthenticationServlet</servlet-name>
@@ -494,9 +499,9 @@
         <servlet-class>com.silverpeas.socialNetwork.myProfil.servlets.MyProfilRequestRouter</servlet-class>
     </servlet>
     <servlet>
-      <display-name>GoToMyProfile</display-name>
-      <servlet-name>GoToMyProfile</servlet-name>
-      <servlet-class>com.silverpeas.socialNetwork.myProfil.servlets.GoToMyProfile</servlet-class>
+        <display-name>GoToMyProfile</display-name>
+        <servlet-name>GoToMyProfile</servlet-name>
+        <servlet-class>com.silverpeas.socialNetwork.myProfil.servlets.GoToMyProfile</servlet-class>
     </servlet>
     <servlet>
         <servlet-name>MyProfilJSONServlet</servlet-name>

--- a/web-core/src/main/java/com/silverpeas/attachment/web/AttachmentRessource.java
+++ b/web-core/src/main/java/com/silverpeas/attachment/web/AttachmentRessource.java
@@ -23,37 +23,30 @@
  */
 package com.silverpeas.attachment.web;
 
+import com.silverpeas.sharing.model.Ticket;
+import com.silverpeas.sharing.security.ShareableAttachment;
+import com.silverpeas.sharing.services.SharingServiceFactory;
+import com.silverpeas.util.MimeTypes;
+import com.silverpeas.util.ZipManager;
+import com.silverpeas.web.RESTWebService;
+import com.stratelia.webactiv.util.FileRepositoryManager;
+import com.stratelia.webactiv.util.attachment.control.AttachmentController;
+import com.stratelia.webactiv.util.attachment.ejb.AttachmentPK;
+import com.stratelia.webactiv.util.attachment.model.AttachmentDetail;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.net.URI;
 import java.util.Date;
 import java.util.StringTokenizer;
-
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
-
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.output.ByteArrayOutputStream;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Service;
-
-import com.silverpeas.web.RESTWebService;
-import com.silverpeas.sharing.model.Ticket;
-import com.silverpeas.sharing.security.ShareableAttachment;
-import com.silverpeas.sharing.services.SharingServiceFactory;
-import com.silverpeas.util.MimeTypes;
-import com.silverpeas.util.ZipManager;
-import com.stratelia.webactiv.util.FileRepositoryManager;
-import com.stratelia.webactiv.util.attachment.control.AttachmentController;
-import com.stratelia.webactiv.util.attachment.ejb.AttachmentPK;
-import com.stratelia.webactiv.util.attachment.model.AttachmentDetail;
 
 @Service
 @Scope("request")

--- a/web-core/src/main/java/com/silverpeas/comment/web/CommentEntity.java
+++ b/web-core/src/main/java/com/silverpeas/comment/web/CommentEntity.java
@@ -28,8 +28,8 @@ import com.silverpeas.comment.model.Comment;
 import com.silverpeas.comment.model.CommentPK;
 import com.silverpeas.profile.web.ProfileResourceBaseURIs;
 import com.silverpeas.profile.web.UserProfileEntity;
-import com.silverpeas.web.Exposable;
 import static com.silverpeas.util.StringUtil.isDefined;
+import com.silverpeas.web.Exposable;
 import com.stratelia.webactiv.util.DateUtil;
 import com.stratelia.webactiv.util.publication.model.PublicationPK;
 import java.net.URI;
@@ -37,6 +37,8 @@ import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
@@ -57,12 +59,16 @@ public class CommentEntity implements Exposable {
   @XmlElement(defaultValue = "")
   private String id;
   @XmlElement(required = true)
+  @NotNull @Size(min=2)
   private String componentId;
   @XmlElement(required = true)
+  @NotNull @Size(min=1)
   private String resourceId;
   @XmlElement(required = true)
+  @NotNull
   private String text;
   @XmlElement(required = true)
+  @NotNull
   private UserProfileEntity author;
   @XmlElement(required = true, defaultValue = "")
   private String creationDate;
@@ -241,6 +247,8 @@ public class CommentEntity implements Exposable {
 
   @Override
   public boolean equals(Object obj) {
+    if (this == obj)
+      return true;
     if (obj == null) {
       return false;
     }

--- a/web-core/src/main/java/com/silverpeas/comment/web/CommentResource.java
+++ b/web-core/src/main/java/com/silverpeas/comment/web/CommentResource.java
@@ -23,34 +23,24 @@
  */
 package com.silverpeas.comment.web;
 
-import com.silverpeas.annotation.Authenticated;
 import com.silverpeas.annotation.Authorized;
-import java.util.logging.Logger;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.POST;
-import java.net.URI;
-import java.util.List;
 import com.silverpeas.comment.CommentRuntimeException;
 import com.silverpeas.comment.model.Comment;
 import com.silverpeas.comment.model.CommentPK;
 import com.silverpeas.comment.service.CommentService;
 import com.silverpeas.web.RESTWebService;
+import java.net.URI;
 import java.util.Comparator;
+import java.util.List;
 import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.inject.Inject;
-import javax.ws.rs.DELETE;
-import javax.ws.rs.GET;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Service;
-import static com.silverpeas.util.StringUtil.*;
 
 /**
  * A REST Web resource representing a given comment.
@@ -131,8 +121,8 @@ public class CommentResource extends RESTWebService {
   @Consumes(MediaType.APPLICATION_JSON)
   public Response saveNewComment(final CommentEntity commentToSave) {
     checkIsValid(commentToSave);
-    Comment comment = commentToSave.toComment();
     try {
+      Comment comment = commentToSave.toComment();
       if (commentToSave.isIndexed()) {
         commentService().createAndIndexComment(comment);
       } else {
@@ -293,10 +283,10 @@ public class CommentResource extends RESTWebService {
    * @param theComment the comment to validate.
    */
   protected void checkIsValid(final CommentEntity theComment) {
-    if (!isDefined(theComment.getComponentId()) || !isDefined(theComment.getResourceId()) ||
-        !isDefined(theComment.getText()) || !isDefined(theComment.getAuthor().getId())) {
-      throw new WebApplicationException(Status.BAD_REQUEST);
-    }
+//    if (!isDefined(theComment.getComponentId()) || !isDefined(theComment.getResourceId()) ||
+//        !isDefined(theComment.getText()) || !isDefined(theComment.getAuthor().getId())) {
+//      throw new WebApplicationException(Status.BAD_REQUEST);
+//    }
     if (!theComment.getComponentId().equals(getComponentId()) || !theComment.getResourceId().equals(
             getContentId())) {
       throw new WebApplicationException(Status.NOT_FOUND);

--- a/web-core/src/main/java/com/silverpeas/pdc/web/PdcAxisValueEntity.java
+++ b/web-core/src/main/java/com/silverpeas/pdc/web/PdcAxisValueEntity.java
@@ -23,11 +23,14 @@
  */
 package com.silverpeas.pdc.web;
 
+import static com.silverpeas.util.StringUtil.isDefined;
 import com.stratelia.silverpeas.pdc.model.Value;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlTransient;
-import static com.silverpeas.util.StringUtil.*;
 
 /**
  * A value of a PdC's axis.
@@ -42,9 +45,9 @@ import static com.silverpeas.util.StringUtil.*;
 public class PdcAxisValueEntity extends PdcValueEntity {
   private static final long serialVersionUID = -1689709605873362349L;
   
-  @XmlElement(required=true)
+  @XmlElement(required=true) @NotNull @Size(min=1)
   private String term;
-  @XmlElement(required=true)
+  @XmlElement(required=true) @NotNull @Min(0)
   private int level;
   @XmlElement(defaultValue="false")
   private boolean ascendant = false;

--- a/web-core/src/main/java/com/silverpeas/pdc/web/PdcClassificationEntity.java
+++ b/web-core/src/main/java/com/silverpeas/pdc/web/PdcClassificationEntity.java
@@ -23,35 +23,24 @@
  */
 package com.silverpeas.pdc.web;
 
-import com.sun.jersey.api.json.JSONConfiguration;
-import com.sun.jersey.api.json.JSONJAXBContext;
-import com.sun.jersey.api.json.JSONUnmarshaller;
-import com.sun.jersey.json.impl.JSONUnmarshallerImpl;
-import java.io.StringReader;
-import javax.xml.bind.JAXBException;
 import com.silverpeas.pdc.model.PdcClassification;
 import com.silverpeas.pdc.model.PdcPosition;
-import com.silverpeas.web.Exposable;
 import com.silverpeas.thesaurus.ThesaurusException;
-import com.stratelia.silverpeas.pdc.model.ClassifyPosition;
-
-import com.sun.jersey.api.json.JSONMarshaller;
-import com.sun.jersey.json.impl.JSONMarshallerImpl;
-import java.io.StringWriter;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlTransient;
-import java.net.URI;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Comparator;
-import java.util.List;
-import java.util.SortedSet;
-import java.util.TreeSet;
-
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
 import static com.silverpeas.util.StringUtil.isDefined;
+import com.silverpeas.web.Exposable;
+import com.stratelia.silverpeas.pdc.model.ClassifyPosition;
+import com.sun.jersey.api.json.JSONConfiguration;
+import com.sun.jersey.api.json.JSONJAXBContext;
+import com.sun.jersey.api.json.JSONMarshaller;
+import com.sun.jersey.api.json.JSONUnmarshaller;
+import com.sun.jersey.json.impl.JSONMarshallerImpl;
+import com.sun.jersey.json.impl.JSONUnmarshallerImpl;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.net.URI;
+import java.util.*;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.annotation.*;
 
 /**
  * The PdC classification entity represents the web entity of the classification of a Silverpeas's

--- a/web-core/src/main/java/com/silverpeas/pdc/web/PdcPositionEntity.java
+++ b/web-core/src/main/java/com/silverpeas/pdc/web/PdcPositionEntity.java
@@ -23,24 +23,24 @@
  */
 package com.silverpeas.pdc.web;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
 import com.silverpeas.pdc.model.PdcAxisValue;
-import java.util.Collections;
 import com.silverpeas.pdc.model.PdcPosition;
-import com.silverpeas.web.Exposable;
 import com.silverpeas.thesaurus.ThesaurusException;
+import static com.silverpeas.util.StringUtil.isDefined;
+import com.silverpeas.web.Exposable;
 import com.stratelia.silverpeas.pdc.model.ClassifyPosition;
 import com.stratelia.silverpeas.pdc.model.ClassifyValue;
-
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
-
-import static com.silverpeas.util.StringUtil.isDefined;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
 
 /**
  * The Web representation of the position of a Silverpeas's resource in the classification plan
@@ -59,7 +59,7 @@ import static com.silverpeas.util.StringUtil.isDefined;
 public class PdcPositionEntity implements Exposable {
 
   private static final long serialVersionUID = 6314816355055147378L;
-  @XmlElement(required = true)
+  @XmlElement(required = true) @NotNull @Size(min=1)
   private List<PdcPositionValueEntity> values = new ArrayList<PdcPositionValueEntity>();
   @XmlElement(defaultValue = "")
   private URI uri;

--- a/web-core/src/main/java/com/silverpeas/pdc/web/PdcPositionValueEntity.java
+++ b/web-core/src/main/java/com/silverpeas/pdc/web/PdcPositionValueEntity.java
@@ -24,12 +24,13 @@
 package com.silverpeas.pdc.web;
 
 import com.silverpeas.pdc.model.PdcAxisValue;
+import static com.silverpeas.util.StringUtil.isDefined;
 import com.stratelia.silverpeas.pdc.model.ClassifyValue;
 import com.stratelia.silverpeas.pdc.model.Value;
 import java.util.List;
+import javax.validation.constraints.NotNull;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
-import static com.silverpeas.util.StringUtil.*;
 
 /**
  * A PdC position value is a value of a position of a resource content on a given axis of the PdC.
@@ -51,7 +52,7 @@ public class PdcPositionValueEntity extends PdcValueEntity {
 
   private static final long serialVersionUID = -6826039385078009600L;
   
-  @XmlElement(defaultValue="")
+  @XmlElement(defaultValue="") @NotNull
   private String meaning;
   
   /**

--- a/web-core/src/main/java/com/silverpeas/profile/web/UserGroupProfileEntity.java
+++ b/web-core/src/main/java/com/silverpeas/profile/web/UserGroupProfileEntity.java
@@ -24,11 +24,13 @@
 package com.silverpeas.profile.web;
 
 import static com.silverpeas.profile.web.ProfileResourceBaseURIs.*;
-import com.silverpeas.web.Exposable;
 import static com.silverpeas.util.StringUtil.isDefined;
+import com.silverpeas.web.Exposable;
 import com.stratelia.webactiv.beans.admin.Group;
 import java.net.URI;
 import java.util.List;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
@@ -83,7 +85,7 @@ public class UserGroupProfileEntity extends Group implements Exposable {
   private URI usersUri;
   @XmlElement
   private int userCount = -1;
-  @XmlElement
+  @XmlElement @NotNull @Size(min=1)
   private String domainName;
   private final Group group;
 

--- a/web-core/src/main/java/com/silverpeas/profile/web/UserProfileEntity.java
+++ b/web-core/src/main/java/com/silverpeas/profile/web/UserProfileEntity.java
@@ -25,12 +25,14 @@ package com.silverpeas.profile.web;
 
 import com.silverpeas.personalization.UserPreferences;
 import static com.silverpeas.profile.web.ProfileResourceBaseURIs.uriOfUser;
-import com.silverpeas.web.Exposable;
 import com.silverpeas.ui.DisplayI18NHelper;
 import static com.silverpeas.util.StringUtil.isDefined;
+import com.silverpeas.web.Exposable;
 import com.stratelia.webactiv.beans.admin.UserDetail;
 import java.net.URI;
 import java.util.List;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
@@ -79,11 +81,11 @@ public class UserProfileEntity extends UserDetail implements Exposable {
   private UserDetail user = null;
   @XmlElement(required=true)
   private URI uri;
-  @XmlElement(required=true)
+  @XmlElement(required=true) @NotNull @Size(min=1)
   private String avatar;
   @XmlElement
   private String domainName;
-  @XmlElement(required=true, defaultValue="")
+  @XmlElement(required=true, defaultValue="") @NotNull
   private String fullName = "";
   @XmlElement(defaultValue="")
   private String language = "";

--- a/web-core/src/main/java/com/silverpeas/web/RESTWebService.java
+++ b/web-core/src/main/java/com/silverpeas/web/RESTWebService.java
@@ -90,7 +90,7 @@ public abstract class RESTWebService {
           WebApplicationException {
     validation.validateUserAuthorizationOnComponentInstance(getUserDetail(), getComponentId());
   }
-
+  
   /**
    * Gets information about the URI with which this web service was invoked.
    *

--- a/web-core/src/main/java/com/silverpeas/web/aspect/WebEntityValidationAspect.java
+++ b/web-core/src/main/java/com/silverpeas/web/aspect/WebEntityValidationAspect.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2000 - 2012 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection withWriter Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have recieved a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "http://www.silverpeas.org/legal/licensing"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.silverpeas.web.aspect;
+
+import com.silverpeas.web.Exposable;
+import java.util.Set;
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.stereotype.Component;
+
+/**
+ * An aspect to insert component existence checking in the web services so that it is performed
+ * implicitly for each web resources managed by a given component instance. If a web resource
+ * doesn't belong to any component instance, then nothing is done.
+ */
+@Component @Aspect
+public class WebEntityValidationAspect {
+
+  @Pointcut("@within(javax.ws.rs.Path) && this(com.silverpeas.web.RESTWebService)")
+  public void webServices() {
+  }
+  
+  @Pointcut("@annotation(javax.ws.rs.POST) && execution(* *(..))")
+  public void methodAnnotatedWithPOST() {
+  }
+
+  @Pointcut("@annotation(javax.ws.rs.PUT) && execution(* *(..))")
+  public void methodAnnotatedWithPUT() {
+  }
+
+  @Before("webServices() && (methodAnnotatedWithPOST() || methodAnnotatedWithPUT()) "
+  + "&& (args(entity,..) || args(..,entity))")
+  public <T extends Exposable> void validateWebEntity(T entity) throws Throwable {
+    ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+    Validator validator = factory.getValidator();
+    Set<ConstraintViolation<T>> violations = validator.validate(entity);
+    if (!violations.isEmpty()) {
+      throw new WebApplicationException(Response.Status.BAD_REQUEST);
+    }
+  }
+}

--- a/web-core/src/main/java/com/silverpeas/web/mappers/EntityNotFoundExceptionMapper.java
+++ b/web-core/src/main/java/com/silverpeas/web/mappers/EntityNotFoundExceptionMapper.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2000 - 2012 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection withWriter Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have recieved a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "http://www.silverpeas.org/legal/licensing"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.silverpeas.web.mappers;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.persistence.EntityNotFoundException;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+/**
+ * Implementation of ExceptionMapper to send down a "404 Not Found" in the event unparsable JSON is
+ * received.
+ */
+@Provider
+public class EntityNotFoundExceptionMapper implements ExceptionMapper<EntityNotFoundException> {
+
+  @Override
+  public Response toResponse(EntityNotFoundException exception) {
+    Logger.getLogger(EntityNotFoundExceptionMapper.class.getSimpleName()).log(Level.INFO,
+            exception.getMessage(), exception);
+    return Response.status(Response.Status.NOT_FOUND).entity("The asked resource isn't found").build();
+  }
+}

--- a/web-core/src/test/java/com/silverpeas/comment/web/CommentCreationTest.java
+++ b/web-core/src/test/java/com/silverpeas/comment/web/CommentCreationTest.java
@@ -24,18 +24,18 @@
 package com.silverpeas.comment.web;
 
 import com.silverpeas.comment.BaseCommentTest;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
 import com.silverpeas.comment.model.Comment;
+import static com.silverpeas.comment.web.CommentTestResources.*;
 import com.silverpeas.web.ResourceCreationTest;
 import com.stratelia.webactiv.beans.admin.UserDetail;
 import com.sun.jersey.api.client.ClientResponse;
 import javax.ws.rs.core.Response.Status;
-import org.junit.Before;
-import org.junit.Test;
-import static org.junit.Assert.*;
 import static org.hamcrest.Matchers.*;
-import static com.silverpeas.comment.web.CommentTestResources.*;
+import org.junit.AfterClass;
+import static org.junit.Assert.assertThat;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
 
 /**
  * Unit tests on the creation of a comment through the CommentResource web service.
@@ -45,16 +45,16 @@ public class CommentCreationTest extends ResourceCreationTest<CommentTestResourc
   private UserDetail user;
   private String sessionKey;
   private CommentEntity theComment;
-  
+
   public CommentCreationTest() {
     super(JAVA_PACKAGE, SPRING_CONTEXT);
   }
-  
+
   @BeforeClass
   public static void prepareMessagingContext() throws Exception {
     BaseCommentTest.boostrapMessagingSystem();
   }
-  
+
   @AfterClass
   public static void releaseMessagingContext() throws Exception {
     BaseCommentTest.shutdownMessagingSystem();
@@ -65,7 +65,7 @@ public class CommentCreationTest extends ResourceCreationTest<CommentTestResourc
     user = aUser();
     sessionKey = authenticate(user);
     theComment = CommentEntity.fromComment(theUser(user).commentTheResource(CONTENT_ID).
-        inComponent(COMPONENT_INSTANCE_ID).withAsText("ceci est un commentaire"));
+            inComponent(COMPONENT_INSTANCE_ID).withAsText("ceci est un commentaire"));
   }
 
   @Test
@@ -83,7 +83,7 @@ public class CommentCreationTest extends ResourceCreationTest<CommentTestResourc
   @Test
   public void postAnAlreadyExistingComment() {
     Comment existingComment = theUser(user).commentTheResource(CONTENT_ID).
-        inComponent(COMPONENT_INSTANCE_ID).withAsText("coucou");
+            inComponent(COMPONENT_INSTANCE_ID).withAsText("coucou");
     getTestResources().save(existingComment);
     CommentEntity aComment = CommentEntity.fromComment(existingComment);
 
@@ -131,6 +131,6 @@ public class CommentCreationTest extends ResourceCreationTest<CommentTestResourc
 
   @Override
   public String[] getExistingComponentInstances() {
-    return new String[] { COMPONENT_INSTANCE_ID };
+    return new String[]{COMPONENT_INSTANCE_ID};
   }
 }

--- a/ws-test-core/src/main/java/com/silverpeas/web/RESTWebServiceTest.java
+++ b/ws-test-core/src/main/java/com/silverpeas/web/RESTWebServiceTest.java
@@ -47,6 +47,7 @@ import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import org.springframework.web.context.ContextLoaderListener;
+import org.springframework.web.context.request.RequestContextListener;
 
 /**
  * The base class for testing REST web services in Silverpeas.
@@ -71,8 +72,8 @@ public abstract class RESTWebServiceTest<T extends TestResources> extends Jersey
     super(new WebAppDescriptor.Builder(webServicePackage).contextPath(CONTEXT_NAME).
             contextParam("contextConfigLocation", "classpath:/" + springContext).
             initParam(JSONConfiguration.FEATURE_POJO_MAPPING, "true").
-            requestListenerClass(
-            org.springframework.web.context.request.RequestContextListener.class).
+            initParam("com.sun.jersey.config.property.packages", "org.codehaus.jackson.jaxrs;com.silverpeas.web.mappers").
+            requestListenerClass(RequestContextListener.class).
             servletClass(SpringServlet.class).
             contextListenerClass(ContextLoaderListener.class).
             build());

--- a/ws-test-core/src/main/java/com/silverpeas/web/ResourceCreationTest.java
+++ b/ws-test-core/src/main/java/com/silverpeas/web/ResourceCreationTest.java
@@ -98,6 +98,15 @@ public abstract class ResourceCreationTest<T extends TestResources> extends REST
     int forbidden = Status.FORBIDDEN.getStatusCode();
     assertThat(receivedStatus, is(forbidden));
   }
+  
+  @Test
+  public void postAnInvalidResourceState() {
+    ClientResponse response = post("{\"uri\": \"http://toto.chez-les-papoos.com/invalid/resource\"}",
+            at(aResourceURI()));
+    int recievedStatus = response.getStatus();
+    int badRequest = Status.BAD_REQUEST.getStatusCode();
+    assertThat(recievedStatus, is(badRequest));
+  }
 
   private <T> ClientResponse post(final T entity, String atURI, String withSessionKey) {
     String thePath = atURI;
@@ -117,4 +126,6 @@ public abstract class ResourceCreationTest<T extends TestResources> extends REST
     }
     return resourcePoster.post(ClientResponse.class, entity);
   }
+  
+  
 }

--- a/ws-test-core/src/main/java/com/silverpeas/web/ResourceUpdateTest.java
+++ b/ws-test-core/src/main/java/com/silverpeas/web/ResourceUpdateTest.java
@@ -23,21 +23,22 @@
  */
 package com.silverpeas.web;
 
-import javax.ws.rs.core.MultivaluedMap;
+import static com.silverpeas.util.StringUtil.isDefined;
+import com.sun.jersey.api.client.UniformInterfaceException;
 import com.sun.jersey.api.client.WebResource;
 import java.util.UUID;
-import com.sun.jersey.api.client.UniformInterfaceException;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response.Status;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 import org.junit.Test;
-import static org.junit.Assert.*;
-import static org.hamcrest.Matchers.*;
-import static com.silverpeas.util.StringUtil.isDefined;
 
 /**
- * Unit tests on the update of a resource in Silverpeas through a REST web service.
- * This class is an abstract one and it implements some tests that are redondant over all 
- * web resources in Silverpeas (about authorization failure, authentication failure, ...)
+ * Unit tests on the update of a resource in Silverpeas through a REST web service. This class is an
+ * abstract one and it implements some tests that are redondant over all web resources in Silverpeas
+ * (about authorization failure, authentication failure, ...)
  */
 public abstract class ResourceUpdateTest<T extends TestResources> extends RESTWebServiceTest<T>
         implements WebResourceTesting {
@@ -50,26 +51,28 @@ public abstract class ResourceUpdateTest<T extends TestResources> extends RESTWe
   }
 
   public abstract <T> T anInvalidResource();
-  
+
   /**
    * A convenient method to improve the readability of the method calls.
+   *
    * @param uri a resource URI.
    * @return the specified resource URI.
    */
   private static String at(String uri) {
     return uri;
   }
-  
+
   private static String withAsSessionKey(String sessionKey) {
     return sessionKey;
   }
 
   /**
    * Puts at the specified URI the specified new state of the resource.
+   *
    * @param <T> the type of the resource's state.
    * @param uri the URI at which the resource is.
    * @param newResourceState the new state of the resource.
-   * @return 
+   * @return
    */
   public <T> T putAt(String uri, T newResourceState) {
     return put(newResourceState, at(uri), withAsSessionKey(getSessionKey()));
@@ -135,7 +138,18 @@ public abstract class ResourceUpdateTest<T extends TestResources> extends RESTWe
       assertThat(receivedStatus, is(notFound));
     }
   }
-  
+
+  @Test
+  public void updateWithAnInvalidResourceState() {
+    try {
+      putAt(aResourceURI(), "{\"uri\": \"http://toto.chez-les-papoos.com/invalid/resource\"}");
+    } catch (UniformInterfaceException ex) {
+      int recievedStatus = ex.getResponse().getStatus();
+      int badRequest = Status.BAD_REQUEST.getStatusCode();
+      assertThat(recievedStatus, is(badRequest));
+    }
+  }
+
   private <T> T put(final T entity, String atURI, String withSessionKey) {
     String thePath = atURI;
     WebResource resource = resource();


### PR DESCRIPTION
Now the web entities can be annotated with the Bean Validation annotations. Theses will be taken into account for each incoming HTTP POST or PUT requests embodied an entity to validate. The validation is performed automatically by the Silverpeas REST API.

Don't forget to merge also the branch jackson-jaxrs-mappers in the Silverpeas-Parent project.
