### PR TITLE
Bug #3914 : removing of boring JavaScript message alerts when logging to Silverpeas (under Chrome only).

### DIFF
--- a/war-core/src/main/webapp/admin/jsp/DomainsBarSilverpeasV5.jsp
+++ b/war-core/src/main/webapp/admin/jsp/DomainsBarSilverpeasV5.jsp
@@ -31,7 +31,6 @@
 <%@ page import="com.silverpeas.util.EncodeHelper"%>
 <%@ page import="com.stratelia.webactiv.util.*"%>
 <%@ page import="com.stratelia.silverpeas.peasCore.URLManager"%>
-<%@ page import="com.silverpeas.look.LookSilverpeasV5Helper"%>
 <%@ page import="com.stratelia.webactiv.beans.admin.Domain"%>
 <%@ page import="com.stratelia.webactiv.util.viewGenerator.html.buttons.Button"%>
 <%@ page import="com.stratelia.webactiv.util.viewGenerator.html.GraphicElementFactory"%>
@@ -98,9 +97,7 @@ out.println(gef.getLookStyleSheet());
 <script type="text/javascript" src="<%=m_sContext%>/util/ajax/ricoAjax.js"></script>
 
 <!-- Add jQuery javascript library -->
-<script type="text/javascript" src="/silverpeas/util/javaScript/jquery/jquery-1.3.2.min.js"></script> <!-- do not remove this line while rico is used -->
 <script type="text/javascript" src="<%=m_sContext%>/util/javaScript/jquery/jquery.loadmask.js"></script>
-<script type="text/javascript" src="<%=m_sContext%>/util/javaScript/jquery/jquery.ajaxQueue.js"></script>
 <script type="text/javascript" src="<%=m_sContext%>/util/javaScript/jquery/jquery.autocomplete.js"></script>
 <script type="text/javascript" src="<%=m_sContext%>/util/javaScript/jquery/jquery.bgiframe.min.js"></script>
 
@@ -258,20 +255,23 @@ out.println(gef.getLookStyleSheet());
         }
     }
 
-    
-  	//used by keyword autocompletion
-    <%  if(resourceSearchEngine.getBoolean("enableAutocompletion", false)){ %>
-    	$(document).ready(function(){
-            $("#query").autocomplete("<%=m_sContext%>/AutocompleteServlet", {
-                        minChars: <%=autocompletionMinChars%>,
-                        max: 50,
-                        autoFill: false,
-                        mustMatch: false,
-                        matchContains: false,
-                        scrollHeight: 220
-                });
-          });
-    <%}%>
+  /**
+   * Using "jQuery" instead of "$" at this level prevents of getting conficts with another
+   * javascript plugin.
+   */
+  //used by keyword autocompletion
+  <%  if(resourceSearchEngine.getBoolean("enableAutocompletion", false)){ %>
+  jQuery(document).ready(function() {
+    jQuery("#query").autocomplete("<%=m_sContext%>/AutocompleteServlet", {
+      minChars : <%=autocompletionMinChars%>,
+      max : 50,
+      autoFill : false,
+      mustMatch : false,
+      matchContains : false,
+      scrollHeight : 220
+    });
+  });
+  <%}%>
 
 </script>
 </head>

--- a/war-core/src/main/webapp/admin/jsp/TopBarSilverpeasV5.jsp
+++ b/war-core/src/main/webapp/admin/jsp/TopBarSilverpeasV5.jsp
@@ -51,8 +51,6 @@ if (goToFavoriteSpaceOnHomeLink) {
 
 List<TopItem> topItems = helper.getTopItems();
 
-String homePage = new String (settings.getString("defaultHomepage"));
-
 boolean isAnonymousAccess 	= helper.isAnonymousAccess();
 
 String wallPaper = helper.getSpaceWallPaper();

--- a/war-core/src/main/webapp/util/ajax/rico.js
+++ b/war-core/src/main/webapp/util/ajax/rico.js
@@ -195,6 +195,6 @@ var Rico = {
     else if (window.opera) window.opera.postError(this.timeStamp()+msg);
   }
 
-}
+};
 
 Rico.init();

