### PR TITLE
bug #4245 : Timezone isn't correctly processed in Google Calendar when importing by URL an Almanch ICS

### DIFF
--- a/lib-core/src/main/java/com/silverpeas/export/ical/ical4j/ICal4JDateCodec.java
+++ b/lib-core/src/main/java/com/silverpeas/export/ical/ical4j/ICal4JDateCodec.java
@@ -28,6 +28,9 @@ import com.silverpeas.export.EncodingException;
 import com.silverpeas.calendar.Datable;
 import com.silverpeas.calendar.DateTime;
 import java.text.ParseException;
+import net.fortuna.ical4j.model.TimeZone;
+import net.fortuna.ical4j.model.TimeZoneRegistry;
+import net.fortuna.ical4j.model.TimeZoneRegistryFactory;
 
 /**
  * A decoder/encoder of iCal4J dates with Silverpeas dates.
@@ -88,6 +91,7 @@ public class ICal4JDateCodec {
           iCal4JDate = new net.fortuna.ical4j.model.DateTime(aDate.toICalInUTC());
         } else {
           iCal4JDate = new net.fortuna.ical4j.model.DateTime(aDate.toICal());
+          ((net.fortuna.ical4j.model.DateTime)iCal4JDate).setTimeZone(getTimeZone(aDate));
         }
       } else if (aDate instanceof com.silverpeas.calendar.Date) {
         iCal4JDate = new net.fortuna.ical4j.model.Date(aDate.toICal());
@@ -96,5 +100,10 @@ public class ICal4JDateCodec {
       throw new EncodingException(ex.getMessage(), ex);
     }
     return iCal4JDate;
+  }
+
+  private TimeZone getTimeZone(final Datable<?> date) {
+    TimeZoneRegistry registry = TimeZoneRegistryFactory.getInstance().createRegistry();
+    return registry.getTimeZone(date.getTimeZone().getID());
   }
 }

--- a/lib-core/src/main/java/com/silverpeas/export/ical/ical4j/ICal4JICalCodec.java
+++ b/lib-core/src/main/java/com/silverpeas/export/ical/ical4j/ICal4JICalCodec.java
@@ -63,6 +63,7 @@ import net.fortuna.ical4j.util.UidGenerator;
 import static com.silverpeas.export.ical.ical4j.ICal4JDateCodec.*;
 import static com.silverpeas.export.ical.ical4j.ICal4JRecurrenceCodec.*;
 import net.fortuna.ical4j.model.*;
+import net.fortuna.ical4j.model.parameter.Value;
 import net.fortuna.ical4j.model.property.ExDate;
 
 /**
@@ -80,7 +81,7 @@ public class ICal4JICalCodec implements ICalCodec {
     StringWriter output = new StringWriter();
 
     Calendar calendarIcs = new Calendar();
-    calendarIcs.getProperties().add(new ProdId("-//Silverpeas//iCal4j 1.0//FR"));
+    calendarIcs.getProperties().add(new ProdId("-//Silverpeas//iCal4j 1.1//FR"));
     calendarIcs.getProperties().add(Version.VERSION_2_0);
     calendarIcs.getProperties().add(CalScale.GREGORIAN);
     List<VEvent> iCalEvents = new ArrayList<VEvent>();
@@ -93,7 +94,6 @@ public class ICal4JICalCodec implements ICalCodec {
       } else {
         iCalEvent = new VEvent(startDate, endDate, event.getTitle());
       }
-      iCalEvent.getProperties().add(asTzId(event.getStartDate().getTimeZone()));
 
       // Generate UID
       try {

--- a/lib-core/src/test/java/com/silverpeas/export/ical/CalendarEventMatcher.java
+++ b/lib-core/src/test/java/com/silverpeas/export/ical/CalendarEventMatcher.java
@@ -81,11 +81,11 @@ public class CalendarEventMatcher extends TypeSafeMatcher<String> {
       failureMessage.append("DTEND").append(asIcalDate(expectedEvent.getEndDate()));
       return false;
     }
-    String timeZone = expectedEvent.getStartDate().getTimeZone().getID();
-    if (!actualICalContent.contains("TZID:" + timeZone + "\r\n")) {
-      failureMessage.append("TZID:").append(timeZone);
-      return false;
-    }
+//    String timeZone = expectedEvent.getStartDate().getTimeZone().getID();
+//    if (!actualICalContent.contains("TZID:" + timeZone + "\r\n")) {
+//      failureMessage.append("TZID:").append(timeZone);
+//      return false;
+//    }
     if (!actualICalContent.contains(asIcalCategories(expectedEvent.getCategories()))) {
       failureMessage.append(asIcalCategories(expectedEvent.getCategories()));
       return false;
@@ -199,7 +199,7 @@ public class CalendarEventMatcher extends TypeSafeMatcher<String> {
     if (aDate instanceof Date) {
       icalDate = ";VALUE=DATE:";
     } else {
-      icalDate = ":";
+      icalDate = ";TZID=" + aDate.getTimeZone().getID() + ":";
     }
     icalDate += aDate.toICal();
     return icalDate;


### PR DESCRIPTION
Now the timezone TZID in ical is directly set with the start and end dates of the events, so that it can be processed correctly by the ics parser of Google when a calendar is added by URL in Google Calendar
