### PR TITLE
bug #5308 : Some HTML entities in some texts are encoded again for HTML 

### DIFF
--- a/config-core/src/main/config/dbRepository/data/mssql/publication-contribution.xml
+++ b/config-core/src/main/config/dbRepository/data/mssql/publication-contribution.xml
@@ -27,136 +27,142 @@
 
 <contribution product="publication">
 
-    <requirement>
-    </requirement>
+  <requirement>
+  </requirement>
 
-    <current version="019">
-        <create_table>
-            <file name="mssql\publication\019\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-        </create_table>
-        <create_constraint>
-            <file name="mssql\publication\019\create_constraint.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-        </create_constraint>
-        <create_index>
-            <file name="mssql\publication\019\create_index.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-        </create_index>
-        <drop_table>
-            <file name="mssql\publication\019\drop_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-        </drop_table>
-        <drop_constraint>
-            <file name="mssql\publication\019\drop_constraint.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-        </drop_constraint>
-        <drop_index>
-            <file name="mssql\publication\019\drop_index.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-        </drop_index>
-    </current>
+  <current version="020">
+    <create_table>
+      <file name="mssql\publication\020\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_table>
+    <create_constraint>
+      <file name="mssql\publication\020\create_constraint.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_constraint>
+    <create_index>
+      <file name="mssql\publication\020\create_index.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_index>
+    <drop_table>
+      <file name="mssql\publication\020\drop_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </drop_table>
+    <drop_constraint>
+      <file name="mssql\publication\020\drop_constraint.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </drop_constraint>
+    <drop_index>
+      <file name="mssql\publication\020\drop_index.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </drop_index>
+  </current>
 
-    <upgrade version="002">
-       <create_table>
-            <file name="mssql\publication\up002\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-       </create_table>
-    </upgrade>
+  <upgrade version="002">
+    <create_table>
+      <file name="mssql\publication\up002\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_table>
+  </upgrade>
 
-    <upgrade version="003">
-       <create_index>
-            <file name="mssql\publication\up003\create_index.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-       </create_index>
-       <drop_index>
-            <file name="mssql\publication\up003\drop_index.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-       </drop_index>
-    </upgrade>
+  <upgrade version="003">
+    <create_index>
+      <file name="mssql\publication\up003\create_index.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_index>
+    <drop_index>
+      <file name="mssql\publication\up003\drop_index.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </drop_index>
+  </upgrade>
 
-    <upgrade version="004">
-       <create_table>
-            <file name="mssql\publication\up004\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-       </create_table>
-    </upgrade>
+  <upgrade version="004">
+    <create_table>
+      <file name="mssql\publication\up004\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_table>
+  </upgrade>
 
-	<upgrade version="005">
-       <create_table>
-            <file name="mssql\publication\up005\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-       </create_table>
-    </upgrade>
-	
-	<upgrade version="006">
-       <create_table>
-            <file name="mssql\publication\up006\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-       </create_table>
-    </upgrade>
+  <upgrade version="005">
+    <create_table>
+      <file name="mssql\publication\up005\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_table>
+  </upgrade>
 
-	<upgrade version="007">
-       <create_table>
-            <file name="mssql\publication\up007\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-       </create_table>
-    </upgrade>
+  <upgrade version="006">
+    <create_table>
+      <file name="mssql\publication\up006\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_table>
+  </upgrade>
 
-	<upgrade version="008">
-       <create_table>
-            <file name="mssql\publication\up008\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-       </create_table>
-    </upgrade>
-    
-    <upgrade version="009">
-       <create_table>
-            <file name="mssql\publication\up009\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-       </create_table>
-    </upgrade>
+  <upgrade version="007">
+    <create_table>
+      <file name="mssql\publication\up007\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_table>
+  </upgrade>
 
-    <upgrade version="010">
-       <create_table>
-            <file name="mssql\publication\up010\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-       </create_table>
-    </upgrade>
+  <upgrade version="008">
+    <create_table>
+      <file name="mssql\publication\up008\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_table>
+  </upgrade>
 
-	<upgrade version="011">
-       <create_table>
-            <file name="mssql\publication\up011\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-       </create_table>
-    </upgrade>
+  <upgrade version="009">
+    <create_table>
+      <file name="mssql\publication\up009\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_table>
+  </upgrade>
 
-	<upgrade version="012">
-       <create_table>
-            <file name="mssql\publication\up012\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-       </create_table>
-	   <create_constraint>
-            <file name="mssql\publication\up012\create_constraint.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-        </create_constraint>
-    </upgrade>
+  <upgrade version="010">
+    <create_table>
+      <file name="mssql\publication\up010\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_table>
+  </upgrade>
 
-	<upgrade version="013">
-       <create_table>
-            <file name="mssql\publication\up013\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-       </create_table>
-    </upgrade>
+  <upgrade version="011">
+    <create_table>
+      <file name="mssql\publication\up011\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_table>
+  </upgrade>
 
-	<upgrade version="014">
-       <create_table>
-            <file name="mssql\publication\up014\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-       </create_table>
-    </upgrade>
+  <upgrade version="012">
+    <create_table>
+      <file name="mssql\publication\up012\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_table>
+    <create_constraint>
+      <file name="mssql\publication\up012\create_constraint.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_constraint>
+  </upgrade>
 
-	<upgrade version="015">
-       <create_table>
-            <file name="mssql\publication\up015\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-       </create_table>
-    </upgrade>
-    
-    <upgrade version="016">
-       <create_constraint>
-            <file name="mssql\publication\up016\create_constraint.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-        </create_constraint>
-    </upgrade>
-    
-    <upgrade version="017">
-       <create_table>
-            <file name="mssql\publication\up017\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-        </create_table>
-    </upgrade>
-    
-    <upgrade version="018">
-       <create_table>
-            <file name="mssql\publication\up018\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-        </create_table>
-    </upgrade>
+  <upgrade version="013">
+    <create_table>
+      <file name="mssql\publication\up013\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_table>
+  </upgrade>
+
+  <upgrade version="014">
+    <create_table>
+      <file name="mssql\publication\up014\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_table>
+  </upgrade>
+
+  <upgrade version="015">
+    <create_table>
+      <file name="mssql\publication\up015\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_table>
+  </upgrade>
+
+  <upgrade version="016">
+    <create_constraint>
+      <file name="mssql\publication\up016\create_constraint.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_constraint>
+  </upgrade>
+
+  <upgrade version="017">
+    <create_table>
+      <file name="mssql\publication\up017\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_table>
+  </upgrade>
+
+  <upgrade version="018">
+    <create_table>
+      <file name="mssql\publication\up018\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_table>
+  </upgrade>
+
+  <upgrade version="019">
+    <create_table>
+      <file name="unescapeHtml.jar" type="javalib" classname="org.silverpeas.migration.publication.HtmlUnescaper" methodname="unescapeHtml"/>
+    </create_table>
+  </upgrade>
 
 </contribution>

--- a/config-core/src/main/config/dbRepository/data/oracle/publication-contribution.xml
+++ b/config-core/src/main/config/dbRepository/data/oracle/publication-contribution.xml
@@ -27,136 +27,142 @@
 
 <contribution product="publication">
 
-    <requirement>
-    </requirement>
+  <requirement>
+  </requirement>
 
-    <current version="019">
-        <create_table>
-            <file name="oracle\publication\019\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-        </create_table>
-        <create_constraint>
-            <file name="oracle\publication\019\create_constraint.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-        </create_constraint>
-        <create_index>
-            <file name="oracle\publication\019\create_index.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-        </create_index>
-        <drop_table>
-            <file name="oracle\publication\019\drop_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-        </drop_table>
-        <drop_constraint>
-            <file name="oracle\publication\019\drop_constraint.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-        </drop_constraint>
-        <drop_index>
-            <file name="oracle\publication\019\drop_index.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-        </drop_index>
-    </current>
+  <current version="020">
+    <create_table>
+      <file name="oracle\publication\020\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_table>
+    <create_constraint>
+      <file name="oracle\publication\020\create_constraint.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_constraint>
+    <create_index>
+      <file name="oracle\publication\020\create_index.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_index>
+    <drop_table>
+      <file name="oracle\publication\020\drop_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </drop_table>
+    <drop_constraint>
+      <file name="oracle\publication\020\drop_constraint.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </drop_constraint>
+    <drop_index>
+      <file name="oracle\publication\020\drop_index.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </drop_index>
+  </current>
 
-    <upgrade version="002">
-        <create_table>
-            <file name="oracle\publication\up002\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-        </create_table>
-    </upgrade>
+  <upgrade version="002">
+    <create_table>
+      <file name="oracle\publication\up002\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_table>
+  </upgrade>
 
