### PR TITLE
fixing bug 4381

### DIFF
--- a/lib-core/src/main/java/com/stratelia/webactiv/beans/admin/Admin.java
+++ b/lib-core/src/main/java/com/stratelia/webactiv/beans/admin/Admin.java
@@ -4865,7 +4865,7 @@ public final class Admin {
       // check TreeCache to know if component is not removed neither into a removed space
       List<String> shortIds = new ArrayList<String>();
       for (String componentId : matchingComponentIds) {
-        ComponentInstLight component = TreeCache.getComponent(componentId);
+        ComponentInstLight component = TreeCache.getComponent(sComponentName+componentId);
         if (component != null) {
           shortIds.add(componentId);
         }


### PR DESCRIPTION
method getCompoId(componentName) has been fixed to return only available components (ie not a removed one or placed in a removed space)
