### PR TITLE
bug #5067 :  The locked documents aren't automatically unlocked according to the nbDayForReservation parameter

### DIFF
--- a/config-core/src/main/config/properties/org/silverpeas/util/attachment/Attachment.properties
+++ b/config-core/src/main/config/properties/org/silverpeas/util/attachment/Attachment.properties
@@ -64,13 +64,11 @@ ScheduledPurgeActify = 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,18,19,20,21,22,2
 # In minutes delay for a directory to be considered as proceeded by Actify and to be deleted
 DelayBeforePurge=4
 
-# Gestion des envois de mail pour les fichiers r\u00e9serv\u00e9s
+# Scheduling of the automatic notification by emails for the reserved files.
+# The cron is in the form: minutes (0-59) hours (0-23) days of a month (1-31) months (1-12) day of a week (0-6)
+cronScheduledReservedFile= 01 00 * * *
 
-# date et heure de la notification automatique pour les fichiers r\u00e9serv\u00e9s
-# sous la forme : minutes (0-59) hours (0-23) days of a month (1-31) months (1-12) day of a week (0-6)
-cronScheduledReservedFile= 00 16 * * *
-
-# % de temps avant relance interm\u00e9diaire (entre 0 et 100)
+# % of time before the intermediate relaunch (by default 60%)
 DelayReservedFile=60
 
 

--- a/lib-core/src/main/java/org/silverpeas/attachment/model/SimpleDocument.java
+++ b/lib-core/src/main/java/org/silverpeas/attachment/model/SimpleDocument.java
@@ -308,7 +308,6 @@ public class SimpleDocument implements Serializable {
   public void edit(String currentEditor) {
     this.editedBy = currentEditor;
     this.reservation = new Date();
-    OrganisationControllerFactory.getFactory();
     String day =
         OrganisationControllerFactory.getOrganisationController()
             .getComponentParameterValue(getInstanceId(), "nbDayForReservation");

--- a/lib-core/src/main/java/org/silverpeas/attachment/repository/DocumentRepository.java
+++ b/lib-core/src/main/java/org/silverpeas/attachment/repository/DocumentRepository.java
@@ -698,7 +698,7 @@ public class DocumentRepository {
   }
 
   /**
-   * Search all the documents in an instance expirying at the specified date.
+   * Search all the documents in an instance expiring at the specified date.
    *
    * @param session the current JCR session.
    * @param expiryDate the date when the document reservation should expire.


### PR DESCRIPTION
The path of the English bundle wasn't correct so its loading throws an exception, causing the failing of the process of the unlocking of documents. Beside that, in order the unlocking date matches more correctly the value of the 'nbDayForReservation' application parameter, the cron of the scheduling of the unlocking process is now planed to every days at 00H01.

Merge also this branch into master and core-5.12.x
