### PR TITLE
Bug #3897. Now the roles of the users or groups on a Kmelia topic is taken into account

### DIFF
--- a/lib-core/src/main/java/com/stratelia/silverpeas/selection/SelectionUsersGroups.java
+++ b/lib-core/src/main/java/com/stratelia/silverpeas/selection/SelectionUsersGroups.java
@@ -29,7 +29,6 @@ import com.stratelia.webactiv.beans.admin.Group;
 import com.stratelia.webactiv.beans.admin.OrganizationController;
 import com.stratelia.webactiv.beans.admin.ProfileInst;
 import com.stratelia.webactiv.beans.admin.UserDetail;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -43,6 +42,7 @@ public class SelectionUsersGroups implements SelectionExtraParams {
 
   String domainId = null;
   String componentId = null;
+  String objectId = null;
   List<String> profileIds = null;
   List<String> profileNames = null;
 
@@ -84,6 +84,14 @@ public class SelectionUsersGroups implements SelectionExtraParams {
     this.profileIds = profileIds;
   }
 
+  /**
+   * Add the identifier of the role the users must play.
+   * @param profileId the unique identifier of a user role.
+   * @deprecated Use instead either both the setObjectId() and setProfileNames() methods to set the roles
+   * for a given object in the component instance or the setProfileNames() method to set the roles
+   * for the whole component instance.
+   */
+  @Deprecated
   public void addProfileId(String profileId) {
     if (profileIds == null) {
       profileIds = new ArrayList<String>();
@@ -91,11 +99,37 @@ public class SelectionUsersGroups implements SelectionExtraParams {
     profileIds.add(profileId);
   }
 
+  /**
+   * Adds the identifiers of the roles the users must play.
+   * @param profileIds the user role identifiers.
+   * @deprecated Use instead either both the setObjectId() and setProfileNames() methods to set the roles
+   * for a given object in the component instance or the setProfileNames() method to set the roles
+   * for the whole component instance.
+   */
+  @Deprecated
   public void addProfileIds(List<String> profileIds) {
     if (this.profileIds == null) {
       this.profileIds = new ArrayList<String>();
     }
     profileIds.addAll(profileIds);
+  }
+
+  /**
+   * Gets the identifier of the object in the component instance for which the users must have
+   * enough right to access.
+   * @return the unique identifier of the object, made up of its type followed by its identifier.
+   */
+  public String getObjectId() {
+    return objectId;
+  }
+
+  /**
+   * Sets the object in the component instance for which the users must have enough right to access.
+   * @param objectId the unique identifier of the object in Silverpeas. It must be made up of its
+   * type followed by its identifier.
+   */
+  public void setObjectId(String objectId) {
+    this.objectId = objectId;
   }
 
   public String getComponentId() {
@@ -114,6 +148,7 @@ public class SelectionUsersGroups implements SelectionExtraParams {
     this.domainId = domainId;
   }
 
+  @Override
   public String getParameter(String name) {
     return null;
   }

--- a/lib-core/src/main/java/com/stratelia/webactiv/beans/admin/OrganizationController.java
+++ b/lib-core/src/main/java/com/stratelia/webactiv/beans/admin/OrganizationController.java
@@ -1,25 +1,22 @@
 /**
  * Copyright (C) 2000 - 2012 Silverpeas
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
  *
- * As a special exception to the terms and conditions of version 3.0 of
- * the GPL, you may redistribute this Program in connection with Free/Libre
- * Open Source Software ("FLOSS") applications as described in Silverpeas's
- * FLOSS exception.  You should have received a copy of the text describing
- * the FLOSS exception, and it is also available here:
+ * As a special exception to the terms and conditions of version 3.0 of the GPL, you may
+ * redistribute this Program in connection with Free/Libre Open Source Software ("FLOSS")
+ * applications as described in Silverpeas's FLOSS exception. You should have received a copy of the
+ * text describing the FLOSS exception, and it is also available here:
  * "http://www.silverpeas.org/legal/licensing"
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Affero General Public License for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU Affero General Public License along with this program.
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 
 /*
@@ -63,6 +60,7 @@ public class OrganizationController implements java.io.Serializable {
   // -------------------------------------------------------------------
   /**
    * Return all the spaces Id available in silverpeas
+   *
    * @return
    */
   public String[] getAllSpaceIds() {
@@ -85,14 +83,14 @@ public class OrganizationController implements java.io.Serializable {
       return asSubSpaceIds;
     } catch (Exception e) {
       SilverTrace.error("admin", "OrganizationController.getAllSubSpaceIds",
-          "admin.MSG_ERR_GET_SUBSPACE_IDS", "father space id: '" + sSpaceId +
-          "'", e);
+          "admin.MSG_ERR_GET_SUBSPACE_IDS", "father space id: '" + sSpaceId + "'", e);
       return new String[0];
     }
   }
 
   /**
    * Return the the spaces name corresponding to the given space ids.
+   *
    * @param asSpaceIds
    * @return
    */
@@ -110,6 +108,7 @@ public class OrganizationController implements java.io.Serializable {
 
   /**
    * Return the space light corresponding to the given space id
+   *
    * @param spaceId
    * @return
    */
@@ -127,6 +126,7 @@ public class OrganizationController implements java.io.Serializable {
 
   /**
    * Method declaration
+   *
    * @return
    * @see
    */
@@ -161,8 +161,8 @@ public class OrganizationController implements java.io.Serializable {
       return getAdminService().getAvailCompoIds(sClientSpaceId, sUserId);
     } catch (AdminException e) {
       SilverTrace.error("admin", "OrganizationController.getAvailCompoIds",
-          "admin.MSG_ERR_GET_USER_AVAILABLE_COMPONENT_IDS", "space Id: '" +
-          sClientSpaceId + "', user Id: '" + sUserId + "'", e);
+          "admin.MSG_ERR_GET_USER_AVAILABLE_COMPONENT_IDS", "space Id: '" + sClientSpaceId
+          + "', user Id: '" + sUserId + "'", e);
       return EMPTY_STRING_ARRAY;
     }
   }
@@ -179,8 +179,8 @@ public class OrganizationController implements java.io.Serializable {
     } catch (Exception e) {
       SilverTrace.error("admin",
           "OrganizationController.getAvailCompoIdsAtRoot",
-          "admin.MSG_ERR_GET_USER_AVAILABLE_COMPONENT_IDS", "space Id: '" +
-          sClientSpaceId + "', user Id: '" + sUserId + "'", e);
+          "admin.MSG_ERR_GET_USER_AVAILABLE_COMPONENT_IDS", "space Id: '" + sClientSpaceId
+          + "', user Id: '" + sUserId + "'", e);
       return new String[0];
     }
   }
@@ -224,14 +224,15 @@ public class OrganizationController implements java.io.Serializable {
       return getAdminService().getAvailDriverCompoIds(sClientSpaceId, sUserId);
     } catch (Exception e) {
       SilverTrace.error("admin", "OrganizationController.getAvailDriverCompoIds",
-          "admin.MSG_ERR_GET_USER_AVAILABLE_COMPONENT_IDS", "space Id: '" +
-          sClientSpaceId + "', user Id: '" + sUserId + "'", e);
+          "admin.MSG_ERR_GET_USER_AVAILABLE_COMPONENT_IDS", "space Id: '" + sClientSpaceId
+          + "', user Id: '" + sUserId + "'", e);
       return EMPTY_STRING_ARRAY;
     }
   }
 
   /**
    * Return the tuples (space id, compo id) allowed for the given user and given component name
+   *
    * @param sUserId
    * @param sCompoName
    * @return
@@ -249,6 +250,7 @@ public class OrganizationController implements java.io.Serializable {
 
   /**
    * gets the available component for a given user
+   *
    * @param userId user identifier used to get component
    * @param componentName type of component to retrieve ( for example : kmelia, forums, blog)
    * @return a list of ComponentInstLight object
@@ -278,6 +280,7 @@ public class OrganizationController implements java.io.Serializable {
 
   /**
    * Return the compo id for the given component name
+   *
    * @param sCompoName
    * @return
    */
