### PR TITLE
Closes Feature #3690

### DIFF
--- a/config-core/src/main/config/properties/org/silverpeas/templatedesigner/multilang/templateDesignerBundle_de.properties
+++ b/config-core/src/main/config/properties/org/silverpeas/templatedesigner/multilang/templateDesignerBundle_de.properties
@@ -108,20 +108,23 @@ templateDesigner.available = Verf\u00fcgbar
 templateDesigner.displayer.image.maxWidth = Max Breite
 templateDesigner.displayer.image.maxHeight = Max H\u00f6he
 templateDesigner.displayer.image.galleries = Fototheken
- 
+
 templateDesigner.displayer.video.width = Breite
 templateDesigner.displayer.video.height = H\u00f6he
 templateDesigner.displayer.video.autoplay = Automatische Wiedergabe
- 
+
 templateDesigner.displayer.wysiwyg.width = Breite
 templateDesigner.displayer.wysiwyg.height = H\u00f6he
 templateDesigner.displayer.wysiwyg.galleries = Fototheken
 templateDesigner.displayer.wysiwyg.fileStorages = Verf\u00fcgbare Dateienbank
- 
+
 templateDesigner.displayer.sequence.minLength = Min L\u00e4nge
 templateDesigner.displayer.sequence.startValue = Startwert
 templateDesigner.displayer.sequence.valueCreation = Wert Erzeugung
 templateDesigner.displayer.sequence.reuseAvailableValues = Wiederverwendung der verf\u00fcgbaren Werte
 templateDesigner.displayer.sequence.alwaysIncrement = Immer Inkrementieren
+templateDesigner.displayer.sequence.globalParam = Visibilit\u00e9 des valeurs
+templateDesigner.displayer.sequence.notGlobal = Chaque instance d'application à sa propre numérotation
+templateDesigner.displayer.sequence.global = La numérotation est globale à la plateforme
 
 templateDesigner.displayer.explorer.scope = Identifizierung(en)

--- a/config-core/src/main/config/properties/org/silverpeas/templatedesigner/multilang/templateDesignerBundle_en.properties
+++ b/config-core/src/main/config/properties/org/silverpeas/templatedesigner/multilang/templateDesignerBundle_en.properties
@@ -120,5 +120,8 @@ templateDesigner.displayer.sequence.startValue = Start value
 templateDesigner.displayer.sequence.valueCreation = Value creation
 templateDesigner.displayer.sequence.reuseAvailableValues = Reuse available values
 templateDesigner.displayer.sequence.alwaysIncrement = Always increment
+templateDesigner.displayer.sequence.globalParam = Values visibility
+templateDesigner.displayer.sequence.notGlobal = Each application instance has its own numerotation
+templateDesigner.displayer.sequence.global = Numerotation is shared in the whole platform
 
 templateDesigner.displayer.explorer.scope = Identifier(s)

--- a/config-core/src/main/config/properties/org/silverpeas/templatedesigner/multilang/templateDesignerBundle_fr.properties
+++ b/config-core/src/main/config/properties/org/silverpeas/templatedesigner/multilang/templateDesignerBundle_fr.properties
@@ -120,5 +120,8 @@ templateDesigner.displayer.sequence.startValue = Valeur de d\u00e9part
 templateDesigner.displayer.sequence.valueCreation = Cr\u00e9ation de valeur
 templateDesigner.displayer.sequence.reuseAvailableValues = R\u00e9utiliser les valeurs disponibles
 templateDesigner.displayer.sequence.alwaysIncrement = Toujours incr\u00e9menter
+templateDesigner.displayer.sequence.globalParam = Visibilit\u00e9 des valeurs
+templateDesigner.displayer.sequence.notGlobal = Chaque instance d'application à sa propre numérotation
+templateDesigner.displayer.sequence.global = La numérotation est globale à la plateforme
 
 templateDesigner.displayer.explorer.scope = Identifiant(s)

