### PR TITLE
bug #5196 :  fix the bug 5196

### DIFF
--- a/web-core/src/main/java/org/silverpeas/accesscontrol/SimpleDocumentAccessController.java
+++ b/web-core/src/main/java/org/silverpeas/accesscontrol/SimpleDocumentAccessController.java
@@ -76,10 +76,13 @@ public class SimpleDocumentAccessController implements AccessController<SimpleDo
         try {
           Collection<NodePK> nodes = getPublicationBm().getAllFatherPK(new PublicationPK(foreignId,
               object.getInstanceId()));
-          for (NodePK nodePk : nodes) {
-            if (getNodeAccessController().isUserAuthorized(userId, nodePk)) {
-              return true;
+          if (!nodes.isEmpty()) {
+            for (NodePK nodePk : nodes) {
+              if (getNodeAccessController().isUserAuthorized(userId, nodePk)) {
+                return true;
+              }
             }
+            return false;
           }
         } catch (Exception ex) {
           SilverTrace.error("accesscontrol", getClass().getSimpleName() + ".isUserAuthorized()",


### PR DESCRIPTION
When the publication to which belongs a document isn't categorized (in a topic for kmelia and filebox, in a category in kmax), the authorization to update the document by the online edition is now authorized. Otherwise, the authorization is delegated to the node access controller.