@@ -300,7 +303,6 @@ public class OrganizationController implements java.io.Serializable {
   // -------------------------------------------------------------------
   // COMPONENTS QUERIES
   // -------------------------------------------------------------------
-
   /**
    * Return the component Instance corresponding to the given component id
    */
@@ -309,8 +311,7 @@ public class OrganizationController implements java.io.Serializable {
       return getAdminService().getComponentInst(sComponentId);
     } catch (Exception e) {
       SilverTrace.error("admin", "OrganizationController.getComponentInst",
-          "admin.MSG_ERR_GET_COMPONENT", "component Id : '" + sComponentId +
-          "'", e);
+          "admin.MSG_ERR_GET_COMPONENT", "component Id : '" + sComponentId + "'", e);
       return null;
     }
   }
@@ -356,8 +357,7 @@ public class OrganizationController implements java.io.Serializable {
       return getAdminService().getComponentInstLight(sComponentId);
     } catch (Exception e) {
       SilverTrace.error("admin", "OrganizationController.getComponentInstLight",
-          "admin.MSG_ERR_GET_COMPONENT", "component Id : '" + sComponentId +
-          "'", e);
+          "admin.MSG_ERR_GET_COMPONENT", "component Id : '" + sComponentId + "'", e);
       return null;
     }
   }
