### PR TITLE
bug #5022 : Fix a possible security flaw with a HTML page to upload a file

### DIFF
--- a/war-core/src/main/webapp/WEB-INF/web.xml
+++ b/war-core/src/main/webapp/WEB-INF/web.xml
@@ -482,7 +482,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
     </init-param>
     <init-param>
       <param-name>WHITE_LIST</param-name>
-      <param-value>html htm odt doc pdf</param-value>
+      <param-value>html htm odt doc docx pdf</param-value>
     </init-param>
   </servlet>
   -->

--- a/war-core/src/main/webapp/attachment/jsp/AjaxFileUpload.html
+++ b/war-core/src/main/webapp/attachment/jsp/AjaxFileUpload.html
@@ -24,6 +24,7 @@
     <script src="jquery-1.3.2.min.js" type="text/javascript"></script>
     <script src="jquery.periodicalupdater.js" type="text/javascript"></script>
     <script type="text/javascript">
+      var PeriodicalTimer = null;
       function checkStatus() {
         $('submitButton').disabled = true;
         $.PeriodicalUpdater({
@@ -38,7 +39,7 @@
       function stop(message, files) {
         $('submitButton').disabled = false;
         clearTimeout(PeriodicalTimer);
-        if (message) {
+        if (message && message.length > 0) {
           $('#results').children().remove();
           $('#results').append($('<div>').addClass('error').append($('<b>').html('Error processing results: ' + message)));
         }
@@ -46,12 +47,12 @@
           var myHtml = ' The file was uploaded: ' + files[i] + '<br/>';
           $('#results').append(myHtml);
         }
-      }
-    </script>
+      }</script>
   </head>
   <body>
     <iframe id="target_upload" name="target_upload" src="" style="display: none"></iframe>
-    <form enctype="multipart/form-data" name="form" method="post" action="/silverpeas/ajaxupload" onsubmit="checkStatus();" target="target_upload">
+    <form enctype="multipart/form-data" name="form" method="post" action="/silverpeas/ajaxupload" onsubmit="checkStatus()
+                ;" target="target_upload">
       File to upload: <input id="cv" name="cv" type="file" /> <br/>
       Second file to upload: <input id="motivation" name="motivation" type="file" /> <br/>
       <input id="submitButton" type="submit"/>

--- a/web-core/src/main/java/com/silverpeas/servlets/upload/AjaxFileUploadServlet.java
+++ b/web-core/src/main/java/com/silverpeas/servlets/upload/AjaxFileUploadServlet.java
@@ -115,8 +115,11 @@ public class AjaxFileUploadServlet extends HttpServlet {
           }
           if (!isInWhiteList(filename)) {
             hasError = true;
-            errorMessage += "The file " + filename
-                + " isn't uploaded! Only HTML files can be uploaded<br/>";
+            errorMessage += "The file " + filename + " is not uploaded!";
+            errorMessage += (StringUtil.isDefined(whiteList) ? " Only " + whiteList.replaceAll(
+                " ", ", ")
+                + " file types can be uploaded<br/>"
+                : " No allowed file format has been defined for upload<br/>");
           } else {
             filename = System.currentTimeMillis() + "-" + filename;
             File targetDirectory = new File(uploadDir, fileItem.getFieldName());


### PR DESCRIPTION
The error message is now well spelled (without any ') and the docx format is added into the whitelist of authorized uploaded files. The variable PeriodicalTimer is now defined in the context of the web page so that it is not null with Firefox
