### PR TITLE
bug #4783 : Fix the notification to the users that have not enough right accesses to the commented content.

### DIFF
--- a/ejb-core/comment/pom.xml
+++ b/ejb-core/comment/pom.xml
@@ -6,7 +6,7 @@
     <artifactId>ejb-core</artifactId>
     <version>5.13.2-SNAPSHOT</version>
   </parent>
-	
+
   <groupId>com.silverpeas.core.ejb-core</groupId>
   <artifactId>comment</artifactId>
   <packaging>jar</packaging>
@@ -19,7 +19,7 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-  
+
   <build>
     <testResources>
       <testResource>
@@ -29,6 +29,6 @@
     </testResources>
     <filters>
       <filter>src/test/filters/filters.properties</filter>
-    </filters>  
+    </filters>
   </build>
 </project>

--- a/ejb-core/comment/src/main/java/com/silverpeas/comment/service/DefaultCommentService.java
+++ b/ejb-core/comment/src/main/java/com/silverpeas/comment/service/DefaultCommentService.java
@@ -1,27 +1,23 @@
 /**
  * Copyright (C) 2000 - 2013 Silverpeas
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
  *
- * As a special exception to the terms and conditions of version 3.0 of
- * the GPL, you may redistribute this Program in connection with Free/Libre
- * Open Source Software ("FLOSS") applications as described in Silverpeas's
- * FLOSS exception.  You should have received a copy of the text describing
- * the FLOSS exception, and it is also available here:
+ * As a special exception to the terms and conditions of version 3.0 of the GPL, you may
+ * redistribute this Program in connection with Free/Libre Open Source Software ("FLOSS")
+ * applications as described in Silverpeas's FLOSS exception. You should have received a copy of the
+ * text describing the FLOSS exception, and it is also available here:
  * "http://www.silverpeas.org/docs/core/legal/floss_exception.html"
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Affero General Public License for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU Affero General Public License along with this program.
+ * If not, see <http://www.gnu.org/licenses/>.
  */
-
 package com.silverpeas.comment.service;
 
 import com.silverpeas.comment.dao.CommentDAO;
@@ -30,18 +26,16 @@ import com.silverpeas.comment.model.CommentPK;
 import com.silverpeas.comment.model.CommentedPublicationInfo;
 import com.silverpeas.util.ForeignPK;
 import com.stratelia.silverpeas.silvertrace.SilverTrace;
-import com.stratelia.webactiv.beans.admin.OrganizationController;
 import com.stratelia.webactiv.util.ResourceLocator;
 import com.stratelia.webactiv.util.WAPrimaryKey;
+import java.util.List;
+import javax.inject.Inject;
+import javax.inject.Named;
 import org.silverpeas.core.admin.OrganisationController;
 import org.silverpeas.core.admin.OrganisationControllerFactory;
 import org.silverpeas.search.indexEngine.model.FullIndexEntry;
 import org.silverpeas.search.indexEngine.model.IndexEngineProxy;
 import org.silverpeas.search.indexEngine.model.IndexEntryPK;
