### PR TITLE
fixing bug #3647

### DIFF
--- a/ejb-core/pdc/src/main/java/com/silverpeas/pdcSubscription/ejb/PdcSubscriptionBmEJB.java
+++ b/ejb-core/pdc/src/main/java/com/silverpeas/pdcSubscription/ejb/PdcSubscriptionBmEJB.java
@@ -465,7 +465,13 @@ public class PdcSubscriptionBmEJB implements SessionBean {
    */
   protected boolean checkValueInPath(String value, List<String> pathList) {
     for (String path : pathList) {
-      if (path.contains(value)) {
+      String p = "/0/";
+      if (path != null) {
+        // use given path if it not null
+        // otherwise this means that first level has been removed, so use root path
+        p = new String(path);
+      }
+      if (p.contains(value)) {
         return true;
       }
     }


### PR DESCRIPTION
Preventing NullPointerException in taxonomy subscription service when first level value is removed from taxonomy
