### PR TITLE
Bug 5411. Thanks JProfiler !

### DIFF
--- a/war-core/src/main/java/com/stratelia/silverpeas/pdcPeas/control/PdcSearchSessionController.java
+++ b/war-core/src/main/java/com/stratelia/silverpeas/pdcPeas/control/PdcSearchSessionController.java
@@ -623,7 +623,8 @@ public class PdcSearchSessionController extends AbstractComponentSessionControll
     if (results != null) {
       // Retrieve the black list component (we don't need to filter data on it)
       List<String> blackList = getFacetBlackList();
-
+      Map<String, ComponentInstLight> components = new HashMap<String, ComponentInstLight>();
+      
       // Loop on each result
       for (GlobalSilverResult result : results) {
         if (isEnableExternalSearch) {
@@ -643,15 +644,15 @@ public class PdcSearchSessionController extends AbstractComponentSessionControll
         processFacetComponent(componentFacet, result, blackList);
 
         // manage "datatype" facet
-        processFacetDatatype(dataTypeFacet, result);
+        processFacetDatatype(dataTypeFacet, result, components);
         
-        if (result.isAttachment()) {
-          processFacetFiletype(fileTypeFacet, result);
-        }
-
+        processFacetFiletype(fileTypeFacet, result);
+        
         // manage forms fields facets
         processFacetsFormField(fieldFacetsMap, result);
       }
+      
+      components.clear();
     }
 
     // Fill result filter with current result values
@@ -683,11 +684,12 @@ public class PdcSearchSessionController extends AbstractComponentSessionControll
     }
   }
 
