### PR TITLE
#File Upload Improvement. 

### DIFF
--- a/lib-core/src/main/java/com/silverpeas/util/web/servlet/FileUploadUtil.java
+++ b/lib-core/src/main/java/com/silverpeas/util/web/servlet/FileUploadUtil.java
@@ -1,27 +1,23 @@
 /**
  * Copyright (C) 2000 - 2012 Silverpeas
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
  *
- * As a special exception to the terms and conditions of version 3.0 of
- * the GPL, you may redistribute this Program in connection with Free/Libre
- * Open Source Software ("FLOSS") applications as described in Silverpeas's
- * FLOSS exception.  You should have received a copy of the text describing
- * the FLOSS exception, and it is also available here:
+ * As a special exception to the terms and conditions of version 3.0 of the GPL, you may
+ * redistribute this Program in connection with Free/Libre Open Source Software ("FLOSS")
+ * applications as described in Silverpeas's FLOSS exception. You should have received a copy of the
+ * text describing the FLOSS exception, and it is also available here:
  * "http://www.silverpeas.org/docs/core/legal/floss_exception.html"
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Affero General Public License for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU Affero General Public License along with this program.
+ * If not, see <http://www.gnu.org/licenses/>.
  */
-
 package com.silverpeas.util.web.servlet;
 
 import com.silverpeas.util.StringUtil;
@@ -34,20 +30,22 @@ import java.io.UnsupportedEncodingException;
 import java.util.List;
 import javax.servlet.http.HttpServletRequest;
 import org.apache.commons.fileupload.FileItem;
-import org.apache.commons.fileupload.FileItemFactory;
 import org.apache.commons.fileupload.FileUploadException;