--- a/war-core/src/main/webapp/util/ajax/ricoAjax.js
+++ b/war-core/src/main/webapp/util/ajax/ricoAjax.js
@@ -5,9 +5,9 @@ Rico.AjaxEngine = Class.create();
 Rico.AjaxEngine.prototype = {
 
    initialize: function() {
-      this.ajaxElements = new Array();
-      this.ajaxObjects  = new Array();
-      this.requestURLS  = new Array();
+      this.ajaxElements = [];
+      this.ajaxObjects  = [];
+      this.requestURLS  = [];
       this.options = {};
    },
 
@@ -108,7 +108,7 @@ Rico.AjaxEngine.prototype = {
    },
 
    _createQueryString: function( theArgs, offset ) {
-      var queryString = ""
+      var queryString = "";
       for ( var i = offset ; i < theArgs.length ; i++ ) {
           if ( i != offset )
             queryString += "&";
@@ -116,28 +116,24 @@ Rico.AjaxEngine.prototype = {
           var anArg = theArgs[i];
 
           if ( anArg.name != undefined && anArg.value != undefined ) {
-//Patch DLE use with accents
-//	        	  queryString += anArg.name +  "=" + escape(anArg.value);
               queryString += anArg.name +  "=" + encodeURIComponent(anArg.value);
           }
           else {
              var ePos  = anArg.indexOf('=');
              var argName  = anArg.substring( 0, ePos );
              var argValue = anArg.substring( ePos + 1 );
-//Patch DLE use with accents
-//	             queryString += argName + "=" + escape(argValue);
              queryString += argName + "=" + encodeURIComponent(argValue);
-             
+
           }
       }
 
-	  d = new Date();
-	  trick = d.getYear() + "ie" + d.getMonth() + "t" + d.getDate() + "r" + d.getHours() + "i" 
-		+ d.getMinutes() + "c" + d.getSeconds() + "k" + d.getMilliseconds();
-		
-	  queryString += "&ietrick="+trick;
+     var d = new Date();
+     var trick = d.getYear() + "ie" + d.getMonth() + "t" + d.getDate() + "r" + d.getHours() + "i" +
+         d.getMinutes() + "c" + d.getSeconds() + "k" + d.getMilliseconds();
 
-      return queryString;
+     queryString += "&ietrick=" + trick;
+
+     return queryString;
    },
 
    _onRequestComplete : function(request) {
@@ -151,7 +147,7 @@ Rico.AjaxEngine.prototype = {
       if (response == null || response.length != 1)
          return;
       this._processAjaxResponse( response[0].childNodes );
-      
+
       // Check if user has set a onComplete function
       var onRicoComplete = this.options.onRicoComplete;
       if (onRicoComplete != null)
@@ -186,7 +182,7 @@ Rico.AjaxEngine.prototype = {
       ajaxElement.innerHTML = RicoUtil.getContentAsString(responseElement);
    }
 
-}
+};
 
 var ajaxEngine = new Rico.AjaxEngine();
 

--- a/war-core/src/main/webapp/util/javaScript/animation.js
+++ b/war-core/src/main/webapp/util/javaScript/animation.js
@@ -21,71 +21,96 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-String.prototype.startsWith = function (str) {
+String.prototype.startsWith = function(str) {
   return this.indexOf(str) == 0;
 };
-<!--
+
 // PopUp Window
 // ******* Deprecated ***********
-function MM_openBrWindow(theURL,winName,features) { //v2.0
-  window.open(theURL,winName,features);
+function MM_openBrWindow(theURL, winName, features) { //v2.0
+  window.open(theURL, winName, features);
 }
 // ******************************
 
-function SP_openUserPanel(page,nom,options) {
-    return SP_openWindow(page,nom,'700','730',options);
+function SP_openUserPanel(page, nom, options) {
+  return SP_openWindow(page, nom, '700', '730', options);
 }
 
 // PopUp center
-function SP_openWindow(page,nom,largeur,hauteur,options) {
-	var top=(screen.height-hauteur)/2;
-	var left=(screen.width-largeur)/2;
-    if (screen.height - 20 <= hauteur)
-    {
-        top = 0;
-    }
-    if (screen.width - 10 <= largeur)
-    {
-        left = 0;
-    }
-	var popup=window.open(page,nom,"top="+top+",left="+left+",width="+largeur+",height="+hauteur+","+options);
-	return popup;
+function SP_openWindow(page, nom, largeur, hauteur, options) {
+  var top = (screen.height - hauteur) / 2;
+  var left = (screen.width - largeur) / 2;
+  if (screen.height - 20 <= hauteur) {
+    top = 0;
+  }
+  if (screen.width - 10 <= largeur) {
+    left = 0;
+  }
+  return window.open(page, nom,
+      "top=" + top + ",left=" + left + ",width=" + largeur + ",height=" + hauteur + "," + options);
 }
 
-function openDialog(url, nom, largeur,hauteur, parm) {
-    SP_openWindow(url, nom, largeur, hauteur, parm);
+function openDialog(url, nom, largeur, hauteur, parm) {
+  SP_openWindow(url, nom, largeur, hauteur, parm);
 }
-
 
 function winClose() {
-	window.close();
+  if (window.close) {
+    window.close();
+  }
 }
 
 function winPrint() {
-	window.print();
+  window.print();
 }
 
 // RollOver
 function MM_swapImgRestore() { //v3.0
-  var i,x,a=document.MM_sr; for(i=0;a&&i<a.length&&(x=a[i])&&x.oSrc;i++) x.src=x.oSrc;
+  var i, x, a = document.MM_sr;
+  for (i = 0; a && i < a.length && (x = a[i]) && x.oSrc; i++) x.src = x.oSrc;
 }
 
 function MM_preloadImages() { //v3.0
-  var d=document; if(d.images){ if(!d.MM_p) d.MM_p=new Array();
-    var i,j=d.MM_p.length,a=MM_preloadImages.arguments; for(i=0; i<a.length; i++)
-    if (a[i].indexOf("#")!=0){ d.MM_p[j]=new Image; d.MM_p[j++].src=a[i];}}
+  var d = document;
+  if (d.images) {
+    if (!d.MM_p) {
+      d.MM_p = [];
+    }
+    var i, j = d.MM_p.length, a = MM_preloadImages.arguments;
+    for (i = 0; i < a.length; i++)
+      if (a[i].indexOf("#") != 0) {
+        d.MM_p[j] = new Image;
+        d.MM_p[j++].src = a[i];
+      }
+  }
 }
 
 function MM_findObj(n, d) { //v3.0
-  var p,i,x;  if(!d) d=document; if((p=n.indexOf("?"))>0&&parent.frames.length) {
-    d=parent.frames[n.substring(p+1)].document; n=n.substring(0,p);}
-  if(!(x=d[n])&&d.all) x=d.all[n]; for (i=0;!x&&i<d.forms.length;i++) x=d.forms[i][n];
-  for(i=0;!x&&d.layers&&i<d.layers.length;i++) x=MM_findObj(n,d.layers[i].document); return x;
+  var p, i, x;
+  if (!d) {
+    d = document;
+  }
+  if ((p = n.indexOf("?")) > 0 && parent.frames.length) {
+    d = parent.frames[n.substring(p + 1)].document;
+    n = n.substring(0, p);
+  }
+  if (!(x = d[n]) && d.all) {
+    x = d.all[n];
+  }
+  for (i = 0; !x && i < d.forms.length; i++) x = d.forms[i][n];
+  for (i = 0; !x && d.layers && i < d.layers.length; i++) x = MM_findObj(n, d.layers[i].document);
+  return x;
 }
 
 function MM_swapImage() { //v3.0
-  var i,j=0,x,a=MM_swapImage.arguments; document.MM_sr=new Array; for(i=0;i<(a.length-2);i+=3)
-   if ((x=MM_findObj(a[i]))!=null){document.MM_sr[j++]=x; if(!x.oSrc) x.oSrc=x.src; x.src=a[i+2];}
+  var i, j = 0, x, a = MM_swapImage.arguments;
+  document.MM_sr = [];
+  for (i = 0; i < (a.length - 2); i += 3)
+    if ((x = MM_findObj(a[i])) != null) {
+      document.MM_sr[j++] = x;
+      if (!x.oSrc) {
+        x.oSrc = x.src;
+      }
+      x.src = a[i + 2];
+    }
 }
-
-//-->

--- a/war-core/src/main/webapp/util/javaScript/jquery/jquery-include.js
+++ b/war-core/src/main/webapp/util/javaScript/jquery/jquery-include.js
@@ -1,5 +1,5 @@
 /**
- * $.include - script inclusion jQuery plugin
+ * jQuery.include - script inclusion jQuery plugin
  * Based on idea from http://www.gnucitizen.org/projects/jquery-include/
  * @author Tobiasz Cudnik
  * @link http://meta20.net/.include_script_inclusion_jQuery_plugin
@@ -44,7 +44,7 @@ jQuery.extend({
         dependency = [dependency];
       setTimeout(function(){
         var valid = true;
-        $.each(dependency, function(k, v){
+        jQuery.each(dependency, function(k, v){
           if (! v() ) {
             valid = false;
             return false;
@@ -66,7 +66,7 @@ jQuery.extend({
   ready: function () {
     if (jQuery.isReady) return;
     imReady = true;
-    $.each(jQuery.includeStates, function(url, state) {
+    jQuery.each(jQuery.includeStates, function(url, state) {
       if (! state)
         return imReady = false;
     });

--- a/war-core/src/main/webapp/util/javaScript/lookV5/login.js
+++ b/war-core/src/main/webapp/util/javaScript/lookV5/login.js
@@ -21,25 +21,22 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-function login()
-{
-	var loginField 	= document.authForm.Login.value;
-	if (loginField.length != 0) 
-	{
-		document.authForm.action = getContext()+"/AuthenticationServlet";
-		document.authForm.submit();
-	}
+function login() {
+  var loginField = document.authForm.Login.value;
+  if (loginField.length != 0) {
+    document.authForm.action = getContext() + "/AuthenticationServlet";
+    document.authForm.submit();
+  }
 }
 
-function logout()
-{
-	document.authForm.action = getContext()+"/LogoutServlet";
-	document.authForm.submit();
+function logout() {
+  document.authForm.action = getContext() + "/LogoutServlet";
+  document.authForm.submit();
 }
 
-function checkSubmitToLogin(ev)
-{
-	var touche = ev.keyCode;
-	if (touche == 13)
-		login();
+function checkSubmitToLogin(ev) {
+  var touche = ev.keyCode;
+  if (touche == 13) {
+    login();
+  }
 }

--- a/war-core/src/main/webapp/util/javaScript/lookV5/navigation.js
+++ b/war-core/src/main/webapp/util/javaScript/lookV5/navigation.js
@@ -36,7 +36,7 @@ var currentWallpaper = "0";
 
 var notContextualPDCDisplayed = false;
 var notContextualPDCLoaded = false;
-//User favorite space variable true/false => enable/disable
+// User favorite space variable true/false => enable/disable
 var displayUserFavoriteSpace = false;
 // When user favorite space is enabled, this following parameter enable/disable the "contains sub favorite space" state.
 var enableAllUFSStates = false;
@@ -250,7 +250,7 @@ function openComponent(componentId, componentLevel, componentURL) {
   }
   
   //Remove active class on subtree
-  $("#"+componentId).parent().find(".spaceOn").removeClass("spaceOn");
+  jQuery("#"+componentId).parent().find(".spaceOn").removeClass("spaceOn");
 
   currentAxisId = "-1";
   currentValuePath = "-1";
@@ -455,7 +455,7 @@ function getUserMenuDisplayMode() {
     if (userMenuDispMode == "BOOKMARKS" || userMenuDispMode == "ALL") {
       displayUserFavoriteSpace = true;
       // Check contains user favorite space mode
-      enableAllUFSStates = ($("#enableAllUFSpaceStatesId").val() == "true") ? true : false;
+      enableAllUFSStates = (jQuery("#enableAllUFSpaceStatesId").val() == "true") ? true : false;
     }
     return userMenuDispMode;
   }
@@ -471,26 +471,26 @@ function getUserMenuDisplayMode() {
 function openTab(tabId) {
   //alert("opentTab(" + tabId + ") call");
   // Check tab change
-  if (tabId != $("#userMenuDisplayModeId").val()) {
+  if (tabId != jQuery("#userMenuDisplayModeId").val()) {
     // Check tab change
     if (tabId == 'ALL') {
-      $("#tabsBookMarkSelectedDivId").hide();
-      $("#tabsAllSelectedDivId").show();
+      jQuery("#tabsBookMarkSelectedDivId").hide();
+      jQuery("#tabsAllSelectedDivId").show();
     } else {
-      $("#tabsAllSelectedDivId").hide();
-      $("#tabsBookMarkSelectedDivId").show();
+      jQuery("#tabsAllSelectedDivId").hide();
+      jQuery("#tabsBookMarkSelectedDivId").show();
     }
-    $("#userMenuDisplayModeId").val(tabId);
-    $("#spaceMenuDivId").mask($("#loadingMessageId").val());
+    jQuery("#userMenuDisplayModeId").val(tabId);
+    jQuery("#spaceMenuDivId").mask(jQuery("#loadingMessageId").val());
 
-    $.ajax({
+    jQuery.ajax({
       url: getContext() + '/RAjaxSilverpeasV5/dummy',
       data: {ResponseId: 'spaceUpdater',
         Init:1,
         UserMenuDisplayMode: tabId},
       success: function(data) {
-        if ($("#spaceMenuDivId").isMasked()) {
-          $("#spaceMenuDivId").unmask();
+        if (jQuery("#spaceMenuDivId").isMasked()) {
+          jQuery("#spaceMenuDivId").unmask();
         }
         //alert("Success Data Loaded: data=" + data);
         spaceUpdater = new SpaceUpdater();
@@ -503,27 +503,6 @@ function openTab(tabId) {
       },
       dataType: 'xml'
     });
-
-
-//		$.get(getContext()+'/RAjaxSilverpeasV5/dummy',
-//			{ ResponseId:'spaceUpdater',
-//			  Init:1,
-//			  UserMenuDisplayMode: tabId
-//			},
-//		   function(data){
-//			 if($("#spaceMenuDivId").isMasked()) {
-//				 $("#spaceMenuDivId").unmask();
-//			 }
-//		     alert("Data Loaded: " + data);
-//			 spaceUpdater = new SpaceUpdater();
-//			 var xmlResponse = data.childNodes[0].childNodes[0];
-//		     spaceUpdater.ajaxUpdate(xmlResponse);
-//		     spaceUpdater.displayTree(xmlResponse.childNodes[0]);
-//		     /*$(data).find('spaces').each(function(){
-//		    	 spaceUpdater.displayTree($(this));
-//				});*/
-//		   }
-//		);
   }
 }
 
@@ -534,7 +513,7 @@ function openTab(tabId) {
  * @param spaceId : the space identifier we have to change
  */
 function changeFavoriteSpace(spaceId) {
-  var curImg = $("#favoriteimg" + spaceId);
+  var curImg = jQuery("#favoriteimg" + spaceId);
   var curState = curImg.attr("title");
   if (curState == "favorite") {
     removeFavoriteSpace(spaceId);
@@ -551,18 +530,18 @@ function changeFavoriteSpace(spaceId) {
 function addFavoriteSpace(spaceId) {
   //alert("addFavoriteSpace(" + spaceId + ") call");
 
-  $.ajax({
+  jQuery.ajax({
     url: getContext() + '/RAjaxAction/userMenu',
     data: {Action: 'addSpace',
       SpaceId: spaceId},
     success: function(data) {
       //updateUserFavoriteSpaceStatus
-      $.each(data.spaceids, function(i, item) {
+      jQuery.each(data.spaceids, function(i, item) {
         enableUserFavoriteSpaceStatus(item.spaceid);
       });
       // Check if contains states is enabled to update parent space status
       if (enableAllUFSStates) {
-        $.each(data.parentids, function(i, item) {
+        jQuery.each(data.parentids, function(i, item) {
           enableUserFavoriteParentStatus(item.spaceid);
         });
       }
@@ -585,7 +564,7 @@ var messageBox = null;
 function removeFavoriteSpace(spaceId) {
   //alert("removeFavoriteSpace(" + spaceId + ") call");
 
-  $.ajax({
+  jQuery.ajax({
     url: getContext() + '/RAjaxAction/userMenu',
     data: {Action: 'removeSpace',
       SpaceId: spaceId},
@@ -608,7 +587,7 @@ function removeFavoriteSpace(spaceId) {
 }
 
 function updateUserFavoriteSpaceStatus(spaceId) {
-  var curDiv = $("#favoriteimg" + spaceId);
+  var curDiv = jQuery("#favoriteimg" + spaceId);
   var curState = curDiv.attr("title");
   if (curState == "favorite") {
     curDiv.addClass("favorite_empty");
@@ -623,7 +602,7 @@ function updateUserFavoriteSpaceStatus(spaceId) {
  * Disable user favorite space status
  */
 function disableUserFavoriteSpaceStatus(spaceId, data) {
-  var curDiv = $("#favoriteimg" + spaceId);
+  var curDiv = jQuery("#favoriteimg" + spaceId);
   if (enableAllUFSStates) {
     if (data.spacestate == "contains") {
       curDiv.attr("src", "/silverpeas/util/icons/iconlook_contains_favorites_12px.gif");
@@ -632,7 +611,7 @@ function disableUserFavoriteSpaceStatus(spaceId, data) {
       curDiv.attr("src", "/silverpeas/util/icons/iconlook_favorites_empty_12px.gif");
       curDiv.attr("title", "favorite_empty");
     }
-    $.each(data.parentids, function(i, item) {
+    jQuery.each(data.parentids, function(i, item) {
       disableParentSpaceStatus(item.spaceid, item.spacestate);
     });
   } else {
@@ -642,7 +621,7 @@ function disableUserFavoriteSpaceStatus(spaceId, data) {
 }
 
 function disableParentSpaceStatus(spaceId, spaceStatus) {
-  var curDiv = $("#favoriteimg" + spaceId);
+  var curDiv = jQuery("#favoriteimg" + spaceId);
   if (spaceStatus == "contains") {
     curDiv.attr("src", "/silverpeas/util/icons/iconlook_contains_favorites_12px.gif");
     curDiv.attr("title", "favorite_contains");
@@ -656,7 +635,7 @@ function disableParentSpaceStatus(spaceId, spaceStatus) {
 }
 
 function enableUserFavoriteSpaceStatus(spaceId) {
-  var curDiv = $("#favoriteimg" + spaceId);
+  var curDiv = jQuery("#favoriteimg" + spaceId);
 
   if (curDiv) {
     curDiv.attr("src", "/silverpeas/util/icons/iconlook_favorites_12px.gif");
@@ -665,7 +644,7 @@ function enableUserFavoriteSpaceStatus(spaceId) {
 }
 
 function enableUserFavoriteParentStatus(spaceId) {
-  var curDiv = $("#favoriteimg" + spaceId);
+  var curDiv = jQuery("#favoriteimg" + spaceId);
   if (curDiv) {
     //alert("curDiv.attr(title) = " + curDiv.attr("title"));
     if (curDiv.attr("title") == "favorite_empty") {
@@ -678,7 +657,7 @@ function enableUserFavoriteParentStatus(spaceId) {
 var spaceUpdater;
 
 //Event.observe(window, 'load', function(){
-$(document).ready(function() {
+jQuery(document).ready(function() {
 
   // Handler for .ready() called.
   currentLook = getLook();
@@ -689,29 +668,6 @@ $(document).ready(function() {
   spaceUpdater = new SpaceUpdater();
   ajaxEngine.registerRequest('getSpaceInfo', getContext() + '/RAjaxSilverpeasV5/dummy');
   ajaxEngine.registerAjaxObject('spaceUpdater', spaceUpdater);
-
-//	$.get(getContext()+'/RAjaxSilverpeasV5/dummy',
-//		{ ResponseId:'spaceUpdater',
-//		  Init:1,
-//		  GetPDC: displayPDC(),
-//		  SpaceId: getSpaceIdToInit(),
-//		  ComponentId:getComponentIdToInit(),
-//		  UserMenuDisplayMode: getUserMenuDisplayMode()
-//		},
-//	   function(data){
-//		 if($("#spaceMenuDivId").isMasked()) {
-//			 $("#spaceMenuDivId").unmask();
-//		 }
-//	     //alert("Data Loaded: " + data);
-//		 spaceUpdater = new SpaceUpdater();
-//		 var xmlResponse = data.childNodes[0].childNodes[0];
-//	     spaceUpdater.ajaxUpdate(xmlResponse);
-//	     //spaceUpdater.displayTree(xmlResponse.childNodes[0]);
-//	     /*$(data).find('spaces').each(function(){
-//	    	 spaceUpdater.displayTree($(this));
-//			});*/
-//	   }
-//	);
 
   //Check displayUserMenuDisplayMode in order to enable/disable user favorite space feature
   ajaxEngine.sendRequest('getSpaceInfo', 'ResponseId=spaceUpdater', 'Init=1',
@@ -728,7 +684,7 @@ $(document).ready(function() {
 });
 
 function displayFavoriteSpaceIcon(space, spaceId, newSpace) {
-  if (displayUserFavoriteSpace && $("#userMenuDisplayModeId").val() == "ALL") {
+  if (displayUserFavoriteSpace && jQuery("#userMenuDisplayModeId").val() == "ALL") {
     var favSpace = space.getAttribute("favspace");
     var favDiv = document.createElement("div");
     favDiv.setAttribute("id", "favdiv");
@@ -838,7 +794,7 @@ SpaceUpdater.prototype = {
     document.getElementById("spaces").innerHTML = "";
     var nbSpaces = tree.childNodes.length;
     //alert("nb spaces = "+nbSpaces);
-    for (i = 0; i < nbSpaces; i++) {
+    for (var i = 0; i < nbSpaces; i++) {
       var space = tree.childNodes[i];
 
       //create new entry
@@ -884,8 +840,8 @@ SpaceUpdater.prototype = {
       }
     }
     // Add alert message if user is in display favorite space mode without favorite space selected.
-    if (displayUserFavoriteSpace && $("#userMenuDisplayModeId").val() == "BOOKMARKS" && nbSpaces == 0) {
-      $('#spaces').html("<span class='noFavoriteSpace'>" + $('#noFavoriteSpaceMsgId').val() + "</span> ");
+    if (displayUserFavoriteSpace && jQuery("#userMenuDisplayModeId").val() == "BOOKMARKS" && nbSpaces == 0) {
+      jQuery('#spaces').html("<span class='noFavoriteSpace'>" + jQuery('#noFavoriteSpaceMsgId').val() + "</span> ");
     }
 
     try {
@@ -954,7 +910,7 @@ SpaceUpdater.prototype = {
       spaceHeader.setAttribute("class", "spaceLevel1On");
       spaceHeader.setAttribute("className", "spaceLevel1On");
     } else {
-      $('#' + currentSpaceId).addClass("spaceOn");
+      jQuery('#' + currentSpaceId).addClass("spaceOn");
     }
 
     if (init == "true") {
@@ -982,16 +938,6 @@ SpaceUpdater.prototype = {
     spaceContentDiv.setAttribute("className", "contentSpace");
 
     document.getElementById(currentSpaceId).appendChild(spaceContentDiv);
-
-    /*if (currentSpaceLevel == 0)
-     {
-     if (document.getElementById("pdc") == null)
-     {
-     var pdcDiv = document.createElement("div");
-     pdcDiv.setAttribute("id", "pdc");
-     document.getElementById(currentSpaceId).appendChild(pdcDiv);
-     }
-     }*/
 
     var item = spaceContent.firstChild;
 
@@ -1179,11 +1125,6 @@ SpaceUpdater.prototype = {
       var axisLabel = document.createTextNode(axis.getAttribute("name") + " (" + nbObj + ")");
       axisURL.appendChild(axisLabel);
 
-      //var axisClass = document.createElement("span");
-      //axisClass.setAttribute("class", "browseAxis");
-      //axisClass.setAttribute("className", "browseAxis");
-      //axisClass.appendChild(axisURL);
-
       var newAxis = document.createElement("div");
       newAxis.setAttribute("id", "axis" + axisId);
       newAxis.appendChild(iconURL);
@@ -1238,11 +1179,6 @@ SpaceUpdater.prototype = {
       var valueLabel = document.createTextNode(value.getAttribute("name") + " (" + nbObj + ")");
       valueURL.appendChild(valueLabel);
 
-      //var valueClass = document.createElement("span");
-      //valueClass.setAttribute("class", "browseValue");
-      //valueClass.setAttribute("className", "browseValue");
-      //valueClass.appendChild(valueURL);
-
       var newValue = document.createElement("div");
       newValue.setAttribute("id", "value" + valuePath);
 
@@ -1273,7 +1209,6 @@ SpaceUpdater.prototype = {
             //alert("ancetre = "+ancetre);
 
             var iconIndent = document.createElement("img");
-            //iconIndent.setAttribute("src", "<%=m_sContext%>/util/icons/minusTreeI.gif");
             iconIndent.setAttribute("align", "absmiddle");
             iconIndent.setAttribute("border", "0");
             iconIndent.setAttribute("width", "15");
@@ -1297,7 +1232,6 @@ SpaceUpdater.prototype = {
 
       newValue.appendChild(iconT);
       newValue.appendChild(iconURL);
-      //newValue.appendChild(valueClass);
       newValue.appendChild(valueURL);
 
       var newValueContent = document.createElement("div");

--- a/war-core/src/main/webapp/util/javaScript/lookV5/personalSpace.js
+++ b/war-core/src/main/webapp/util/javaScript/lookV5/personalSpace.js
@@ -21,85 +21,73 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-function listComponents()
-{
-	$.getJSON(getContext()+"/PersonalSpace?Action=GetAvailableComponents&IEFix="+new Date().getTime(),
-			function(data){
-				try
-				{
-					var components = "";
-					for (var i = 0; i < data.length; ++i) {
-		                var component = data[i];
-		                components += getComponentEntry(component.name, component.description, component.label);
-					}
-					var labels = getPersonalSpaceLabels();
-					$("#addComponent").html(labels[0]);
-					$("#addComponent").append("<ul id=\"availables\"></ul>");
-					$("#availables").html(components);
-				} catch (e) {
-					//do nothing
-					//alert(e);
-				}
-			});
+function listComponents() {
+  jQuery.getJSON(getContext() + "/PersonalSpace?Action=GetAvailableComponents&IEFix=" +
+      new Date().getTime(), function(data) {
+        try {
+          var components = "";
+          for (var i = 0; i < data.length; ++i) {
+            var component = data[i];
+            components += getComponentEntry(component.name, component.description, component.label);
+          }
+          var labels = getPersonalSpaceLabels();
+          jQuery("#addComponent").html(labels[0]);
+          jQuery("#addComponent").append("<ul id=\"availables\"></ul>");
+          jQuery("#availables").html(components);
+        } catch (e) {
+          //do nothing
+          //alert(e);
+        }
+      });
 }
 
-function addComponent(name)
-{
-	$.getJSON(getContext()+"/PersonalSpace?Action=AddComponent&ComponentName="+name+"&IEFix="+new Date().getTime(),
-			function(data){
-				if (data.successfull == true)
-				{
-					$("#"+data.name).remove();
-					var newEntry = getPersonalSpaceElement(data.id, 1, "personalComponent", "component", false, data.url, data.label);
-					$(newEntry).insertBefore('#addComponent');
-					if ($("#availables li").size() == 0)
-					{
-						$("#addComponent").remove();
-					}
-				}
-				else
-				{
-					alert(data.exception);
-				}
-			});
+function addComponent(name) {
+  jQuery.getJSON(getContext() + "/PersonalSpace?Action=AddComponent&ComponentName=" + name + "&IEFix=" +
+      new Date().getTime(), function(data) {
+        if (data.successfull == true) {
+          jQuery("#" + data.name).remove();
+          var newEntry = getPersonalSpaceElement(data.id, 1, "personalComponent", "component",
+              false, data.url, data.label);
+          jQuery(newEntry).insertBefore('#addComponent');
+          if (jQuery("#availables li").size() == 0) {
+            jQuery("#addComponent").remove();
+          }
+        } else {
+          alert(data.exception);
+        }
+      });
 }
 
-function removeComponent(id)
-{
-	var labels = getPersonalSpaceLabels();
-    if (window.confirm(labels[1]))
-    {
-    	$.getJSON(getContext()+"/PersonalSpace?Action=RemoveComponent&ComponentId="+id+"&IEFix="+new Date().getTime(),
-				function(data){
-					if (data.successfull == true)
-					{
-						var componentId = data.id;
-						$("#"+componentId).remove();
-						
-						if ($("#addComponent").length == 0)
-						{
-							//Le lien "Ajouter un composant..." n'existe pas, on le crée
-							var labels = getPersonalSpaceLabels();
-							var newEntry = getPersonalSpaceElement("addComponent", 1, "", "component", false, "javascript:listComponents()", labels[2]);
-							$("#contentSpacespacePerso").append(newEntry);
-						}
-						if ($("#availables").length != 0)
-						{
-							//Le lien "Ajouter un composant..." existe, on remet le composant supprimé dedans
-							var liElem = getComponentEntry(data.name, data.description, data.label);
-			                
-							$("#availables").append(liElem);
-						}
-					}
-					else
-					{
-						alert(data.exception);
-					}
-				});
-    }
+function removeComponent(id) {
+  var labels = getPersonalSpaceLabels();
+  if (window.confirm(labels[1])) {
+    jQuery.getJSON(getContext() + "/PersonalSpace?Action=RemoveComponent&ComponentId=" + id + "&IEFix=" +
+        new Date().getTime(), function(data) {
+          if (data.successfull == true) {
+            var componentId = data.id;
+            jQuery("#" + componentId).remove();
+
+            if (jQuery("#addComponent").length == 0) {
+              //Le lien "Ajouter un composant..." n'existe pas, on le crée
+              var labels = getPersonalSpaceLabels();
+              var newEntry = getPersonalSpaceElement("addComponent", 1, "", "component", false,
+                  "javascript:listComponents()", labels[2]);
+              jQuery("#contentSpacespacePerso").append(newEntry);
+            }
+            if (jQuery("#availables").length != 0) {
+              //Le lien "Ajouter un composant..." existe, on remet le composant supprimé dedans
+              var liElem = getComponentEntry(data.name, data.description, data.label);
+
+              jQuery("#availables").append(liElem);
+            }
+          } else {
+            alert(data.exception);
+          }
+        });
+  }
 }
 
-function getComponentEntry(name, description, label)
-{
-	return "<li id=\""+name+"\"><a href=\"javascript:addComponent('"+name+"')\" title=\""+description+"\">"+label+"</a></li>";
+function getComponentEntry(name, description, label) {
+  return "<li id=\"" + name + "\"><a href=\"javascript:addComponent('" + name + "')\" title=\"" +
+      description + "\">" + label + "</a></li>";
 }

--- a/war-core/src/main/webapp/util/javaScript/silverpeas-invitme.js
+++ b/war-core/src/main/webapp/util/javaScript/silverpeas-invitme.js
@@ -141,16 +141,21 @@
   }
 })( jQuery );
 
-$(function() {
-  $('.invitation').each(function(i, element) {
-    var userParams = $(element).attr('rel');
+/**
+ * Using "jQuery" instead of "$" at this level prevents of getting conficts with another
+ * javascript plugin.
+ */
+jQuery(document).ready(function() {
+  jQuery('.invitation').each(function(i, element) {
+    var userParams = jQuery(element).attr('rel');
     if (userParams != null && userParams.length > 1) {
       userParams = userParams.split(',');
-      if ($(element).data('invitMe') == null)
-        $(element).invitMe({
-          id: userParams[0],
-          fullName: userParams[1]
+      if (jQuery(element).data('invitMe') == null) {
+        jQuery(element).invitMe({
+          id : userParams[0],
+          fullName : userParams[1]
         });
+      }
     }
-  });
+  })
 });

--- a/war-core/src/main/webapp/util/javaScript/silverpeas-messageme.js
+++ b/war-core/src/main/webapp/util/javaScript/silverpeas-messageme.js
@@ -163,16 +163,21 @@
   }
 })( jQuery );
 
-$(function() {
-  $('.notification').each(function(i, element) {
-    var userParams = $(element).attr('rel');
+/**
+ * Using "jQuery" instead of "$" at this level prevents of getting conficts with another
+ * javascript plugin.
+ */
+jQuery(document).ready(function() {
+  jQuery('.notification').each(function(i, element) {
+    var userParams = jQuery(element).attr('rel');
     if (userParams != null && userParams.length > 1) {
       userParams = userParams.split(',');
-      if ($(element).data('messageMe') == null)
-        $(element).messageMe({
-          id: userParams[0],
-          fullName: userParams[1]
+      if (jQuery(element).data('messageMe') == null) {
+        jQuery(element).messageMe({
+          id : userParams[0],
+          fullName : userParams[1]
         });
+      }
     }
-  });
+  })
 });

--- a/war-core/src/main/webapp/util/javaScript/silverpeas-profile.js
+++ b/war-core/src/main/webapp/util/javaScript/silverpeas-profile.js
@@ -587,7 +587,10 @@ function UserProfileManagement(params) {
         loaded(self.users);
       },
       error: function (jqXHR, textStatus, errorThrown) {
-        alert(errorThrown);
+        window.console &&
+        window.console.log(('Silverpeas Profile JQuery Plugin - UserProfileManagement - ERROR - ' +
+            (errorThrown && errorThrown.length > 0 ? errorThrown :
+                'Unknown error, could be reload of javascript while an ajax request is being ...')));
       }
     });
     return self;
@@ -751,7 +754,10 @@ function UserGroupManagement(params) {
         loaded(self.groups);
       },
       error: function (jqXHR, textStatus, errorThrown) {
-        alert(errorThrown);
+        window.console &&
+        window.console.log(('Silverpeas Profile JQuery Plugin - UserGroupManagement - ERROR - ' + (
+            errorThrown && errorThrown.length > 0 ? errorThrown :
+                'Unknown error, could be reload of javascript while an ajax request is being ...')));
       }
     });
     return self;

--- a/war-core/src/main/webapp/util/javaScript/silverpeas-userZoom.js
+++ b/war-core/src/main/webapp/util/javaScript/silverpeas-userZoom.js
@@ -269,12 +269,18 @@
   
 })( jQuery );
 
-$(function() {
-  $('.userToZoom').each(function() {
-    var $this = $(this);
-    if ($this.data('userZoom') == null)
+
+/**
+ * Using "jQuery" instead of "$" at this level prevents of getting conficts with another
+ * javascript plugin.
+ */
+jQuery(document).ready(function() {
+  jQuery('.userToZoom').each(function() {
+    var $this = jQuery(this);
+    if ($this.data('userZoom') == null) {
       $this.userZoom({
-        id: $this.attr('rel')
+        id : $this.attr('rel')
       });
-  });
+    }
+  })
 });


### PR DESCRIPTION
- preventing from getting conflicts between jQuery plugin and another javascript plugin
- removing some dead code
- removing calls of javascript plugins that don't exist

The reason of getting JavaScript message alerts, the ones that are now removed, still exists. But instead of displaying the error with JavaScript message alert, the error is logged into the log console of the Web browser.
The origin of the error is very hard to explain because of frameset use (that is sometimes inducing, but not always, some frame reloading) and because of several ajax requests performed when arriving to Silverpeas's homepage from login page.