-    <upgrade version="003">
-       <create_index>
-            <file name="oracle\publication\up003\create_index.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-       </create_index>
-       <drop_index>
-            <file name="oracle\publication\up003\drop_index.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-       </drop_index>
-    </upgrade>
+  <upgrade version="003">
+    <create_index>
+      <file name="oracle\publication\up003\create_index.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_index>
+    <drop_index>
+      <file name="oracle\publication\up003\drop_index.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </drop_index>
+  </upgrade>
 
-    <upgrade version="004">
-        <create_table>
-            <file name="oracle\publication\up004\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-        </create_table>
-    </upgrade>
+  <upgrade version="004">
+    <create_table>
+      <file name="oracle\publication\up004\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_table>
+  </upgrade>
 
-    <upgrade version="005">
-        <create_table>
-            <file name="oracle\publication\up005\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-        </create_table>
-    </upgrade>
-	
-	<upgrade version="006">
-        <create_table>
-            <file name="oracle\publication\up006\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-        </create_table>
-    </upgrade>
+  <upgrade version="005">
+    <create_table>
+      <file name="oracle\publication\up005\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_table>
+  </upgrade>
 
-	<upgrade version="007">
-        <create_table>
-            <file name="oracle\publication\up007\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-        </create_table>
-    </upgrade>
+  <upgrade version="006">
+    <create_table>
+      <file name="oracle\publication\up006\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_table>
+  </upgrade>
 
-	<upgrade version="008">
-        <create_table>
-            <file name="oracle\publication\up008\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-        </create_table>
-    </upgrade>
-    
-    <upgrade version="009">
-        <create_table>
-            <file name="oracle\publication\up009\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-        </create_table>
-    </upgrade>
+  <upgrade version="007">
+    <create_table>
+      <file name="oracle\publication\up007\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_table>
+  </upgrade>
 
-    <upgrade version="010">
-        <create_table>
-            <file name="oracle\publication\up010\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-        </create_table>
-    </upgrade>
+  <upgrade version="008">
+    <create_table>
+      <file name="oracle\publication\up008\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_table>
+  </upgrade>
 
-	<upgrade version="011">
-        <create_table>
-            <file name="oracle\publication\up011\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-        </create_table>
-    </upgrade>
+  <upgrade version="009">
+    <create_table>
+      <file name="oracle\publication\up009\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_table>
+  </upgrade>
 
-	<upgrade version="012">
-       <create_table>
-            <file name="oracle\publication\up012\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-       </create_table>
-	   <create_constraint>
-            <file name="oracle\publication\up012\create_constraint.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-        </create_constraint>
-    </upgrade>
+  <upgrade version="010">
+    <create_table>
+      <file name="oracle\publication\up010\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_table>
+  </upgrade>
 
-	<upgrade version="013">
-       <create_table>
-            <file name="oracle\publication\up013\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-       </create_table>
-    </upgrade>
+  <upgrade version="011">
+    <create_table>
+      <file name="oracle\publication\up011\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_table>
+  </upgrade>
 
-	<upgrade version="014">
-       <create_table>
-            <file name="oracle\publication\up014\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-       </create_table>
-    </upgrade>
+  <upgrade version="012">
+    <create_table>
+      <file name="oracle\publication\up012\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_table>
+    <create_constraint>
+      <file name="oracle\publication\up012\create_constraint.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_constraint>
+  </upgrade>
 
-	<upgrade version="015">
-       <create_table>
-            <file name="oracle\publication\up015\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-       </create_table>
-    </upgrade>
-    
-    <upgrade version="016">
-	   <create_constraint>
-            <file name="oracle\publication\up016\create_constraint.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-        </create_constraint>
-    </upgrade>
-    
-    <upgrade version="017">
-	   <create_constraint>
-            <file name="oracle\publication\up017\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-        </create_constraint>
-    </upgrade>
-    
-    <upgrade version="018">
-	   <create_constraint>
-            <file name="oracle\publication\up018\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-        </create_constraint>
-    </upgrade>
+  <upgrade version="013">
+    <create_table>
+      <file name="oracle\publication\up013\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_table>
+  </upgrade>
+
+  <upgrade version="014">
+    <create_table>
+      <file name="oracle\publication\up014\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_table>
+  </upgrade>
+
+  <upgrade version="015">
+    <create_table>
+      <file name="oracle\publication\up015\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_table>
+  </upgrade>
+
+  <upgrade version="016">
+    <create_constraint>
+      <file name="oracle\publication\up016\create_constraint.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_constraint>
+  </upgrade>
+
+  <upgrade version="017">
+    <create_constraint>
+      <file name="oracle\publication\up017\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_constraint>
+  </upgrade>
+
+  <upgrade version="018">
+    <create_constraint>
+      <file name="oracle\publication\up018\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_constraint>
+  </upgrade>
+
+  <upgrade version="019">
+    <create_table>
+      <file name="unescapeHtml.jar" type="javalib" classname="org.silverpeas.migration.publication.HtmlUnescaper" methodname="unescapeHtml"/>
+    </create_table>
+  </upgrade>
 
 </contribution>

--- a/config-core/src/main/config/dbRepository/data/postgres/publication-contribution.xml
+++ b/config-core/src/main/config/dbRepository/data/postgres/publication-contribution.xml
@@ -27,136 +27,142 @@
 
 <contribution product="publication">
 
-    <requirement>
-    </requirement>
+  <requirement>
+  </requirement>
 
-    <current version="019">
-        <create_table>
-            <file name="postgres\publication\019\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-        </create_table>
-        <create_constraint>
-            <file name="postgres\publication\019\create_constraint.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-        </create_constraint>
-        <create_index>
-            <file name="postgres\publication\019\create_index.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-        </create_index>
-        <drop_table>
-            <file name="postgres\publication\019\drop_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-        </drop_table>
-        <drop_constraint>
-            <file name="postgres\publication\019\drop_constraint.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-        </drop_constraint>
-        <drop_index>
-            <file name="postgres\publication\019\drop_index.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-        </drop_index>
-    </current>
+  <current version="020">
+    <create_table>
+      <file name="postgres\publication\020\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_table>
+    <create_constraint>
+      <file name="postgres\publication\020\create_constraint.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_constraint>
+    <create_index>
+      <file name="postgres\publication\020\create_index.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_index>
+    <drop_table>
+      <file name="postgres\publication\020\drop_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </drop_table>
+    <drop_constraint>
+      <file name="postgres\publication\020\drop_constraint.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </drop_constraint>
+    <drop_index>
+      <file name="postgres\publication\020\drop_index.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </drop_index>
+  </current>
 
-    <upgrade version="002">
-        <create_table>
-            <file name="postgres\publication\up002\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-        </create_table>
-    </upgrade>
+  <upgrade version="002">
+    <create_table>
+      <file name="postgres\publication\up002\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_table>
+  </upgrade>
 
-    <upgrade version="003">
-       <create_index>
-            <file name="postgres\publication\up003\create_index.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-       </create_index>
-       <drop_index>
-            <file name="postgres\publication\up003\drop_index.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-       </drop_index>
-    </upgrade>
+  <upgrade version="003">
+    <create_index>
+      <file name="postgres\publication\up003\create_index.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_index>
+    <drop_index>
+      <file name="postgres\publication\up003\drop_index.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </drop_index>
+  </upgrade>
 
-    <upgrade version="004">
-        <create_table>
-            <file name="postgres\publication\up004\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-        </create_table>
-    </upgrade>
+  <upgrade version="004">
+    <create_table>
+      <file name="postgres\publication\up004\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_table>
+  </upgrade>
 
-    <upgrade version="005">
-        <create_table>
-            <file name="postgres\publication\up005\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-        </create_table>
-    </upgrade>
-	
-	<upgrade version="006">
-        <create_table>
-            <file name="postgres\publication\up006\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-        </create_table>
-    </upgrade>
+  <upgrade version="005">
+    <create_table>
+      <file name="postgres\publication\up005\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_table>
+  </upgrade>
 
-	<upgrade version="007">
-        <create_table>
-            <file name="postgres\publication\up007\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-        </create_table>
-    </upgrade>
+  <upgrade version="006">
+    <create_table>
+      <file name="postgres\publication\up006\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_table>
+  </upgrade>
 
-	<upgrade version="008">
-        <create_table>
-            <file name="postgres\publication\up008\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-        </create_table>
-    </upgrade>
-    
-    <upgrade version="009">
-        <create_table>
-            <file name="postgres\publication\up009\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-        </create_table>
-    </upgrade>
+  <upgrade version="007">
+    <create_table>
+      <file name="postgres\publication\up007\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_table>
+  </upgrade>
 
-    <upgrade version="010">
-        <create_table>
-            <file name="postgres\publication\up010\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-        </create_table>
-    </upgrade>
+  <upgrade version="008">
+    <create_table>
+      <file name="postgres\publication\up008\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_table>
+  </upgrade>
 
-	 <upgrade version="011">
-        <!--<create_table>
-            <file name="postgres\publication\up011\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-        </create_table>-->
-    </upgrade>
+  <upgrade version="009">
+    <create_table>
+      <file name="postgres\publication\up009\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_table>
+  </upgrade>
 
