### PR TITLE
Fix Bug #3657

### DIFF
--- a/ejb-core/formtemplate/src/main/java/com/silverpeas/workflow/engine/model/FormImpl.java
+++ b/ejb-core/formtemplate/src/main/java/com/silverpeas/workflow/engine/model/FormImpl.java
@@ -345,6 +345,7 @@ public class FormImpl extends AbstractReferrableObject implements Form, Abstract
           ft.setReadOnly(input.isReadonly());
         }
         ft.setMandatory(input.isMandatory());
+        ft.setTemplateName("form:"+name);
         if (input.getDisplayerName() != null
             && input.getDisplayerName().length() > 0) {
           ft.setDisplayerName(input.getDisplayerName());
@@ -384,7 +385,7 @@ public class FormImpl extends AbstractReferrableObject implements Form, Abstract
   // ~ Methods ////////////////////////////////////////////////////////////////
 
   /*
-	 * 
+	 *
 	 */
   public void setId(int id) {
     this.id = id;


### PR DESCRIPTION
when transforming workflow form definition in silverpeas form objects,
templatename wsa omitted in fields templates.
There was no impact until SequenceField was created and used that attribute.
