### PR TITLE
Bug #3730. Bug in the Javascript interpreter in IE < 9

### DIFF
--- a/war-core/src/main/webapp/selection/jsp/userpanel.jsp
+++ b/war-core/src/main/webapp/selection/jsp/userpanel.jsp
@@ -178,7 +178,7 @@
         // selection panel
         function loadPreselectionOfUsers() {
           if (preselectedUsers && preselectedUsers.length > 0) {
-            for(var i in preselectedUsers) {
+            for(var i = 0; i < preselectedUsers.length; i++) {
               new UserProfile({id: preselectedUsers[i]}).load(userSelection.add);
             }
           }
@@ -191,7 +191,7 @@
         // selection panel
         function loadPreselectionOfGroups() {
           if (preselectedUserGroups && preselectedUserGroups.length > 0) {
-            for(var i in preselectedUserGroups) {
+            for(var i = 0; i < preselectedUserGroups.length; i++) {
               new UserGroup({id: preselectedUserGroups[i]}).load(groupSelection.add);
             }
           }

--- a/war-core/src/main/webapp/util/javaScript/silverpeas.js
+++ b/war-core/src/main/webapp/util/javaScript/silverpeas.js
@@ -22,7 +22,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// some web navigators (like IE < 9) doesn't support completely the javascript standard (ECMA)
+/* some web navigators (like IE < 9) doesn't support completely the javascript standard (ECMA) */
 if (!Array.prototype.indexOf)
 {
   Array.prototype.indexOf = function(elt /*, from*/)


### PR DESCRIPTION
The issue come from the misbehavior of IE < 9 with methods added to an object prototype in some strange circumstances: in the case of the array, an added method can be considered as ... an item of the arrays when it is browsed with the 'in' keyword! In order to fix this situation whatever the circumstances, the array browsing with 'in' is replaced by the old-school way (a la C browsing)