-	<upgrade version="012">
-       <create_table>
-            <file name="postgres\publication\up012\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-       </create_table>
-	   <create_constraint>
-            <file name="postgres\publication\up012\create_constraint.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-        </create_constraint>
-    </upgrade>
+  <upgrade version="010">
+    <create_table>
+      <file name="postgres\publication\up010\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_table>
+  </upgrade>
 
-	<upgrade version="013">
-       <create_table>
-            <file name="postgres\publication\up013\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-       </create_table>
-    </upgrade>
+  <upgrade version="011">
+    <!--<create_table>
+        <file name="postgres\publication\up011\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_table>-->
+  </upgrade>
 
-	<upgrade version="014">
-       <create_table>
-            <file name="postgres\publication\up014\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-       </create_table>
-    </upgrade>
+  <upgrade version="012">
+    <create_table>
+      <file name="postgres\publication\up012\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_table>
+    <create_constraint>
+      <file name="postgres\publication\up012\create_constraint.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_constraint>
+  </upgrade>
 
-	<upgrade version="015">
-       <create_table>
-            <file name="postgres\publication\up015\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-       </create_table>
-    </upgrade>
-    
-    <upgrade version="016">
-       <create_constraint>
-            <file name="postgres\publication\up016\create_constraint.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-        </create_constraint>
-    </upgrade>
+  <upgrade version="013">
+    <create_table>
+      <file name="postgres\publication\up013\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_table>
+  </upgrade>
 
-    <upgrade version="017">
-       <create_table>
-            <file name="postgres\publication\up017\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-        </create_table>
-    </upgrade>
-    
-    <upgrade version="018">
-       <create_table>
-            <file name="postgres\publication\up018\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
-        </create_table>
-    </upgrade>
-    
+  <upgrade version="014">
+    <create_table>
+      <file name="postgres\publication\up014\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_table>
+  </upgrade>
+
+  <upgrade version="015">
+    <create_table>
+      <file name="postgres\publication\up015\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_table>
+  </upgrade>
+
+  <upgrade version="016">
+    <create_constraint>
+      <file name="postgres\publication\up016\create_constraint.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_constraint>
+  </upgrade>
+
+  <upgrade version="017">
+    <create_table>
+      <file name="postgres\publication\up017\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_table>
+  </upgrade>
+
+  <upgrade version="018">
+    <create_table>
+      <file name="postgres\publication\up018\create_table.sql" type="sqlstatementlist" delimiter=";" keepdelimiter="NO"/>
+    </create_table>
+  </upgrade>
+
+  <upgrade version="019">
+    <create_table>
+      <file name="unescapeHtml.jar" type="javalib" classname="org.silverpeas.migration.publication.HtmlUnescaper" methodname="unescapeHtml"/>
+    </create_table>
+  </upgrade>
+
 </contribution>

--- a/config-core/src/main/config/dbRepository/mssql/publication/020/create_constraint.sql
+++ b/config-core/src/main/config/dbRepository/mssql/publication/020/create_constraint.sql
@@ -1,0 +1,73 @@
+ALTER TABLE SB_Publication_Info WITH NOCHECK ADD 
+	 CONSTRAINT PK_Publication_Info PRIMARY KEY  CLUSTERED 
+	(
+		infoId
+	)   
+;
+
+ALTER TABLE SB_Publication_InfoAttachment WITH NOCHECK ADD 
+	 CONSTRAINT PK_Publication_InfoAttachment PRIMARY KEY  CLUSTERED 
+	(
+		infoAttachmentId
+	)   
+;
+
+ALTER TABLE SB_Publication_InfoImage WITH NOCHECK ADD 
+	 CONSTRAINT PK_Publication_InfoImage PRIMARY KEY  CLUSTERED 
+	(
+		infoImageId
+	)   
+;
+
+ALTER TABLE SB_Publication_InfoLink WITH NOCHECK ADD 
+	 CONSTRAINT PK_Publication_InfoLink PRIMARY KEY  CLUSTERED 
+	(
+		infoLinkId
+	)   
+;
+
+ALTER TABLE SB_Publication_InfoText WITH NOCHECK ADD 
+	 CONSTRAINT PK_Publication_InfoText PRIMARY KEY  CLUSTERED 
+	(
+		infoTextId
+	)   
+;
+
+ALTER TABLE SB_Publication_Publi WITH NOCHECK ADD 
+	 CONSTRAINT PK_Publication_Publi PRIMARY KEY  CLUSTERED 
+	(
+		pubId
+	)   
+;
+
+ALTER TABLE SB_Publication_PubliFather WITH NOCHECK ADD 
+	 CONSTRAINT PK_Publication_PubliFather PRIMARY KEY  CLUSTERED 
+	(
+		pubId,
+		nodeId,
+		instanceId
+	)   
+;
+
+ALTER TABLE SB_SeeAlso_Link WITH NOCHECK ADD 
+	 CONSTRAINT PK_SeeAlso_Link PRIMARY KEY CLUSTERED  
+	(
+		id
+	)   
+;
+
+ALTER TABLE SB_Publication_PubliI18N WITH NOCHECK ADD 
+	 CONSTRAINT PK_Publication_PubliI18N PRIMARY KEY CLUSTERED
+	(
+		id
+	)   
+;
+
+ALTER TABLE SB_Thumbnail_Thumbnail WITH NOCHECK ADD 
+	 CONSTRAINT PK_Thumbnail_Thumbnail PRIMARY KEY CLUSTERED 
+	(
+		objectId,
+		objectType,
+		instanceId
+	)   
+;

--- a/config-core/src/main/config/dbRepository/mssql/publication/020/create_index.sql
+++ b/config-core/src/main/config/dbRepository/mssql/publication/020/create_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IN_Publi_Father ON SB_Publication_PubliFather (nodeId);

--- a/config-core/src/main/config/dbRepository/mssql/publication/020/create_table.sql
+++ b/config-core/src/main/config/dbRepository/mssql/publication/020/create_table.sql
@@ -1,0 +1,141 @@
+CREATE TABLE SB_Publication_History 
+(
+	historyDate		varchar (10)	NOT NULL ,
+	historyActorId		varchar (100)	NOT NULL ,
+	nodeId			int		NOT NULL ,
+	pubId			int		NOT NULL 
+);
+
+CREATE TABLE SB_Publication_Info 
+(
+	infoId		int		NOT NULL ,
+	modelId		int		NULL ,
+	infoContent	varchar (2000)	NULL ,
+	instanceId	varchar (50)	NOT NULL
+);
+
+CREATE TABLE SB_Publication_InfoAttachment 
+(
+	infoAttachmentId		int		NOT NULL ,
+	infoId				int		NOT NULL ,
+	infoAttachmentPhysicalName	varchar (1000)	NOT NULL ,
+	infoAttachmentLogicalName	varchar (1000)	NOT NULL ,
+	infoAttachmentDescription	varchar (2000)	NULL ,
+	infoAttachmentType		varchar (50)	NOT NULL ,
+	infoAttachmentSize		int		NULL ,
+	infoAttachmentDisplayOrder	int		NOT NULL 
+) 
+;
+
+CREATE TABLE SB_Publication_InfoImage 
+(
+	infoImageId		int		NOT NULL ,
+	infoId			int		NOT NULL ,
+	infoImagePhysicalName	varchar (1000)	NOT NULL ,
+	infoImageLogicalName	varchar (1000)	NOT NULL ,
+	infoImageDescription	varchar (2000)	NULL ,
+	infoImageType		varchar (50)	NOT NULL ,
+	infoImageSize		int		NULL ,
+	infoImageDisplayOrder	int		NOT NULL 
+);
+
+CREATE TABLE SB_Publication_InfoLink 
+(
+	infoLinkId		int		NOT NULL ,
+	infoId			int		NOT NULL ,
+	pubId			int		NOT NULL ,
+	infoLinkDisplayOrder	int		NOT NULL 
+);
+
+CREATE TABLE SB_Publication_InfoText 
+(
+	infoTextId		int		NOT NULL ,
+	infoId			int		NOT NULL ,
+	infoTextContent		varchar (4000)	NOT NULL ,
+	infoTextDisplayOrder	int		NOT NULL 
+);
+
+CREATE TABLE SB_Publication_Publi 
+(
+	pubId			int		NOT NULL ,
+	infoId			varchar (50)	NULL ,
+	pubName			varchar (400)	NOT NULL ,
+	pubDescription		varchar (2000)	NULL ,
+	pubCreationDate		varchar (10)	NOT NULL ,
+	pubBeginDate		varchar (10)	NOT NULL ,
+	pubEndDate		varchar (10)	NOT NULL ,
+	pubCreatorId		varchar (100)	NOT NULL ,
+	pubImportance		int		NULL ,
+	pubVersion		varchar (100)	NULL ,
+	pubKeywords		varchar (1000)	NULL ,
+	pubContent		varchar (2000)	NULL ,
+	pubStatus		varchar (100)	NULL ,
+	pubUpdateDate		varchar (10)	NULL ,
+	instanceId		varchar (50)	NOT NULL ,
+	pubUpdaterId        	varchar (100)	NULL ,
+	pubValidateDate		varchar (10)	NULL ,
+	pubValidatorId		varchar (50)	NULL ,
+	pubBeginHour		varchar (5)	NULL ,
+	pubEndHour		varchar (5)	NULL,
+	pubAuthor		varchar (50)	NULL,
+	pubTargetValidatorId	varchar (50)	NULL,
+	pubCloneId		int		NOT NULL DEFAULT (-1),
+	pubCloneStatus		varchar (50)	NULL,
+	lang			char(2)		NULL,
+	pubdraftoutdate		varchar (10)	NULL
+);
+
+CREATE TABLE SB_Publication_PubliFather 
+(
+	pubId		int		NOT NULL ,
+	nodeId		int		NOT NULL ,
+	instanceId	varchar (50)	NOT NULL,
+	aliasUserId	int,	
+	aliasDate	varchar (20),
+	pubOrder	int		NOT NULL DEFAULT (0)
+);
+
+CREATE TABLE SB_SeeAlso_Link 
+(
+	id			int		NOT NULL,
+	objectId		int		NOT NULL,
+	objectInstanceId	varchar (50)	NOT NULL,
+	targetId		int		NOT NULL,
+	targetInstanceId	varchar (50)	NOT NULL 
+);
+
+CREATE TABLE SB_Publication_PubliI18N
+(
+	id		int		NOT NULL,
+	pubId		int		NOT NULL,
+	lang		char (2)	NOT NULL,
+	name		varchar (400)	NOT NULL,
+	description	varchar (2000),
+	keywords	varchar (1000)
+);
+
+CREATE TABLE SB_Publication_Validation
+(
+	id		int		NOT NULL,
+	pubId		int		NOT NULL,
+	instanceId	varchar(50)	NOT NULL,
+	userId		int		NOT NULL,
+	decisionDate	varchar(20)	NOT NULL,
+	decision	varchar(50)	NOT NULL
+)
+;
+
+CREATE TABLE SB_Thumbnail_Thumbnail 
+(
+	instanceId		varchar (50)	NOT NULL ,
+	objectId		int	NOT NULL ,
+	objectType		int	NOT NULL ,
+	originalAttachmentName		varchar(250)  NOT NULL ,
+	modifiedAttachmentName		varchar(250)  NULL ,
+  mimeType		varchar(250)  NULL ,
+	xStart		int NULL ,
+	yStart		int NULL ,
+	xLength		int NULL ,
+	yLength		int NULL
+) 
+;

