### PR TITLE
bug #5196 : the unlocking of reserved documents fails because of the verification of the user  rights on its classification node is verified

### DIFF
--- a/lib-core/src/main/java/com/silverpeas/admin/components/Instanciateur.java
+++ b/lib-core/src/main/java/com/silverpeas/admin/components/Instanciateur.java
@@ -81,6 +81,10 @@ public class Instanciateur {
     }
   }
 
+  public static void addWAComponentForTest(WAComponent component) {
+    componentsByName.put(component.getName(), component);
+  }
+
   /**
    * Creates new instantiator
    */

--- a/web-core/src/main/java/com/silverpeas/accesscontrol/NodeAccessController.java
+++ b/web-core/src/main/java/com/silverpeas/accesscontrol/NodeAccessController.java
@@ -27,6 +27,7 @@ package com.silverpeas.accesscontrol;
 import javax.inject.Inject;
 import javax.inject.Named;
 
+import com.silverpeas.util.ComponentHelper;
 import com.stratelia.silverpeas.silvertrace.SilverTrace;
 import com.stratelia.webactiv.beans.admin.ObjectType;
 import com.stratelia.webactiv.util.EJBUtilitaire;
@@ -62,7 +63,13 @@ public class NodeAccessController implements AccessController<NodePK> {
   public boolean isUserAuthorized(String userId, NodePK nodePK) {
     NodeDetail node;
     try {
-      node = getNodeBm().getHeader(nodePK, false);
+      if (isKmax(nodePK)) {
+        // publications in kmax are categorized into one or more classification axis instead of
+        // nodes and the positioning don't support a right mechanism.
+        return true;
+      } else {
+        node = getNodeBm().getHeader(nodePK, false);
+      }
     } catch (Exception ex) {
       SilverTrace.error("accesscontrol", getClass().getSimpleName() + ".isUserAuthorized()",
           "root.NO_EX_MESSAGE", ex);
@@ -91,5 +98,9 @@ public class NodeAccessController implements AccessController<NodePK> {
       controller = OrganisationControllerFactory.getOrganisationController();
     }
     return controller;
+  }
+
+  private boolean isKmax(NodePK nodePK) {
+    return ComponentHelper.getInstance().isKmax(nodePK.getInstanceId());
   }
 }

--- a/web-core/src/test/java/com/silverpeas/accesscontrol/NodeAccessControllerTest.java
+++ b/web-core/src/test/java/com/silverpeas/accesscontrol/NodeAccessControllerTest.java
@@ -24,6 +24,9 @@
 
 package com.silverpeas.accesscontrol;
 
+import com.silverpeas.admin.components.Instanciateur;
+import com.silverpeas.admin.components.WAComponent;
+import org.junit.Before;
 import org.silverpeas.core.admin.OrganisationController;
 
 import com.stratelia.webactiv.beans.admin.ObjectType;
@@ -55,6 +58,13 @@ public class NodeAccessControllerTest {
   private final String componentId = "kmelia18";
 
   public NodeAccessControllerTest() {
+  }
+
+  @Before
+  public void setUp() {
+    WAComponent kmelia = Mockito.mock(WAComponent.class);
+    Mockito.when(kmelia.getName()).thenReturn("kmelia");
+    Instanciateur.addWAComponentForTest(kmelia);
   }
 
   /**


### PR DESCRIPTION
In Kmax applications, the publications aren't categorized into a path of topics/folders like in Kmelia but instead into some classification axis. Unlike the topics/folders, there is no right access mechanism with the classification axis and then there is no need to verify them. So, when the publication comes from a kmax application, the controller of access rights returns directly  ok.

Please, integrate this PR into both core-5.12.x, core 5.13.x and master.
