### PR TITLE
Bug #5297 : escaping HTML only when script keyword exists in ErrorCode request parameter in order to display correctly the functional HTML messages returned by the server.

### DIFF
--- a/war-core/src/main/webapp/defaultLogin.jsp
+++ b/war-core/src/main/webapp/defaultLogin.jsp
@@ -27,6 +27,7 @@
 <%@ page isELIgnored="false" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn" %>
 <%@ taglib uri="http://www.silverpeas.com/tld/viewGenerator" prefix="view" %>
 <fmt:setLocale value="${pageContext.request.locale.language}"/>
 <%@ include file="headLog.jsp" %>
@@ -201,7 +202,7 @@
             <c:choose>
               <c:when test="${!empty param.ErrorCode && '4' != param.ErrorCode && 'null' != param.ErrorCode}">
                 <fmt:message key="authentication.logon.${param.ErrorCode}" var="errorMessage"/>
-                <span><c:out value="${errorMessage}"/></span>
+                <span><c:out value="${errorMessage}" escapeXml="${fn:contains(errorMessage, 'script') ? 'true' : 'false'}"/></span>
               </c:when>
               <c:otherwise>
                 <fmt:message key="authentication.logon.subtitle"/>


### PR DESCRIPTION
Don't forget to integrate it into 5.12.8-SNAPSHOT (and master too)