--- a/config-core/src/main/config/dbRepository/mssql/publication/020/drop_constraint.sql
+++ b/config-core/src/main/config/dbRepository/mssql/publication/020/drop_constraint.sql
@@ -1,0 +1,8 @@
+ALTER TABLE SB_Publication_Info			DROP CONSTRAINT PK_Publication_Info;
+ALTER TABLE SB_Publication_InfoAttachment	DROP CONSTRAINT PK_Publication_InfoAttachment;
+ALTER TABLE SB_Publication_InfoImage		DROP CONSTRAINT PK_Publication_InfoImage;
+ALTER TABLE SB_Publication_InfoLink		DROP CONSTRAINT PK_Publication_InfoLink;
+ALTER TABLE SB_Publication_InfoText		DROP CONSTRAINT PK_Publication_InfoText;
+ALTER TABLE SB_Publication_Publi		DROP CONSTRAINT PK_Publication_Publi;
+ALTER TABLE SB_Publication_PubliFather		DROP CONSTRAINT PK_Publication_PubliFather;
+ALTER TABLE SB_Thumbnail_Thumbnail		DROP CONSTRAINT PK_Thumbnail_Thumbnail;

--- a/config-core/src/main/config/dbRepository/mssql/publication/020/drop_index.sql
+++ b/config-core/src/main/config/dbRepository/mssql/publication/020/drop_index.sql
@@ -1,0 +1,1 @@
+DROP INDEX SB_Publication_PubliFather.IN_Publi_Father;

--- a/config-core/src/main/config/dbRepository/mssql/publication/020/drop_table.sql
+++ b/config-core/src/main/config/dbRepository/mssql/publication/020/drop_table.sql
@@ -1,0 +1,8 @@
+drop table SB_Publication_Info;
+drop table SB_Publication_InfoAttachment;
+drop table SB_Publication_InfoImage;
+drop table SB_Publication_InfoLink;
+drop table SB_Publication_InfoText;
+drop table SB_Publication_Publi;
+drop table SB_Publication_PubliFather;
+drop table SB_Thumbnail_Thumbnail;

--- a/config-core/src/main/config/dbRepository/oracle/publication/020/create_constraint.sql
+++ b/config-core/src/main/config/dbRepository/oracle/publication/020/create_constraint.sql
@@ -1,0 +1,73 @@
+ALTER TABLE SB_Publication_Info ADD 
+	 CONSTRAINT PK_Publication_Info PRIMARY KEY   
+	(
+		infoId
+	)   
+;
+
+ALTER TABLE SB_Publication_InfoAttachment  ADD 
+	 CONSTRAINT PK_Publication_InfoAttachment PRIMARY KEY   
+	(
+		infoAttachmentId
+	)   
+;
+
+ALTER TABLE SB_Publication_InfoImage  ADD 
+	 CONSTRAINT PK_Publication_InfoImage PRIMARY KEY   
+	(
+		infoImageId
+	)   
+;
+
+ALTER TABLE SB_Publication_InfoLink  ADD 
+	 CONSTRAINT PK_Publication_InfoLink PRIMARY KEY   
+	(
+		infoLinkId
+	)   
+;
+
+ALTER TABLE SB_Publication_InfoText  ADD 
+	 CONSTRAINT PK_Publication_InfoText PRIMARY KEY   
+	(
+		infoTextId
+	)   
+;
+
+ALTER TABLE SB_Publication_Publi  ADD 
+	 CONSTRAINT PK_Publication_Publi PRIMARY KEY   
+	(
+		pubId
+	)   
+;
+
+ALTER TABLE SB_Publication_PubliFather  ADD 
+	 CONSTRAINT PK_Publication_PubliFather PRIMARY KEY   
+	(
+		pubId,
+		nodeId,
+		instanceId
+	)   
+;
+
+ALTER TABLE SB_SeeAlso_Link  ADD 
+	 CONSTRAINT PK_SeeAlso_Link PRIMARY KEY   
+	(
+		id
+	)   
+;
+
+ALTER TABLE SB_Publication_PubliI18N  ADD 
+	 CONSTRAINT PK_Publication_PubliI18N PRIMARY KEY   
+	(
+		id
+	)
+;
+
+ALTER TABLE SB_Thumbnail_Thumbnail ADD 
+	 CONSTRAINT PK_Thumbnail_Thumbnail PRIMARY KEY   
+	(
+		objectId,
+		objectType,
+		instanceId
+	)   
+;

--- a/config-core/src/main/config/dbRepository/oracle/publication/020/create_index.sql
+++ b/config-core/src/main/config/dbRepository/oracle/publication/020/create_index.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IN_Publi_Father
+ON SB_Publication_PubliFather (nodeId);

