### PR TITLE
Closes Feature #3685

### DIFF
--- a/config-core/src/main/config/properties/org/silverpeas/util/viewGenerator/settings/SilverpeasLight.properties
+++ b/config-core/src/main/config/properties/org/silverpeas/util/viewGenerator/settings/SilverpeasLight.properties
@@ -66,7 +66,7 @@ customVisible =
 helpVisible =
 clipboardVisible =
 glossaryVisible =
-directoryVisible = 
+directoryVisible =
 
 # Visibilit\u00e9 composants Espace personnel ("false" pour masquer)
 personnalSpaceVisible =
@@ -93,7 +93,7 @@ spaceMaxChar = 25
 
 # Default homepage (Ex: http://<host>/page.htm)
 defaultHomepage =
-persoHomepage = 
+persoHomepage =
 
 # Ids des composants affich\u00e9s dans la Topbar
 # les ids doivent \u00eatre s\u00e9par\u00e9s par des virgules.
@@ -113,3 +113,6 @@ displayConnectedUsers = true
 # displayUserFavoriteSpace allowed values are : DISABLE, BOOKMARKS, ALL
 displayUserFavoriteSpace = DISABLE
 enableUFSContainsState = false
+
+# In case of transversal subspace, parent tree can be hidden (restrictedPathForSpaceTransverse=true)
+restrictedPathForSpaceTransverse=false

--- a/war-core/src/main/java/com/silverpeas/lookV5/AjaxServletLookV5.java
+++ b/war-core/src/main/java/com/silverpeas/lookV5/AjaxServletLookV5.java
@@ -103,6 +103,7 @@ public class AjaxServletLookV5 extends HttpServlet {
     String pdc = request.getParameter("Pdc");
     boolean displayContextualPDC = helper.displayContextualPDC();
     boolean displayPDC = "true".equalsIgnoreCase(request.getParameter("GetPDC"));
+    boolean restrictedPath = helper.getSettings("restrictedPathForSpaceTransverse", false);
 
     // User favorite space DAO
     List<UserFavoriteSpaceVO> listUserFS = new ArrayList<UserFavoriteSpaceVO>();
@@ -159,7 +160,7 @@ public class AjaxServletLookV5 extends HttpServlet {
         // space transverse
         displaySpace(spaceId, componentId, spaceIdsPath, userId, preferences.getLanguage(),
                 defaultLook, displayPDC, true, orgaController, helper, writer, listUserFS,
-                displayMode);
+                displayMode, restrictedPath);
 
         // other spaces
         displayTree(userId, componentId, spaceIdsPath, preferences.getLanguage(),
@@ -190,7 +191,7 @@ public class AjaxServletLookV5 extends HttpServlet {
         List<String> spaceIdsPath = getSpaceIdsPath(spaceId, componentId, orgaController);
         displaySpace(spaceId, componentId, spaceIdsPath, userId, preferences.getLanguage(),
                 defaultLook, displayPDC, false, orgaController, helper, writer, listUserFS,
-                displayMode);
+                displayMode,restrictedPath);
         displayPDC(displayPDC, spaceId, componentId, userId, mainSessionController, writer);
       }
     } else if (StringUtil.isDefined(componentId)) {
@@ -292,7 +293,7 @@ public class AjaxServletLookV5 extends HttpServlet {
           String userId, String language, String defaultLook,
           boolean displayPDC, boolean displayTransverse,
           OrganizationController orgaController, LookHelper helper, Writer writer,
-          List<UserFavoriteSpaceVO> listUFS, UserMenuDisplay userMenuDisplayMode)
+          List<UserFavoriteSpaceVO> listUFS, UserMenuDisplay userMenuDisplayMode, boolean restrictedPath)
       throws IOException {
     boolean isTransverse = false;
     int i = 0;
@@ -307,7 +308,7 @@ public class AjaxServletLookV5 extends HttpServlet {
     }
 
     boolean open = (spacePath != null && spacePath.contains(spaceId));
-    if (open) {
+    if ((open) && (!restrictedPath)) {
       spaceId = spacePath.remove(0);
     }
 
@@ -390,7 +391,7 @@ public class AjaxServletLookV5 extends HttpServlet {
       if (loadCurSpace && isSpaceVisible(userId, spaceId, orgaController, helper)) {
         displaySpace(spaceId, targetComponentId, spacePath, userId, language,
                 defaultLook, false, false, orgaController, helper, out, listUFS,
-            userMenuDisplayMode);
+            userMenuDisplayMode, false);
       }
       loadCurSpace = false;
     }


### PR DESCRIPTION
Closes Feature #3685

Quand l'utilisateur sélectionne un sous espace transverse, celui ci s'affiche en haut à gauche de la "domainsBar",
mais avec toute l'arborescence depuis la racine, ce qui peut être génant selon l'architecture de l'information.
