### PR TITLE
Bug #5197 - fixing displaying of old wysiwyg attachments after a 5.12 migration on a Silverpeas with multilingual content activated...

### DIFF
--- a/config-core/src/main/config/dbRepository/data/mssql/attachment-contribution.xml
+++ b/config-core/src/main/config/dbRepository/data/mssql/attachment-contribution.xml
@@ -30,7 +30,7 @@
   <requirement>
   </requirement>
   
-  <current version="012">
+  <current version="013">
   </current>
 
   <upgrade version="002">
@@ -93,6 +93,12 @@
   <upgrade version="011">
     <create_table>
       <file name="AttachmentMigrator.jar" type="javalib" classname="org.silverpeas.migration.jcr.attachment.AttachmentMigrator" methodname="migrateAttachments"/>
+    </create_table>
+  </upgrade>
+
+  <upgrade version="012">
+    <create_table>
+      <file name="WysiwygMigrator.jar" type="javalib" classname="org.silverpeas.migration.jcr.wysiwyg.WysiwygCorrector" methodname="migrateDocuments"/>
     </create_table>
   </upgrade>
 

--- a/config-core/src/main/config/dbRepository/data/oracle/attachment-contribution.xml
+++ b/config-core/src/main/config/dbRepository/data/oracle/attachment-contribution.xml
@@ -30,7 +30,7 @@
   <requirement>
   </requirement>
 
-  <current version="012">
+  <current version="013">
   </current>
 
   <upgrade version="002">
@@ -90,10 +90,15 @@
     </create_table>
   </upgrade>
   
-    
   <upgrade version="011">
     <create_table>
       <file name="AttachmentMigrator.jar" type="javalib" classname="org.silverpeas.migration.jcr.attachment.AttachmentMigrator" methodname="migrateAttachments"/>
+    </create_table>
+  </upgrade>
+
+  <upgrade version="012">
+    <create_table>
+      <file name="WysiwygMigrator.jar" type="javalib" classname="org.silverpeas.migration.jcr.wysiwyg.WysiwygCorrector" methodname="migrateDocuments"/>
     </create_table>
   </upgrade>
 

--- a/config-core/src/main/config/dbRepository/data/postgres/attachment-contribution.xml
+++ b/config-core/src/main/config/dbRepository/data/postgres/attachment-contribution.xml
@@ -30,7 +30,7 @@
   <requirement>
   </requirement>
 
-  <current version="012">
+  <current version="013">
   </current>
 
   <upgrade version="003">
@@ -85,10 +85,15 @@
     </create_table>
   </upgrade>
   
-  
   <upgrade version="011">
     <create_table>
       <file name="AttachmentMigrator.jar" type="javalib" classname="org.silverpeas.migration.jcr.attachment.AttachmentMigrator" methodname="migrateAttachments"/>
+    </create_table>
+  </upgrade>
+
+  <upgrade version="012">
+    <create_table>
+      <file name="WysiwygMigrator.jar" type="javalib" classname="org.silverpeas.migration.jcr.wysiwyg.WysiwygCorrector" methodname="migrateDocuments"/>
     </create_table>
   </upgrade>
 


### PR DESCRIPTION
- fixing also the display of wrong content according to the selected content language

Don't forget to check the Silverpeas-Setup project (A new release of Silvepeas installer packages must be done).