--- a/config-core/src/main/config/dbRepository/oracle/publication/020/create_table.sql
+++ b/config-core/src/main/config/dbRepository/oracle/publication/020/create_table.sql
@@ -1,0 +1,134 @@
+CREATE TABLE SB_Publication_Info 
+(
+	infoId		int		NOT NULL ,
+	modelId		int		NULL ,
+	infoContent	varchar (2000)	NULL ,
+	instanceId	varchar (50)	NOT NULL
+);
+
+CREATE TABLE SB_Publication_InfoAttachment 
+(
+	infoAttachmentId		int		NOT NULL ,
+	infoId				int		NOT NULL ,
+	infoAttachmentPhysicalName	varchar (1000)	NOT NULL ,
+	infoAttachmentLogicalName	varchar (1000)	NOT NULL ,
+	infoAttachmentDescription	varchar (2000)	NULL ,
+	infoAttachmentType		varchar (50)	NOT NULL ,
+	infoAttachmentSize		int		NULL ,
+	infoAttachmentDisplayOrder	int		NOT NULL 
+) 
+;
+
+CREATE TABLE SB_Publication_InfoImage 
+(
+	infoImageId		int		NOT NULL ,
+	infoId			int		NOT NULL ,
+	infoImagePhysicalName	varchar (1000)	NOT NULL ,
+	infoImageLogicalName	varchar (1000)	NOT NULL ,
+	infoImageDescription	varchar (2000)	NULL ,
+	infoImageType		varchar (50)	NOT NULL ,
+	infoImageSize		int		NULL ,
+	infoImageDisplayOrder	int		NOT NULL 
+);
+
+CREATE TABLE SB_Publication_InfoLink 
+(
+	infoLinkId		int		NOT NULL ,
+	infoId			int		NOT NULL ,
+	pubId			int		NOT NULL ,
+	infoLinkDisplayOrder	int		NOT NULL 
+);
+
+CREATE TABLE SB_Publication_InfoText 
+(
+	infoTextId		int		NOT NULL ,
+	infoId			int		NOT NULL ,
+	infoTextContent		varchar (4000) NULL,
+	infoTextDisplayOrder	int		NOT NULL 
+);
+
+CREATE TABLE SB_Publication_Publi 
+(
+	pubId			int		NOT NULL ,
+	infoId			varchar (50)	NULL ,
+	pubName			varchar (400)	NOT NULL ,
+	pubDescription		varchar (2000)	NULL ,
+	pubCreationDate		varchar (10)	NOT NULL ,
+	pubBeginDate		varchar (10)	NOT NULL ,
+	pubEndDate		varchar (10)	NOT NULL ,
+	pubCreatorId		varchar (100)	NOT NULL ,
+	pubImportance		int		NULL ,
+	pubVersion		varchar (100)	NULL ,
+	pubKeywords		varchar (1000)	NULL ,
+	pubContent		varchar (2000)	NULL ,
+	pubStatus		varchar (100)	NULL ,
+	pubUpdateDate		varchar (10)	NULL ,
+	instanceId		varchar (50)	NOT NULL ,
+	pubUpdaterId        	varchar (100)	NULL ,
+	pubValidateDate		varchar (10)	NULL , 
+	pubValidatorId		varchar (50)	NULL ,
+	pubBeginHour		varchar (5)	NULL ,
+	pubEndHour		varchar (5)	NULL ,
+	pubAuthor		varchar (50)	NULL,
+	pubTargetValidatorId	varchar (50)	NULL,
+	pubCloneId		int		DEFAULT (-1) NOT NULL,
+	pubCloneStatus		varchar (50)	NULL,
+	lang			char(2)		NULL,
+	pubdraftoutdate		varchar (10)	NULL
+);
+
+CREATE TABLE SB_Publication_PubliFather
+(
+	pubId		int		NOT NULL,
+	nodeId		int		NOT NULL,
+	instanceId	varchar (50)	NOT NULL,
+	aliasUserId	int,
+	aliasDate	varchar(20),
+	pubOrder	int		DEFAULT (0) NULL
+);
+
+CREATE TABLE SB_SeeAlso_Link 
+(
+	id			int		NOT NULL,
+	objectId		int		NOT NULL,
+	objectInstanceId	varchar (50)	NOT NULL,
+	targetId		int		NOT NULL,
+	targetInstanceId	varchar (50)	NOT NULL 
+)
+;
+
+CREATE TABLE SB_Publication_PubliI18N
+(
+	id		int		NOT NULL,
+	pubId		int		NOT NULL,
+	lang		char (2)	NOT NULL,
+	name		varchar (400)	NOT NULL,
+	description	varchar (2000),
+	keywords	varchar (1000)
+);
+
+CREATE TABLE SB_Publication_Validation
+(
+	id		int		NOT NULL,
+	pubId		int		NOT NULL,
+	instanceId	varchar(50)	NOT NULL,
+	userId		int		NOT NULL,
+	decisionDate	varchar(20)	NOT NULL,
+	decision	varchar(50)	NOT NULL
+)
+;
+
+CREATE TABLE SB_Thumbnail_Thumbnail 
+(
+	instanceId		varchar (50)	NOT NULL ,
+	objectId		int	NOT NULL ,
+	objectType		int	NOT NULL ,
+	originalAttachmentName		varchar(250)  NOT NULL ,
+	modifiedAttachmentName		varchar(250)  NULL ,
+  mimeType		varchar(250)  NULL ,
+	xStart		int NULL ,
+	yStart		int NULL ,
+	xLength		int NULL ,
+	yLength		int NULL
+) 
+;

--- a/config-core/src/main/config/dbRepository/oracle/publication/020/drop_constraint.sql
+++ b/config-core/src/main/config/dbRepository/oracle/publication/020/drop_constraint.sql
@@ -1,0 +1,8 @@
+ALTER TABLE SB_Publication_Info			DROP CONSTRAINT PK_Publication_Info;
+ALTER TABLE SB_Publication_InfoAttachment	DROP CONSTRAINT PK_Publication_InfoAttachment;
+ALTER TABLE SB_Publication_InfoImage		DROP CONSTRAINT PK_Publication_InfoImage;
+ALTER TABLE SB_Publication_InfoLink		DROP CONSTRAINT PK_Publication_InfoLink;
+ALTER TABLE SB_Publication_InfoText		DROP CONSTRAINT PK_Publication_InfoText;
+ALTER TABLE SB_Publication_Publi		DROP CONSTRAINT PK_Publication_Publi;
+ALTER TABLE SB_Publication_PubliFather		DROP CONSTRAINT PK_Publication_PubliFather;
+ALTER TABLE SB_Thumbnail_Thumbnail DROP CONSTRAINT PK_Thumbnail_Thumbnail;

--- a/config-core/src/main/config/dbRepository/oracle/publication/020/drop_index.sql
+++ b/config-core/src/main/config/dbRepository/oracle/publication/020/drop_index.sql
@@ -1,0 +1,1 @@
+DROP INDEX IN_Publi_Father;

--- a/config-core/src/main/config/dbRepository/oracle/publication/020/drop_table.sql
+++ b/config-core/src/main/config/dbRepository/oracle/publication/020/drop_table.sql
@@ -1,0 +1,8 @@
+DROP TABLE SB_Publication_Info;
+DROP TABLE SB_Publication_InfoAttachment;
+DROP TABLE SB_Publication_InfoImage;
+DROP TABLE SB_Publication_InfoLink;
+DROP TABLE SB_Publication_InfoText;
+DROP TABLE SB_Publication_Publi;
+DROP TABLE SB_Publication_PubliFather;
+DROP TABLE SB_Thumbnail_Thumbnail;

--- a/config-core/src/main/config/dbRepository/postgres/publication/020/create_constraint.sql
+++ b/config-core/src/main/config/dbRepository/postgres/publication/020/create_constraint.sql
@@ -1,0 +1,73 @@
+ALTER TABLE SB_Publication_Info ADD 
+	 CONSTRAINT PK_Publication_Info PRIMARY KEY   
+	(
+		infoId
+	)   
+;
+
+ALTER TABLE SB_Publication_InfoAttachment  ADD 
+	 CONSTRAINT PK_Publication_InfoAttachment PRIMARY KEY   
+	(
+		infoAttachmentId
+	)   
+;
+
+ALTER TABLE SB_Publication_InfoImage  ADD 
+	 CONSTRAINT PK_Publication_InfoImage PRIMARY KEY   
+	(
+		infoImageId
+	)   
+;
+
+ALTER TABLE SB_Publication_InfoLink  ADD 
+	 CONSTRAINT PK_Publication_InfoLink PRIMARY KEY   
+	(
+		infoLinkId
+	)   
+;
+
+ALTER TABLE SB_Publication_InfoText  ADD 
+	 CONSTRAINT PK_Publication_InfoText PRIMARY KEY   
+	(
+		infoTextId
+	)   
+;
+
+ALTER TABLE SB_Publication_Publi  ADD 
+	 CONSTRAINT PK_Publication_Publi PRIMARY KEY   
+	(
+		pubId
+	)   
+;
+
+ALTER TABLE SB_Publication_PubliFather  ADD 
+	 CONSTRAINT PK_Publication_PubliFather PRIMARY KEY   
+	(
+		pubId,
+		nodeId,
+		instanceId
+	)   
+;
+
+ALTER TABLE SB_SeeAlso_Link  ADD 
+	 CONSTRAINT PK_SeeAlso_Link PRIMARY KEY   
+	(
+		id
+	)   
+;
+
+ALTER TABLE SB_Publication_PubliI18N  ADD 
+	 CONSTRAINT PK_Publication_PubliI18N PRIMARY KEY   
+	(
+		id
+	)   
+;
+
+ALTER TABLE SB_Thumbnail_Thumbnail ADD 
+	 CONSTRAINT PK_Thumbnail_Thumbnail PRIMARY KEY   
+	(
+		objectId,
+		objectType,
+		instanceId
+	)   
+;

--- a/config-core/src/main/config/dbRepository/postgres/publication/020/create_index.sql
+++ b/config-core/src/main/config/dbRepository/postgres/publication/020/create_index.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IN_Publi_Father
+ON SB_Publication_PubliFather (nodeId);