@@ -431,8 +431,8 @@ public class OrganizationController implements java.io.Serializable {
       }
     } catch (Exception e) {
       SilverTrace.error("admin", "OrganizationController.getAllUsers",
-          "admin.MSG_ERR_GET_USERS_FOR_PROFILE_AND_COMPONENT", "space Id: '" +
-          sPrefixTableName + "' component Id: '" + sComponentName, e);
+          "admin.MSG_ERR_GET_USERS_FOR_PROFILE_AND_COMPONENT", "space Id: '" + sPrefixTableName
+          + "' component Id: '" + sComponentName, e);
 
     }
     return null;
@@ -452,9 +452,10 @@ public class OrganizationController implements java.io.Serializable {
     }
     return null;
   }
-  
+
   /**
    * Gets all the users that belong to the specified domain.
+   *
    * @param domainId the unique identifier of the domain.
    * @return an array of UserDetail objects or null if no such domain exists.
    */
@@ -469,9 +470,10 @@ public class OrganizationController implements java.io.Serializable {
     }
     return null;
   }
-  
-   /**
+
+  /**
    * Searches the users that match the specified criteria.
+   *
    * @param criteria the criteria in searching of user details.
    * @return an array of user details matching the criteria or an empty array of no ones are found.
    * @throws AdminException if an error occurs while getting the user details.
@@ -479,15 +481,16 @@ public class OrganizationController implements java.io.Serializable {
   public UserDetail[] searchUsers(final SearchCriteria criteria) {
     try {
       return getAdminService().searchUsers(criteria);
-    } catch(AdminException ex) {
+    } catch (AdminException ex) {
       SilverTrace.error("admin", "OrganizationController.getUsersMatchingCriteria",
           "admin.EX_ERR_GET_USER_DETAILS", "criteria: '" + criteria.toString(), ex);
     }
     return null;
   }
-  
+
   /**
    * Gets all the user groups that belong to the specified domain.
+   *
    * @param domainId the unique identifier of the domain.
    * @return an array of Group objects or null if no such domain exists.
    */
@@ -606,9 +609,8 @@ public class OrganizationController implements java.io.Serializable {
       return aUserDetail;
     } catch (Exception e) {
       SilverTrace.error("admin", "OrganizationController.getUsers",
-          "admin.MSG_ERR_GET_USERS_FOR_PROFILE_AND_COMPONENT", "profile: '" +
-          sProfile + "', space Id: '" + sPrefixTableName +
-          "' component Id: '" + sComponentName, e);
+          "admin.MSG_ERR_GET_USERS_FOR_PROFILE_AND_COMPONENT", "profile: '" + sProfile
+          + "', space Id: '" + sPrefixTableName + "' component Id: '" + sComponentName, e);
       return null;
     }
   }
