### PR TITLE
Bug 4793

### DIFF
--- a/config-core/src/main/config/properties/org/silverpeas/general.properties
+++ b/config-core/src/main/config/properties/org/silverpeas/general.properties
@@ -41,7 +41,13 @@ securityPath = @SecurityDir@
 sessionTimeout = /admin/jsp/SessionTimeout.jsp
 accessForbidden = /admin/jsp/accessForbidden.jsp
 redirectAppInMaintenance = /admin/jsp/appInMaintenance.jsp
+
+# If Silverpeas is directly accessed through a secure channel, don't forget to set here the secure
+# port behind which Silverpeas is listening.
 server.http.port=
+# Whether Silverpeas is access through a secure channel like HTTPS, set this parameter to true.
+# This parameter must be set to true if Silverpeas is after a reverse-proxy that handles the HTTPS
+# connections for Silverpeas.
 server.ssl=false
 
 RepositoryTypeTemp = Temp

--- a/web-core/src/main/java/com/silverpeas/authentication/SilverpeasSessionOpener.java
+++ b/web-core/src/main/java/com/silverpeas/authentication/SilverpeasSessionOpener.java
@@ -275,9 +275,21 @@ public class SilverpeasSessionOpener {
     return absoluteUrl.toString();
   }
 
+  /**
+   * The navigation is secure when silverpeas is either directly accessed through a secure chanel
+   * like HTTPS or after a reverse-proxy handling secure connections for Silverpeas.
+   *
+   * From the specified request, we can detect if Silverpeas is accessed directly through a secure
+   * channel like HTTPS, therefore the channel is then considered as secure. then if the navigation
+   * is secure. Whether Silverpeas is after a reverse-proxy that handles HTTPS connections, it is
+   * then required to inform Silverpeas about it by setting the parameter server.ssl to true in
+   * <code>org/silverpeas/general.properties</code>.
+   *
+   * @param request the HTTP/HTTPS request
+   * @return true the Web navigation with Silverpeas is secured.
+   */
   public boolean isNavigationSecure(HttpServletRequest request) {
-    return !(request.isSecure() && !GeneralPropertiesManager.getBoolean("server.ssl", false))
-        && request.isSecure();
+    return (request.isSecure() || GeneralPropertiesManager.getBoolean("server.ssl", false));
   }
 
   private int getServerPort(HttpServletRequest request) {


### PR DESCRIPTION
Before 5.12, il was possible to place a reverse-proxy before Silverpeas to open a secure channel: 
client <-- HTTPS --> reverse-proxy <-- HTTP --> Silverpeas
With the first releases of 5.12, this feature was no more possible: the secure channel has had to be continued up silverpeas itself : <-- HTTPS --> reverse-proxy <-- HTTPS --> Silverpeas
This PR fixes this situation by restoring the previous behaviour. Now, when Silverpeas is after a reverse-proxy that handles HTTPS connections, the parameter server.ssl in org/silverpeas/general.properties has to be set to true.