--- a/config-core/src/main/config/dbRepository/postgres/publication/020/create_table.sql
+++ b/config-core/src/main/config/dbRepository/postgres/publication/020/create_table.sql
@@ -1,0 +1,134 @@
+CREATE TABLE SB_Publication_Info
+(
+	infoId		int		NOT NULL ,
+	modelId		int		NULL ,
+	infoContent	varchar (2000)	NULL ,
+	instanceId	varchar (50)	NOT NULL
+);
+
+CREATE TABLE SB_Publication_InfoAttachment
+(
+	infoAttachmentId		int		NOT NULL ,
+	infoId				int		NOT NULL ,
+	infoAttachmentPhysicalName	varchar (1000)	NOT NULL ,
+	infoAttachmentLogicalName	varchar (1000)	NOT NULL ,
+	infoAttachmentDescription	varchar (2000)	NULL ,
+	infoAttachmentType		varchar (50)	NOT NULL ,
+	infoAttachmentSize		int		NULL ,
+	infoAttachmentDisplayOrder	int		NOT NULL
+)
+;
+
+CREATE TABLE SB_Publication_InfoImage
+(
+	infoImageId		int		NOT NULL ,
+	infoId			int		NOT NULL ,
+	infoImagePhysicalName	varchar (1000)	NOT NULL ,
+	infoImageLogicalName	varchar (1000)	NOT NULL ,
+	infoImageDescription	varchar (2000)	NULL ,
+	infoImageType		varchar (50)	NOT NULL ,
+	infoImageSize		int		NULL ,
+	infoImageDisplayOrder	int		NOT NULL
+);
+
+CREATE TABLE SB_Publication_InfoLink
+(
+	infoLinkId		int		NOT NULL ,
+	infoId			int		NOT NULL ,
+	pubId			int		NOT NULL ,
+	infoLinkDisplayOrder	int		NOT NULL
+);
+
+CREATE TABLE SB_Publication_InfoText
+(
+	infoTextId		int		NOT NULL ,
+	infoId			int		NOT NULL ,
+	infoTextContent		varchar (4000) NULL,
+	infoTextDisplayOrder	int		NOT NULL
+);
+
+CREATE TABLE SB_Publication_Publi
+(
+	pubId			int		NOT NULL ,
+	infoId			varchar (50) 	NULL ,
+	pubName			varchar (400)	NOT NULL ,
+	pubDescription		varchar (2000)	NULL ,
+	pubCreationDate		varchar (10)	NOT NULL ,
+	pubBeginDate		varchar (10)	NOT NULL ,
+	pubEndDate		varchar (10)	NOT NULL ,
+	pubCreatorId		varchar (100)	NOT NULL ,
+	pubImportance		int		NULL ,
+	pubVersion		varchar (100)	NULL ,
+	pubKeywords		varchar (1000)	NULL ,
+	pubContent		varchar (2000)	NULL ,
+	pubStatus		varchar (100)	NULL ,
+	pubUpdateDate		varchar (10)	NULL ,
+	instanceId		varchar (50)	NOT NULL ,
+	pubUpdaterId            varchar (100)	NULL ,
+	pubValidateDate		varchar (10)	NULL ,
+	pubValidatorId		varchar (50)	NULL ,
+	pubBeginHour		varchar (5)	NULL ,
+	pubEndHour		varchar (5)	NULL ,
+	pubAuthor		varchar (50)	NULL,
+	pubTargetValidatorId	varchar (50)	NULL,
+	pubCloneId		int		DEFAULT (-1),
+	pubCloneStatus		varchar (50)	NULL,
+	lang			char(2)		NULL,
+	pubdraftoutdate		varchar (10)	NULL
+);
+
+CREATE TABLE SB_Publication_PubliFather
+(
+	pubId		int		NOT NULL ,
+	nodeId		int		NOT NULL ,
+	instanceId	varchar (50)	NOT NULL,
+	aliasUserId	int,
+	aliasDate	varchar (20),
+	pubOrder	int		DEFAULT (0) NULL
+);
+
+CREATE TABLE SB_SeeAlso_Link
+(
+	id			int		NOT NULL,
+	objectId		int		NOT NULL,
+	objectInstanceId	varchar (50)	NOT NULL,
+	targetId		int		NOT NULL,
+	targetInstanceId	varchar (50)	NOT NULL
+)
+;
+
+CREATE TABLE SB_Publication_PubliI18N
+(
+	id		int		NOT NULL,
+	pubId		int		NOT NULL,
+	lang		char (2)	NOT NULL,
+	name		varchar (400)	NOT NULL,
+	description	varchar (2000),
+	keywords	varchar (1000)
+);
+
+CREATE TABLE SB_Publication_Validation
+(
+	id		int		NOT NULL,
+	pubId		int		NOT NULL,
+	instanceId	varchar(50)	NOT NULL,
+	userId		int		NOT NULL,
+	decisionDate	varchar(20)	NOT NULL,
+	decision	varchar(50)	NOT NULL
+)
+;
+
+CREATE TABLE SB_Thumbnail_Thumbnail 
+(
+	instanceId		          varchar (50)	NOT NULL ,
+	objectId              	          int	NOT NULL ,
+	objectType              	          int	NOT NULL ,
+	originalAttachmentName		varchar(250)  NOT NULL ,
+	modifiedAttachmentName		varchar(250)  NULL ,
+  mimeType		varchar(250)  NULL ,
+	xStart	                int NULL ,
+	yStart	                int NULL ,
+	xLength	                int NULL ,
+	yLength	                int NULL
+) 
+;

--- a/config-core/src/main/config/dbRepository/postgres/publication/020/drop_constraint.sql
+++ b/config-core/src/main/config/dbRepository/postgres/publication/020/drop_constraint.sql
@@ -1,0 +1,8 @@
+ALTER TABLE SB_Publication_Info			DROP CONSTRAINT PK_Publication_Info;
+ALTER TABLE SB_Publication_InfoAttachment	DROP CONSTRAINT PK_Publication_InfoAttachment;
+ALTER TABLE SB_Publication_InfoImage		DROP CONSTRAINT PK_Publication_InfoImage;
+ALTER TABLE SB_Publication_InfoLink		DROP CONSTRAINT PK_Publication_InfoLink;
+ALTER TABLE SB_Publication_InfoText		DROP CONSTRAINT PK_Publication_InfoText;
+ALTER TABLE SB_Publication_Publi		DROP CONSTRAINT PK_Publication_Publi;
+ALTER TABLE SB_Publication_PubliFather		DROP CONSTRAINT PK_Publication_PubliFather;
+ALTER TABLE SB_Thumbnail_Thumbnail DROP CONSTRAINT PK_Thumbnail_Thumbnail;

--- a/config-core/src/main/config/dbRepository/postgres/publication/020/drop_index.sql
+++ b/config-core/src/main/config/dbRepository/postgres/publication/020/drop_index.sql
@@ -1,0 +1,1 @@
+DROP INDEX IN_Publi_Father;

--- a/config-core/src/main/config/dbRepository/postgres/publication/020/drop_table.sql
+++ b/config-core/src/main/config/dbRepository/postgres/publication/020/drop_table.sql
@@ -1,0 +1,8 @@
+DROP TABLE SB_Publication_Info;
+DROP TABLE SB_Publication_InfoAttachment;
+DROP TABLE SB_Publication_InfoImage;
+DROP TABLE SB_Publication_InfoLink;
+DROP TABLE SB_Publication_InfoText;
+DROP TABLE SB_Publication_Publi;
+DROP TABLE SB_Publication_PubliFather;
+drop table SB_Thumbnail_Thumbnail;

--- a/war-core/src/main/java/com/silverpeas/socialnetwork/myProfil/control/MyProfilSessionController.java
+++ b/war-core/src/main/java/com/silverpeas/socialnetwork/myProfil/control/MyProfilSessionController.java
@@ -148,11 +148,11 @@ public class MyProfilSessionController extends AbstractComponentSessionControlle
       // It is important to load user data the most later possible because of potential updates
       // of user data by password management services
       UserFull theModifiedUser = adminCtrl.getUserFull(idUser);
