### PR TITLE
blowfish #crypto :  The blowfish encryption/decryption of the password for a web connection with an external site failed

### DIFF
--- a/lib-core/src/main/java/org/silverpeas/util/crypto/BlowfishKey.java
+++ b/lib-core/src/main/java/org/silverpeas/util/crypto/BlowfishKey.java
@@ -1,27 +1,23 @@
 /**
  * Copyright (C) 2000 - 2012 Silverpeas
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
  *
- * As a special exception to the terms and conditions of version 3.0 of
- * the GPL, you may redistribute this Program in connection with Free/Libre
- * Open Source Software ("FLOSS") applications as described in Silverpeas's
- * FLOSS exception.  You should have received a copy of the text describing
- * the FLOSS exception, and it is also available here:
+ * As a special exception to the terms and conditions of version 3.0 of the GPL, you may
+ * redistribute this Program in connection with Free/Libre Open Source Software ("FLOSS")
+ * applications as described in Silverpeas's FLOSS exception. You should have received a copy of the
+ * text describing the FLOSS exception, and it is also available here:
  * "http://www.silverpeas.org/docs/core/legal/floss_exception.html"
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Affero General Public License for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU Affero General Public License along with this program.
+ * If not, see <http://www.gnu.org/licenses/>.
  */
-
 package org.silverpeas.util.crypto;
 
 import java.io.UnsupportedEncodingException;
@@ -29,8 +25,8 @@ import java.security.Key;
 import javax.crypto.spec.SecretKeySpec;
 
 /**
- * A representation of a symmetric key used in the Blowfish cipher.
- * It is a wrapper of the actual key it generates from a plain text representation of the key.
+ * A representation of a symmetric key used in the Blowfish cipher. It is a wrapper of the actual
+ * key it generates from a plain text representation of the key.
  */
 public class BlowfishKey implements Key {
 
@@ -50,6 +46,7 @@ public class BlowfishKey implements Key {
 
   /**
    * Constructs a new symmetric key for the Blowfish cypher from the specified key code in text.
+   *
    * @param keyCode the code of the key.
    */
   public BlowfishKey(String keyCode) {
@@ -60,17 +57,18 @@ public class BlowfishKey implements Key {
   }
 
   /**
-    * Constructs a new symmetric key for the Blowfish cypher from the specified binary key code.
-    * @param keyCode the code of the key.
-    */
-   public BlowfishKey(byte[] keyCode) {
-     if (key == null) {
-       byte[] keybyte = getKeyBytes("ƒþX]Lh/‘");
-       key = new SecretKeySpec(keybyte, CryptographicAlgorithmName.Blowfish.name());
-     }
-   }
+   * Constructs a new symmetric key for the Blowfish cypher from the specified binary key code.
+   *
+   * @param keyCode the code of the key.
+   */
+  public BlowfishKey(byte[] keyCode) {
+    if (key == null) {
+      byte[] keybyte = getKeyBytes("ƒþX]Lh/‘");
+      key = new SecretKeySpec(keybyte, CryptographicAlgorithmName.Blowfish.name());
+    }
+  }
 
-  private final byte[] getKeyBytes(String keyCode) {
+  private byte[] getKeyBytes(String keyCode) {
     byte[] keybyte;
     try {
       keybyte = "ƒþX]Lh/‘".getBytes("ISO-8859-1");
@@ -87,7 +85,7 @@ public class BlowfishKey implements Key {
 
   @Override
   public String getFormat() {
-    return this.getFormat();
+    return this.key.getFormat();
   }
 
   @Override

--- a/lib-core/src/test/java/org/silverpeas/util/crypto/BlowfishCipherTest.java
+++ b/lib-core/src/test/java/org/silverpeas/util/crypto/BlowfishCipherTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2000-2013 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Writer Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have recieved a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "http://www.silverpeas.org/legal/licensing"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.silverpeas.util.crypto;
+
+import javax.crypto.KeyGenerator;
+import javax.crypto.SecretKey;
+import org.junit.Before;
+import org.junit.Test;
+import org.silverpeas.util.Charsets;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Unit tests on the Blowfish cipher as implemented in Silverpeas.
+ */
+public class BlowfishCipherTest {
+
+  private static final String KNOWN_PLAIN_TEXT = "Il était une fois un joli petit pois tout argenté";
+  private Cipher blowfish;
+  private CipherKey key;
+
+  public BlowfishCipherTest() {
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    blowfish = initBlowhfishCipher();
+    key = initCipherKey();
+  }
+
+  @Test
+  public void testGetAlgorithmName() throws Exception {
+    assertThat(blowfish.getAlgorithmName(), is(CryptographicAlgorithmName.Blowfish));
+  }
+
+  @Test
+  public void testEncrypt() throws Exception {
+    byte[] encryptedText = blowfish.encrypt(KNOWN_PLAIN_TEXT, key);
+    byte[] expectedEncryptedText = encryptTextWithKey(KNOWN_PLAIN_TEXT, key.getRawKey());
+    assertThat(encryptedText, is(expectedEncryptedText));
+  }
+
+  @Test
+  public void testDecrypt() throws Exception {
+    byte[] expectedEncryptedText = encryptTextWithKey(KNOWN_PLAIN_TEXT, key.getRawKey());
+    String decryptedText = blowfish.decrypt(expectedEncryptedText, key);
+    assertThat(decryptedText, is(KNOWN_PLAIN_TEXT));
+  }
+
+  private Cipher initBlowhfishCipher() {
+    CipherFactory cipherFactory = CipherFactory.getFactory();
+    Cipher cipher = cipherFactory.getCipher(CryptographicAlgorithmName.Blowfish);
+    assertNotNull(cipher);
+    return cipher;
+  }
+
+  private CipherKey initCipherKey() throws Exception {
+    KeyGenerator keyGenerator = KeyGenerator.getInstance("Blowfish");
+    SecretKey secretKey = keyGenerator.generateKey();
+    return CipherKey.aKeyFromBinary(secretKey.getEncoded());
+  }
+
+  private byte[] encryptTextWithKey(String text, byte[] encodedKey)
+      throws Exception {
+    javax.crypto.Cipher cipher = javax.crypto.Cipher.getInstance("Blowfish");
+    BlowfishKey blowfishKey = new BlowfishKey(encodedKey);
+    cipher.init(javax.crypto.Cipher.ENCRYPT_MODE, blowfishKey);
+    return cipher.doFinal(text.getBytes(Charsets.UTF_8));
+  }
+}


### PR DESCRIPTION
Fix an endless recursive method call that has caused blowfish encryption and decryption failure
