### PR TITLE
fixing bug #4738

### DIFF
--- a/lib-core/src/main/java/com/silverpeas/form/record/GenericRecordSetManager.java
+++ b/lib-core/src/main/java/com/silverpeas/form/record/GenericRecordSetManager.java
@@ -528,7 +528,9 @@ public class GenericRecordSetManager {
         
         int nbRowsUpdated = update.executeUpdate();
         if (nbRowsUpdated != 1) {
-          // do something ?
+          SilverTrace.error("form", this.getClass().getName() + ".updateFieldRows()",
+              "root.MSG_GEN_PARAM_VALUE", "Update failed for record " + row.getRecordId() +
+                  " and field '" + row.getFieldName() + "' with value " + row.getFieldValue());
         }
       }
     } finally {


### PR DESCRIPTION
When fieldnames start with S or P, fieldname was truncated !
using StringUtils.splitByWholeSeparator instead of StringUtils.split.
adding several traces to simplifying debug