--- a/lib-core/src/main/java/com/silverpeas/form/displayers/SequenceFieldDisplayer.java
+++ b/lib-core/src/main/java/com/silverpeas/form/displayers/SequenceFieldDisplayer.java
@@ -40,6 +40,7 @@ import com.silverpeas.form.FormException;
 import com.silverpeas.form.PagesContext;
 import com.silverpeas.form.fieldType.SequenceField;
 import com.silverpeas.util.EncodeHelper;
+import com.silverpeas.util.StringUtil;
 import com.stratelia.silverpeas.silvertrace.SilverTrace;
 
 /**
@@ -88,10 +89,10 @@ public class SequenceFieldDisplayer extends AbstractFieldDisplayer<SequenceField
         if (parameters.containsKey("startValue")) {
           startValue = Integer.parseInt(parameters.get("startValue"));
         }
-        boolean reuseAvailableValues = (parameters.containsKey("reuseAvailableValues")
-            && "true".equals(parameters.get("reuseAvailableValues")));
+        boolean reuseAvailableValues = StringUtil.getBooleanValue( parameters.get("reuseAvailableValues") );
+        boolean global = StringUtil.getBooleanValue( parameters.get("global") );
         value = sequenceField.getNextValue(fieldName, template.getTemplateName(),
-            pagesContext.getComponentId(), minLength, startValue, reuseAvailableValues);
+            pagesContext.getComponentId(), minLength, startValue, reuseAvailableValues, global);
       }
     } else {
       value = field.getValue(language);

--- a/war-core/src/main/webapp/templateDesigner/jsp/fieldSequence.jsp
+++ b/war-core/src/main/webapp/templateDesigner/jsp/fieldSequence.jsp
@@ -24,6 +24,7 @@
 
 --%>
 
+<%@page import="com.silverpeas.util.StringUtil"%>
 <%@ include file="includeParamsField.jsp.inc" %>
 	<script type="text/javascript">
 		function isCorrectForm()  {
@@ -60,6 +61,7 @@
 	String minLength = "1";
 	String startValue = "1";
 	boolean reuseAvailableValues = false;
+	boolean global = false;
 	if (field != null) {
 		if (parameters.containsKey("minLength")) {
 		  	minLength = (String) parameters.get("minLength");
@@ -70,6 +72,7 @@
 		if (parameters.containsKey("reuseAvailableValues")) {
 		  	reuseAvailableValues = "true".equals((String) parameters.get("reuseAvailableValues"));
 		}
+		global = StringUtil.getBooleanValue( (String) parameters.get("global") );
 	}
 %>
 <%@ include file="includeTopField.jsp.inc" %>
@@ -87,6 +90,15 @@
 		<select name="Param_reuseAvailableValues">
 			<option value="false"<%if (!reuseAvailableValues) {%> selected<%}%>><%=resource.getString("templateDesigner.displayer.sequence.alwaysIncrement")%></option>
 			<option value="true"<%if (reuseAvailableValues) {%> selected<%}%>><%=resource.getString("templateDesigner.displayer.sequence.reuseAvailableValues")%></option>
+		</select>
+	</td>
+</tr>
+<tr>
+	<td class="txtlibform" width="170px"><%=resource.getString("templateDesigner.displayer.sequence.globalParam")%> :</td>
+	<td>
+		<select name="Param_global">
+			<option value="false"<%if (!global) {%> selected<%}%>><%=resource.getString("templateDesigner.displayer.sequence.notGlobal")%></option>
+			<option value="true"<%if (global) {%> selected<%}%>><%=resource.getString("templateDesigner.displayer.sequence.global")%></option>
 		</select>
 	</td>
 </tr>


### PR DESCRIPTION
Closes Feature #3690

Les valeurs des champs de type séquence sont isolés par formulaire mais aussi par instance de composant.

Donc si dans une GED a, j'ai les valeur 1,2,3,4, dans la GED b utilisant le même formulaire, la séquence recommence à 1.

Il faudrait donc ajouter un paramètre booléen global qui serait à faux par défaut pour préserver le comportement actuel.
Si ce paramètre est présent et égal à true, alors toutes les valeurs des contenus rentré avec le formulaire concerné, quelque soit le type ou l'instance d'application,
seront utilisées pour déterminer la prochaine valeur.