-      theModifiedUser.setLastName(Encode.forHtml(userLastName));
-      theModifiedUser.setFirstName(Encode.forHtml(userFirstName));
-      theModifiedUser.seteMail(Encode.forHtml(userEMail));
-      theModifiedUser.setLoginQuestion(Encode.forHtml(userLoginQuestion));
-      theModifiedUser.setLoginAnswer(Encode.forHtml(userLoginAnswer));
+      theModifiedUser.setLastName(userLastName);
+      theModifiedUser.setFirstName(userFirstName);
+      theModifiedUser.seteMail(userEMail);
+      theModifiedUser.setLoginQuestion(userLoginQuestion);
+      theModifiedUser.setLoginAnswer(userLoginAnswer);
       // Si l'utilisateur n'a pas entré de nouveau mdp, on ne le change pas
       if (newPassword != null && newPassword.length() != 0) {
         theModifiedUser.setPassword(newPassword);
@@ -196,8 +196,8 @@ public class MyProfilSessionController extends AbstractComponentSessionControlle
    */
   public List<InvitationUser> getAllMyInvitationsSent() {
     List<InvitationUser> invitationUsers = new ArrayList<InvitationUser>();
-    List<Invitation> invitations =
-        invitationService.getAllMyInvitationsSent(Integer.parseInt(getUserId()));
+    List<Invitation> invitations = invitationService.getAllMyInvitationsSent(Integer.parseInt(
+        getUserId()));
     for (Invitation varI : invitations) {
       invitationUsers.add(new InvitationUser(varI,
           getUserDetail(Integer.toString(varI.getReceiverId()))));
@@ -212,8 +212,8 @@ public class MyProfilSessionController extends AbstractComponentSessionControlle
    */
   public List<InvitationUser> getAllMyInvitationsReceived() {
     List<InvitationUser> invitationUsers = new ArrayList<InvitationUser>();
-    List<Invitation> invitations =
-        invitationService.getAllMyInvitationsReceive(Integer.parseInt(getUserId()));
+    List<Invitation> invitations = invitationService.getAllMyInvitationsReceive(Integer.parseInt(
+        getUserId()));
     for (Invitation varI : invitations) {
       invitationUsers.add(new InvitationUser(varI, getUserDetail(
           Integer.toString(varI.getSenderId()))));
@@ -223,8 +223,8 @@ public class MyProfilSessionController extends AbstractComponentSessionControlle
 
   public void sendInvitation(String receiverId, String message) {
     String safeMessage = Encode.forHtml(message);
-    Invitation invitation =
-        new Invitation(Integer.parseInt(getUserId()), Integer.parseInt(receiverId), safeMessage,
+    Invitation invitation = new Invitation(Integer.parseInt(getUserId()), Integer.parseInt(
+        receiverId), safeMessage,
         new Date());
     if (invitationService.invite(invitation) >= 0) {
       notifyUser(receiverId, message);
@@ -244,8 +244,8 @@ public class MyProfilSessionController extends AbstractComponentSessionControlle
       SilverTrace.debug("MyProfilSessionController", MyProfilSessionController.class.getName()
           + ".getAlertNotificationMetaData()", "root.MSG_GEN_PARAM_VALUE", "subject = " + subject);
 
-      NotificationMetaData notifMetaData =
-          new NotificationMetaData(NotificationParameters.NORMAL, subject, templates,
+      NotificationMetaData notifMetaData = new NotificationMetaData(NotificationParameters.NORMAL,
+          subject, templates,
           "sendInvitation");
 
       UserDetail senderUser = getUserDetail();
@@ -322,8 +322,8 @@ public class MyProfilSessionController extends AbstractComponentSessionControlle
       SilverTrace.debug("MyProfilSessionController", MyProfilSessionController.class.getName()
           + ".getAlertNotificationMetaData()", "root.MSG_GEN_PARAM_VALUE", "subject = " + subject);
 
-      NotificationMetaData notifMetaData =
-          new NotificationMetaData(NotificationParameters.NORMAL, subject, templates,
+      NotificationMetaData notifMetaData = new NotificationMetaData(NotificationParameters.NORMAL,
+          subject, templates,
           "acceptInvitation");
 
       notifMetaData.setSource(displayedName);
@@ -371,8 +371,8 @@ public class MyProfilSessionController extends AbstractComponentSessionControlle
   public Map<SocialNetworkID, ExternalAccount> getAllMyNetworks() {
     Map<SocialNetworkID, ExternalAccount> networks = new HashMap<SocialNetworkID, ExternalAccount>();
 
-    List<ExternalAccount> externalAccounts =
-        SocialNetworkService.getInstance().getUserExternalAccounts(getUserId());
+    List<ExternalAccount> externalAccounts = SocialNetworkService.getInstance().
+        getUserExternalAccounts(getUserId());
     for (ExternalAccount account : externalAccounts) {
       networks.put(account.getNetworkId(), account);
     }

--- a/war-core/src/main/java/com/silverpeas/socialnetwork/myProfil/servlets/JSONServlet.java
+++ b/war-core/src/main/java/com/silverpeas/socialnetwork/myProfil/servlets/JSONServlet.java
@@ -56,11 +56,11 @@ public class JSONServlet extends HttpServlet {
       String status = request.getParameter("status");
       // if status is empty or set with a text, update it (an empty status means no status)
       if (status != null) {
-        status = socialNetworkService.changeStatusService(Encode.forHtml(status));
+        status = socialNetworkService.changeStatusService(status);
 
       } // if status equal null don't do update status and do get Last status
       else {
-        status = socialNetworkService.getLastStatusService();
+        status = Encode.forHtml(socialNetworkService.getLastStatusService());
       }
       JSONObject jsonStatus = new JSONObject();
       jsonStatus.put("status", status);

--- a/war-core/src/main/java/com/silverpeas/socialnetwork/myProfil/servlets/MyProfilRequestRouter.java
+++ b/war-core/src/main/java/com/silverpeas/socialnetwork/myProfil/servlets/MyProfilRequestRouter.java
@@ -33,7 +33,6 @@ import com.silverpeas.util.StringUtil;
 import com.silverpeas.util.web.servlet.FileUploadUtil;
 import com.stratelia.silverpeas.peasCore.ComponentContext;
 import com.stratelia.silverpeas.peasCore.MainSessionController;
-import com.stratelia.silverpeas.peasCore.PeasCoreException;
 import com.stratelia.silverpeas.peasCore.servlets.ComponentRequestRouter;
 import com.stratelia.silverpeas.silvertrace.SilverTrace;
 import com.stratelia.webactiv.beans.admin.UserDetail;
@@ -243,8 +242,8 @@ public class MyProfilRequestRouter extends ComponentRequestRouter<MyProfilSessio
    */
   private List<UserDetail> getContactsToDisplay(List<String> contactIds,
       MyProfilSessionController sc) {
-    int numberOfContactsTodisplay =
-        sc.getSettings().getInteger("numberOfContactsTodisplay", NUMBER_CONTACTS_TO_DISPLAY);
+    int numberOfContactsTodisplay = sc.getSettings().getInteger("numberOfContactsTodisplay",
+        NUMBER_CONTACTS_TO_DISPLAY);
     List<UserDetail> contacts = new ArrayList<UserDetail>();
     if (contactIds.size() <= numberOfContactsTodisplay) {
       for (String userId : contactIds) {
@@ -265,8 +264,8 @@ public class MyProfilRequestRouter extends ComponentRequestRouter<MyProfilSessio
   private void updateUserFull(HttpServletRequest request, MyProfilSessionController sc) {
     ResourceLocator rl = new ResourceLocator(
         "org.silverpeas.personalizationPeas.settings.personalizationPeasSettings", "");
-    ResourceLocator authenticationSettings =
-        new ResourceLocator("org.silverpeas.authentication.settings.authenticationSettings", "");
+    ResourceLocator authenticationSettings = new ResourceLocator(
+        "org.silverpeas.authentication.settings.authenticationSettings", "");
     UserDetail currentUser = sc.getUserDetail();
     // Update informations only if updateMode is allowed for each field
     try {

--- a/war-core/src/main/webapp/portlets/jsp/lastPublications/portlet.jsp
+++ b/war-core/src/main/webapp/portlets/jsp/lastPublications/portlet.jsp
@@ -75,7 +75,7 @@ for (PublicationDetail pub : publications) {
 <% } else {
     first = false;
   }%>
-<a href="javaScript:goTo('<%=url %>','<%=pub.getPK().getInstanceId() %>')"><b><%=pub.getName(language)%></b></a>
+  <a href="javaScript:goTo('<%=url %>','<%=pub.getPK().getInstanceId() %>')"><b><%=EncodeHelper.javaStringToHtmlString(pub.getName(language))%></b></a>
     <% if (pubUpdater != null && pub.getUpdateDate() != null) { %>
       <br/><view:username userId="<%=pubUpdater.getId() %>"/> - <%=DateUtil.getOutputDate(pub.getUpdateDate(), language)%>
     <% } else if (pubUpdater != null && pub.getUpdateDate() == null) { %>
@@ -85,7 +85,7 @@ for (PublicationDetail pub : publications) {
       <br/><%=DateUtil.getOutputDate(pub.getUpdateDate(), language) %>
     <% } %>
     <% if ("checked".equalsIgnoreCase(pref.getValue("displayDescription", "")) && StringUtil.isDefined(pub.getDescription(language))) { %>
-      <br/><%=EncodeHelper.convertWhiteSpacesForHTMLDisplay(pub.getDescription(language)) %>
+      <br/><%=EncodeHelper.convertWhiteSpacesForHTMLDisplay(EncodeHelper.javaStringToHtmlString(pub.getDescription(language))) %>
     <% } %>
 <% } %>
 <br/>

--- a/web-core/src/main/java/com/silverpeas/comment/web/CommentEntity.java
+++ b/web-core/src/main/java/com/silverpeas/comment/web/CommentEntity.java
@@ -126,10 +126,9 @@ public class CommentEntity implements Exposable {
    * @return a comment instance.
    */
   public Comment toComment() {
-    String safeText = Encode.forHtml(text);
-    Comment comment =
-        new Comment(new CommentPK(id, componentId), resourceType, new PublicationPK(resourceId,
-        componentId), Integer.valueOf(author.getId()), author.getFullName(), safeText,
+    Comment comment = new Comment(new CommentPK(id, componentId), resourceType, new PublicationPK(
+        resourceId,
+        componentId), Integer.valueOf(author.getId()), author.getFullName(), text,
         decodeFromDisplayDate(creationDate, getAuthor().getLanguage()),
         decodeFromDisplayDate(modificationDate, getAuthor().getLanguage()));
     comment.setOwnerDetail(getAuthor().toUserDetail());
@@ -237,7 +236,7 @@ public class CommentEntity implements Exposable {
   /**
    * Is this comment indexed? By default, the comment isn't indexed by the system.
    *
-* @return true if the comment is indexed, false otherwise.
+   * @return true if the comment is indexed, false otherwise.
    */
   public boolean isIndexed() {
     return indexed;
@@ -259,7 +258,7 @@ public class CommentEntity implements Exposable {
     this.id = comment.getCommentPK().getId();
     this.resourceType = comment.getResourceType();
     this.resourceId = comment.getForeignKey().getId();
-    this.text = comment.getMessage();
+    this.text = Encode.forHtml(comment.getMessage());
     this.author = UserProfileEntity.fromUser(comment.getCreator());
     this.creationDate = encodeToDisplayDate(comment.getCreationDate(), this.author.getLanguage());
     this.modificationDate = encodeToDisplayDate(comment.getModificationDate(), this.author.

--- a/web-core/src/main/java/com/silverpeas/look/LookSilverpeasV5Helper.java
+++ b/web-core/src/main/java/com/silverpeas/look/LookSilverpeasV5Helper.java
@@ -372,8 +372,7 @@ public class LookSilverpeasV5Helper implements LookHelper {
       // Remove the current user
       SessionManagementFactory factory = SessionManagementFactory.getFactory();
       SessionManagement sessionManagement = factory.getSessionManagement();
-      nbConnectedUsers =
-          sessionManagement.getNbConnectedUsersList(getMainSessionController().
+      nbConnectedUsers = sessionManagement.getNbConnectedUsersList(getMainSessionController().
           getCurrentUserDetail()) - 1;
     }
     return nbConnectedUsers;
@@ -445,8 +444,7 @@ public class LookSilverpeasV5Helper implements LookHelper {
     if (topItems == null) {
       topItems = new ArrayList<TopItem>();
       topSpaceIds = new ArrayList<String>();
-      StringTokenizer tokenizer =
-          new StringTokenizer(resources.getString("componentsTop", ""), ",");
+      StringTokenizer tokenizer = new StringTokenizer(resources.getString("componentsTop", ""), ",");
       while (tokenizer.hasMoreTokens()) {
         String itemId = tokenizer.nextToken();
 
@@ -650,7 +648,7 @@ public class LookSilverpeasV5Helper implements LookHelper {
           getMainSessionController().getCurrentUserDetail().getLogin());
       destination = getParsedDestination(destination, "%ST_USER_FULLNAME%",
           URLEncoder.encode(getMainSessionController().getCurrentUserDetail().getDisplayedName(),
-          "UTF-8"));
+              "UTF-8"));
       destination = getParsedDestination(destination, "%ST_USER_ID%",
           URLEncoder.encode(getMainSessionController().getUserId(), "UTF-8"));
       destination = getParsedDestination(destination, "%ST_SESSION_ID%",

--- a/web-core/src/main/java/com/silverpeas/profile/web/UserProfileEntity.java
+++ b/web-core/src/main/java/com/silverpeas/profile/web/UserProfileEntity.java
@@ -41,6 +41,7 @@ import com.silverpeas.web.Exposable;
 
 import com.stratelia.silverpeas.peasCore.URLManager;
 import com.stratelia.webactiv.beans.admin.UserDetail;
+import org.owasp.encoder.Encode;
 
 import org.springframework.web.context.ContextLoaderListener;
 import org.springframework.web.context.WebApplicationContext;
@@ -121,7 +122,7 @@ public class UserProfileEntity extends UserDetail implements Exposable {
     } else {
       this.domainName = user.getDomain().getName();
     }
-    this.fullName = user.getDisplayedName();
+    this.fullName = Encode.forHtml(user.getDisplayedName());
     this.avatar = getAvatarURI();
     this.connected = this.user.isConnected();
     this.webPage = getUserProfileWebPageURI();
@@ -150,19 +151,19 @@ public class UserProfileEntity extends UserDetail implements Exposable {
   @Override
   @XmlElement(required = true)
   public String getFirstName() {
-    return this.user.getFirstName();
+    return Encode.forHtml(this.user.getFirstName());
   }
 
   @Override
   @XmlElement(required = true)
   public String getLastName() {
-    return this.user.getLastName();
+    return Encode.forHtml(this.user.getLastName());
   }
 
   @Override
   @XmlElement
   public String geteMail() {
-    return this.user.geteMail();
+    return Encode.forHtml(this.user.geteMail());
   }
 
   /**

--- a/web-core/src/main/java/com/stratelia/webactiv/util/viewGenerator/html/UserNameGenerator.java
+++ b/web-core/src/main/java/com/stratelia/webactiv/util/viewGenerator/html/UserNameGenerator.java
@@ -10,9 +10,9 @@ public class UserNameGenerator {
   public static span generate(String userId, String currentUserId) {
     return generate(UserDetail.getById(userId), currentUserId);
   }
-  
+
   public static span generate(UserDetail user, String currentUserId) {
-    span userName = new span(user.getDisplayedName());
+    span userName = new span(org.owasp.encoder.Encode.forHtml(user.getDisplayedName()));
     if (StringUtil.isDefined(currentUserId)) {
       if (!user.getId().equals(currentUserId) && !UserDetail.isAnonymousUser(currentUserId)) {
         userName.setClass("userToZoom");
@@ -21,13 +21,13 @@ public class UserNameGenerator {
     }
     return userName;
   }
-  
+
   public static String toString(String userId, String currentUserId) {
     return generate(userId, currentUserId).toString();
   }
-  
+
   public static String toString(UserDetail user, String currentUserId) {
     return generate(user, currentUserId).toString();
   }
-  
+
 }

--- a/web-core/src/main/java/org/silverpeas/publication/web/PublicationEntity.java
+++ b/web-core/src/main/java/org/silverpeas/publication/web/PublicationEntity.java
@@ -41,6 +41,7 @@ import com.silverpeas.web.Exposable;
 import com.stratelia.webactiv.beans.admin.UserDetail;
 import com.stratelia.webactiv.util.publication.model.PublicationDetail;
 import org.apache.commons.lang3.CharEncoding;
+import org.owasp.encoder.Encode;
 import org.silverpeas.attachment.model.SimpleDocument;
 
 public class PublicationEntity implements Exposable {
@@ -77,8 +78,8 @@ public class PublicationEntity implements Exposable {
   }
 
   private PublicationEntity(final PublicationDetail publication, URI uri) {
-    this.setName(publication.getName());
-    this.setDescription(publication.getDescription());
+    this.setName(Encode.forHtml(publication.getName()));
+    this.setDescription(Encode.forHtml(publication.getDescription()));
     this.setUri(uri);
     this.setUpdateDate(publication.getUpdateDate());
     this.creator = UserProfileEntity.fromUser(publication.getCreator());
@@ -109,7 +110,7 @@ public class PublicationEntity implements Exposable {
     try {
       sharedUri = new URI(baseURI + "attachments/" + attachment.getInstanceId() + "/" + token + "/"
           + attachment.getId() + "/" + URLEncoder.encode(attachment.getFilename(),
-          CharEncoding.UTF_8));
+              CharEncoding.UTF_8));
     } catch (UnsupportedEncodingException ex) {
       Logger.getLogger(NodeEntity.class.getName()).log(Level.SEVERE, null, ex);
       throw new RuntimeException(ex.getMessage(), ex);


### PR DESCRIPTION
Remove the encoding for HTML rendering of the publications and of the comments at their persisting. The encoding for HTML should be done at the HTML rendering and only for the data that were set by a user. (The encoding for HTML is to avoid XSS attacks.)

Don't forget to integrate also the branch bug-5308 in Silverpeas-Components and in Silverpeas-Setup. 

The integration should be done also for 5.12.8-SNAPSHOT