@@ -619,8 +621,8 @@ public class OrganizationController implements java.io.Serializable {
     } catch (Exception e) {
       if (!isToolAvailable(componentId)) {
         SilverTrace.error("admin", "OrganizationController.getUserProfiles",
-            "admin.MSG_ERR_GET_PROFILES_FOR_USER_AND_COMPONENT", "userId: '" +
-                userId + "', componentId: '" + componentId + "'", e);
+            "admin.MSG_ERR_GET_PROFILES_FOR_USER_AND_COMPONENT", "userId: '" + userId
+            + "', componentId: '" + componentId + "'", e);
       }
       return null;
     }
@@ -633,20 +635,29 @@ public class OrganizationController implements java.io.Serializable {
           componentId, userId);
     } catch (Exception e) {
       SilverTrace.error("admin", "OrganizationController.getUserProfiles",
-          "admin.MSG_ERR_GET_PROFILES_FOR_USER_AND_COMPONENT", "userId = " +
-          userId + ", componentId = " + componentId + ", objectId = " +
-          objectId, e);
+          "admin.MSG_ERR_GET_PROFILES_FOR_USER_AND_COMPONENT", "userId = " + userId
+          + ", componentId = " + componentId + ", objectId = " + objectId, e);
       return null;
     }
   }
-  
+
+  public List<ProfileInst> getUserProfiles(String componentId, String objectId, String objectType) {
+    try {
+      return getAdminService().getProfilesByObject(objectId, objectType, componentId);
+    } catch (Exception e) {
+      SilverTrace.error("admin", "OrganizationController.getUserProfiles",
+          "admin.MSG_ERR_GET_PROFILE", "componentId = " + componentId + ", objectId = " + objectType
+          + objectId, e);
+      return null;
+    }
+  }
+
   public ProfileInst getUserProfile(String profileId) {
     try {
       return getAdminService().getProfileInst(profileId);
     } catch (Exception e) {
       SilverTrace.error("admin", "OrganizationController.getUserProfile",
-          "admin.MSG_ERR_GET_PROFILE", "profileId: '" +
-           profileId, e);
+          "admin.MSG_ERR_GET_PROFILE", "profileId: '" + profileId, e);
       return null;
     }
   }
@@ -845,8 +856,8 @@ public class OrganizationController implements java.io.Serializable {
       return getAdminService().getAllSubSpaceIds(sSpaceId, sUserId);
     } catch (Exception e) {
       SilverTrace.error("admin", "OrganizationController.getAllSubSpaceIds",
-          "admin.MSG_ERR_GET_USER_AVAILABLE_SUBSPACE_IDS", "user Id: '" +
-          sUserId + "', father space id: '" + sSpaceId, e);
+          "admin.MSG_ERR_GET_USER_AVAILABLE_SUBSPACE_IDS", "user Id: '" + sUserId
+          + "', father space id: '" + sSpaceId, e);
       return EMPTY_STRING_ARRAY;
     }
   }
