### PR TITLE
Feature 4011

### DIFF
--- a/lib-core/src/main/java/org/silverpeas/util/mail/EMLExtractor.java
+++ b/lib-core/src/main/java/org/silverpeas/util/mail/EMLExtractor.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.List;
 import java.util.Properties;
 
@@ -47,8 +48,10 @@ import com.silverpeas.util.EncodeHelper;
 import com.silverpeas.util.MimeTypes;
 import com.silverpeas.util.StringUtil;
 
+import com.stratelia.webactiv.util.FileRepositoryManager;
 import com.stratelia.webactiv.util.exception.SilverpeasException;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.text.translate.CharSequenceTranslator;
 import org.apache.commons.lang3.text.translate.EntityArrays;
@@ -158,7 +161,13 @@ public class EMLExtractor implements MailExtractor {
         String fileName = getFileName(part);
         if (fileName != null) {
           MailAttachment attachment = new MailAttachment(fileName);
-          attachment.setFile(part.getInputStream());
+          String dir =
+            FileRepositoryManager.getTemporaryPath() + "mail" +
+                Calendar.getInstance().getTimeInMillis();
+          File file = new File(dir, fileName);
+          FileUtils.writeByteArrayToFile(file, IOUtils.toByteArray(part.getInputStream()));
+          attachment.setPath(file.getAbsolutePath());
+          attachment.setSize(file.length());
           attachments.add(attachment);
         }
       }

--- a/lib-core/src/main/java/org/silverpeas/util/mail/MSGExtractor.java
+++ b/lib-core/src/main/java/org/silverpeas/util/mail/MSGExtractor.java
@@ -37,6 +37,7 @@ import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
@@ -44,6 +45,7 @@ import java.util.Locale;
 import javax.mail.Address;
 import javax.mail.internet.InternetAddress;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.poi.hsmf.MAPIMessage;
 import org.apache.poi.hsmf.datatypes.AttachmentChunks;
@@ -54,6 +56,7 @@ import org.apache.poi.hsmf.exceptions.ChunkNotFoundException;
 import com.silverpeas.converter.DocumentFormatConverterFactory;
 import com.silverpeas.util.EncodeHelper;
 import com.stratelia.silverpeas.silvertrace.SilverTrace;
+import com.stratelia.webactiv.util.FileRepositoryManager;
 import com.stratelia.webactiv.util.exception.SilverpeasException;
 
 public class MSGExtractor implements MailExtractor {
@@ -195,10 +198,13 @@ public class MSGExtractor implements MailExtractor {
     AttachmentChunks[] attachmentChunks = message.getAttachmentFiles();
     for (AttachmentChunks attachment : attachmentChunks) {
       byte[] data = attachment.attachData.getValue();
-      
-      MailAttachment mailAttachment = new MailAttachment(attachment.attachLongFileName.getValue());
-      mailAttachment.setFile(new ByteArrayInputStream(data));
-      
+      String fileName = attachment.attachLongFileName.getValue();
+      MailAttachment mailAttachment = new MailAttachment(fileName);
+      String dir = FileRepositoryManager.getTemporaryPath() + "mail" + Calendar.getInstance().getTimeInMillis();
+      File file = new File(dir, fileName);
+      FileUtils.writeByteArrayToFile(file, data);
+      mailAttachment.setPath(file.getAbsolutePath());
+      mailAttachment.setSize(file.length());
       mailAttachments.add(mailAttachment);
     }
     return mailAttachments;

--- a/lib-core/src/main/java/org/silverpeas/util/mail/MailAttachment.java
+++ b/lib-core/src/main/java/org/silverpeas/util/mail/MailAttachment.java
@@ -23,28 +23,38 @@
  */
 package org.silverpeas.util.mail;
 
-import java.io.InputStream;
-
 public class MailAttachment {
-  
+
   private String name;
-  private InputStream file;
-  
+  private String path;
+  private long size;
+
   public MailAttachment(String name) {
     setName(name);
   }
-  
+
   public String getName() {
     return name;
   }
+
   public void setName(String name) {
     this.name = name;
   }
-  public InputStream getFile() {
-    return file;
+
+  public String getPath() {
+    return path;
   }
-  public void setFile(InputStream file) {
-    this.file = file;
+
+  public void setPath(String path) {
+    this.path = path;
+  }
+
+  public void setSize(long size) {
+    this.size = size;
+  }
+
+  public long getSize() {
+    return size;
   }
 
 }

--- a/lib-core/src/test/java/org/silverpeas/util/mail/MailExtractorTest.java
+++ b/lib-core/src/test/java/org/silverpeas/util/mail/MailExtractorTest.java
@@ -161,15 +161,9 @@ public class MailExtractorTest {
 
     MailAttachment attachment = attachments.get(0);
     assertThat(attachment.getName(), is("Liste des applications-V1.0.pdf"));
-    File file1 = new File(dir + "temp" + PathTestUtil.SEPARATOR + attachment.getName());
-    FileUtils.copyInputStreamToFile(attachment.getFile(), file1);
-    assertThat(attachment.getName(), is(file1.getName()));
-    assertThat(file1.length(), is(149463L));
-    IOUtils.closeQuietly(attachment.getFile());
-    FileUtils.deleteQuietly(file1);
-
+    assertThat(attachment.getSize(), is(149463L));
+    
     attachment = attachments.get(1);
     assertThat(attachment.getName(), is("Silverpeas-SearchEngine.odt"));
-    IOUtils.closeQuietly(attachment.getFile());
   }
 }


### PR DESCRIPTION
Enable drag and drop of EML and MSG files.
Content is extracted and used to generate header and content of the publication.
Each file attached to e-mail is also extracted and attached to publication