-  private void processFacetDatatype(Facet facet, GlobalSilverResult result) {
+  private void processFacetDatatype(Facet facet, GlobalSilverResult result,
+      Map<String, ComponentInstLight> components) {
     String instanceId = result.getInstanceId();
     String type = result.getType();
     if (StringUtil.isDefined(type)) {
-      SearchTypeConfigurationVO theSearchType = getSearchType(instanceId, type);
+      SearchTypeConfigurationVO theSearchType = getSearchType(instanceId, type, components);
       if (theSearchType != null) {
         FacetEntryVO facetEntry = new FacetEntryVO(theSearchType.getName(), String.valueOf(
             theSearchType.getConfigId()));
@@ -839,7 +841,7 @@ public class PdcSearchSessionController extends AbstractComponentSessionControll
     // Tous les résultats
     List<GlobalSilverResult> results =
         matchingIndexEntries2GlobalSilverResults(filterMatchingIndexEntries(indexEntries));
-    setGlobalSR(results, true);
+    setGlobalSR(results);
     return results;
   }
 
@@ -847,7 +849,7 @@ public class PdcSearchSessionController extends AbstractComponentSessionControll
       throws Exception {
     // Tous les résultats
     List<GlobalSilverResult> results = globalSilverContents2GlobalSilverResults(silverContents);
-    setGlobalSR(results, true);
+    setGlobalSR(results);
 
     // case of PDC results : pertinence sort is not applicable
     // sort by updateDate desc
@@ -861,17 +863,6 @@ public class PdcSearchSessionController extends AbstractComponentSessionControll
 
     // Tous les résultats
     List<GlobalSilverResult> results = getGlobalSR();
-
-    if (results != null && getSelectedSilverContents() != null) {
-      for (int i = 0; i < results.size(); i++) {
-        GlobalSilverResult result = results.get(i);
-        if (getSelectedSilverContents().contains(result)) {
-          result.setSelected(true);
-        } else {
-          result.setSelected(false);
-        }
-      }
-    }
 
     // Tri de tous les résultats
     // Gets a SortResult implementation to realize the sorting and/or filtering results
@@ -890,16 +881,19 @@ public class PdcSearchSessionController extends AbstractComponentSessionControll
     }
     List<GlobalSilverResult> sortedResults = sortResults.execute(results, sortOrder, sortValString,
         getLanguage());
+    List<GlobalSilverResult> resultsToDisplay = new ArrayList<GlobalSilverResult>();
     if (filter != null && !filter.isEmpty()) {
       // Check Author filter
-      return filterResult(filter, sortedResults);
+      resultsToDisplay = filterResult(filter, sortedResults);
     } else {
       // Put the full result list in session
-      setGlobalSR(sortedResults, false);
+      setGlobalSR(sortedResults);
 
       // get the part of results to display
-      return sortedResults.subList(getIndexOfFirstResultToDisplay(), getLastIndexToDisplay());
+      resultsToDisplay = sortedResults.subList(getIndexOfFirstResultToDisplay(), getLastIndexToDisplay());
     }
+    setExtraInfoToResultsToDisplay(resultsToDisplay);
+    return resultsToDisplay;
   }
 
   private void setPopularityToResults() {
@@ -960,6 +954,7 @@ public class PdcSearchSessionController extends AbstractComponentSessionControll
     boolean filterFormFields = !filter.isSelectedFormFieldFacetsEmpty();
 
     List<String> blackList = getFacetBlackList();
+    Map<String, ComponentInstLight> components = new HashMap<String, ComponentInstLight>();
 
     for (GlobalSilverResult gsResult : listGSR) {
       if (!blackList.contains(gsResult.getType())) {
@@ -979,7 +974,7 @@ public class PdcSearchSessionController extends AbstractComponentSessionControll
 
         // check datatype facet
         if (visible && filterDatatype) {
-          SearchTypeConfigurationVO theSearchType = getSearchType(gsrInstanceId, gsResult.getType());
+          SearchTypeConfigurationVO theSearchType = getSearchType(gsrInstanceId, gsResult.getType(), components);
           if (theSearchType == null || !datatypeFilter.equals(String.valueOf(theSearchType.
               getConfigId()))) {
             visible = false;
@@ -1024,6 +1019,7 @@ public class PdcSearchSessionController extends AbstractComponentSessionControll
         }
       }
     }
+    components.clear();
 
     // Put the full result list in session
     setFilteredSR(sortedResults);
@@ -1218,7 +1214,12 @@ public class PdcSearchSessionController extends AbstractComponentSessionControll
       if (isExportEnabled()) {
         result.setExportable(isCompliantResult(result));
       }
-
+      
+      if (getSelectedSilverContents() != null && getSelectedSilverContents().contains(result)) {
+        result.setSelected(true);
+      } else {
+        result.setSelected(false);
+      }
     }
   }
 
@@ -2837,10 +2838,7 @@ public class PdcSearchSessionController extends AbstractComponentSessionControll
    *
    * @param globalSR : the current list of result
    */
-  private void setGlobalSR(List<GlobalSilverResult> globalSR, boolean setExtraInfo) {
-    if (setExtraInfo) {
-      setExtraInfoToResultsToDisplay(globalSR);
-    }
+  private void setGlobalSR(List<GlobalSilverResult> globalSR) {
     this.globalSR = globalSR;
     clearFilteredSR();
   }
@@ -2956,8 +2954,12 @@ public class PdcSearchSessionController extends AbstractComponentSessionControll
     return dataSearchTypes;
   }
 
-  private SearchTypeConfigurationVO getSearchType(String componentId, String type) {
-    ComponentInstLight component = getOrganisationController().getComponentInstLight(componentId);
+  private SearchTypeConfigurationVO getSearchType(String componentId, String type, Map<String, ComponentInstLight> components) {
+    ComponentInstLight component = components.get(componentId);
+    if (component == null) {
+      component = getOrganisationController().getComponentInstLight(componentId);
+      components.put(componentId, component);
+    }
     if (component != null) {
       for (SearchTypeConfigurationVO aSearchType : getSearchTypeConfig()) {
         if (aSearchType.getComponents().contains(component.getName())) {


### PR DESCRIPTION
The following optimizations were performed :
- information about files was processed by not taking into account the pagination
- using a local self-made cache of ComponentIntLight (facet 'resource type')

For more than 3000 results, performance has improved from 2 minutes to 5 seconds !
