### PR TITLE
Bug #5197 : modifying the name of the called method for document adjustment in order to prevent call of treatments that were already existing but with wrong corrections (Fortunately, these wrong corrections were never called by dbBuilder).

### DIFF
--- a/config-core/src/main/config/dbRepository/data/mssql/versioning-contribution.xml
+++ b/config-core/src/main/config/dbRepository/data/mssql/versioning-contribution.xml
@@ -104,7 +104,7 @@
 
   <upgrade version="012">
     <create_table>
-      <file name="WysiwygMigrator.jar" type="javalib" classname="org.silverpeas.migration.jcr.wysiwyg.WysiwygCorrector" methodname="migrateDocuments"/>
+      <file name="WysiwygMigrator.jar" type="javalib" classname="org.silverpeas.migration.jcr.wysiwyg.WysiwygCorrector" methodname="adjustDocuments"/>
     </create_table>
   </upgrade>
 

--- a/config-core/src/main/config/dbRepository/data/oracle/versioning-contribution.xml
+++ b/config-core/src/main/config/dbRepository/data/oracle/versioning-contribution.xml
@@ -104,7 +104,7 @@
 
   <upgrade version="012">
     <create_table>
-      <file name="WysiwygMigrator.jar" type="javalib" classname="org.silverpeas.migration.jcr.wysiwyg.WysiwygCorrector" methodname="migrateDocuments"/>
+      <file name="WysiwygMigrator.jar" type="javalib" classname="org.silverpeas.migration.jcr.wysiwyg.WysiwygCorrector" methodname="adjustDocuments"/>
     </create_table>
   </upgrade>
 

--- a/config-core/src/main/config/dbRepository/data/postgres/versioning-contribution.xml
+++ b/config-core/src/main/config/dbRepository/data/postgres/versioning-contribution.xml
@@ -104,7 +104,7 @@
 
   <upgrade version="012">
     <create_table>
-      <file name="WysiwygMigrator.jar" type="javalib" classname="org.silverpeas.migration.jcr.wysiwyg.WysiwygCorrector" methodname="migrateDocuments"/>
+      <file name="WysiwygMigrator.jar" type="javalib" classname="org.silverpeas.migration.jcr.wysiwyg.WysiwygCorrector" methodname="adjustDocuments"/>
     </create_table>
   </upgrade>
 


### PR DESCRIPTION
Don't forget to check https://github.com/Silverpeas/Silverpeas-setup/pull/11
