### PR TITLE
bug #5107 :  reactivate the mixed mode HTTPS/HTTP

### DIFF
--- a/config-core/src/main/config/properties/org/silverpeas/general.properties
+++ b/config-core/src/main/config/properties/org/silverpeas/general.properties
@@ -43,12 +43,20 @@ accessForbidden = /admin/jsp/accessForbidden.jsp
 redirectAppInMaintenance = /admin/jsp/appInMaintenance.jsp
 
 # If Silverpeas is directly accessed through a secure channel, don't forget to set here the secure
-# port behind which Silverpeas is listening.
+# port at which Silverpeas listens.
+# In mixed mode (see below), don't forget to set here the unsecure port at which Silverpeas listens.
 server.http.port=
-# Whether Silverpeas is access through a secure channel like HTTPS, set this parameter to true.
+# Whether Silverpeas is accessed through a secure channel like HTTPS, set this parameter to true.
 # This parameter must be set to true if Silverpeas is after a reverse-proxy that handles the HTTPS
 # connections for Silverpeas.
 server.ssl=false
+# The mixed mode: the authentication is performed within a secured channel whereas the site access
+# stays unsecured. By default, set at false as it is a very bad idea to run a site in a mixed mode
+# (because the site navigation is done in a clear channel, it is then possible for an attacker to
+# wait the authentication is done to steal afterward the opened session) and a site should be either
+# completely secured or not.
+# This parameter prevails on the server.ssl one.
+server.mixed=false
 
 RepositoryTypeTemp = Temp
 

--- a/web-core/src/main/java/com/silverpeas/authentication/SilverpeasSessionOpener.java
+++ b/web-core/src/main/java/com/silverpeas/authentication/SilverpeasSessionOpener.java
@@ -175,9 +175,9 @@ public class SilverpeasSessionOpener {
     Enumeration<String> names = session.getAttributeNames();
     while (names.hasMoreElements()) {
       String attributeName = names.nextElement();
-      if (!attributeName.startsWith("Redirect") && !"gotoNew".equals(attributeName) &&
-          !Authentication.PASSWORD_CHANGE_ALLOWED.equals(attributeName) &&
-          !Authentication.PASSWORD_IS_ABOUT_TO_EXPIRE.equals(attributeName)) {
+      if (!attributeName.startsWith("Redirect") && !"gotoNew".equals(attributeName)
+          && !Authentication.PASSWORD_CHANGE_ALLOWED.equals(attributeName)
+          && !Authentication.PASSWORD_IS_ABOUT_TO_EXPIRE.equals(attributeName)) {
         session.removeAttribute(attributeName);
       }
     }
@@ -294,7 +294,8 @@ public class SilverpeasSessionOpener {
    * @return true the Web navigation with Silverpeas is secured.
    */
   public boolean isNavigationSecure(HttpServletRequest request) {
-    return (request.isSecure() || GeneralPropertiesManager.getBoolean("server.ssl", false));
+    return !GeneralPropertiesManager.getBoolean("server.mixed", false) && (request.isSecure()
+        || GeneralPropertiesManager.getBoolean("server.ssl", false));
   }
 
   private int getServerPort(HttpServletRequest request) {
@@ -304,11 +305,11 @@ public class SilverpeasSessionOpener {
   private String alertUserAboutPwdExpiration(String userId, String fromUserId,
       String language, boolean allowPasswordChange) {
     try {
-      ResourceLocator settings =
-          new ResourceLocator("org.silverpeas.authentication.settings.passwordExpiration", "");
+      ResourceLocator settings = new ResourceLocator(
+          "org.silverpeas.authentication.settings.passwordExpiration", "");
       String notificationType = settings.getString("notificationType", "POPUP");
-      String passwordChangeURL =
-          settings.getString("passwordChangeURL", "defaultPasswordAboutToExpire.jsp");
+      String passwordChangeURL = settings.getString("passwordChangeURL",
+          "defaultPasswordAboutToExpire.jsp");
 
       if ("POPUP".equalsIgnoreCase(notificationType) || !allowPasswordChange) {
         sendPopupNotificationAboutPwdExpiration(userId, fromUserId, language);
@@ -327,8 +328,7 @@ public class SilverpeasSessionOpener {
     ResourceLocator messages = new ResourceLocator(
         "org.silverpeas.peasCore.multilang.peasCoreBundle", language);
     NotificationSender sender = new NotificationSender(null);
-    NotificationMetaData notifMetaData =
-        new NotificationMetaData(NotificationParameters.NORMAL,
+    NotificationMetaData notifMetaData = new NotificationMetaData(NotificationParameters.NORMAL,
         messages.getString("passwordExpirationAlert"), messages
         .getString("passwordExpirationMessage"));
     notifMetaData.setSender(fromUserId);


### PR DESCRIPTION
Add a new parameter server.mixed to permit a site to be mixed with a secured authentication and a site navigation in clear. By default, this parameter is valued at false and we don't recommend to setup a site in a mixed mode as it is a flaw in the security.