-import org.apache.commons.fileupload.disk.DiskFileItemFactory;
+import org.apache.commons.fileupload.disk.SilverpeasDiskFileItemFactory;
 import org.apache.commons.fileupload.servlet.ServletFileUpload;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 
 /**
  * Utility class for file uploading.
+ *
  * @author ehugonnet
  */
 public class FileUploadUtil {
 
   public static final String DEFAULT_ENCODING = "UTF-8";
+  private static ServletFileUpload upload = new ServletFileUpload(
+      new SilverpeasDiskFileItemFactory());
 
   public static boolean isRequestMultipart(HttpServletRequest request) {
     return ServletFileUpload.isMultipartContent(request);
@@ -57,29 +55,6 @@ public class FileUploadUtil {
   public static List<FileItem> parseRequest(HttpServletRequest request)
       throws UtilException {
     try {
-      // Create a factory for disk-based file items
-      FileItemFactory factory = new DiskFileItemFactory();
-      // Create a new file upload handler
-      ServletFileUpload upload = new ServletFileUpload(factory);
-
-      // Parse the request
-      return (List<FileItem>) upload.parseRequest(request);
-    } catch (FileUploadException fuex) {
-      throw new UtilException("FileUploadUtil.parseRequest",
-          "Error uploading files", fuex);
-    }
-  }
-
-  @SuppressWarnings("unchecked")
-  public static List<FileItem> parseRequest(HttpServletRequest request, int maxSize)
-      throws UtilException {
-    try { // Create a factory for disk-based file items
-      DiskFileItemFactory factory = new DiskFileItemFactory();
-      // Set factory constraints
-      factory.setSizeThreshold(maxSize);
-      // Create a new file upload handler
-      ServletFileUpload upload = new ServletFileUpload(factory);
-
       // Parse the request
       return (List<FileItem>) upload.parseRequest(request);
     } catch (FileUploadException fuex) {
@@ -91,6 +66,7 @@ public class FileUploadUtil {
   /**
    * Get the parameter value from the list of FileItems. Returns the defaultValue if the parameter
    * is not found.
+   *
    * @param items the items resulting from parsing the request.
    * @param parameterName
    * @param defaultValue the value to be returned if the parameter is not found.
@@ -115,6 +91,7 @@ public class FileUploadUtil {
   /**
    * Get the parameter value from the list of FileItems. Returns the defaultValue if the parameter
    * is not found.
+   *
    * @param items the items resulting from parsing the request.
    * @param parameterName
    * @param defaultValue the value to be returned if the parameter is not found.
@@ -127,6 +104,7 @@ public class FileUploadUtil {
 
   /**
    * Get the parameter value from the list of FileItems. Returns null if the parameter is not found.
+   *
    * @param items the items resulting from parsing the request.
    * @param parameterName
    * @return the parameter value from the list of FileItems. Returns null if the parameter is not
@@ -182,6 +160,7 @@ public class FileUploadUtil {
 
   /**
    * Convert a path to the current OS path format.
+   *
    * @param undeterminedOsPath
    * @return server OS pah.
    */

--- a/lib-core/src/main/java/org/apache/commons/fileupload/disk/SilverpeasDiskFileItemFactory.java
+++ b/lib-core/src/main/java/org/apache/commons/fileupload/disk/SilverpeasDiskFileItemFactory.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2000-2012 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Writer Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have recieved a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "http://www.silverpeas.org/legal/licensing"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.apache.commons.fileupload.disk;
+
+import com.stratelia.webactiv.util.FileRepositoryManager;
+import java.io.File;
+import org.apache.commons.fileupload.FileItem;
+import org.apache.commons.io.FileCleaningTracker;
+
+/**
+ * This factory is to replace the one provided by the FileUpload Apache Commons as a workaround of a
+ * no yet fixed bug in the Apache library.
+ *
+ * The DiskFileItemFactory class in FileUpload Apache Commons has a bug when used in conjonction
+ * with a tracker of non-long used temporary files (see
+ * http://blog.novoj.net/2012/09/19/commons-file-upload-contains-a-severe-memory-leak/ for a
+ * description of the bug and https://issues.apache.org/jira/browse/FILEUPLOAD-189 for a look at the
+ * bug fix status). This implementation aims to replace the original DiskFileItemFactory class by
+ * fixing the bug (in the hope it will be fix in a next release of the FileUpload Apache Commons
+ * library).
+ *
+ * Beside this bug, some default parameters are also set for the particular use of Silverpeas:
+ * <ul>
+ * <li>the path of the temporary directory in use in Silverpeas,</li>
+ * <li>the thresold size above which the uploaded files are temporarly stored in disk.</li>
+ * </ul>
+ *
+ * @author mmoquillon
+ */
+public class SilverpeasDiskFileItemFactory extends DiskFileItemFactory {
+
+  private static final int THRESHOLD_SIZE = 2097152;
+
+  /**
+   * Constructs a new SilverpeasDiskFileItemFactory by setting by default the following
+   * parameters:
+   * <ul>
+   * <li>the size threshold is set at 2Mo: about this size, the file are temporarly stored in disk;</li>
+   * <li>the temporary directory is the default one used in Silverpeas
+   * (@see com.stratelia.webactiv.util.FileRepositoryManager#getTemporaryPath());</li>
+   * <li>a temporary file cleaner is set: all stored file in disks are deleted once no more unused
+   * (@see org.apache.commons.fileupload.disk.DiskFileItemFactory).<li>
+   * </ul>
+   */
+  public SilverpeasDiskFileItemFactory() {
+    super();
+    this.setSizeThreshold(THRESHOLD_SIZE);
+    this.setRepository(new File(FileRepositoryManager.getTemporaryPath()));
+    this.setFileCleaningTracker(new FileCleaningTracker());
+  }
+
+  @Override
+  public FileItem createItem(String fieldName, String contentType, boolean isFormField,
+      String fileName) {
+    DiskFileItem result = new DiskFileItem(fieldName, contentType,
+        isFormField, fileName, getSizeThreshold(), getRepository());
+    FileCleaningTracker tracker = getFileCleaningTracker();
+    if (tracker != null) {
+      tracker.track(result.getTempFile(), result);
+    }
+    return result;
+  }
+}

--- a/war-core/src/main/java/com/stratelia/webactiv/servlets/FileUploader.java
+++ b/war-core/src/main/java/com/stratelia/webactiv/servlets/FileUploader.java
@@ -24,20 +24,8 @@
 
 package com.stratelia.webactiv.servlets;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.Date;
-import java.util.List;
-
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
-import org.apache.commons.fileupload.DiskFileUpload;
-import org.apache.commons.fileupload.FileItem;
-
 import com.silverpeas.util.StringUtil;
+import com.silverpeas.util.web.servlet.FileUploadUtil;
 import com.stratelia.silverpeas.peasCore.MainSessionController;
 import com.stratelia.silverpeas.silvertrace.SilverTrace;
 import com.stratelia.silverpeas.versioning.model.DocumentPK;
@@ -47,6 +35,15 @@ import com.stratelia.webactiv.util.FileRepositoryManager;
 import com.stratelia.webactiv.util.attachment.control.AttachmentController;
 import com.stratelia.webactiv.util.attachment.ejb.AttachmentPK;
 import com.stratelia.webactiv.util.attachment.model.AttachmentDetail;
+import java.io.File;
+import java.io.IOException;
+import java.util.Date;
+import java.util.List;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.apache.commons.fileupload.FileItem;
 
 /**
  * Class declaration
@@ -83,15 +80,14 @@ public class FileUploader extends HttpServlet {
       throws ServletException, IOException {
     SilverTrace.info("peasUtil", "FileUploader.doPost", "root.MSG_GEN_ENTER_METHOD");
     try {
-      DiskFileUpload dfu = new DiskFileUpload();
-      List<FileItem> items = dfu.parseRequest(req);
-      FileItem file = getUploadedFile(items, "FileField");
-      String userId = getParameterValue(items, "UserId");
-      String attachmentId = getParameterValue(items, "FileId");
-      String contentLanguage = getParameterValue(items, "FileLang");
+      List<FileItem> items = FileUploadUtil.parseRequest(req);
+      FileItem file = FileUploadUtil.getFile(items, "FileField");
+      String userId = FileUploadUtil.getParameter(items, "UserId");
+      String attachmentId = FileUploadUtil.getParameter(items, "FileId");
+      String contentLanguage = FileUploadUtil.getParameter(items, "FileLang");
       // in case of versioning
-      String privateOrPublic = getParameterValue(items, "Version");
-      String comments = getParameterValue(items, "Comment");
+      String privateOrPublic = FileUploadUtil.getParameter(items, "Version");
+      String comments = FileUploadUtil.getParameter(items, "Comment");
 
       if (StringUtil.isDefined(privateOrPublic)) {
         int versionType = ("publique".equals(privateOrPublic) ? DocumentVersion.TYPE_PUBLIC_VERSION
@@ -135,24 +131,6 @@ public class FileUploader extends HttpServlet {
     File uploadFile = new File(newVersionFile);
     file.write(uploadFile);
     versioningUtil.checkinFile(documentId, versionType, comment, userId, newPhysicalName);
-  }
-
-  private FileItem getUploadedFile(List<FileItem> items, String parameterName) {
-    for (FileItem item : items) {
-      if (!item.isFormField() && parameterName.equals(item.getFieldName())) {
-        return item;
-      }
-    }
-    return null;
-  }
-
-  private String getParameterValue(List<FileItem> items, String parameterName) {
-    for (FileItem item : items) {
-      if (item.isFormField() && parameterName.equals(item.getFieldName())) {
-        return item.getString();
-      }
-    }
-    return null;
   }
 
   private String getUserId(HttpServletRequest request) {

--- a/war-core/src/main/java/com/sun/portal/portletcontainer/driver/admin/UploadServlet.java
+++ b/war-core/src/main/java/com/sun/portal/portletcontainer/driver/admin/UploadServlet.java
@@ -41,7 +41,7 @@ import javax.servlet.http.HttpSession;
 
 import org.apache.commons.fileupload.FileItem;
 import org.apache.commons.fileupload.FileUploadException;
-import org.apache.commons.fileupload.disk.DiskFileItemFactory;
+import org.apache.commons.fileupload.disk.SilverpeasDiskFileItemFactory;
 import org.apache.commons.fileupload.servlet.ServletFileUpload;
 import org.apache.commons.io.FilenameUtils;
 
@@ -103,7 +103,7 @@ public class UploadServlet extends HttpServlet {
 
     HttpSession session = AdminUtils.getClearedSession(request);
 
-    DiskFileItemFactory factory = new DiskFileItemFactory();
+    SilverpeasDiskFileItemFactory factory = new SilverpeasDiskFileItemFactory();
     ServletFileUpload upload = new ServletFileUpload(factory);
     upload.setSizeMax(maxUploadSize);
 


### PR DESCRIPTION
Now, the file upload is done through the central location FileUploadUtil (update of the AjaxFileUploadServlet servlet).
As DiskFileUpload is deprecated, FileUploadUtil uses instead ServletFileUpload class to perform the file uploading as recommended by the Apache Commons FileUpload library.
By taking profit of the ServletFileUpload, additional parameters are set:
- the temporary directory used to temporarily store the uploaded file is the Silverpeas temporary directory,

-and the size above which the uploaded file are temporarily stored is 2MB (under this size, the files are loaded in memory).