-
-import javax.inject.Inject;
-import javax.inject.Named;
-import java.util.List;
 
 /**
  * A service that provide the features to handle the comments in Silverpeas. Such features are, for
@@ -55,9 +49,8 @@ import java.util.List;
 @Named("commentService")
 public class DefaultCommentService extends CommentActionNotifier implements CommentService {
 
-  private static final String SETTINGS_PATH = "com.stratelia.webactiv.util.comment.Comment";
-  private static final String MESSAGES_PATH =
-      "com.stratelia.webactiv.util.comment.multilang.comment";
+  private static final String SETTINGS_PATH = "org.silverpeas.util.comment.Comment";
+  private static final String MESSAGES_PATH = "org.silverpeas.util.comment.multilang.comment";
   private static final ResourceLocator settings = new ResourceLocator(SETTINGS_PATH, "");
 
   @Inject
@@ -71,6 +64,7 @@ public class DefaultCommentService extends CommentActionNotifier implements Comm
 
   /**
    * Gets the comment DAO with wich operations with the underlying data source can be performed.
+   *
    * @return the DAO on the comments.
    */
   protected CommentDAO getCommentDAO() {
@@ -83,6 +77,7 @@ public class DefaultCommentService extends CommentActionNotifier implements Comm
    * interested by the adding of a comment will be invoked through the CallBackManager. The callback
    * will recieve as invocation parameters respectively the identifier of the commented publication,
    * the component instance name, and the new comment.
+   *
    * @param cmt the comment to save.
    */
   @Override
@@ -99,6 +94,7 @@ public class DefaultCommentService extends CommentActionNotifier implements Comm
    * interested by the adding of a comment will be invoked through the CallBackManager. The callback
    * will recieve as invocation parameters respectively the identifier of the commented publication,
    * the component instance name, and the new comment.
+   *
    * @param cmt the comment to save.
    */
   @Override
@@ -113,6 +109,7 @@ public class DefaultCommentService extends CommentActionNotifier implements Comm
    * The callback will recieve as invocation parameters respectively the identifier of the commented
    * publication, the component instance name, and the deleted comment. If no such comment exists
    * with the specified identifier, then a CommentRuntimeException is thrown.
+   *
    * @param pk the unique identifier of the comment to remove from the business layer (the primary
    * key).
    */
@@ -129,13 +126,14 @@ public class DefaultCommentService extends CommentActionNotifier implements Comm
    * parameters respectively the identifier of the commented publication, the component instance
    * name, and the deleted comment. If no such publication exists with the specified identifier,
    * then a CommentRuntimeException is thrown.
+   *
    * @param resourceType the type of the commented publication.
    * @param pk the identifier of the publication the comments are on.
    */
   @Override
   public void deleteAllCommentsOnPublication(final String resourceType, final WAPrimaryKey pk) {
-    List<Comment> comments =
-        getCommentDAO().getAllCommentsByForeignKey(resourceType, new ForeignPK(pk));
+    List<Comment> comments = getCommentDAO().getAllCommentsByForeignKey(resourceType, new ForeignPK(
+        pk));
     for (Comment comment : comments) {
       deleteComment(comment);
     }
@@ -147,6 +145,7 @@ public class DefaultCommentService extends CommentActionNotifier implements Comm
    * CallBackManager. The callback will recieve as invocation parameters respectively the identifier
    * of the commented publication, the component instance name, and the deleted comment. If no such
    * publication exists with the specified identifier, then a CommentRuntimeException is thrown.
+   *
    * @param resourceType the type of the commented publication.
    * @param pk the identifier of the publication the comments are on.
    */
@@ -161,6 +160,7 @@ public class DefaultCommentService extends CommentActionNotifier implements Comm
    * the deletion of a comment will be invoked through the CallBackManager. The callback will
    * recieve as invocation parameters respectively the identifier of the commented publication, the
    * component instance name, and the deleted comment.
+   *
    * @param comment the comment to remove.
    */
   @Override
@@ -175,6 +175,7 @@ public class DefaultCommentService extends CommentActionNotifier implements Comm
    * resulting operation is that the comments will be on the another publication and all the
    * previous indexes on them are removed. If at least one of the publications doesn't exist with
    * the specified identifier, then a CommentRuntimeException is thrown.
+   *
    * @param resourceType the type of the commented publication.
    * @param fromPK the identifier of the source publication.
    * @param toPK the identifier of the destination publication.
@@ -192,6 +193,7 @@ public class DefaultCommentService extends CommentActionNotifier implements Comm
    * they are reindexed (or simply indexed if not already) accordingly to the new publication. If at
    * least one of the publications doesn't exist with the specified identifier, then a
    * CommentRuntimeException is thrown.
+   *
    * @param resourceType the type of the commented publication.
    * @param fromPK the identifier of the source publication.
    * @param toPK the identifier of the destination publication.
@@ -206,6 +208,7 @@ public class DefaultCommentService extends CommentActionNotifier implements Comm
   /**
    * Updates the specified comment in the business layer. The comment to update is identified by its
    * unique identifier and the update information are carried by the given Comment instance.
+   *
    * @param cmt the updated comment.
    */
   @Override
@@ -217,6 +220,7 @@ public class DefaultCommentService extends CommentActionNotifier implements Comm
    * Updates and indexes the specified comment in the business layer. The comment to update in the
    * business layer is identified by its unique identifier and the update information are carried by
    * the given Comment instance.
+   *
    * @param cmt the comment to update and to index.
    */
   @Override
@@ -228,6 +232,7 @@ public class DefaultCommentService extends CommentActionNotifier implements Comm
   /**
    * Gets the comment that identified by the specified identifier. If no such comment exists with
    * the specified identifier, then a CommentRuntimeException is thrown.
+   *
    * @param pk the identifier of the comment in the business layer.
    * @return the comment.
    */
@@ -243,6 +248,7 @@ public class DefaultCommentService extends CommentActionNotifier implements Comm
    * Gets all of the comments on the publication identified by the resource type and the specified
    * identifier. If no such publication exists with the specified identifier, then a
    * CommentRuntimeException is thrown.
+   *
    * @param resourceType the type of the commented publication.
    * @param pk the identifier of the publication.
    * @return a list of the comments on the given publication. The list is empty if the publication
@@ -250,8 +256,8 @@ public class DefaultCommentService extends CommentActionNotifier implements Comm
    */
   @Override
   public List<Comment> getAllCommentsOnPublication(final String resourceType, final WAPrimaryKey pk) {
-    List<Comment> vComments =
-        getCommentDAO().getAllCommentsByForeignKey(resourceType, new ForeignPK(pk));
+    List<Comment> vComments = getCommentDAO().getAllCommentsByForeignKey(resourceType,
+        new ForeignPK(pk));
     for (Comment comment : vComments) {
       setOwnerDetail(comment);
     }
@@ -261,6 +267,7 @@ public class DefaultCommentService extends CommentActionNotifier implements Comm
   /**
    * Gets information about the commented publications among the specified ones. The publication
    * information are returned ordered down to the lesser comment publication.
+   *
    * @param resourceType the type of the commented publication.
    * @param pks a collection of primary keys refering the publications to get information and to
    * order by comments count.
@@ -276,6 +283,7 @@ public class DefaultCommentService extends CommentActionNotifier implements Comm
   /**
    * Gets information about all the commented publications in Silverpeas. The publication
    * information are returned ordered down to the lesser comment publication.
+   *
    * @return an ordered list of information about the most commented publication. The list is sorted
    * by their comments count in a descendent order.
    */
@@ -287,6 +295,7 @@ public class DefaultCommentService extends CommentActionNotifier implements Comm
   /**
    * Gets the count of comments on the publication identified by the resource type and the specified
    * identifier.
+   *
    * @param resourceType the type of the commented publication.
    * @param pk the identifier of the publication.
    * @return the number of comments on the publication.
@@ -300,13 +309,14 @@ public class DefaultCommentService extends CommentActionNotifier implements Comm
    * Indexes all the comments on the publication identified by the resource type and the specified
    * identifier. If no such publication exists with the specified identifier, then a
    * CommentRuntimeException is thrown.
+   *
    * @param resourceType the type of the commented publication.
    * @param pk the identifier of the publication.
    */
   @Override
   public void indexAllCommentsOnPublication(final String resourceType, final WAPrimaryKey pk) {
-    List<Comment> vComments =
-        getCommentDAO().getAllCommentsByForeignKey(resourceType, new ForeignPK(pk));
+    List<Comment> vComments = getCommentDAO().getAllCommentsByForeignKey(resourceType,
+        new ForeignPK(pk));
     for (Comment comment : vComments) {
       createIndex(comment);
     }
@@ -316,13 +326,14 @@ public class DefaultCommentService extends CommentActionNotifier implements Comm
    * Removes the indexes on all the comments of the publication identified by the resource type and
    * the specified identifier. If no such publication exists with the specified identifier, then a
    * CommentRuntimeException is thrown.
+   *
    * @param resourceType the type of the commented publication.
    * @param pk the identifier of the publication.
    */
   @Override
   public void unindexAllCommentsOnPublication(final String resourceType, final WAPrimaryKey pk) {
-    List<Comment> vComments =
-        getCommentDAO().getAllCommentsByForeignKey(resourceType, new ForeignPK(pk));
+    List<Comment> vComments = getCommentDAO().getAllCommentsByForeignKey(resourceType,
+        new ForeignPK(pk));
     for (Comment comment : vComments) {
       deleteIndex(comment);
     }
@@ -380,10 +391,11 @@ public class DefaultCommentService extends CommentActionNotifier implements Comm
 
   /**
    * Gets an organization controller.
+   *
    * @return an OrganizationController instance.
    */
   protected OrganisationController getOrganisationController() {
-    return  OrganisationControllerFactory.getOrganisationController();
+    return OrganisationControllerFactory.getOrganisationController();
   }
 
   @Override

--- a/ejb-core/comment/src/test/java/com/silverpeas/comment/service/notification/Classified.java
+++ b/ejb-core/comment/src/test/java/com/silverpeas/comment/service/notification/Classified.java
@@ -25,8 +25,13 @@
 package com.silverpeas.comment.service.notification;
 
 import com.silverpeas.SilverpeasContent;
+import com.silverpeas.accesscontrol.AccessController;
+import com.silverpeas.accesscontrol.AccessControllerProvider;
 import com.stratelia.webactiv.beans.admin.UserDetail;
+
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 
 /**
  * A silverpeas content to use in tests.
@@ -38,6 +43,7 @@ public class Classified implements SilverpeasContent {
   private String instanceId;
   private UserDetail author;
   private String title;
+  private List<String> unauthorizedUsers = new ArrayList<String>();
   
   public Classified(String id, String instanceId) {
     this.id = id;
@@ -90,8 +96,17 @@ public class Classified implements SilverpeasContent {
   }
 
   @Override
+  public boolean canBeAccessedBy(final UserDetail user) {
+    return !unauthorizedUsers.contains(user.getId());
+  }
+
+  @Override
   public String getSilverpeasContentId() {
     return "";
+  }
+
+  public void unauthorize(UserDetail user) {
+    unauthorizedUsers.add(user.getId());
   }
   
 }

--- a/ejb-core/publication/src/main/java/com/stratelia/webactiv/util/publication/model/PublicationDetail.java
+++ b/ejb-core/publication/src/main/java/com/stratelia/webactiv/util/publication/model/PublicationDetail.java
@@ -20,25 +20,14 @@
  */
 package com.stratelia.webactiv.util.publication.model;
 
-import java.io.PrintWriter;
-import java.io.Serializable;
-import java.io.StringWriter;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-
-import org.silverpeas.attachment.AttachmentServiceFactory;
-import org.silverpeas.attachment.model.DocumentType;
-import org.silverpeas.attachment.model.SimpleDocument;
-import org.silverpeas.attachment.model.SimpleDocumentPK;
-import org.silverpeas.importExport.attachment.AttachmentPK;
-import org.silverpeas.search.indexEngine.model.IndexManager;
-import org.silverpeas.wysiwyg.control.WysiwygController;
-
 import com.silverpeas.SilverpeasContent;
-import com.silverpeas.form.*;
+import com.silverpeas.accesscontrol.AccessController;
+import com.silverpeas.accesscontrol.AccessControllerProvider;
+import com.silverpeas.form.DataRecord;
+import com.silverpeas.form.Field;
+import com.silverpeas.form.FieldDisplayer;
+import com.silverpeas.form.PagesContext;
+import com.silverpeas.form.TypeManager;
 import com.silverpeas.form.displayers.WysiwygFCKFieldDisplayer;
 import com.silverpeas.form.importExport.XMLField;
 import com.silverpeas.form.record.GenericFieldTemplate;
@@ -51,7 +40,6 @@ import com.silverpeas.util.EncodeHelper;
 import com.silverpeas.util.StringUtil;
 import com.silverpeas.util.i18n.AbstractI18NBean;
 import com.silverpeas.util.i18n.I18NHelper;
-
 import com.stratelia.silverpeas.contentManager.ContentManager;
 import com.stratelia.silverpeas.contentManager.ContentManagerException;
 import com.stratelia.silverpeas.contentManager.ContentManagerFactory;
@@ -62,11 +50,26 @@ import com.stratelia.webactiv.util.DateUtil;
 import com.stratelia.webactiv.util.EJBUtilitaire;
 import com.stratelia.webactiv.util.JNDINames;
 import com.stratelia.webactiv.util.exception.SilverpeasRuntimeException;
+import com.stratelia.webactiv.util.node.model.NodePK;
 import com.stratelia.webactiv.util.publication.control.PublicationBm;
 import com.stratelia.webactiv.util.publication.info.model.InfoDetail;
 import com.stratelia.webactiv.util.publication.info.model.InfoTextDetail;
-
+import java.io.PrintWriter;
+import java.io.Serializable;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
 import org.apache.commons.lang3.ObjectUtils;
+import org.silverpeas.attachment.AttachmentServiceFactory;
+import org.silverpeas.attachment.model.DocumentType;
+import org.silverpeas.attachment.model.SimpleDocument;
+import org.silverpeas.attachment.model.SimpleDocumentPK;
+import org.silverpeas.importExport.attachment.AttachmentPK;
+import org.silverpeas.search.indexEngine.model.IndexManager;
+import org.silverpeas.wysiwyg.control.WysiwygController;
 
 /**
  * This object contains the description of a publication
@@ -905,7 +908,7 @@ public class PublicationDetail extends AbstractI18NBean implements SilverContent
           } else {
             SimpleDocument attachment = AttachmentServiceFactory.getAttachmentService()
                 .searchDocumentById(new SimpleDocumentPK(attachmentId, getPK().getInstanceId()),
-                language);
+                    language);
             if (attachment != null) {
               fieldValue = attachment.getAttachmentURL();
             }
@@ -1003,12 +1006,12 @@ public class PublicationDetail extends AbstractI18NBean implements SilverContent
         getComponentName());
     SilverTrace.
         info("publication", "PublicationDetail.getAttachments()", "root.MSG_GEN_PARAM_VALUE",
-        "foreignKey = " + foreignKey.toString());
+            "foreignKey = " + foreignKey.toString());
     Collection<SimpleDocument> attachmentList = AttachmentServiceFactory.getAttachmentService().
         listDocumentsByForeignKeyAndType(foreignKey, DocumentType.attachment, null);
     SilverTrace.
         info("publication", "PublicationDetail.getAttachments()", "root.MSG_GEN_PARAM_VALUE",
-        "attachmentList.size() = " + attachmentList.size());
+            "attachmentList.size() = " + attachmentList.size());
     return attachmentList;
   }
 
@@ -1259,6 +1262,36 @@ public class PublicationDetail extends AbstractI18NBean implements SilverContent
   @Override
   public String getContributionType() {
     return TYPE;
+  }
+
+  /**
+   * Is the specified user can access this publication?
+   * <p/>
+   * A user can access a publication if he has enough rights to access both the application instance
+   * in which is managed this publication and one of the nodes to which this publication belongs to.
+   *
+   * @param user a user in Silverpeas.
+   * @return true if the user can access this publication, false otherwise.
+   */
+  @Override
+  public boolean canBeAccessedBy(final UserDetail user) {
+    AccessController<String> accessController = AccessControllerProvider.getAccessController(
+        "componentAccessController");
+    boolean canBeAccessed = accessController.
+        isUserAuthorized(user.getId(), getComponentInstanceId());
+    if (canBeAccessed) {
+      AccessController<NodePK> nodeAccessController = AccessControllerProvider.getAccessController(
+          "nodeAccessController");
+      Collection<NodePK> nodes = getPublicationBm().getAllFatherPK(new PublicationPK(getId(),
+          getInstanceId()));
+      for (NodePK aNode : nodes) {
+        canBeAccessed = nodeAccessController.isUserAuthorized(user.getId(), aNode);
+        if (canBeAccessed) {
+          break;
+        }
+      }
+    }
+    return canBeAccessed;
   }
 
   /**

--- a/ejb-core/questioncontainer/src/main/java/com/stratelia/webactiv/util/questionContainer/model/QuestionContainerDetail.java
+++ b/ejb-core/questioncontainer/src/main/java/com/stratelia/webactiv/util/questionContainer/model/QuestionContainerDetail.java
@@ -30,6 +30,8 @@ import java.util.Iterator;
 
 import com.silverpeas.SilverpeasContent;
 
+import com.silverpeas.accesscontrol.AccessController;
+import com.silverpeas.accesscontrol.AccessControllerProvider;
 import com.stratelia.silverpeas.contentManager.ContentManagerException;
 import com.stratelia.webactiv.beans.admin.UserDetail;
 import com.stratelia.webactiv.util.question.model.Question;
@@ -154,6 +156,21 @@ public class QuestionContainerDetail implements java.io.Serializable, Silverpeas
   public String getContributionType() {
     // TODO Add an attribute in order to distinguish survey/poll or quizz contribution type
     return null;
+  }
+
+  /**
+   * Is the specified user can access this container of questions?
+   * <p/>
+   * A user can access a container if it has enough rights to access the application instance in
+   * which is managed this container.
+   * @param user a user in Silverpeas.
+   * @return true if the user can access this container of questions, false otherwise.
+   */
+  @Override
+  public boolean canBeAccessedBy(final UserDetail user) {
+    AccessController<String> accessController =
+        AccessControllerProvider.getAccessController("componentAccessController");
+    return accessController.isUserAuthorized(user.getId(), getComponentInstanceId());
   }
 
   @Override

--- a/lib-core/src/main/java/com/silverpeas/SilverpeasComponentService.java
+++ b/lib-core/src/main/java/com/silverpeas/SilverpeasComponentService.java
@@ -1,27 +1,23 @@
 /**
  * Copyright (C) 2000 - 2013 Silverpeas
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
  *
- * As a special exception to the terms and conditions of version 3.0 of
- * the GPL, you may redistribute this Program in connection with Free/Libre
- * Open Source Software ("FLOSS") applications as described in Silverpeas's
- * FLOSS exception.  You should have received a copy of the text describing
- * the FLOSS exception, and it is also available here:
+ * As a special exception to the terms and conditions of version 3.0 of the GPL, you may
+ * redistribute this Program in connection with Free/Libre Open Source Software ("FLOSS")
+ * applications as described in Silverpeas's FLOSS exception. You should have received a copy of the
+ * text describing the FLOSS exception, and it is also available here:
  * "http://www.silverpeas.org/docs/core/legal/floss_exception.html"
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Affero General Public License for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU Affero General Public License along with this program.
+ * If not, see <http://www.gnu.org/licenses/>.
  */
-
 package com.silverpeas;
 
 import com.stratelia.webactiv.util.ResourceLocator;
@@ -30,14 +26,16 @@ import com.stratelia.webactiv.util.ResourceLocator;
  * A service providing the transverse operations related to a given Silverpeas component. A
  * Silverpeas component aims to manage a given type of content and it is based upon some settings
  * and i18n messages. Some capabilities of a Silverpeas component are provided by a service that is
- * a bean with business logic transverse methods; the core business logic of the component should
- * be provided by the resources themselves (see the DDD (Domain Driven Development) approach).
+ * a bean with business logic transverse methods; the core business logic of the component should be
+ * provided by the resources themselves (see the DDD (Domain Driven Development) approach).
+ *
+ * @param <T> The concrete type of the content the component is dedicated to manage.
  */
 public interface SilverpeasComponentService<T extends SilverpeasContent> {
 
   /**
    * Gets the content handled by an instance of the component with the specified unique identifier.
-   * @param <T> the concrete type of the content.
+   *
    * @param contentId the unique identifier of the content to get.
    * @return a Silverpeas content.
    */
@@ -45,12 +43,14 @@ public interface SilverpeasComponentService<T extends SilverpeasContent> {
 
   /**
    * Gets the settings of this Silverpeas component.
+   *
    * @return a ResourceLocator instance giving access the settings.
    */
   ResourceLocator getComponentSettings();
 
   /**
    * Gets the localized messages defined in this Silverpeas component.
+   *
    * @param language the language in which the messages has to be localized. If empty or null, then
    * the bundle with default messages is returned.
    * @return a ResourceLocator instance giving access the localized messages.

--- a/lib-core/src/main/java/com/silverpeas/SilverpeasContent.java
+++ b/lib-core/src/main/java/com/silverpeas/SilverpeasContent.java
@@ -99,4 +99,16 @@ public interface SilverpeasContent extends Serializable {
    * @return the resource type. This can be Post, Message, Publication, Survey...
    */
   String getContributionType();
+
+  /**
+   * Is the specified user can access this content?
+   *
+   * A user can access a content if it has enough rights to access the application instance in
+   * which is managed this content. In the case where the application instance distributes its
+   * contents among one or more nodes and these nodes have access rights, then the user must have
+   * also the rights to access the node to which belongs the content.
+   * @param user a user in Silverpeas.
+   * @return true if the user can access this content, false otherwise.
+   */
+  boolean canBeAccessedBy(UserDetail user);
 }

--- a/lib-core/src/main/java/com/silverpeas/accesscontrol/AccessControllerProvider.java
+++ b/lib-core/src/main/java/com/silverpeas/accesscontrol/AccessControllerProvider.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (C) 2000 - 2013 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "http://www.silverpeas.org/docs/core/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.silverpeas.accesscontrol;
+
+import org.springframework.beans.BeansException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+
+import java.util.Map;
+
+/**
+ * A provider of the different access controllers available in Silverpeas.
+ *
+ * The different access controllers are all managed in the IoC container and then can be get by
+ * dependency injection. Nevertheless, not all objects in Silverpeas are managed by the IoC
+ * container and they can need the services of an access controller. The AccessControllerProvider
+ * aims to make available the different access controllers to such objects.
+ */
+public class AccessControllerProvider implements ApplicationContextAware {
+
+  private static final AccessControllerProvider instance = new AccessControllerProvider();
+
+  private ApplicationContext context;
+
+  /**
+   * Gets an instance of the AccessControllerProvider class.
+   * @return an AccessControllerProvider instance.
+   */
+  public static AccessControllerProvider getInstance() {
+    return instance;
+  }
+
+  /**
+   * Gets the access controller identified by the specified name.
+   * @param name the unique name of the access controller. It is the name under which it has been
+   * registered into the IoC container.
+   * @param <T> the type of the resource that is used in the access control mechanism.
+   * @return the asked access controller.
+   */
+  public static <T> AccessController<T> getAccessController(String name) {
+    return (AccessController<T>) getInstance().context.getBean(name);
+  }
+
+  /**
+   * Set the ApplicationContext that this object runs in.
+   * Normally this call will be used to initialize the object.
+   * <p>Invoked after population of normal bean properties but before an init callback such
+   * as {@link org.springframework.beans.factory.InitializingBean#afterPropertiesSet()}
+   * or a custom init-method. Invoked after {@link org.springframework.context
+   * .ResourceLoaderAware#setResourceLoader},
+   * {@link org.springframework.context.ApplicationEventPublisherAware#setApplicationEventPublisher}
+   * and
+   * {@link org.springframework.context.MessageSourceAware}, if applicable.
+   * @param applicationContext the ApplicationContext object to be used by this object
+   * @throws org.springframework.context.ApplicationContextException in case of context
+   * initialization errors
+   * @throws org.springframework.beans.BeansException if thrown by application context methods
+   * @see org.springframework.beans.factory.BeanInitializationException
+   */
+  @Override
+  public void setApplicationContext(final ApplicationContext applicationContext)
+      throws BeansException {
+    this.context = applicationContext;
+  }
+}

--- a/lib-core/src/main/java/com/silverpeas/comment/model/Comment.java
+++ b/lib-core/src/main/java/com/silverpeas/comment/model/Comment.java
@@ -27,6 +27,8 @@ package com.silverpeas.comment.model;
 import java.util.Date;
 
 import com.silverpeas.SilverpeasContent;
+import com.silverpeas.accesscontrol.AccessController;
+import com.silverpeas.accesscontrol.AccessControllerProvider;
 import com.stratelia.webactiv.beans.admin.UserDetail;
 import com.stratelia.webactiv.util.WAPrimaryKey;
 
@@ -196,6 +198,24 @@ public class Comment implements SilverpeasContent {
   @Override
   public String getContributionType() {
     return TYPE;
+  }
+
+  /**
+   * Is the specified user can access this comment?
+   * <p/>
+   * A user can access a comment if it has enough rights to access the application instance in
+   * which is managed this comment.
+   * <p/>
+   * Be caution, the access control on the commented resource is usually more reliable than using
+   * this method.
+   * @param user a user in Silverpeas.
+   * @return true if the user can access this comment, false otherwise.
+   */
+  @Override
+  public boolean canBeAccessedBy(final UserDetail user) {
+    AccessController<String> accessController =
+        AccessControllerProvider.getAccessController("componentAccessController");
+    return accessController.isUserAuthorized(user.getId(), getComponentInstanceId());
   }
 
   @Override

--- a/lib-core/src/test/java/com/silverpeas/notification/builder/ResourceDataTest.java
+++ b/lib-core/src/test/java/com/silverpeas/notification/builder/ResourceDataTest.java
@@ -108,4 +108,9 @@ public class ResourceDataTest implements SilverpeasContent {
   public String getContributionType() {
     return "aContributionTypeFromResource";
   }
+
+  @Override
+  public boolean canBeAccessedBy(final UserDetail user) {
+    return true;
+  }
 }

--- a/lib-core/src/test/java/com/silverpeas/util/security/TextContent.java
+++ b/lib-core/src/test/java/com/silverpeas/util/security/TextContent.java
@@ -127,6 +127,11 @@ public class TextContent implements SilverpeasContent {
     return "Text";
   }
 
+  @Override
+  public boolean canBeAccessedBy(final UserDetail user) {
+    return true;
+  }
+
   public void setTitle(final String title) {
     this.title = title;
   }

--- a/war-core/src/main/webapp/WEB-INF/config/spring-silverpeas.xml
+++ b/war-core/src/main/webapp/WEB-INF/config/spring-silverpeas.xml
@@ -188,5 +188,9 @@
         It wraps and provides an access to different service instances relative to cache handling -->
   <bean id="cacheServiceFactory" class="org.silverpeas.cache.service.CacheServiceFactory"
         factory-method="getInstance"/>
+
+  <!-- the provider of the differnt access controllers available in Silverpeas -->
+  <bean id="accessControllerProvider" class="com.silverpeas.accesscontrol.AccessControllerProvider"
+        factory-method="getInstance"/>
         
 </beans>


### PR DESCRIPTION
A new method is added to the SilverpeasContent interface: canBeAccessed(). This method is to verify a specified user has enough rights to access the content. Each concrete content must implement their way to verify the access right of a user by using the correct access controllers.

The comment notification service uses now this new method to verify a user can be recipient of the notification. In order to be notified, a user must have the privileges to access the commented content.

Don't forget to merge also the same branch in Silverpeas-Components.