@@ -880,6 +891,7 @@ public class OrganizationController implements java.io.Serializable {
   /**
    * Return all the components Id recursively in (Space+subspaces, or only subspaces or all
    * silverpeas) available in silverpeas given a userId and a componentNameRoot
+   *
    * @author dlesimple
    * @param sSpaceId
    * @param sUserId
@@ -904,8 +916,8 @@ public class OrganizationController implements java.io.Serializable {
     } catch (AdminException e) {
       SilverTrace.error("admin",
           "OrganizationController.getRootSpacesContainingComponent",
-          "admin.MSG_ERR_GET_ROOT_SPACES", "userId = " + userId + ", componentName = " +
-          componentName, e);
+          "admin.MSG_ERR_GET_ROOT_SPACES", "userId = " + userId + ", componentName = "
+          + componentName, e);
       return new ArrayList<SpaceInstLight>();
     }
   }
@@ -917,8 +929,8 @@ public class OrganizationController implements java.io.Serializable {
     } catch (AdminException e) {
       SilverTrace.error("admin",
           "OrganizationController.getSubSpacesContainingComponent",
-          "admin.MSG_ERR_GET_SUB_SPACES", "spaceId = " + spaceId + ", userId = " + userId +
-          ", componentName = " + componentName, e);
+          "admin.MSG_ERR_GET_SUB_SPACES", "spaceId = " + spaceId + ", userId = " + userId
+          + ", componentName = " + componentName, e);
       return new ArrayList<SpaceInstLight>();
     }
   }
@@ -941,8 +953,8 @@ public class OrganizationController implements java.io.Serializable {
       return getAdminService().isComponentAvailable(componentId, userId);
     } catch (Exception e) {
       SilverTrace.error("admin", "OrganizationController.isComponentAvailable",
-          "admin.MSG_ERR_GET_USER_AVAILABLE_COMPONENT_IDS", "user Id: '" +
-          userId + "', componentId: '" + componentId + "'", e);
+          "admin.MSG_ERR_GET_USER_AVAILABLE_COMPONENT_IDS", "user Id: '" + userId
+          + "', componentId: '" + componentId + "'", e);
       return false;
     }
   }
@@ -962,8 +974,8 @@ public class OrganizationController implements java.io.Serializable {
       return getAdminService().isComponentManageable(componentId, userId);
     } catch (Exception e) {
       SilverTrace.error("admin", "OrganizationController.isComponentManageable",
-          "admin.MSG_ERR_GET_USER_AVAILABLE_COMPONENT_IDS", "user Id: '" +
-          userId + "', componentId: '" + componentId + "'", e);
+          "admin.MSG_ERR_GET_USER_AVAILABLE_COMPONENT_IDS", "user Id: '" + userId
+          + "', componentId: '" + componentId + "'", e);
       return false;
     }
   }
@@ -973,8 +985,8 @@ public class OrganizationController implements java.io.Serializable {
       return getAdminService().isSpaceAvailable(userId, spaceId);
     } catch (Exception e) {
       SilverTrace.error("admin", "OrganizationController.isSpaceAvailable",
-          "admin.MSG_ERR_GET_USER_AVAILABLE_SPACE_IDS", "user Id: '" + userId +
-          "', spaceId: '" + spaceId + "'", e);
+          "admin.MSG_ERR_GET_USER_AVAILABLE_SPACE_IDS", "user Id: '" + userId + "', spaceId: '"
+          + spaceId + "'", e);
       return false;
     }
   }
@@ -986,8 +998,8 @@ public class OrganizationController implements java.io.Serializable {
           userId);
     } catch (Exception e) {
       SilverTrace.error("admin", "OrganizationController.isObjectAvailable",
-          "admin.MSG_ERR_GET_USER_AVAILABLE_OBJECT", "userId = " + userId +
-          ", componentId = " + componentId + ", objectId = " + objectId, e);
+          "admin.MSG_ERR_GET_USER_AVAILABLE_OBJECT", "userId = " + userId + ", componentId = "
+          + componentId + ", objectId = " + objectId, e);
       return false;
     }
   }
@@ -1007,8 +1019,8 @@ public class OrganizationController implements java.io.Serializable {
       return getAdminService().getAllowedSubSpaceIds(userId, spaceFatherId);
     } catch (AdminException e) {
       SilverTrace.error("admin", "OrganizationController.getSpaceTreeview",
-          "admin.MSG_ERR_GET_USER_AVAILABLE_SUBSPACE_IDS", "user Id = " + userId + ", spaceId = " +
-          spaceFatherId, e);
+          "admin.MSG_ERR_GET_USER_AVAILABLE_SUBSPACE_IDS", "user Id = " + userId + ", spaceId = "
+          + spaceFatherId, e);
       return EMPTY_STRING_ARRAY;
     }
   }
@@ -1055,6 +1067,7 @@ public class OrganizationController implements java.io.Serializable {
 
   /**
    * Return userIds according to a list of profile names
+   *
    * @param componentId the instance id
    * @param profileNames the list which contains the profile names
    * @return a string array of user id
@@ -1070,9 +1083,8 @@ public class OrganizationController implements java.io.Serializable {
           profileIds.add(profileInst.getId());
           SilverTrace.info("admin",
               "OrganizationController.getUsersIdsByRoleNames",
-              "root.MSG_GEN_PARAM_VALUE", "profileName = " +
-              profileInst.getName() + ", profileId = " +
-              profileInst.getId());
+              "root.MSG_GEN_PARAM_VALUE", "profileName = " + profileInst.getName()
+              + ", profileId = " + profileInst.getId());
         }
       }
 
@@ -1094,8 +1106,7 @@ public class OrganizationController implements java.io.Serializable {
   public String[] getUsersIdsByRoleNames(String componentId, String objectId,
       ObjectType objectType, List<String> profileNames) {
     SilverTrace.info("admin", "OrganizationController.getUsersIdsByRoleNames",
-        "root.MSG_GEN_ENTER_METHOD", "componentId = " + componentId +
-        ", objectId = " + objectId);
+        "root.MSG_GEN_ENTER_METHOD", "componentId = " + componentId + ", objectId = " + objectId);
     try {
       List<ProfileInst> profiles = getAdminService().getProfilesByObject(objectId, objectType.
           getCode(),
@@ -1205,6 +1216,7 @@ public class OrganizationController implements java.io.Serializable {
    * Is the anonymous access is activated for the running Silverpeas? When the anonymous access is
    * activated, then a specific user for anonymous access should be set; all anonym accesses to the
    * running Silverpeas are done with this user profile.
+   *
    * @return true if the anonym access is activated, false otherwise.
    */
   public boolean isAnonymousAccessActivated() {

--- a/war-core/src/main/webapp/selection/jsp/userpanel.jsp
+++ b/war-core/src/main/webapp/selection/jsp/userpanel.jsp
@@ -18,6 +18,7 @@
 <c:set var="multipleSelection" value="${selection.multiSelect}"/>
 <c:set var="instanceId"        value="${selection.extraParams.componentId}"/>
 <c:set var="roles"             value="${selection.extraParams.joinedProfileNames}"/>
+<c:set var="resourceId"        value="${selection.extraParams.objectId}"/>
 <c:set var="validationURL"     value="${selection.goBackURL}"/>
 <c:set var="cancelationURL"    value="${selection.cancelURL}"/>
 <c:set var="hotSetting"        value="${selection.hotSetting}"/>
@@ -75,16 +76,18 @@
       var MaximizedPageSize   = 10;
       
       rootUserGroup.name      = '<fmt:message key="selection.RootUserGroups"/>';
-      rootUserGroup.inComponent('<c:out value="${instanceId}"/>').withRoles('<c:out value="${roles}"/>');
+      rootUserGroup.inComponent('${instanceId}').withRoles('${roles}').forResource('${resourceId}');
       
       var allUsers = new UserProfileManagement({
-        component: '<c:out value="${instanceId}"/>',
-        roles: '<c:out value="${roles}"/>'
+        component: '${instanceId}',
+        resource: '${resourceId}',
+        roles: '${roles}'
       });
       
-      var me = new UserProfile({id: '<c:out value="${currentUserId}"/>'}).
-        inComponent('<c:out value="${instanceId}"/>').
-        withRoles('<c:out value="${roles}"/>');      
+      var me = new UserProfile({id: '${currentUserId}'}).
+        inComponent('${instanceId}').
+        withRoles('${roles}').
+        forResource('${resourceId}');
       var nameInUserSearch = null; // required for the pagination with the results of a search (as at each page, the users are loaded for that page, so
       // we have to remind the name on which users are filtered if any)
       

--- a/war-core/src/main/webapp/util/javaScript/silverpeas-profile.js
+++ b/war-core/src/main/webapp/util/javaScript/silverpeas-profile.js
@@ -69,8 +69,8 @@ function UserProfile(user) {
   }
   
   /**
-   * Sets this user as belonging to the specified component instance (the unique identifier
-   * of the component instance).
+   * Sets this user as having access priviledges in the specified component instance
+   * (the unique identifier of the component instance).
    */
   this.inComponent = function(component) {
     usermgt.filter.component = component;
@@ -82,6 +82,15 @@ function UserProfile(user) {
    */
   this.withRoles = function(roles) {
     usermgt.filter.roles = roles;
+    return self;
+  }
+
+  /**
+   * Sets this user as having access priviledges for the specified resource within a given component
+   * instance. The component instance must be set.
+   */
+  this.forResource = function(resource) {
+    usermgt.filter.resource = resource;
     return self;
   }
   
@@ -166,8 +175,8 @@ function UserGroup(group) {
       this[prop] = group[prop];
   
   /**
-   * Sets this user group as belonging to the specified component instance (the unique identifier
-   * of the component instance).
+   * Sets this user group as having access priviledges in the specified component instance
+   * (the unique identifier of the component instance).
    */
   this.inComponent = function(component) {
     subgroupmgt.filter.component = component;
@@ -181,6 +190,15 @@ function UserGroup(group) {
   this.withRoles = function(roles) {
     subgroupmgt.filter.roles = roles;
     usermgt.filter.roles = roles;
+    return self;
+  }
+
+  /**
+   * Sets this user group as having access priviledges for the specified resource within a given
+   * component instance. The component instance must be set.
+   */
+  this.forResource = function(resource) {
+    subgroupmgt.filter.resource = resource;
     return self;
   }
   
@@ -325,6 +343,8 @@ function UserProfileManagement(params) {
     group: null, // a user group unique identifier
     name: null, // a pattern about a user name (* is a wildcard)
     component: null, // a component instance identifier
+    resource: null, // an identifier of a resource belonging to a component instance (the identifier
+                    // must be set the resource type following by resource identifier in Silverpeas).
     roles: null, // a string with a comma-separated role names
     pagination: null // pagination data in the form of 
   // { page: <number of the page>, count: <count of users to fetch> }
@@ -384,6 +404,10 @@ function UserProfileManagement(params) {
         urlOfUsers += separator + 'roles=' + self.filter.roles;
         separator = '&';
       }
+      if (self.filter.resource) {
+        urlOfUsers += separator + 'resource=' + self.filter.resource;
+        separator = '&';
+      }
     }
     if (self.filter.group) {
       urlOfUsers += separator + 'group=' + self.filter.group;
@@ -430,7 +454,9 @@ function UserGroupManagement(params) {
     // not, the filtering paramater name is always parsed.
     name: null, // a pattern about a group name (* is a wildcard)
     component: null, // a component instance identifier
-    roles: null // a string with a comma-separated role names
+    roles: null, // a string with a comma-separated role names
+    resource: null // an identifier of a resource belonging to a component instance (the identifier
+                   // must be set the resource type following by resource identifier in Silverpeas).
   };
   
   /**
@@ -484,6 +510,10 @@ function UserGroupManagement(params) {
       urlOfGroups += '/application/' + self.filter.component;
       if (self.filter.roles) {
         urlOfGroups += separator + 'roles=' + self.filter.roles;
+        separator = '&';
+      }
+      if (self.filter.resource) {
+        urlOfGroups += separator + 'resource=' + self.filter.resource;
         separator = '&';
       }
     }

--- a/web-core/src/main/java/com/silverpeas/profile/web/UserGroupProfileResource.java
+++ b/web-core/src/main/java/com/silverpeas/profile/web/UserGroupProfileResource.java
@@ -106,9 +106,10 @@ public class UserGroupProfileResource extends RESTWebService {
   public UserGroupProfileEntity[] getGroupsInApplication(
           @PathParam("instanceId") String instanceId,
           @QueryParam("roles") String roles,
+          @QueryParam("resource") String resource,
           @QueryParam("name") String name) {
     String[] roleNames = (isDefined(roles) ? roles.split(","):new String[0]);
-    String[] roleIds = profileService.getRoleIds(instanceId, roleNames);
+    String[] roleIds = profileService.getRoleIds(instanceId, resource, roleNames);
     String[] groupIds = getOrganizationController().searchGroupsIds(false, null, roleIds,
             aFilteringModel(name, null));
     Group[] groups = getOrganizationController().getGroups(groupIds);

--- a/web-core/src/main/java/com/silverpeas/profile/web/UserProfileResource.java
+++ b/web-core/src/main/java/com/silverpeas/profile/web/UserProfileResource.java
@@ -24,11 +24,10 @@
 package com.silverpeas.profile.web;
 
 import com.silverpeas.annotation.Authenticated;
-import static com.silverpeas.profile.web.ProfileResourceBaseURIs.USERS_BASE_URI;
-import static com.silverpeas.profile.web.SearchCriteriaBuilder.aSearchCriteria;
+import com.silverpeas.annotation.RequestScoped;
+import com.silverpeas.annotation.Service;
 import com.silverpeas.socialnetwork.relationShip.RelationShip;
 import com.silverpeas.socialnetwork.relationShip.RelationShipService;
-import static com.silverpeas.util.StringUtil.isDefined;
 import com.silverpeas.web.RESTWebService;
 import com.stratelia.webactiv.beans.admin.Group;
 import com.stratelia.webactiv.beans.admin.SearchCriteria;
@@ -45,8 +44,10 @@ import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
-import com.silverpeas.annotation.RequestScoped;
-import com.silverpeas.annotation.Service;
+
+import static com.silverpeas.profile.web.ProfileResourceBaseURIs.USERS_BASE_URI;
+import static com.silverpeas.profile.web.SearchCriteriaBuilder.aSearchCriteria;
+import static com.silverpeas.util.StringUtil.isDefined;
 
 /**
  * A REST-based Web service that acts on the user profiles in Silverpeas. Each provided method is a
@@ -161,6 +162,12 @@ public class UserProfileResource extends RESTWebService {
    * to.
    * @param groupId the unique identifier of the group the users must belong to. The particular
    * identifier "all" means all user groups.
+   * @param roles the name of the roles the users must play either for the component instance or
+   * for a given resource of the component instance.
+   * @param resource the unique identifier of the resource in the component instance the users to get
+   * must have enough rights to access. This query filter is coupled with the <code>roles</code> one.
+   * If it is not set, by default the resource refered is the whole component instance. As for 
+   * component instance identifier, a resource one is defined by its type followed by its identifier.
    * @param name a pattern the name of the users has to satisfy. The wildcard * means anything
    * string of characters.
    * @param page the pagination parameters formatted as "page number;item count in the page". From
@@ -176,10 +183,12 @@ public class UserProfileResource extends RESTWebService {
           @PathParam("instanceId") String instanceId,
           @QueryParam("group") String groupId,
           @QueryParam("roles") String roles,
+          @QueryParam("resource") String resource,
           @QueryParam("name") String name,
           @QueryParam("page") String page) {
-    String[] rolesIds = (isDefined(roles) ? profileService.getRoleIds(instanceId, roles.split(","))
-            : null);
+    String[] rolesIds = (isDefined(roles) ?
+        profileService.getRoleIds(instanceId, resource, roles.split(","))
+        : null);
     String domainId = null;
     if (isDefined(groupId) && !groupId.equals(QUERY_ALL_GROUP)) {
       Group group = profileService.getGroupAccessibleToUser(groupId, getUserDetail());
@@ -214,10 +223,11 @@ public class UserProfileResource extends RESTWebService {
   public Response getUserContacts(@PathParam("userId") String userId,
           @QueryParam("application") String instanceId,
           @QueryParam("roles") String roles,
+          @QueryParam("resource") String resource,
           @QueryParam("name") String name,
           @QueryParam("page") String page) {
     UserDetail theUser = getUserDetailMatching(userId);
-    String[] rolesIds = (isDefined(roles) ? profileService.getRoleIds(instanceId, roles.split(","))
+    String[] rolesIds = (isDefined(roles) ? profileService.getRoleIds(instanceId, resource, roles.split(","))
             : null);
     String[] contactIds = getContactIds(theUser.getId());
     UserDetail[] contacts;


### PR DESCRIPTION
The user roles defined for a given resource belonging to an application instance are now taken into account by the user/group selection panel. For doing, a new query parameter is now supported by the REST-based web service on the user profiles to indicate the unique identifier of the resource in Silverpeas (it's made up of its type and of its identifier). When this query filter is set, the role names are then seek for the related resource and not for the whole application instance. The methods used in the selection object to set explicitly the user role identifier and that was no more used by the new user panel are now annotated as deprecated.

Don't forget to integrate also the branch bug-3897 of the Silverpeas-Component project.
