### PR TITLE
Bug #5196 : Exceptionaly, this contribution references a bug issue. Actually it takes into account that has been fixed on previous version of Silverpeas.

### DIFF
--- a/lib-core/src/main/java/com/silverpeas/accesscontrol/AbstractAccessController.java
+++ b/lib-core/src/main/java/com/silverpeas/accesscontrol/AbstractAccessController.java
@@ -23,6 +23,14 @@
  */
 package com.silverpeas.accesscontrol;
 
+import com.stratelia.webactiv.SilverpeasRole;
+import com.stratelia.webactiv.util.WAPrimaryKey;
+import org.apache.commons.lang.NotImplementedException;
+import org.silverpeas.cache.service.CacheServiceFactory;
+
+import java.util.EnumSet;
+import java.util.Set;
+
 /**
  * User: Yohann Chastagnier
  * Date: 30/12/13
@@ -32,5 +40,62 @@ public abstract class AbstractAccessController<T> implements AccessController<T>
   @Override
   public final boolean isUserAuthorized(String userId, T object) {
     return isUserAuthorized(userId, object, AccessControlContext.init());
+  }
+
+  /**
+   * Gets the user roles about the aimed object and by taking in account the context of the access.
+   * After a first call, user role are cached (REQUEST live time) in order to increase the
+   * performances in case of several call on the same user and object.
+   * @param context
+   * @param userId
+   * @param object
+   * @return
+   */
+  @SuppressWarnings("unchecked")
+  public Set<SilverpeasRole> getUserRoles(AccessControlContext context, String userId, T object) {
+    String cacheKey = buildUserRoleCacheKey(userId, object);
+    Set<SilverpeasRole> userRoles =
+        CacheServiceFactory.getRequestCacheService().get(cacheKey, Set.class);
+    if (userRoles == null) {
+      userRoles = EnumSet.noneOf(SilverpeasRole.class);
+      fillUserRoles(userRoles, context, userId, object);
+      CacheServiceFactory.getRequestCacheService().put(cacheKey, userRoles);
+    }
+    return userRoles;
+  }
+
+  /**
+   * This method must fill user roles into the given container by taking in account the other
+   * parameters.
+   * @param userRoles
+   * @param context
+   * @param userId
+   * @param object
+   */
+  protected void fillUserRoles(Set<SilverpeasRole> userRoles, AccessControlContext context,
+      String userId, T object) {
+    // This method must be overridden if needed
+    throw new NotImplementedException();
+  }
+
+  /**
+   * Build a unique key for user role cache.
+   * @param userId
+   * @param object
+   * @return
+   */
+  private String buildUserRoleCacheKey(String userId, T object) {
+    StringBuilder cacheKey = new StringBuilder(getClass().getName()).append("@#@");
+    cacheKey.append("USERID").append(userId).append("@#@");
+    cacheKey.append("OBJECTID");
+    if (object instanceof String) {
+      cacheKey.append(object);
+    } else if (object instanceof WAPrimaryKey) {
+      WAPrimaryKey pk = (WAPrimaryKey) object;
+      cacheKey.append(pk.getId()).append("|").append(pk.getInstanceId());
+    } else if (object != null) {
+      throw new NotImplementedException();
+    }
+    return cacheKey.toString();
   }
 }

--- a/web-core/src/test/java/com/silverpeas/accesscontrol/ComponentAccessControllerTest.java
+++ b/web-core/src/test/java/com/silverpeas/accesscontrol/ComponentAccessControllerTest.java
@@ -37,6 +37,7 @@ import org.mockito.stubbing.Answer;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.silverpeas.admin.user.constant.UserAccessLevel;
+import org.silverpeas.cache.service.CacheServiceFactory;
 import org.silverpeas.core.admin.OrganisationController;
 
 import java.util.HashMap;
@@ -414,6 +415,7 @@ public class ComponentAccessControllerTest {
    */
   private void assertGetUserRolesAndIsUserAuthorized(String instanceId,
       boolean expectedUserAuthorization, SilverpeasRole... expectedUserRoles) {
+    CacheServiceFactory.getRequestCacheService().clear();
     Set<SilverpeasRole> componentUserRole =
         instance.getUserRoles(accessControlContext, userId, instanceId);
     if (expectedUserRoles.length > 0) {

--- a/web-core/src/test/java/com/silverpeas/accesscontrol/SimpleDocumentAccessControllerTest.java
+++ b/web-core/src/test/java/com/silverpeas/accesscontrol/SimpleDocumentAccessControllerTest.java
@@ -50,6 +50,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.Set;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
@@ -1433,7 +1434,6 @@ public class SimpleDocumentAccessControllerTest {
       nbCallOfPublicationBmGetAllFatherPK = 1;
       return this;
     }
-
 
     public void verifyMethodCalls() {
       verify(componentAccessController, times(nbCallOfComponentAccessControllerGetUserRoles))


### PR DESCRIPTION
But the fixes that have been done can not be applied to master version because of the effective integration of the feature #4843 (forbidden download for readers). Indeed, this feature requested to upgrade resource access control mechanism and part of the fixes of the bug #5196 have been already implemented.
- handling a user role cache in order to increase the performances in cases of several call on same resources
- upgrading the node access controller to take into account some fixes made for previous versions of Silverpeas
