### PR TITLE
Feature #4096

### DIFF
--- a/lib-core/src/main/java/com/stratelia/webactiv/util/attachment/control/AttachmentController.java
+++ b/lib-core/src/main/java/com/stratelia/webactiv/util/attachment/control/AttachmentController.java
@@ -964,6 +964,13 @@ public class AttachmentController {
               indexEntry.setKeywords(title, language);
             }
 
+            if(translation.getLogicalName() != null){
+                int lastDot = translation.getLogicalName().lastIndexOf('.');
+                if(lastDot != -1){
+                    indexEntry.addTextContent(translation.getLogicalName().substring(0,lastDot));
+                }
+            }
+
             String info = translation.getInfo();
             if (StringUtil.isDefined(info)) {
               indexEntry.setPreview(info, language);

--- a/lib-core/src/main/java/org/silverpeas/search/indexEngine/model/IndexManager.java
+++ b/lib-core/src/main/java/org/silverpeas/search/indexEngine/model/IndexManager.java
@@ -477,7 +477,7 @@ public class IndexManager {
 
         if (indexEntry.getTitle(language) != null) {
           doc.add(new Field(getFieldName(CONTENT, language), indexEntry.getTitle(language),
-              Store.NO, Index.NOT_ANALYZED));
+              Store.NO, Index.ANALYZED));
         }
         if (indexEntry.getPreview(language) != null) {
           doc.add(new Field(getFieldName(CONTENT, language), indexEntry.getPreview(language).
@@ -541,35 +541,6 @@ public class IndexManager {
       doc.add(new Field(FIELDS_FOR_FACETS, sFieldsForFacet, Store.YES, Index.NO));
     }
 
-    if (!isWysiwyg(indexEntry)) {
-      // Lucene doesn't index all the words in a field
-      // (the max is given by the maxFieldLength property)
-      // The problem is that we don't no which words are skipped
-      // and which ones are taken. So the trick used here :
-      // the words which MUST been indexed are given twice to lucene
-      // at the beginning of the field CONTENT and at the end of this field.
-      // (In the current implementation of lucene and without this trick;
-      // some key words are not indexed !!!)
-      languages = indexEntry.getLanguages();
-      while (languages.hasNext()) {
-        String language = languages.next();
-        if (indexEntry.getTitle(language) != null) {
-          doc.add(new Field(getFieldName(CONTENT, language), indexEntry.getTitle(language).
-              toLowerCase(), Store.NO,
-              Index.ANALYZED));
-        }
-        if (indexEntry.getPreview(language) != null) {
-          doc.add(new Field(getFieldName(CONTENT, language), indexEntry.getPreview(language).
-              toLowerCase(), Store.NO,
-              Index.ANALYZED));
-        }
-        if (indexEntry.getKeywords(language) != null) {
-          doc.add(new Field(getFieldName(CONTENT, language), indexEntry.getKeywords(language).
-              toLowerCase(), Store.NO,
-              Index.ANALYZED));
-        }
-      }
-    }
     // Add server name inside Lucene doc
     doc.add(new Field(SERVER_NAME, indexEntry.getServerName(), Store.YES, Index.NOT_ANALYZED));
     return doc;


### PR DESCRIPTION
- for an attachment, index the base file name (without the suffix) as a text content
- remove a deprecated trick (duplicate text in content field) that was used for older Lucene versions
- title is now only added once in the content field, and analyzed (whereas it was added twice, one time as analyzed and one time as not analyzed)
