### PR TITLE
Fixing of an authentication security problem ...

### DIFF
--- a/web-core/src/main/java/com/silverpeas/authentication/AuthenticationServlet.java
+++ b/web-core/src/main/java/com/silverpeas/authentication/AuthenticationServlet.java
@@ -141,7 +141,10 @@ public class AuthenticationServlet extends HttpServlet {
       }
 
       String absoluteUrl = silverpeasSessionOpener.openSession(request, authenticationKey);
-      writeSessionCookie(response, session, securedAccess);
+      // The session must again be recovered from the HTTP request because of opening a session
+      // that could to induce the creation of a new HttpSession instance that is setted to the
+      // request
+      writeSessionCookie(response, request.getSession(), securedAccess);
       response.sendRedirect(response.encodeRedirectURL(absoluteUrl));
       return;
     }

--- a/web-core/src/main/java/com/silverpeas/authentication/SilverpeasSessionOpener.java
+++ b/web-core/src/main/java/com/silverpeas/authentication/SilverpeasSessionOpener.java
@@ -98,6 +98,9 @@ public class SilverpeasSessionOpener {
    * occurred during the session opening (for example, the user wasn't authenticated).
    */
   public String openSession(HttpServletRequest request, String authKey) {
+    // Before opening a Silverpeas session, clearing all old session potential residues
+    closeSession(request);
+    // Opening a new session (new JSESSIONID)
     HttpSession session = request.getSession();
     try {
       // Get the user profile from the admin


### PR DESCRIPTION
Fixing of an authentication security problem that could in some case permit a user to usurp identity of an other user. This is almost an utopia case, but it is possible.
This problem can also make thinking the users on the fact that Silverpeas would not be a serious application.

To obtain the authentication mistake :
. logon successfully with an administrator
. after that, fill the URL address of the Web navigator : http(s)://[server host][: server port]/silverpeas/ (not click on disconnect)
. you are now on the login page. Now, logon with an other user that is not an administrator
. do you see what i saw ?
