### PR TITLE
Fixing bug #4388

### DIFF
--- a/lib-core/src/main/java/com/stratelia/webactiv/organization/UserTable.java
+++ b/lib-core/src/main/java/com/stratelia/webactiv/organization/UserTable.java
@@ -20,7 +20,6 @@
  */
 package com.stratelia.webactiv.organization;
 
-import com.stratelia.silverpeas.domains.ldapdriver.LDAPUtility;
 import com.stratelia.silverpeas.silverpeasinitialize.CallBackManager;
 import com.stratelia.webactiv.beans.admin.SynchroReport;
 import com.stratelia.webactiv.beans.admin.UserDetail;
@@ -156,13 +155,12 @@ public class UserTable extends Table<UserRow> {
     }
 
     StringBuilder clauseIN = new StringBuilder("(");
-    String specificId;
     for (int s = 0; s < specificIds.size(); s++) {
       if (s != 0) {
         clauseIN.append(", ");
       }
-      specificId = specificIds.get(s);
-      clauseIN.append("'").append(LDAPUtility.dblBackSlashesForDNInFilters(specificId)).append("'");
+      String specificId = specificIds.get(s);
+      clauseIN.append("'").append(specificId).append("'");
     }
     clauseIN.append(")");
     String query = SELECT_USERS_BY_SPECIFICIDS + clauseIN;


### PR DESCRIPTION
specificId from LDAP must not be encoded when it is used in a SQL query
It must be encoded only in a LDAP query
