### PR TITLE
Bug #5479 : JCR copy and move problems

### DIFF
--- a/lib-core/src/main/java/com/stratelia/webactiv/util/FileServerUtils.java
+++ b/lib-core/src/main/java/com/stratelia/webactiv/util/FileServerUtils.java
@@ -50,7 +50,6 @@ public class FileServerUtils {
   public static final String FILE_NAME_PARAMETER = "fileName";
   public static final String ATTACHMENT_ID_PARAMETER = "attachmentId";
   public static final String LANGUAGE_PARAMETER = "lang";
-  public static final String DOCUMENT_ID_PARAMETER = "DocumentId";
   public static final String VERSION_ID_PARAMETER = "VersionId";
   public static final String NODE_ID_PARAMETER = "NodeId";
   public static final String PUBLICATION_ID_PARAMETER = "PubId";

--- a/lib-core/src/main/java/com/stratelia/webactiv/util/WAPrimaryKey.java
+++ b/lib-core/src/main/java/com/stratelia/webactiv/util/WAPrimaryKey.java
@@ -36,7 +36,7 @@ import java.io.Serializable;
  * @author Nicolas Eysseric
  * @version 1.0
  */
-public abstract class WAPrimaryKey implements Serializable {
+public abstract class WAPrimaryKey implements Serializable, Cloneable {
 
   private static final long serialVersionUID = -2456912022917180222L;
 
@@ -230,5 +230,15 @@ public abstract class WAPrimaryKey implements Serializable {
 
   public String getInstanceId() {
     return getComponentName();
+  }
+
+  @SuppressWarnings("CloneDoesntDeclareCloneNotSupportedException")
+  @Override
+  public WAPrimaryKey clone() {
+    try {
+      return (WAPrimaryKey) super.clone();
+    } catch (CloneNotSupportedException e) {
+      throw new RuntimeException(e);
+    }
   }
 }

--- a/lib-core/src/main/java/org/silverpeas/attachment/SimpleDocumentService.java
+++ b/lib-core/src/main/java/org/silverpeas/attachment/SimpleDocumentService.java
@@ -942,7 +942,7 @@ public class SimpleDocumentService implements AttachmentService {
       session = BasicDaoFactory.getSystemSession();
       SimpleDocumentPK pk = repository.moveDocument(session, document, destination);
       SimpleDocument moveDoc = repository.findDocumentById(session, pk, null);
-      repository.moveMultilangContent(document, moveDoc);
+      repository.moveFullContent(document, moveDoc);
       session.save();
       return pk;
     } catch (RepositoryException ex) {

--- a/lib-core/src/main/java/org/silverpeas/attachment/model/HistorisedDocumentVersion.java
+++ b/lib-core/src/main/java/org/silverpeas/attachment/model/HistorisedDocumentVersion.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2000 - 2014 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception. You should have recieved a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "http://www.silverpeas.org/docs/core/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.silverpeas.attachment.model;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+
+/**
+ * This class permits to get an historised document behaviour not from the master version but
+ * from a frozen version of the document.
+ * The history is accorded to the specified version.
+ * To obtain the master version, please use {@link #getVersionMaster()} method.
+ * To check if the current instance is indexed on master version,
+ * please use {@link #isVersionMaster()} method.
+ * @author Yohann Chastagnier
+ */
+public class HistorisedDocumentVersion extends HistorisedDocument {
+  private static final long serialVersionUID = -3077658530477641631L;
+
+  /**
+   * Default constructor.
+   * @param version the simple document version from which the historised document is indexed.
+   */
+  public HistorisedDocumentVersion(SimpleDocumentVersion version) {
+    super(version);
+    setVersionMaster(version.getVersionMaster());
+    setHistory(new ArrayList<SimpleDocumentVersion>(version.getVersionMaster().getHistory()));
+    Iterator<SimpleDocumentVersion> historyIt = getHistory().iterator();
+    while (historyIt.hasNext()) {
+      SimpleDocumentVersion currentVersion = historyIt.next();
+      if (currentVersion.getVersionIndex() >= getVersionIndex()) {
+        historyIt.remove();
+      } else {
+        break;
+      }
+    }
+  }
+}

--- a/lib-core/src/main/java/org/silverpeas/attachment/model/SimpleDocument.java
+++ b/lib-core/src/main/java/org/silverpeas/attachment/model/SimpleDocument.java
@@ -171,80 +171,104 @@ public class SimpleDocument implements Serializable {
   public SimpleDocument() {
   }
 
+  protected SimpleDocument(SimpleDocument simpleDocument) {
+    this.repositoryPath = simpleDocument.getRepositoryPath();
+    this.versionMaster = simpleDocument.getVersionMaster();
+    this.versionIndex = simpleDocument.getVersionIndex();
+    this.pk = simpleDocument.getPk();
+    this.foreignId = simpleDocument.getForeignId();
+    this.order = simpleDocument.getOrder();
+    this.versioned = simpleDocument.isVersioned();
+    this.editedBy = simpleDocument.getEditedBy();
+    this.reservation = simpleDocument.getReservation();
+    this.alert = simpleDocument.getAlert();
+    this.expiry = simpleDocument.getExpiry();
+    this.status = simpleDocument.getStatus();
+    this.cloneId = simpleDocument.getCloneId();
+    this.minorVersion = simpleDocument.getMinorVersion();
+    this.majorVersion = simpleDocument.getMajorVersion();
+    this.publicDocument = simpleDocument.isPublic();
+    this.nodeName = simpleDocument.getNodeName();
+    this.comment = simpleDocument.getComment();
+    this.documentType = simpleDocument.getDocumentType();
+    this.forbiddenDownloadForRoles = simpleDocument.forbiddenDownloadForRoles;
+    this.file = simpleDocument.getFile();
+  }
+
   public String getFilename() {
-    return file.getFilename();
+    return getFile().getFilename();
   }
 
   public void setFilename(String filename) {
-    file.setFilename(filename);
+    getFile().setFilename(filename);
   }
 
   public String getLanguage() {
-    return file.getLanguage();
+    return getFile().getLanguage();
   }
 
   public void setLanguage(String language) {
-    file.setLanguage(language);
+    getFile().setLanguage(language);
   }
 
   public String getTitle() {
-    return file.getTitle();
+    return getFile().getTitle();
   }
 
   public void setTitle(String title) {
-    file.setTitle(title);
+    getFile().setTitle(title);
   }
 
   public String getDescription() {
-    return file.getDescription();
+    return getFile().getDescription();
   }
 
   public void setDescription(String description) {
-    file.setDescription(description);
+    getFile().setDescription(description);
   }
 
   public long getSize() {
-    return file.getSize();
+    return getFile().getSize();
   }
 
   public void setSize(long size) {
-    file.setSize(size);
+    getFile().setSize(size);
   }
 
   public String getContentType() {
-    return file.getContentType();
+    return getFile().getContentType();
   }
 
   public void setContentType(String contentType) {
-    file.setContentType(contentType);
+    getFile().setContentType(contentType);
   }
 
   public String getCreatedBy() {
-    return file.getCreatedBy();
+    return getFile().getCreatedBy();
   }
 
   public Date getCreated() {
-    return file.getCreated();
+    return getFile().getCreated();
   }
 
   public void setCreated(Date created) {
-    file.setCreated(created);
+    getFile().setCreated(created);
   }
 
   public String getUpdatedBy() {
-    return file.getUpdatedBy();
+    return getFile().getUpdatedBy();
   }
 
   public void setUpdatedBy(String updatedBy) {
-    file.setUpdatedBy(updatedBy);
+    getFile().setUpdatedBy(updatedBy);
   }
 
   public Date getUpdated() {
-    return file.getUpdated();
+    return getFile().getUpdated();
   }
 
   public void setUpdated(Date updated) {
-    file.setUpdated(updated);
+    getFile().setUpdated(updated);
   }
 
   public Date getReservation() {
@@ -270,7 +294,11 @@ public class SimpleDocument implements Serializable {
   }
 
   public void setAlert(Date alert) {
-    this.alert = DateUtil.getBeginOfDay(alert);
+    if(alert == null) {
+      this.alert = null;
+    } else {
+      this.alert = DateUtil.getBeginOfDay(alert);
+    }
   }
 
   public Date getExpiry() {
@@ -281,7 +309,11 @@ public class SimpleDocument implements Serializable {
   }
 
   public void setExpiry(Date expiry) {
-    this.expiry = DateUtil.getBeginOfDay(expiry);
+    if (expiry == null) {
+      this.expiry = null;
+    } else {
+      this.expiry = DateUtil.getBeginOfDay(expiry);
+    }
   }
 
   public String getStatus() {
@@ -315,7 +347,7 @@ public class SimpleDocument implements Serializable {
    * @return
    */
   public String getVersion() {
-    return majorVersion + "." + minorVersion;
+    return getMajorVersion() + "." + getMinorVersion();
   }
 
   public String getComment() {
@@ -332,7 +364,7 @@ public class SimpleDocument implements Serializable {
 
   public void edit(String currentEditor) {
     this.editedBy = currentEditor;
-    this.reservation = new Date();
+    setReservation(new Date());
     String day =
         OrganisationControllerFactory.getOrganisationController()
             .getComponentParameterValue(getInstanceId(), "nbDayForReservation");
@@ -357,31 +389,31 @@ public class SimpleDocument implements Serializable {
 
   public void release() {
     this.editedBy = null;
-    this.reservation = null;
+    setReservation(null);
     setExpiry(null);
     setAlert(null);
   }
 
   public String getXmlFormId() {
-    return file.getXmlFormId();
+    return getFile().getXmlFormId();
   }
 
   public void setXmlFormId(String xmlFormId) {
-    file.setXmlFormId(xmlFormId);
+    getFile().setXmlFormId(xmlFormId);
   }
 
   public String getId() {
-    if (pk != null) {
-      return pk.getId();
+    if (getPk() != null) {
+      return getPk().getId();
     }
     return null;
   }
 
   public void setId(String id) {
-    if (pk != null) {
-      this.pk.setId(id);
+    if (getPk() != null) {
+      getPk().setId(id);
     } else {
-      this.pk = new SimpleDocumentPK(id);
+      setPK(new SimpleDocumentPK(id));
     }
   }
 
@@ -390,15 +422,15 @@ public class SimpleDocument implements Serializable {
   }
 
   public String getInstanceId() {
-    return this.pk.getInstanceId();
+    return getPk().getInstanceId();
   }
 
   public long getOldSilverpeasId() {
-    return this.pk.getOldSilverpeasId();
+    return getPk().getOldSilverpeasId();
   }
 
   public void setOldSilverpeasId(long oldSilverpeasId) {
-    this.pk.setOldSilverpeasId(oldSilverpeasId);
+    getPk().setOldSilverpeasId(oldSilverpeasId);
   }
 
   public String getForeignId() {
@@ -443,8 +475,8 @@ public class SimpleDocument implements Serializable {
 
   public void unlock() {
     this.editedBy = null;
-    this.expiry = null;
-    this.alert = null;
+    setExpiry(null);
+    setAlert(null);
   }
 
   public String getNodeName() {
@@ -456,7 +488,7 @@ public class SimpleDocument implements Serializable {
   }
 
   public String computeNodeName() {
-    if (!StringUtil.isDefined(nodeName)) {
+    if (!StringUtil.isDefined(getNodeName())) {
       if (getOldSilverpeasId() <= 0L) {
         setOldSilverpeasId(DBUtil.getNextId("sb_simple_document", "id"));
       }
@@ -472,7 +504,7 @@ public class SimpleDocument implements Serializable {
    * @return the full JCR path to the file node (starting with /).
    */
   public String getFullJcrContentPath() {
-    return getFullJcrPath() + '/' + file.getNodeName();
+    return getFullJcrPath() + '/' + getFile().getNodeName();
   }
 
   /**
@@ -539,20 +571,21 @@ public class SimpleDocument implements Serializable {
 
   @Override
   public String toString() {
-    return "SimpleDocument{" + nodeName + " pk=" + pk + ", foreignId=" + foreignId + ", order="
-        + order + ", versioned=" + versioned + ", editedBy=" + editedBy + ", reservation="
-        + reservation + ", alert=" + alert + ", expiry=" + expiry + ", status=" + status
-        + ", cloneId=" + cloneId + ", file=" + file + ", minorVersion=" + minorVersion
-        + ", majorVersion=" + majorVersion + ", comment=" + comment + '}';
+    return "SimpleDocument{" + getNodeName() + " pk=" + getPk() + ", foreignId=" + getForeignId() +
+        ", order=" + getOrder() + ", versioned=" + isVersioned() + ", editedBy=" + getEditedBy() +
+        ", reservation=" + getReservation() + ", alert=" + getAlert() + ", expiry=" + getExpiry() +
+        ", status=" + getStatus() + ", cloneId=" + getCloneId() + ", file=" + getFile() +
+        ", minorVersion=" + getMinorVersion() + ", majorVersion=" + getMajorVersion() +
+        ", comment=" + getComment() + '}';
   }
 
   @Override
   public int hashCode() {
     int hash = 3;
-    hash = 31 * hash + (this.pk != null ? this.pk.hashCode() : 0);
-    hash = 31 * hash + this.minorVersion;
-    hash = 31 * hash + this.majorVersion;
-    hash = 31 * hash + this.versionIndex;
+    hash = 31 * hash + (getPk() != null ? getPk().hashCode() : 0);
+    hash = 31 * hash + getMinorVersion();
+    hash = 31 * hash + getMajorVersion();
+    hash = 31 * hash + getVersionIndex();
     return hash;
   }
 
@@ -565,16 +598,17 @@ public class SimpleDocument implements Serializable {
       return false;
     }
     final SimpleDocument other = (SimpleDocument) obj;
-    if (this.pk != other.pk && (this.pk == null || !this.pk.equals(other.pk))) {
+    if (getPk() != other.getPk() &&
+        (getPk() == null || !getPk().equals(other.getPk()))) {
       return false;
     }
-    if (this.minorVersion != other.minorVersion) {
+    if (getMinorVersion() != other.getMinorVersion()) {
       return false;
     }
-    if (this.majorVersion != other.majorVersion) {
+    if (getMajorVersion() != other.getMajorVersion()) {
       return false;
     }
-    if (this.versionIndex != other.versionIndex) {
+    if (getVersionIndex() != other.getVersionIndex()) {
       return false;
     }
     return true;
@@ -586,17 +620,18 @@ public class SimpleDocument implements Serializable {
    * @return the attachment URL.
    */
   public String getAttachmentURL() {
-    return FileServerUtils.getAttachmentURL(pk.getInstanceId(), getFilename(), pk.getId(),
-        getLanguage());
+    return FileServerUtils
+        .getAttachmentURL(getPk().getInstanceId(), getFilename(), getPk().getId(), getLanguage());
   }
 
   public String getUniversalURL() {
-    return URLManager.getSimpleURL(URLManager.URL_FILE, getId());
+    return URLManager.getSimpleURL(URLManager.URL_FILE, getId()) + "?ContentLanguage=" +
+        getLanguage();
   }
 
   public String getOnlineURL() {
-    String onlineUrl = FileServerUtils.getOnlineURL(pk.getComponentName(), getFilename(), "",
-        getContentType(), "");
+    String onlineUrl = FileServerUtils
+        .getOnlineURL(getPk().getComponentName(), getFilename(), "", getContentType(), "");
     String extension = FileRepositoryManager.getFileExtension(getFilename());
     if ("exe".equalsIgnoreCase(extension) || "pdf".equalsIgnoreCase(extension)) {
       onlineUrl += "&logicalName=" + URLUtils.encodePathParamValue(getFilename());
@@ -605,7 +640,8 @@ public class SimpleDocument implements Serializable {
   }
 
   public String getAliasURL() {
-    String aliasUrl = FileServerUtils.getAliasURL(pk.getInstanceId(), getFilename(), pk.getId());
+    String aliasUrl =
+        FileServerUtils.getAliasURL(getPk().getInstanceId(), getFilename(), getPk().getId());
     if (I18NHelper.isI18N && !I18NHelper.isDefaultLanguage(getLanguage())) {
       aliasUrl += "&lang=" + getLanguage();
     }
@@ -657,8 +693,8 @@ public class SimpleDocument implements Serializable {
    */
   @Deprecated
   public String getWebURL() {
-    return FileServerUtils.getAttachmentURL(pk.getInstanceId(), getFilename(), pk.getId(),
-        getLanguage());
+    return FileServerUtils
+        .getAttachmentURL(getPk().getInstanceId(), getFilename(), getPk().getId(), getLanguage());
   }
 
   /**
@@ -674,6 +710,14 @@ public class SimpleDocument implements Serializable {
 
   public void setVersionMaster(final SimpleDocument versionMaster) {
     this.versionMaster = versionMaster;
+  }
+
+  /**
+   * Indicates if the current instance is a master one.
+   * @return true if current instance is master, false otherwise.
+   */
+  public boolean isVersionMaster() {
+    return this == getVersionMaster();
   }
 
   /**
@@ -711,7 +755,7 @@ public class SimpleDocument implements Serializable {
   }
 
   public String getFolder() {
-    return documentType.getFolderName();
+    return getDocumentType().getFolderName();
   }
 
   /**

--- a/lib-core/src/main/java/org/silverpeas/attachment/model/SimpleDocumentPK.java
+++ b/lib-core/src/main/java/org/silverpeas/attachment/model/SimpleDocumentPK.java
@@ -102,4 +102,9 @@ public class SimpleDocumentPK extends WAPrimaryKey {
         append(getComponentName()).append(", oldSilverpeasId=").append(oldSilverpeasId).append('}');
     return buffer.toString();
   }
+
+  @Override
+  public SimpleDocumentPK clone() {
+    return (SimpleDocumentPK) super.clone();
+  }
 }

--- a/lib-core/src/main/java/org/silverpeas/attachment/model/SimpleDocumentVersion.java
+++ b/lib-core/src/main/java/org/silverpeas/attachment/model/SimpleDocumentVersion.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (C) 2000 - 2014 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception. You should have recieved a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "http://www.silverpeas.org/docs/core/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.silverpeas.attachment.model;
+
+import com.stratelia.silverpeas.peasCore.URLManager;
+
+/**
+ * This class represents one version in the history of a versioned simple document.
+ * <p/>
+ * The identifier of the component instance provided by this class is the one of the head version.
+ * It is the same thing for the provided foreign identifier information.
+ * To retrieve the real historised values of the version, please use methods for which the name
+ * prefix is <b>getRealVersion</b>...
+ * @author Yohann Chastagnier
+ */
+public class SimpleDocumentVersion extends SimpleDocument {
+  private static final long serialVersionUID = 6383649345169447613L;
+
+  private SimpleDocumentVersion previousVersion;
+  private SimpleDocumentPK realVersionPk;
+  private String realVersionForeignId;
+
+  /**
+   * The default constructor of a simple document version.
+   * @param documentVersion the original version.
+   * @param masterVersion
+   */
+  public SimpleDocumentVersion(final SimpleDocument documentVersion,
+      final HistorisedDocument masterVersion) {
+    super(documentVersion);
+    setVersionMaster(masterVersion);
+  }
+
+  @Override
+  public HistorisedDocument getVersionMaster() {
+    return (HistorisedDocument) super.getVersionMaster();
+  }
+
+  @Override
+  public void setVersionMaster(final SimpleDocument versionMaster) {
+    if (!(versionMaster instanceof HistorisedDocument)) {
+      throw new IllegalArgumentException("The master version must be an historised one ...");
+    }
+    super.setVersionMaster(versionMaster);
+    if (realVersionPk == null) {
+      realVersionPk = getPk().clone();
+      realVersionForeignId = getForeignId();
+    }
+    getPk().setComponentName(getVersionMaster().getInstanceId());
+    getPk().setOldSilverpeasId(getVersionMaster().getOldSilverpeasId());
+    setForeignId(getVersionMaster().getForeignId());
+    setNodeName(getVersionMaster().getNodeName());
+  }
+
+  public SimpleDocumentVersion getPreviousVersion() {
+    return previousVersion;
+  }
+
+  public void setPreviousVersion(final SimpleDocumentVersion previousVersion) {
+    this.previousVersion = previousVersion;
+  }
+
+  /**
+   * Gets the real value of the PK of the version and not the one of the head version.
+   * @return the historised PK value of the historised version.
+   */
+  public SimpleDocumentPK getRealVersionPk() {
+    if (realVersionPk == null) {
+      return getPk();
+    }
+    return realVersionPk;
+  }
+
+  /**
+   * Gets the real value of the foreign identifier of the version and not the one of the head
+   * version.
+   * @return the historised foreign identifier value of the historised version.
+   */
+  public String getRealVersionForeignId() {
+    if (realVersionForeignId == null) {
+      return getForeignId();
+    }
+    return realVersionForeignId;
+  }
+
+  @Override
+  public boolean isVersioned() {
+    return true;
+  }
+
+  @Override
+  public SimpleDocument getLastPublicVersion() {
+    SimpleDocumentVersion current = this;
+    while (current != null) {
+      if (current.isPublic()) {
+        return current;
+      }
+      current = current.getPreviousVersion();
+    }
+    return null;
+  }
+
+  @Override
+  public String getWebdavUrl() {
+    return null;
+  }
+
+  @Override
+  public String getOnlineURL() {
+    return null;
+  }
+
+  @Override
+  public String getAttachmentURL() {
+    return super.getAttachmentURL();
+  }
+
+  @Override
+  public String getUniversalURL() {
+    return URLManager.getSimpleURL(URLManager.URL_VERSION, getId()) + "?ContentLanguage=" +
+        getLanguage();
+  }
+}

--- a/lib-core/src/main/java/org/silverpeas/attachment/repository/DocumentConverter.java
+++ b/lib-core/src/main/java/org/silverpeas/attachment/repository/DocumentConverter.java
@@ -30,13 +30,16 @@ import com.stratelia.webactiv.SilverpeasRole;
 import org.apache.jackrabbit.core.state.NoSuchItemStateException;
 import org.silverpeas.attachment.model.DocumentType;
 import org.silverpeas.attachment.model.HistorisedDocument;
+import org.silverpeas.attachment.model.HistorisedDocumentVersion;
 import org.silverpeas.attachment.model.SimpleAttachment;
 import org.silverpeas.attachment.model.SimpleDocument;
 import org.silverpeas.attachment.model.SimpleDocumentPK;
+import org.silverpeas.attachment.model.SimpleDocumentVersion;
 import org.silverpeas.util.jcr.AbstractJcrConverter;
 
 import javax.jcr.Node;
 import javax.jcr.NodeIterator;
+import javax.jcr.PathNotFoundException;
 import javax.jcr.RepositoryException;
 import javax.jcr.version.Version;
 import javax.jcr.version.VersionHistory;
@@ -60,20 +63,21 @@ class DocumentConverter extends AbstractJcrConverter {
   final SimpleAttachmentConverter attachmentConverter = new SimpleAttachmentConverter();
 
   /**
-   * Convert the document history in a list of SimpleDocument.
-   *
-   *
-   * @param historisedDocument
-   * @param rootVersionNode
-   * @param lang
-   * @return
+   * Builds from the root version node and from a language the object representation of a
+   * versioned document and its history.
+   * @param rootVersionNode the root version node (master).
+   * @param lang the aimed content language.
+   * @return the instance of a versioned document.
    * @throws RepositoryException
    */
-  void setDocumentHistory(final HistorisedDocument historisedDocument, Node rootVersionNode,
-      String lang) throws RepositoryException {
+  HistorisedDocument buildHistorisedDocument(Node rootVersionNode, String lang)
+  throws RepositoryException {
+
+    VersionManager versionManager = rootVersionNode.getSession().getWorkspace().getVersionManager();
+    HistorisedDocument historisedDocument =
+        new HistorisedDocument(fillDocument(rootVersionNode, lang));
+
     try {
-      VersionManager versionManager =
-          rootVersionNode.getSession().getWorkspace().getVersionManager();
 
       String path = rootVersionNode.getPath();
       VersionHistory history = versionManager.getVersionHistory(path);
@@ -88,62 +92,61 @@ class DocumentConverter extends AbstractJcrConverter {
         baseId = base.getIdentifier();
       }
       VersionIterator versionsIterator = history.getAllVersions();
-      List<SimpleDocument> documentHistory = new ArrayList<SimpleDocument>((int) versionsIterator.
-          getSize());
+      List<SimpleDocumentVersion> documentHistory =
+          new ArrayList<SimpleDocumentVersion>((int) versionsIterator.
+              getSize());
 
-      SimpleDocument masterVersion = fillDocument(rootVersionNode, lang);
       int versionIndex = 0;
-      boolean historisedVersionIndexPerformed = false;
+      SimpleDocumentVersion previousVersion = null;
       while (versionsIterator.hasNext()) {
         Version version = versionsIterator.nextVersion();
         if (!version.getIdentifier().equals(rootId) && !version.getIdentifier().equals(baseId)) {
-          SimpleDocument versionDocument = fillDocument(version.getFrozenNode(), lang);
+          SimpleDocumentVersion versionDocument =
+              new SimpleDocumentVersion(fillDocument(version.getFrozenNode(), lang),
+                  historisedDocument);
           versionDocument.setNodeName(rootVersionNode.getName());
-          versionDocument.setVersionMaster(masterVersion);
           versionDocument.setVersionIndex(versionIndex++);
-          if (versionDocument.getId().equals(historisedDocument.getId())) {
-            historisedDocument.setVersionIndex(versionDocument.getVersionIndex());
-            historisedVersionIndexPerformed = true;
-          }
+          versionDocument.setPreviousVersion(previousVersion);
           documentHistory.add(versionDocument);
+          previousVersion = versionDocument;
         }
       }
 
-      HistoryDocumentSorter.sortHistory(documentHistory);
+      HistoryDocumentSorter.sortHistory((List) documentHistory);
       historisedDocument.setHistory(documentHistory);
-
-      if (!historisedVersionIndexPerformed) {
-        historisedDocument.setVersionIndex(versionIndex);
-      }
-      historisedDocument.setVersionMaster(masterVersion);
-      masterVersion.setVersionIndex(versionIndex);
+      historisedDocument.setVersionIndex(versionIndex);
     } catch (RepositoryException ex) {
       if (ex.getCause() instanceof NoSuchItemStateException) {
-        historisedDocument.setHistory(new ArrayList<SimpleDocument>(0));
-        return;
+        historisedDocument.setHistory(new ArrayList<SimpleDocumentVersion>(0));
+      } else {
+        throw ex;
       }
-      throw ex;
     }
+    return historisedDocument;
   }
 
   public SimpleDocument convertNode(Node node, String lang) throws RepositoryException {
-    if (isVersioned(node)) {
-      HistorisedDocument document = new HistorisedDocument(fillDocument(node, lang));
-      setDocumentHistory(document, node, lang);
-      return document;
+    if (isVersionedMaster(node)) {
+      return buildHistorisedDocument(node, lang);
     }
     Node parentNode = node.getParent();
     if (parentNode instanceof Version) {
-      //We are accessing a version directly throught its id
-      HistorisedDocument document = new HistorisedDocument(fillDocument(node, lang));
-      Node fullNode = getCurrentNodeForVersion((Version) parentNode);
-      setDocumentHistory(document, fullNode, lang);
-      return document;
+      // Getting the parent node, the versionned one
+      Node masterNode = getMasterNodeForVersion((Version) parentNode);
+      // The historised document is built from the parent node
+      HistorisedDocument document = buildHistorisedDocument(masterNode, lang);
+      // Returning the version
+      SimpleDocumentVersion version = document.getVersionIdentifiedBy(node.getIdentifier());
+      if (version != null) {
+        return new HistorisedDocumentVersion(version);
+      }
+      throw new PathNotFoundException(
+          "Version identified by " + node.getIdentifier() + " has not been found.");
     }
     return fillDocument(node, lang);
   }
 
-  public Node getCurrentNodeForVersion(Version version) throws RepositoryException {
+  public Node getMasterNodeForVersion(Version version) throws RepositoryException {
     String uuid = version.getContainingHistory().getVersionableIdentifier();
     return version.getSession().getNodeByIdentifier(uuid);
   }
@@ -294,7 +297,7 @@ class DocumentConverter extends AbstractJcrConverter {
     }
   }
 
-  public boolean isVersioned(Node node) throws RepositoryException {
+  public boolean isVersionedMaster(Node node) throws RepositoryException {
     return getBooleanProperty(node, SLV_PROPERTY_VERSIONED) && !node.hasProperty(
         JCR_FROZEN_PRIMARY_TYPE) && isMixinApplied(node, MIX_SIMPLE_VERSIONABLE);
   }
@@ -306,7 +309,7 @@ class DocumentConverter extends AbstractJcrConverter {
   public String updateVersion(Node node, String lang, boolean isPublic) throws RepositoryException {
     int majorVersion = getIntProperty(node, SLV_PROPERTY_MAJOR);
     int minorVersion = getIntProperty(node, SLV_PROPERTY_MINOR);
-    if (isVersioned(node) && node.isCheckedOut()) {
+    if (isVersionedMaster(node) && node.isCheckedOut()) {
       releaseDocumentNode(node, lang);
       if (isPublic) {
         majorVersion = majorVersion + 1;

--- a/lib-core/src/main/java/org/silverpeas/importExport/versioning/DocumentPK.java
+++ b/lib-core/src/main/java/org/silverpeas/importExport/versioning/DocumentPK.java
@@ -34,7 +34,7 @@ import com.stratelia.webactiv.util.WAPrimaryKey;
  * @version 1.0
  */
 
-public class DocumentPK extends WAPrimaryKey implements Serializable, Cloneable {
+public class DocumentPK extends WAPrimaryKey implements Serializable {
   private static final long serialVersionUID = -93533696421871014L;
 
   /**
@@ -93,18 +93,6 @@ public class DocumentPK extends WAPrimaryKey implements Serializable, Cloneable 
     builder.append("(id = ").append(getId()).append(", space = ").append(getSpace());
     builder.append(", componentName = ").append(getComponentName()).append(")");
     return builder.toString();
-  }
-
-  /**
-   * Support Cloneable Interface
-   */
-  @Override
-  public Object clone() {
-    try {
-      return super.clone();
-    } catch (CloneNotSupportedException e) {
-      return null; // this should never happened
-    }
   }
 
   @Override

--- a/lib-core/src/main/java/org/silverpeas/importExport/versioning/DocumentVersionPK.java
+++ b/lib-core/src/main/java/org/silverpeas/importExport/versioning/DocumentVersionPK.java
@@ -33,7 +33,7 @@ import com.stratelia.webactiv.util.WAPrimaryKey;
  * @author Georgy Shakirin
  * @version 1.0
  */
-public class DocumentVersionPK extends WAPrimaryKey implements Serializable, Cloneable {
+public class DocumentVersionPK extends WAPrimaryKey implements Serializable {
 
   private static final long serialVersionUID = -2771550937468713859L;
 
@@ -128,16 +128,5 @@ public class DocumentVersionPK extends WAPrimaryKey implements Serializable, Clo
    */
   public int hashCode() {
     return (getId() != null) ? getId().hashCode() : 0;
-  }
-
-  /**
-   * Support Cloneable Interface
-   */
-  public Object clone() {
-    try {
-      return super.clone();
-    } catch (CloneNotSupportedException e) {
-      return null; // this should never happened
-    }
   }
 }

--- a/lib-core/src/test/java/org/silverpeas/attachment/model/SimpleDocumentTest.java
+++ b/lib-core/src/test/java/org/silverpeas/attachment/model/SimpleDocumentTest.java
@@ -222,7 +222,9 @@ public class SimpleDocumentTest {
     SimpleDocument instance = new SimpleDocument();
     String id = UUID.randomUUID().toString();
     instance.setPK(new SimpleDocumentPK(id, instanceId));
-    String expResult = "/silverpeas/File/" + id;
+    instance.setFile(new SimpleAttachment());
+    instance.getFile().setLanguage("en");
+    String expResult = "/silverpeas/File/" + id + "?ContentLanguage=en";
     String result = instance.getUniversalURL();
     assertThat(result, is(expResult));
   }

--- a/lib-core/src/test/java/org/silverpeas/attachment/repository/HistorisedDocumentRepositoryTest.java
+++ b/lib-core/src/test/java/org/silverpeas/attachment/repository/HistorisedDocumentRepositoryTest.java
@@ -34,48 +34,58 @@ import com.silverpeas.util.PathTestUtil;
 import com.stratelia.webactiv.SilverpeasRole;
 import com.stratelia.webactiv.util.DBUtil;
 import com.stratelia.webactiv.util.DateUtil;
+import org.apache.commons.beanutils.BeanUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.ArrayUtils;
 import org.apache.jackrabbit.api.JackrabbitRepository;
 import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.silverpeas.attachment.model.DocumentType;
 import org.silverpeas.attachment.model.HistorisedDocument;
 import org.silverpeas.attachment.model.SimpleAttachment;
 import org.silverpeas.attachment.model.SimpleDocument;
 import org.silverpeas.attachment.model.SimpleDocumentPK;
+import org.silverpeas.attachment.model.SimpleDocumentVersion;
 import org.silverpeas.util.Charsets;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabase;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
 
+import javax.jcr.Node;
 import javax.jcr.NodeIterator;
+import javax.jcr.PathNotFoundException;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
+import javax.jcr.version.Version;
+import javax.jcr.version.VersionHistory;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.Collections;
 import java.util.Date;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
 import static com.silverpeas.jcrutil.JcrConstants.NT_FOLDER;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 public class HistorisedDocumentRepositoryTest {
 
   private static final String instanceId = "kmelia73";
-  private static EmbeddedDatabase dataSource;
-  private static ClassPathXmlApplicationContext context;
-  private static JackrabbitRepository repository;
+  private EmbeddedDatabase dataSource;
+  private ClassPathXmlApplicationContext context;
+  private JackrabbitRepository repository;
   private DocumentRepository documentRepository = new DocumentRepository();
 
   public HistorisedDocumentRepositoryTest() {
@@ -83,6 +93,7 @@ public class HistorisedDocumentRepositoryTest {
 
   @Before
   public void setupJcr() throws Exception {
+    loadSpringContext();
     Session session = null;
     try {
       session = repository.login(new SilverpeasSystemCredentials());
@@ -98,7 +109,7 @@ public class HistorisedDocumentRepositoryTest {
   }
 
   @After
-  public void cleanRepository() throws RepositoryException {
+  public void cleanRepository() throws Exception {
     Session session = null;
     try {
       session = repository.login(new SilverpeasSystemCredentials());
@@ -114,12 +125,12 @@ public class HistorisedDocumentRepositoryTest {
         session.logout();
       }
     }
+    tearDown();
   }
 
-  @BeforeClass
-  public static void loadSpringContext() throws Exception {
-    FileUtils.deleteQuietly(new File(PathTestUtil.TARGET_DIR + "tmp" + File.separatorChar
-        + "temp_jackrabbit"));
+  public void loadSpringContext() throws Exception {
+    FileUtils.deleteQuietly(
+        new File(PathTestUtil.TARGET_DIR + "tmp" + File.separatorChar + "temp_jackrabbit"));
     Reader reader = new InputStreamReader(DocumentRepositoryTest.class.getClassLoader().
         getResourceAsStream("silverpeas-jcr.txt"), Charsets.UTF_8);
 
@@ -139,8 +150,7 @@ public class HistorisedDocumentRepositoryTest {
     DBUtil.getInstanceForTest(dataSource.getConnection());
   }
 
-  @AfterClass
-  public static void tearDown() throws Exception {
+  public void tearDown() throws Exception {
     dataSource.shutdown();
     DBUtil.clearTestInstance();
     repository.shutdown();
@@ -272,7 +282,6 @@ public class HistorisedDocumentRepositoryTest {
       assertThat(result, is(expResult));
       long oldSilverpeasId = document.getOldSilverpeasId();
       emptyId = new SimpleDocumentPK("-1", instanceId);
-      content = new ByteArrayInputStream("Ceci est un test".getBytes(Charsets.UTF_8));
       attachment = createFrenchVersionnedAttachment();
       content = new ByteArrayInputStream("Ceci est un test".getBytes(Charsets.UTF_8));
       foreignId = "node78";
@@ -956,24 +965,720 @@ public class HistorisedDocumentRepositoryTest {
     try {
       SimpleDocumentPK emptyId = new SimpleDocumentPK("-1", instanceId);
       String language = "en";
-      ByteArrayInputStream content = new ByteArrayInputStream("This is a test".getBytes(
-          Charsets.UTF_8));
+      ByteArrayInputStream content =
+          new ByteArrayInputStream("This is a test".getBytes(Charsets.UTF_8));
       SimpleAttachment attachment = createEnglishVersionnedAttachment();
       Date creationDate = attachment.getCreated();
       String foreignId = "node78";
-      SimpleDocument document = new HistorisedDocument(emptyId, foreignId, 0, attachment);
+      HistorisedDocument document = new HistorisedDocument(emptyId, foreignId, 0, attachment);
+      document.setContentType(MimeTypes.PDF_MIME_TYPE);
+      document.setPublicDocument(false);
       createVersionedDocument(session, document, content);
-      foreignId = "kmelia36";
-      SimpleDocumentPK result = documentRepository.moveDocument(session, document, new ForeignPK(
-          "45", foreignId));
-      SimpleDocumentPK expResult = new SimpleDocumentPK(result.getId(), foreignId);
+      SimpleDocumentPK sourcePk = document.getPk();
+      document =
+          (HistorisedDocument) documentRepository.findDocumentById(session, sourcePk, language);
+
+      assertThat(document, is(notNullValue()));
+      assertThat(document.getOrder(), is(0));
+      assertThat(document.getContentType(), is(MimeTypes.PDF_MIME_TYPE));
+      assertThat(document.getSize(), is(14L));
+      assertThat(document.getHistory(), is(notNullValue()));
+      assertThat(document.getHistory(), hasSize(0));
+      assertThat(document.getFunctionalHistory(), is(notNullValue()));
+      assertThat(document.getFunctionalHistory(), hasSize(0));
+      assertThat(document.getMajorVersion(), is(0));
+      assertThat(document.getMinorVersion(), is(1));
+      assertThat(document.getVersionIndex(), is(0));
+      assertThat(document.getRepositoryPath(), is("/kmelia73/attachments/simpledoc_1"));
+
+      /*
+      History :
+      Technical   Functional  Action
+      1.0                     initialization
+       */
+
+      String targetInstanceId = "kmelia36";
+      String targetForeignId = "foreignId45";
+      SimpleDocumentPK result = documentRepository
+          .moveDocument(session, document, new ForeignPK(targetForeignId, targetInstanceId));
+      try {
+        assertThat(document.getRepositoryPath(), is("/kmelia73/attachments/simpledoc_1"));
+        session.getNode(document.getFullJcrPath());
+        fail("The JCR path " + document.getFullJcrPath() + " should not longer exist...");
+      } catch (PathNotFoundException ex) {
+        // OK
+      }
+      SimpleDocumentPK expResult = new SimpleDocumentPK(result.getId(), targetInstanceId);
       expResult.setOldSilverpeasId(document.getOldSilverpeasId());
       assertThat(result, is(expResult));
-      SimpleDocument doc = documentRepository.findDocumentById(session, expResult, language);
+      HistorisedDocument doc =
+          (HistorisedDocument) documentRepository.findDocumentById(session, expResult, language);
       assertThat(doc, is(notNullValue()));
       assertThat(doc.getOldSilverpeasId(), is(document.getOldSilverpeasId()));
       assertThat(doc.getCreated(), is(creationDate));
       checkEnglishSimpleDocument(doc);
+      assertThat(doc.getMajorVersion(), is(0));
+      assertThat(doc.getMinorVersion(), is(1));
+      assertThat(doc.getVersionIndex(), is(1));
+      assertThat(doc.getRepositoryPath(), is("/kmelia36/attachments/simpledoc_1"));
+
+      String[] ignoredBeanPropertiesInComparison =
+          new String[]{"history", "functionalHistory", "created", "updated", "repositoryPath",
+              "publicVersions", "lastPublicVersion", "versionMaster", "realVersionPk",
+              "realVersionForeignId", "previousVersion"};
+      document.getPk().setComponentName(targetInstanceId);
+      document.setForeignId(targetForeignId);
+      document.setVersionIndex(1);
+      assertSimpleDocumentsAreEquals(doc, document, ignoredBeanPropertiesInComparison);
+
+      // Version path pattern
+      assertThat(document.getVersionMaster().getId(), is(doc.getVersionMaster().getId()));
+      String masterUuid = doc.getVersionMaster().getId();
+      String versionPathPattern =
+          "/jcr:system/jcr:versionStorage/" + masterUuid.substring(0, 2) + "/" +
+              masterUuid.substring(2, 4) + "/" + masterUuid.substring(4, 6) + "/" + masterUuid +
+              "/%s/jcr:frozenNode";
+
+      // History
+      assertThat(doc.getHistory(), hasSize(1));
+      assertThat(doc.getFunctionalHistory(), hasSize(0));
+
+
+      SimpleDocumentVersion resultHistory = doc.getHistory().remove(0);
+      assertThat(resultHistory.getVersionIndex(), is(0));
+      assertThat(resultHistory.getRepositoryPath(), is(String.format(versionPathPattern, "1.0")));
+      assertThat(resultHistory.getPk(), not(sameInstance(resultHistory.getRealVersionPk())));
+      assertThat(resultHistory.getPk().getId(), is(resultHistory.getRealVersionPk().getId()));
+      assertThat(resultHistory.getPk().getComponentName(), is(targetInstanceId));
+      assertThat(resultHistory.getRealVersionPk().getComponentName(), is(instanceId));
+      assertThat(resultHistory.getPk().getOldSilverpeasId(),
+          is(resultHistory.getRealVersionPk().getOldSilverpeasId()));
+      assertThat(resultHistory.getForeignId(), is(targetForeignId));
+      assertThat(resultHistory.getRealVersionForeignId(), is(foreignId));
+      document.getPk().setId(resultHistory.getId());
+      document.setVersionIndex(resultHistory.getVersionIndex());
+      document.setOrder(resultHistory.getOrder());
+      assertSimpleDocumentsAreEquals(resultHistory, document, ArrayUtils
+          .addAll(ignoredBeanPropertiesInComparison, "class", "universalURL", "webdavUrl",
+              "onlineURL"));
+    } finally {
+      BasicDaoFactory.logout(session);
+    }
+  }
+
+  /**
+   * Test of moveDocument method, of class DocumentRepository.
+   * @throws Exception
+   */
+  @Test
+  public void testMoveDocumentChangingFunctionalVersion() throws Exception {
+    Session session = BasicDaoFactory.getSystemSession();
+    try {
+      SimpleDocumentPK emptyId = new SimpleDocumentPK("-1", instanceId);
+      String language = "en";
+      ByteArrayInputStream content =
+          new ByteArrayInputStream("This is a test".getBytes(Charsets.UTF_8));
+      SimpleAttachment attachment = createEnglishVersionnedAttachment();
+      Date creationDate = attachment.getCreated();
+      String foreignId = "node78";
+      HistorisedDocument document = new HistorisedDocument(emptyId, foreignId, 0, attachment);
+      document.setContentType(MimeTypes.PDF_MIME_TYPE);
+      document.setPublicDocument(false);
+      createVersionedDocument(session, document, content);
+      SimpleDocumentPK sourcePk = document.getPk();
+      document =
+          (HistorisedDocument) documentRepository.findDocumentById(session, sourcePk, language);
+
+      // Version path pattern
+      String masterUuid = document.getVersionMaster().getId();
+      String versionPathPattern =
+          "/jcr:system/jcr:versionStorage/" + masterUuid.substring(0, 2) + "/" +
+              masterUuid.substring(2, 4) + "/" +
+              masterUuid.substring(4, 6) + "/" + masterUuid + "/%s/jcr:frozenNode";
+
+      assertThat(document, is(notNullValue()));
+      assertThat(document.getOrder(), is(0));
+      assertThat(document.getContentType(), is(MimeTypes.PDF_MIME_TYPE));
+      assertThat(document.getSize(), is(14L));
+      assertThat(document.getHistory(), is(notNullValue()));
+      assertThat(document.getHistory(), hasSize(0));
+      assertThat(document.getFunctionalHistory(), is(notNullValue()));
+      assertThat(document.getFunctionalHistory(), hasSize(0));
+      assertThat(document.getMajorVersion(), is(0));
+      assertThat(document.getMinorVersion(), is(1));
+      assertThat(document.getVersionIndex(), is(0));
+      assertThat(document.getRepositoryPath(), is("/kmelia73/attachments/simpledoc_1"));
+
+      documentRepository.lock(session, document, document.getEditedBy());
+      documentRepository.updateDocument(session, document);
+      session.save();
+      documentRepository.unlock(session, document, false);
+      document =
+          (HistorisedDocument) documentRepository.findDocumentById(session, sourcePk, language);
+
+      assertThat(document, is(notNullValue()));
+      assertThat(document.getOrder(), is(0));
+      assertThat(document.getContentType(), is(MimeTypes.PDF_MIME_TYPE));
+      assertThat(document.getSize(), is(14L));
+      assertThat(document.getHistory(), is(notNullValue()));
+      assertThat(document.getHistory(), hasSize(1));
+      assertThat(document.getFunctionalHistory(), is(notNullValue()));
+      assertThat(document.getFunctionalHistory(), hasSize(1));
+      assertThat(document.getMajorVersion(), is(0));
+      assertThat(document.getMinorVersion(), is(2));
+      assertThat(document.getVersionIndex(), is(1));
+      assertThat(document.getRepositoryPath(), is("/kmelia73/attachments/simpledoc_1"));
+      assertThat(document.getHistory().get(0).getRepositoryPath(),
+          is(String.format(versionPathPattern, "1.0")));
+
+      /*
+      History :
+      Technical   Functional  Action
+      1.0                     initialization
+      1.1         0.1         update private
+       */
+
+      String targetInstanceId = "kmelia36";
+      String targetForeignId = "foreignId45";
+      SimpleDocumentPK result = documentRepository
+          .moveDocument(session, document, new ForeignPK(targetForeignId, targetInstanceId));
+      try {
+        assertThat(document.getRepositoryPath(), is("/kmelia73/attachments/simpledoc_1"));
+        session.getNode(document.getFullJcrPath());
+        fail("The JCR path " + document.getFullJcrPath() + " should not longer exist...");
+      } catch (PathNotFoundException ex) {
+        // OK
+      }
+      SimpleDocumentPK expResult = new SimpleDocumentPK(result.getId(), targetInstanceId);
+      expResult.setOldSilverpeasId(document.getOldSilverpeasId());
+      assertThat(result, is(expResult));
+      HistorisedDocument doc =
+          (HistorisedDocument) documentRepository.findDocumentById(session, expResult, language);
+      assertThat(doc, is(notNullValue()));
+      assertThat(doc.getOldSilverpeasId(), is(document.getOldSilverpeasId()));
+      assertThat(doc.getCreated(), is(creationDate));
+      checkEnglishSimpleDocument(doc);
+      assertThat(doc.getMajorVersion(), is(0));
+      assertThat(doc.getMinorVersion(), is(2));
+      assertThat(doc.getVersionIndex(), is(2));
+      assertThat(doc.getRepositoryPath(), is("/kmelia36/attachments/simpledoc_1"));
+
+      String[] ignoredBeanPropertiesInComparison =
+          new String[]{"history", "functionalHistory", "created", "updated", "repositoryPath",
+              "publicVersions", "lastPublicVersion", "versionMaster", "realVersionPk",
+              "realVersionForeignId", "previousVersion"};
+      document.getPk().setComponentName(targetInstanceId);
+      document.setForeignId(targetForeignId);
+      document.setVersionIndex(2);
+      assertSimpleDocumentsAreEquals(doc, document, ignoredBeanPropertiesInComparison);
+
+      // Version path pattern
+      assertThat(document.getVersionMaster().getId(), is(doc.getVersionMaster().getId()));
+      masterUuid = doc.getVersionMaster().getId();
+      versionPathPattern = "/jcr:system/jcr:versionStorage/" + masterUuid.substring(0, 2) + "/" +
+          masterUuid.substring(2, 4) + "/" +
+          masterUuid.substring(4, 6) + "/" + masterUuid + "/%s/jcr:frozenNode";
+
+      // History
+      assertThat(doc.getHistory(), hasSize(2));
+      assertThat(doc.getFunctionalHistory(), hasSize(1));
+
+
+      SimpleDocumentVersion currentVersion = doc.getHistory().remove(0);
+      assertThat(currentVersion.getVersionIndex(), is(1));
+      assertThat(currentVersion.getRepositoryPath(), is(String.format(versionPathPattern, "1.1")));
+      assertThat(currentVersion.getPk(), not(sameInstance(currentVersion.getRealVersionPk())));
+      assertThat(currentVersion.getPk().getId(), is(currentVersion.getRealVersionPk().getId()));
+      assertThat(currentVersion.getPk().getComponentName(), is(targetInstanceId));
+      assertThat(currentVersion.getRealVersionPk().getComponentName(), is(instanceId));
+      assertThat(currentVersion.getPk().getOldSilverpeasId(),
+          is(currentVersion.getRealVersionPk().getOldSilverpeasId()));
+      assertThat(currentVersion.getForeignId(), is(targetForeignId));
+      assertThat(currentVersion.getRealVersionForeignId(), is(foreignId));
+      document.getPk().setId(currentVersion.getId());
+      document.setVersionIndex(currentVersion.getVersionIndex());
+      document.setOrder(currentVersion.getOrder());
+      assertSimpleDocumentsAreEquals(currentVersion, document, ArrayUtils.addAll(ignoredBeanPropertiesInComparison, "class", "universalURL", "webdavUrl",
+              "onlineURL"));
+
+      for (SimpleDocumentVersion expectedVersion : document.getHistory()) {
+        expectedVersion.setVersionMaster(doc.getVersionMaster());
+      }
+      int versionIndex = doc.getHistory().size();
+      Iterator<SimpleDocumentVersion> resultHistoryIt = doc.getHistory().iterator();
+      for (SimpleDocumentVersion expectedVersion : document.getHistory()) {
+        currentVersion = resultHistoryIt.next();
+        assertThat(currentVersion.getRepositoryPath(),
+            is(String.format(versionPathPattern, "1." + (--versionIndex))));
+        assertThat(currentVersion.getFullJcrPath(), is(doc.getFullJcrPath()));
+        assertThat(currentVersion.getPk(), not(sameInstance(currentVersion.getRealVersionPk())));
+        assertThat(currentVersion.getPk().getId(), is(currentVersion.getRealVersionPk().getId()));
+        assertThat(currentVersion.getPk().getComponentName(), is(targetInstanceId));
+        assertThat(currentVersion.getRealVersionPk().getComponentName(), is(instanceId));
+        assertThat(currentVersion.getPk().getOldSilverpeasId(),
+            is(currentVersion.getRealVersionPk().getOldSilverpeasId()));
+        assertThat(currentVersion.getForeignId(), is(targetForeignId));
+        assertThat(currentVersion.getRealVersionForeignId(), is(foreignId));
+        assertSimpleDocumentsAreEquals(currentVersion, expectedVersion,
+            ignoredBeanPropertiesInComparison);
+      }
+    } finally {
+      BasicDaoFactory.logout(session);
+    }
+  }
+
+  /**
+   * Test of moveDocument method, of class DocumentRepository.
+   * @throws Exception
+   */
+  @Test
+  public void testMoveDocumentWithoutChangingFunctionalVersion() throws Exception {
+    Session session = BasicDaoFactory.getSystemSession();
+    try {
+      SimpleDocumentPK emptyId = new SimpleDocumentPK("-1", instanceId);
+      String language = "en";
+      ByteArrayInputStream content =
+          new ByteArrayInputStream("This is a test".getBytes(Charsets.UTF_8));
+      SimpleAttachment attachment = createEnglishVersionnedAttachment();
+      Date creationDate = attachment.getCreated();
+      String foreignId = "node78";
+      HistorisedDocument document = new HistorisedDocument(emptyId, foreignId, 0, attachment);
+      document.setContentType(MimeTypes.PDF_MIME_TYPE);
+      document.setPublicDocument(false);
+      createVersionedDocument(session, document, content);
+      SimpleDocumentPK sourcePk = document.getPk();
+      document =
+          (HistorisedDocument) documentRepository.findDocumentById(session, sourcePk, language);
+
+      // Version path pattern
+      String masterUuid = document.getVersionMaster().getId();
+      String versionPathPattern =
+          "/jcr:system/jcr:versionStorage/" + masterUuid.substring(0, 2) + "/" +
+              masterUuid.substring(2, 4) + "/" +
+              masterUuid.substring(4, 6) + "/" + masterUuid + "/%s/jcr:frozenNode";
+
+      assertThat(document, is(notNullValue()));
+      assertThat(document.getOrder(), is(0));
+      assertThat(document.getContentType(), is(MimeTypes.PDF_MIME_TYPE));
+      assertThat(document.getSize(), is(14L));
+      assertThat(document.getHistory(), is(notNullValue()));
+      assertThat(document.getHistory(), hasSize(0));
+      assertThat(document.getFunctionalHistory(), is(notNullValue()));
+      assertThat(document.getFunctionalHistory(), hasSize(0));
+      assertThat(document.getMajorVersion(), is(0));
+      assertThat(document.getMinorVersion(), is(1));
+      assertThat(document.getVersionIndex(), is(0));
+      assertThat(document.getRepositoryPath(), is("/kmelia73/attachments/simpledoc_1"));
+
+      document.setOrder(10);
+      documentRepository.setOrder(session, document);
+      document =
+          (HistorisedDocument) documentRepository.findDocumentById(session, sourcePk, language);
+
+      assertThat(document, is(notNullValue()));
+      assertThat(document.getOrder(), is(10));
+      assertThat(document.getContentType(), is(MimeTypes.PDF_MIME_TYPE));
+      assertThat(document.getSize(), is(14L));
+      assertThat(document.getHistory(), is(notNullValue()));
+      assertThat(document.getHistory(), hasSize(1));
+      assertThat(document.getFunctionalHistory(), is(notNullValue()));
+      assertThat(document.getFunctionalHistory(), hasSize(0));
+      assertThat(document.getMajorVersion(), is(0));
+      assertThat(document.getMinorVersion(), is(1));
+      assertThat(document.getVersionIndex(), is(1));
+      assertThat(document.getFullJcrPath(), is("/kmelia73/attachments/simpledoc_1"));
+      assertThat(document.getHistory().get(0).getRepositoryPath(),
+          is(String.format(versionPathPattern, "1.0")));
+
+      /*
+      History :
+      Technical   Functional  Action
+      1.0                     initialization
+      1.1         0.1         change order
+       */
+
+      String targetInstanceId = "kmelia36";
+      String targetForeignId = "foreignId45";
+      SimpleDocumentPK result = documentRepository
+          .moveDocument(session, document, new ForeignPK(targetForeignId, targetInstanceId));
+      try {
+        assertThat(document.getRepositoryPath(), is("/kmelia73/attachments/simpledoc_1"));
+        session.getNode(document.getFullJcrPath());
+        fail("The JCR path " + document.getFullJcrPath() + " should not longer exist...");
+      } catch (PathNotFoundException ex) {
+        // OK
+      }
+      SimpleDocumentPK expResult = new SimpleDocumentPK(result.getId(), targetInstanceId);
+      expResult.setOldSilverpeasId(document.getOldSilverpeasId());
+      assertThat(result, is(expResult));
+      HistorisedDocument doc =
+          (HistorisedDocument) documentRepository.findDocumentById(session, expResult, language);
+      assertThat(doc, is(notNullValue()));
+      assertThat(doc.getOldSilverpeasId(), is(document.getOldSilverpeasId()));
+      assertThat(doc.getCreated(), is(creationDate));
+      checkEnglishSimpleDocument(doc);
+      assertThat(doc.getMajorVersion(), is(0));
+      assertThat(doc.getMinorVersion(), is(1));
+      assertThat(doc.getVersionIndex(), is(2));
+      assertThat(doc.getRepositoryPath(), is("/kmelia36/attachments/simpledoc_1"));
+
+      String[] ignoredBeanPropertiesInComparison =
+          new String[]{"history", "functionalHistory", "created", "updated", "repositoryPath",
+              "publicVersions", "lastPublicVersion", "versionMaster", "realVersionPk",
+              "realVersionForeignId", "previousVersion"};
+      document.getPk().setComponentName(targetInstanceId);
+      document.setForeignId(targetForeignId);
+      document.setVersionIndex(2);
+      assertSimpleDocumentsAreEquals(doc, document, ignoredBeanPropertiesInComparison);
+
+      // Version path pattern
+      assertThat(document.getVersionMaster().getId(), is(doc.getVersionMaster().getId()));
+      masterUuid = doc.getVersionMaster().getId();
+      versionPathPattern = "/jcr:system/jcr:versionStorage/" + masterUuid.substring(0, 2) + "/" +
+          masterUuid.substring(2, 4) + "/" +
+          masterUuid.substring(4, 6) + "/" + masterUuid + "/%s/jcr:frozenNode";
+
+      // History
+      assertThat(doc.getHistory(), hasSize(2));
+      assertThat(doc.getFunctionalHistory(), hasSize(0));
+
+
+      SimpleDocumentVersion currentVersion = doc.getHistory().remove(0);
+      assertThat(currentVersion.getVersionIndex(), is(1));
+      assertThat(currentVersion.getRepositoryPath(), is(String.format(versionPathPattern, "1.1")));
+      assertThat(currentVersion.getPk(), not(sameInstance(currentVersion.getRealVersionPk())));
+      assertThat(currentVersion.getPk().getId(), is(currentVersion.getRealVersionPk().getId()));
+      assertThat(currentVersion.getPk().getComponentName(), is(targetInstanceId));
+      assertThat(currentVersion.getRealVersionPk().getComponentName(), is(instanceId));
+      assertThat(currentVersion.getPk().getOldSilverpeasId(),
+          is(currentVersion.getRealVersionPk().getOldSilverpeasId()));
+      assertThat(currentVersion.getForeignId(), is(targetForeignId));
+      assertThat(currentVersion.getRealVersionForeignId(), is(foreignId));
+      document.getPk().setId(currentVersion.getId());
+      document.setVersionIndex(currentVersion.getVersionIndex());
+      document.setOrder(currentVersion.getOrder());
+      assertSimpleDocumentsAreEquals(currentVersion, document, ArrayUtils.addAll(ignoredBeanPropertiesInComparison, "class", "universalURL", "webdavUrl",
+              "onlineURL"));
+
+      for (SimpleDocumentVersion expectedVersion : document.getHistory()) {
+        expectedVersion.setVersionMaster(doc.getVersionMaster());
+      }
+      int versionIndex = doc.getHistory().size();
+      Iterator<SimpleDocumentVersion> resultHistoryIt = doc.getHistory().iterator();
+      for (SimpleDocumentVersion expectedVersion : document.getHistory()) {
+        currentVersion = resultHistoryIt.next();
+        assertThat(currentVersion.getRepositoryPath(),
+            is(String.format(versionPathPattern, "1." + (--versionIndex))));
+        assertThat(currentVersion.getFullJcrPath(), is(doc.getFullJcrPath()));
+        assertThat(currentVersion.getPk(), not(sameInstance(currentVersion.getRealVersionPk())));
+        assertThat(currentVersion.getPk().getId(), is(currentVersion.getRealVersionPk().getId()));
+        assertThat(currentVersion.getPk().getComponentName(), is(targetInstanceId));
+        assertThat(currentVersion.getRealVersionPk().getComponentName(), is(instanceId));
+        assertThat(currentVersion.getPk().getOldSilverpeasId(),
+            is(currentVersion.getRealVersionPk().getOldSilverpeasId()));
+        assertThat(currentVersion.getForeignId(), is(targetForeignId));
+        assertThat(currentVersion.getRealVersionForeignId(), is(foreignId));
+        assertSimpleDocumentsAreEquals(currentVersion, expectedVersion,
+            ignoredBeanPropertiesInComparison);
+      }
+    } finally {
+      BasicDaoFactory.logout(session);
+    }
+  }
+
+  /**
+   * Test of moveDocument method, of class DocumentRepository.
+   * @throws Exception
+   */
+  @Test
+  public void testMoveDocumentWithHugeHistory() throws Exception {
+    Session session = BasicDaoFactory.getSystemSession();
+    try {
+      SimpleDocumentPK emptyId = new SimpleDocumentPK("-1", instanceId);
+      String language = "en";
+      ByteArrayInputStream content =
+          new ByteArrayInputStream("This is a test".getBytes(Charsets.UTF_8));
+      SimpleAttachment attachment = createEnglishVersionnedAttachment();
+      Date creationDate = attachment.getCreated();
+      String foreignId = "node78";
+      HistorisedDocument document = new HistorisedDocument(emptyId, foreignId, 0, attachment);
+      document.setContentType(MimeTypes.PDF_MIME_TYPE);
+      document.setPublicDocument(false);
+      createVersionedDocument(session, document, content);
+      SimpleDocumentPK sourcePk = document.getPk();
+      document =
+          (HistorisedDocument) documentRepository.findDocumentById(session, sourcePk, language);
+
+      // Version path pattern
+      String masterUuid = document.getVersionMaster().getId();
+      String versionPathPattern =
+          "/jcr:system/jcr:versionStorage/" + masterUuid.substring(0, 2) + "/" +
+              masterUuid.substring(2, 4) + "/" +
+              masterUuid.substring(4, 6) + "/" + masterUuid + "/%s/jcr:frozenNode";
+
+      assertThat(document, is(notNullValue()));
+      assertThat(document.getOrder(), is(0));
+      assertThat(document.getContentType(), is(MimeTypes.PDF_MIME_TYPE));
+      assertThat(document.getSize(), is(14L));
+      assertThat(document.getHistory(), is(notNullValue()));
+      assertThat(document.getHistory(), hasSize(0));
+      assertThat(document.getFunctionalHistory(), is(notNullValue()));
+      assertThat(document.getFunctionalHistory(), hasSize(0));
+      assertThat(document.getMajorVersion(), is(0));
+      assertThat(document.getMinorVersion(), is(1));
+      assertThat(document.getVersionIndex(), is(0));
+      assertThat(document.getRepositoryPath(), is("/kmelia73/attachments/simpledoc_1"));
+
+      document.setOrder(10);
+      documentRepository.setOrder(session, document);
+      document =
+          (HistorisedDocument) documentRepository.findDocumentById(session, sourcePk, language);
+
+      assertThat(document, is(notNullValue()));
+      assertThat(document.getOrder(), is(10));
+      assertThat(document.getContentType(), is(MimeTypes.PDF_MIME_TYPE));
+      assertThat(document.getSize(), is(14L));
+      assertThat(document.getHistory(), is(notNullValue()));
+      assertThat(document.getHistory(), hasSize(1));
+      assertThat(document.getFunctionalHistory(), is(notNullValue()));
+      assertThat(document.getFunctionalHistory(), hasSize(0));
+      assertThat(document.getMajorVersion(), is(0));
+      assertThat(document.getMinorVersion(), is(1));
+      assertThat(document.getVersionIndex(), is(1));
+      assertThat(document.getFullJcrPath(), is("/kmelia73/attachments/simpledoc_1"));
+      assertThat(document.getHistory().get(0).getRepositoryPath(),
+          is(String.format(versionPathPattern, "1.0")));
+
+      documentRepository.lock(session, document, document.getEditedBy());
+      documentRepository.updateDocument(session, document);
+      session.save();
+      documentRepository.unlock(session, document, false);
+      document =
+          (HistorisedDocument) documentRepository.findDocumentById(session, sourcePk, language);
+
+      assertThat(document, is(notNullValue()));
+      assertThat(document.getOrder(), is(10));
+      assertThat(document.getContentType(), is(MimeTypes.PDF_MIME_TYPE));
+      assertThat(document.getSize(), is(14L));
+      assertThat(document.getHistory(), is(notNullValue()));
+      assertThat(document.getHistory(), hasSize(2));
+      assertThat(document.getFunctionalHistory(), is(notNullValue()));
+      assertThat(document.getFunctionalHistory(), hasSize(1));
+      assertThat(document.getMajorVersion(), is(0));
+      assertThat(document.getMinorVersion(), is(2));
+      assertThat(document.getVersionIndex(), is(2));
+      assertThat(document.getRepositoryPath(), is("/kmelia73/attachments/simpledoc_1"));
+      assertThat(document.getHistory().get(0).getRepositoryPath(),
+          is(String.format(versionPathPattern, "1.1")));
+
+      document.setPublicDocument(true);
+      documentRepository.lock(session, document, document.getEditedBy());
+      documentRepository.updateDocument(session, document);
+      session.save();
+      documentRepository.unlock(session, document, false);
+      document =
+          (HistorisedDocument) documentRepository.findDocumentById(session, sourcePk, language);
+
+      assertThat(document, is(notNullValue()));
+      assertThat(document.getOrder(), is(10));
+      assertThat(document.getContentType(), is(MimeTypes.PDF_MIME_TYPE));
+      assertThat(document.getSize(), is(14L));
+      assertThat(document.getHistory(), is(notNullValue()));
+      assertThat(document.getHistory(), hasSize(3));
+      assertThat(document.getFunctionalHistory(), is(notNullValue()));
+      assertThat(document.getFunctionalHistory(), hasSize(2));
+      assertThat(document.getMajorVersion(), is(1));
+      assertThat(document.getMinorVersion(), is(0));
+      assertThat(document.getVersionIndex(), is(3));
+      assertThat(document.getRepositoryPath(), is("/kmelia73/attachments/simpledoc_1"));
+      assertThat(document.getHistory().get(0).getRepositoryPath(),
+          is(String.format(versionPathPattern, "1.2")));
+
+      document.setPublicDocument(false);
+      documentRepository.lock(session, document, document.getEditedBy());
+      documentRepository.updateDocument(session, document);
+      session.save();
+      documentRepository.unlock(session, document, false);
+      document =
+          (HistorisedDocument) documentRepository.findDocumentById(session, sourcePk, language);
+
+      assertThat(document, is(notNullValue()));
+      assertThat(document.getOrder(), is(10));
+      assertThat(document.getContentType(), is(MimeTypes.PDF_MIME_TYPE));
+      assertThat(document.getSize(), is(14L));
+      assertThat(document.getHistory(), is(notNullValue()));
+      assertThat(document.getHistory(), hasSize(4));
+      assertThat(document.getFunctionalHistory(), is(notNullValue()));
+      assertThat(document.getFunctionalHistory(), hasSize(3));
+      assertThat(document.getMajorVersion(), is(1));
+      assertThat(document.getMinorVersion(), is(1));
+      assertThat(document.getVersionIndex(), is(4));
+      assertThat(document.getRepositoryPath(), is("/kmelia73/attachments/simpledoc_1"));
+      assertThat(document.getHistory().get(0).getRepositoryPath(),
+          is(String.format(versionPathPattern, "1.3")));
+
+      document.setPublicDocument(false);
+      documentRepository.lock(session, document, document.getEditedBy());
+      documentRepository.updateDocument(session, document);
+      session.save();
+      documentRepository.unlock(session, document, false);
+      document =
+          (HistorisedDocument) documentRepository.findDocumentById(session, sourcePk, language);
+
+      assertThat(document, is(notNullValue()));
+      assertThat(document.getOrder(), is(10));
+      assertThat(document.getContentType(), is(MimeTypes.PDF_MIME_TYPE));
+      assertThat(document.getSize(), is(14L));
+      assertThat(document.getHistory(), is(notNullValue()));
+      assertThat(document.getHistory(), hasSize(5));
+      assertThat(document.getFunctionalHistory(), is(notNullValue()));
+      assertThat(document.getFunctionalHistory(), hasSize(4));
+      assertThat(document.getMajorVersion(), is(1));
+      assertThat(document.getMinorVersion(), is(2));
+      assertThat(document.getVersionIndex(), is(5));
+      assertThat(document.getRepositoryPath(), is("/kmelia73/attachments/simpledoc_1"));
+      assertThat(document.getHistory().get(0).getRepositoryPath(),
+          is(String.format(versionPathPattern, "1.4")));
+
+      document.setOrder(0);
+      documentRepository.setOrder(session, document);
+      document =
+          (HistorisedDocument) documentRepository.findDocumentById(session, sourcePk, language);
+
+      assertThat(document, is(notNullValue()));
+      assertThat(document.getOrder(), is(0));
+      assertThat(document.getContentType(), is(MimeTypes.PDF_MIME_TYPE));
+      assertThat(document.getSize(), is(14L));
+      assertThat(document.getHistory(), is(notNullValue()));
+      assertThat(document.getHistory(), hasSize(6));
+      assertThat(document.getFunctionalHistory(), is(notNullValue()));
+      assertThat(document.getFunctionalHistory(), hasSize(4));
+      assertThat(document.getMajorVersion(), is(1));
+      assertThat(document.getMinorVersion(), is(2));
+      assertThat(document.getVersionIndex(), is(6));
+      assertThat(document.getRepositoryPath(), is("/kmelia73/attachments/simpledoc_1"));
+      assertThat(document.getHistory().get(0).getRepositoryPath(),
+          is(String.format(versionPathPattern, "1.5")));
+
+      document.setPublicDocument(true);
+      documentRepository.lock(session, document, document.getEditedBy());
+      documentRepository.updateDocument(session, document);
+      session.save();
+      documentRepository.unlock(session, document, false);
+      document =
+          (HistorisedDocument) documentRepository.findDocumentById(session, sourcePk, language);
+
+      assertThat(document, is(notNullValue()));
+      assertThat(document.getOrder(), is(0));
+      assertThat(document.getContentType(), is(MimeTypes.PDF_MIME_TYPE));
+      assertThat(document.getSize(), is(14L));
+      assertThat(document.getHistory(), is(notNullValue()));
+      assertThat(document.getHistory(), hasSize(7));
+      assertThat(document.getFunctionalHistory(), is(notNullValue()));
+      assertThat(document.getFunctionalHistory(), hasSize(5));
+      assertThat(document.getMajorVersion(), is(2));
+      assertThat(document.getMinorVersion(), is(0));
+      assertThat(document.getVersionIndex(), is(7));
+      assertThat(document.getRepositoryPath(), is("/kmelia73/attachments/simpledoc_1"));
+      assertThat(document.getHistory().get(0).getRepositoryPath(),
+          is(String.format(versionPathPattern, "1.6")));
+
+      /*
+      History :
+      Technical   Functional  Action
+      1.0                     initialization
+      1.1         0.1         change order
+      1.2         0.1         update private
+      1.3         0.2         update public
+      1.4         1.0         update private
+      1.5         1.1         update private
+      1.6         1.1         change order
+      1.7         1.2         update public
+       */
+
+      String targetInstanceId = "kmelia36";
+      String targetForeignId = "foreignId45";
+      SimpleDocumentPK result = documentRepository
+          .moveDocument(session, document, new ForeignPK(targetForeignId, targetInstanceId));
+      try {
+        assertThat(document.getRepositoryPath(), is("/kmelia73/attachments/simpledoc_1"));
+        session.getNode(document.getFullJcrPath());
+        fail("The JCR path " + document.getFullJcrPath() + " should not longer exist...");
+      } catch (PathNotFoundException ex) {
+        // OK
+      }
+      SimpleDocumentPK expResult = new SimpleDocumentPK(result.getId(), targetInstanceId);
+      expResult.setOldSilverpeasId(document.getOldSilverpeasId());
+      assertThat(result, is(expResult));
+      HistorisedDocument doc =
+          (HistorisedDocument) documentRepository.findDocumentById(session, expResult, language);
+      assertThat(doc, is(notNullValue()));
+      assertThat(doc.getOldSilverpeasId(), is(document.getOldSilverpeasId()));
+      assertThat(doc.getCreated(), is(creationDate));
+      checkEnglishSimpleDocument(doc);
+      assertThat(doc.getMajorVersion(), is(2));
+      assertThat(doc.getMinorVersion(), is(0));
+      assertThat(doc.getVersionIndex(), is(8));
+      assertThat(doc.getRepositoryPath(), is("/kmelia36/attachments/simpledoc_1"));
+
+      String[] ignoredBeanPropertiesInComparison =
+          new String[]{"history", "functionalHistory", "created", "updated", "repositoryPath",
+              "publicVersions", "versionMaster", "realVersionPk", "realVersionForeignId",
+              "previousVersion"};
+      document.getPk().setComponentName(targetInstanceId);
+      document.setForeignId(targetForeignId);
+      document.setVersionIndex(8);
+      assertSimpleDocumentsAreEquals(doc, document, ignoredBeanPropertiesInComparison);
+
+      // Version path pattern
+      assertThat(document.getVersionMaster().getId(), is(doc.getVersionMaster().getId()));
+      masterUuid = doc.getVersionMaster().getId();
+      versionPathPattern = "/jcr:system/jcr:versionStorage/" + masterUuid.substring(0, 2) + "/" +
+          masterUuid.substring(2, 4) + "/" +
+          masterUuid.substring(4, 6) + "/" + masterUuid + "/%s/jcr:frozenNode";
+
+      // History
+      assertThat(doc.getHistory(), hasSize(8));
+      assertThat(doc.getFunctionalHistory(), hasSize(5));
+
+
+      SimpleDocumentVersion currentVersion = doc.getHistory().remove(0);
+      assertThat(currentVersion.getVersionIndex(), is(7));
+      assertThat(currentVersion.getRepositoryPath(), is(String.format(versionPathPattern, "1.7")));
+      assertThat(currentVersion.getPk(), not(sameInstance(currentVersion.getRealVersionPk())));
+      assertThat(currentVersion.getPk().getId(), is(currentVersion.getRealVersionPk().getId()));
+      assertThat(currentVersion.getPk().getComponentName(), is(targetInstanceId));
+      assertThat(currentVersion.getRealVersionPk().getComponentName(), is(instanceId));
+      assertThat(currentVersion.getPk().getOldSilverpeasId(),
+          is(currentVersion.getRealVersionPk().getOldSilverpeasId()));
+      assertThat(currentVersion.getForeignId(), is(targetForeignId));
+      assertThat(currentVersion.getRealVersionForeignId(), is(foreignId));
+      document.getPk().setId(currentVersion.getId());
+      document.setVersionIndex(currentVersion.getVersionIndex());
+      assertSimpleDocumentsAreEquals(currentVersion, document, ArrayUtils.addAll(ignoredBeanPropertiesInComparison, "class", "universalURL", "webdavUrl",
+              "onlineURL"));
+
+      for (SimpleDocumentVersion expectedVersion : document.getHistory()) {
+        expectedVersion.setVersionMaster(doc.getVersionMaster());
+      }
+      int versionIndex = doc.getHistory().size();
+      Iterator<SimpleDocumentVersion> resultHistoryIt = doc.getHistory().iterator();
+      for (SimpleDocumentVersion expectedVersion : document.getHistory()) {
+        currentVersion = resultHistoryIt.next();
+        assertThat(currentVersion.getRepositoryPath(),
+            is(String.format(versionPathPattern, "1." + (--versionIndex))));
+        assertThat(currentVersion.getFullJcrPath(), is(doc.getFullJcrPath()));
+        assertThat(currentVersion.getPk(), not(sameInstance(currentVersion.getRealVersionPk())));
+        assertThat(currentVersion.getPk().getId(), is(currentVersion.getRealVersionPk().getId()));
+        assertThat(currentVersion.getPk().getComponentName(), is(targetInstanceId));
+        assertThat(currentVersion.getRealVersionPk().getComponentName(), is(instanceId));
+        assertThat(currentVersion.getPk().getOldSilverpeasId(),
+            is(currentVersion.getRealVersionPk().getOldSilverpeasId()));
+        assertThat(currentVersion.getForeignId(), is(targetForeignId));
+        assertThat(currentVersion.getRealVersionForeignId(), is(foreignId));
+        assertSimpleDocumentsAreEquals(currentVersion, expectedVersion,
+            ignoredBeanPropertiesInComparison);
+      }
     } finally {
       BasicDaoFactory.logout(session);
     }
@@ -995,28 +1700,675 @@ public class HistorisedDocumentRepositoryTest {
       SimpleAttachment attachment = createEnglishVersionnedAttachment();
       Date creationDate = attachment.getCreated();
       String foreignId = "node78";
-      SimpleDocument document = new HistorisedDocument(emptyId, foreignId, 0, attachment);
+      HistorisedDocument document = new HistorisedDocument(emptyId, foreignId, 0, attachment);
       document.setContentType(MimeTypes.PDF_MIME_TYPE);
+      document.setPublicDocument(false);
       createVersionedDocument(session, document, content);
-      document = documentRepository.findDocumentById(session, document.getPk(), language);
-      session.save();
-      foreignId = "node36";
-      SimpleDocumentPK result = documentRepository.copyDocument(session, document, new ForeignPK(
-          foreignId, instanceId));
-      SimpleDocumentPK expResult = new SimpleDocumentPK(result.getId(), instanceId);
+      SimpleDocumentPK sourcePk = document.getPk();
+      document = (HistorisedDocument) documentRepository
+          .findDocumentById(session, sourcePk, language);
+
+      assertThat(document, is(notNullValue()));
+      assertThat(document.getOrder(), is(0));
+      assertThat(document.getContentType(), is(MimeTypes.PDF_MIME_TYPE));
+      assertThat(document.getSize(), is(14L));
+      assertThat(document.getHistory(), is(notNullValue()));
+      assertThat(document.getHistory(), hasSize(0));
+      assertThat(document.getFunctionalHistory(), is(notNullValue()));
+      assertThat(document.getFunctionalHistory(), hasSize(0));
+      assertThat(document.getMajorVersion(), is(0));
+      assertThat(document.getMinorVersion(), is(1));
+      assertThat(document.getVersionIndex(), is(0));
+      assertThat(document.getRepositoryPath(), is("/kmelia73/attachments/simpledoc_1"));
+
+      /*
+      History :
+      Technical   Functional  Action
+      1.0                     initialization
+       */
+
+      String targetInstanceId = "kmelia26";
+      String targetForeignId = "node36";
+      SimpleDocumentPK result = documentRepository
+          .copyDocument(session, document, new ForeignPK(targetForeignId, targetInstanceId));
+      SimpleDocumentPK expResult = new SimpleDocumentPK(result.getId(), targetInstanceId);
       expResult.setOldSilverpeasId(result.getOldSilverpeasId());
       assertThat(result, is(expResult));
-      SimpleDocument doc = documentRepository.findDocumentById(session, expResult, language);
+      HistorisedDocument doc =
+          (HistorisedDocument) documentRepository.findDocumentById(session, expResult, language);
       assertThat(doc, is(notNullValue()));
       assertThat(doc.getOldSilverpeasId(), is(not(document.getOldSilverpeasId())));
       assertThat(doc.getCreated(), is(creationDate));
-      document.setForeignId(foreignId);
+      document.setForeignId(targetForeignId);
+      document.setPK(result);
+      document.setNodeName(doc.getNodeName());
+      document.setUpdatedBy(null);
+      assertThat(doc, SimpleDocumentAttributesMatcher.matches(document));
+      checkEnglishSimpleDocument(doc);
+      assertThat(doc.getMajorVersion(), is(0));
+      assertThat(doc.getMinorVersion(), is(1));
+      assertThat(doc.getVersionIndex(), is(0));
+      assertThat(doc.getRepositoryPath(), is("/kmelia26/attachments/simpledoc_2"));
+
+      String[] ignoredBeanPropertiesInComparison =
+          new String[]{"history", "functionalHistory", "created", "updated", "repositoryPath",
+              "publicVersions", "lastPublicVersion", "versionMaster", "realVersionPk",
+              "realVersionForeignId", "previousVersion"};
+      assertSimpleDocumentsAreEquals(doc, document, ignoredBeanPropertiesInComparison);
+
+      // Reloading original for following assertions.
+      document =
+          (HistorisedDocument) documentRepository.findDocumentById(session, sourcePk, language);
+      assertThat(document.getVersionMaster().getId(), is(not(doc.getVersionMaster().getId())));
+      assertThat(document.getRepositoryPath(), is("/kmelia73/attachments/simpledoc_1"));
+
+      // History
+      assertThat(doc.getHistory(), hasSize(0));
+      assertThat(doc.getFunctionalHistory(), hasSize(0));
+    } finally {
+      BasicDaoFactory.logout(session);
+    }
+  }
+
+  /**
+   * Test of copyDocument method, of class DocumentRepository.
+   * @throws Exception
+   */
+  @Test
+  public void testCopyDocumentChangingFunctionalVersion() throws Exception {
+    Session session = BasicDaoFactory.getSystemSession();
+    try {
+      SimpleDocumentPK emptyId = new SimpleDocumentPK("-1", instanceId);
+      String language = "en";
+      ByteArrayInputStream content =
+          new ByteArrayInputStream("This is a test".getBytes(Charsets.UTF_8));
+      SimpleAttachment attachment = createEnglishVersionnedAttachment();
+      Date creationDate = attachment.getCreated();
+      String foreignId = "node78";
+      HistorisedDocument document = new HistorisedDocument(emptyId, foreignId, 0, attachment);
+      document.setContentType(MimeTypes.PDF_MIME_TYPE);
+      document.setPublicDocument(false);
+      createVersionedDocument(session, document, content);
+      SimpleDocumentPK sourcePk = document.getPk();
+      document =
+          (HistorisedDocument) documentRepository.findDocumentById(session, sourcePk, language);
+
+      // Version path pattern
+      String masterUuid = document.getVersionMaster().getId();
+      String versionPathPattern =
+          "/jcr:system/jcr:versionStorage/" + masterUuid.substring(0, 2) + "/" +
+              masterUuid.substring(2, 4) + "/" +
+              masterUuid.substring(4, 6) + "/" + masterUuid + "/%s/jcr:frozenNode";
+
+      assertThat(document, is(notNullValue()));
+      assertThat(document.getOrder(), is(0));
+      assertThat(document.getContentType(), is(MimeTypes.PDF_MIME_TYPE));
+      assertThat(document.getSize(), is(14L));
+      assertThat(document.getHistory(), is(notNullValue()));
+      assertThat(document.getHistory(), hasSize(0));
+      assertThat(document.getFunctionalHistory(), is(notNullValue()));
+      assertThat(document.getFunctionalHistory(), hasSize(0));
+      assertThat(document.getMajorVersion(), is(0));
+      assertThat(document.getMinorVersion(), is(1));
+      assertThat(document.getVersionIndex(), is(0));
+      assertThat(document.getRepositoryPath(), is("/kmelia73/attachments/simpledoc_1"));
+
+      documentRepository.lock(session, document, document.getEditedBy());
+      documentRepository.updateDocument(session, document);
+      session.save();
+      documentRepository.unlock(session, document, false);
+      document =
+          (HistorisedDocument) documentRepository.findDocumentById(session, sourcePk, language);
+
+      assertThat(document, is(notNullValue()));
+      assertThat(document.getOrder(), is(0));
+      assertThat(document.getContentType(), is(MimeTypes.PDF_MIME_TYPE));
+      assertThat(document.getSize(), is(14L));
+      assertThat(document.getHistory(), is(notNullValue()));
+      assertThat(document.getHistory(), hasSize(1));
+      assertThat(document.getFunctionalHistory(), is(notNullValue()));
+      assertThat(document.getFunctionalHistory(), hasSize(1));
+      assertThat(document.getMajorVersion(), is(0));
+      assertThat(document.getMinorVersion(), is(2));
+      assertThat(document.getVersionIndex(), is(1));
+      assertThat(document.getRepositoryPath(), is("/kmelia73/attachments/simpledoc_1"));
+      assertThat(document.getHistory().get(0).getRepositoryPath(),
+          is(String.format(versionPathPattern, "1.0")));
+
+      /*
+      History :
+      Technical   Functional  Action
+      1.0                     initialization
+      1.1         0.1         update private
+       */
+
+      String targetInstanceId = "kmelia26";
+      String targetForeignId = "node36";
+      SimpleDocumentPK result = documentRepository
+          .copyDocument(session, document, new ForeignPK(targetForeignId, targetInstanceId));
+      SimpleDocumentPK expResult = new SimpleDocumentPK(result.getId(), targetInstanceId);
+      expResult.setOldSilverpeasId(result.getOldSilverpeasId());
+      assertThat(result, is(expResult));
+      HistorisedDocument doc =
+          (HistorisedDocument) documentRepository.findDocumentById(session, expResult, language);
+      assertThat(doc, is(notNullValue()));
+      assertThat(doc.getOldSilverpeasId(), is(not(document.getOldSilverpeasId())));
+      assertThat(doc.getCreated(), is(creationDate));
+      document.setForeignId(targetForeignId);
       document.setPK(result);
       document.setNodeName(doc.getNodeName());
       assertThat(doc, SimpleDocumentAttributesMatcher.matches(document));
       checkEnglishSimpleDocument(doc);
+      assertThat(doc.getMajorVersion(), is(0));
+      assertThat(doc.getMinorVersion(), is(2));
+      assertThat(doc.getVersionIndex(), is(1));
+      assertThat(doc.getRepositoryPath(), is("/kmelia26/attachments/simpledoc_2"));
+
+      String[] ignoredBeanPropertiesInComparison =
+          new String[]{"history", "functionalHistory", "created", "updated", "repositoryPath",
+              "publicVersions", "lastPublicVersion", "versionMaster", "realVersionPk",
+              "realVersionForeignId", "previousVersion"};
+      assertSimpleDocumentsAreEquals(doc, document, ignoredBeanPropertiesInComparison);
+
+      // Reloading original for following assertions.
+      document =
+          (HistorisedDocument) documentRepository.findDocumentById(session, sourcePk, language);
+      assertThat(document.getRepositoryPath(), is("/kmelia73/attachments/simpledoc_1"));
+      assertThat(document.getVersionMaster().getId(), is(not(doc.getVersionMaster().getId())));
+
+      // Version path pattern
+      masterUuid = doc.getVersionMaster().getId();
+      versionPathPattern = "/jcr:system/jcr:versionStorage/" + masterUuid.substring(0, 2) + "/" +
+          masterUuid.substring(2, 4) + "/" +
+          masterUuid.substring(4, 6) + "/" + masterUuid + "/%s/jcr:frozenNode";
+
+      // History
+      assertThat(doc.getHistory(), hasSize(1));
+      assertThat(doc.getFunctionalHistory(), hasSize(1));
+
+      for (SimpleDocumentVersion expectedVersion : document.getHistory()) {
+        expectedVersion.setVersionMaster(doc.getVersionMaster());
+      }
+      Iterator<SimpleDocumentVersion> resultHistoryIt = doc.getHistory().iterator();
+      int versionIndex = doc.getHistory().size();
+      for (SimpleDocumentVersion expectedVersion : document.getHistory()) {
+        SimpleDocumentVersion currentVersion = resultHistoryIt.next();
+        assertThat(currentVersion.getRepositoryPath(),
+            is(String.format(versionPathPattern, "1." + (--versionIndex))));
+        assertThat(currentVersion.getFullJcrPath(), is(doc.getFullJcrPath()));
+        assertThat(currentVersion.getPk(), not(sameInstance(currentVersion.getRealVersionPk())));
+        assertThat(currentVersion.getPk().getId(), is(currentVersion.getRealVersionPk().getId()));
+        assertThat(currentVersion.getPk().getComponentName(),
+            is(currentVersion.getRealVersionPk().getComponentName()));
+        assertThat(currentVersion.getPk().getOldSilverpeasId(),
+            is(currentVersion.getRealVersionPk().getOldSilverpeasId()));
+        assertThat(currentVersion.getForeignId(), is(targetForeignId));
+        assertThat(currentVersion.getForeignId(), is(currentVersion.getRealVersionForeignId()));
+        expectedVersion.setId(currentVersion.getId());
+        assertSimpleDocumentsAreEquals(currentVersion, expectedVersion,
+            ignoredBeanPropertiesInComparison);
+      }
     } finally {
       BasicDaoFactory.logout(session);
+    }
+  }
+
+  /**
+   * Test of copyDocument method, of class DocumentRepository.
+   *
+   * @throws Exception
+   */
+  @Test
+  public void testCopyDocumentWithoutChangingFunctionalVersion() throws Exception {
+    Session session = BasicDaoFactory.getSystemSession();
+    try {
+      SimpleDocumentPK emptyId = new SimpleDocumentPK("-1", instanceId);
+      String language = "en";
+      ByteArrayInputStream content = new ByteArrayInputStream("This is a test".getBytes(
+          Charsets.UTF_8));
+      SimpleAttachment attachment = createEnglishVersionnedAttachment();
+      Date creationDate = attachment.getCreated();
+      String foreignId = "node78";
+      HistorisedDocument document = new HistorisedDocument(emptyId, foreignId, 0, attachment);
+      document.setContentType(MimeTypes.PDF_MIME_TYPE);
+      document.setPublicDocument(false);
+      createVersionedDocument(session, document, content);
+      SimpleDocumentPK sourcePk = document.getPk();
+      document = (HistorisedDocument) documentRepository
+          .findDocumentById(session, sourcePk, language);
+
+      // Version path pattern
+      String masterUuid = document.getVersionMaster().getId();
+      String versionPathPattern =
+          "/jcr:system/jcr:versionStorage/" + masterUuid.substring(0, 2) + "/" +
+              masterUuid.substring(2, 4) + "/" +
+              masterUuid.substring(4, 6) + "/" + masterUuid + "/%s/jcr:frozenNode";
+
+      assertThat(document, is(notNullValue()));
+      assertThat(document.getOrder(), is(0));
+      assertThat(document.getContentType(), is(MimeTypes.PDF_MIME_TYPE));
+      assertThat(document.getSize(), is(14L));
+      assertThat(document.getHistory(), is(notNullValue()));
+      assertThat(document.getHistory(), hasSize(0));
+      assertThat(document.getFunctionalHistory(), is(notNullValue()));
+      assertThat(document.getFunctionalHistory(), hasSize(0));
+      assertThat(document.getMajorVersion(), is(0));
+      assertThat(document.getMinorVersion(), is(1));
+      assertThat(document.getVersionIndex(), is(0));
+      assertThat(document.getRepositoryPath(), is("/kmelia73/attachments/simpledoc_1"));
+
+      document.setOrder(10);
+      documentRepository.setOrder(session, document);
+      document = (HistorisedDocument) documentRepository
+          .findDocumentById(session, sourcePk, language);
+
+      assertThat(document, is(notNullValue()));
+      assertThat(document.getOrder(), is(10));
+      assertThat(document.getContentType(), is(MimeTypes.PDF_MIME_TYPE));
+      assertThat(document.getSize(), is(14L));
+      assertThat(document.getHistory(), is(notNullValue()));
+      assertThat(document.getHistory(), hasSize(1));
+      assertThat(document.getFunctionalHistory(), is(notNullValue()));
+      assertThat(document.getFunctionalHistory(), hasSize(0));
+      assertThat(document.getMajorVersion(), is(0));
+      assertThat(document.getMinorVersion(), is(1));
+      assertThat(document.getVersionIndex(), is(1));
+      assertThat(document.getFullJcrPath(), is("/kmelia73/attachments/simpledoc_1"));
+      assertThat(document.getHistory().get(0).getRepositoryPath(),
+          is(String.format(versionPathPattern, "1.0")));
+
+      /*
+      History :
+      Technical   Functional  Action
+      1.0                     initialization
+      1.1         0.1         change order
+       */
+
+      String targetInstanceId = "kmelia26";
+      String targetForeignId = "node36";
+      SimpleDocumentPK result = documentRepository
+          .copyDocument(session, document, new ForeignPK(targetForeignId, targetInstanceId));
+      SimpleDocumentPK expResult = new SimpleDocumentPK(result.getId(), targetInstanceId);
+      expResult.setOldSilverpeasId(result.getOldSilverpeasId());
+      assertThat(result, is(expResult));
+      HistorisedDocument doc =
+          (HistorisedDocument) documentRepository.findDocumentById(session, expResult, language);
+      assertThat(doc, is(notNullValue()));
+      assertThat(doc.getOldSilverpeasId(), is(not(document.getOldSilverpeasId())));
+      assertThat(doc.getCreated(), is(creationDate));
+      document.setForeignId(targetForeignId);
+      document.setPK(result);
+      document.setNodeName(doc.getNodeName());
+      assertThat(doc, SimpleDocumentAttributesMatcher.matches(document));
+      checkEnglishSimpleDocument(doc);
+      assertThat(doc.getMajorVersion(), is(0));
+      assertThat(doc.getMinorVersion(), is(1));
+      assertThat(doc.getVersionIndex(), is(1));
+      assertThat(doc.getRepositoryPath(), is("/kmelia26/attachments/simpledoc_2"));
+
+      String[] ignoredBeanPropertiesInComparison =
+          new String[]{"history", "functionalHistory", "created", "updated", "repositoryPath",
+              "publicVersions", "lastPublicVersion", "versionMaster", "realVersionPk",
+              "realVersionForeignId", "previousVersion"};
+      assertSimpleDocumentsAreEquals(doc, document, ignoredBeanPropertiesInComparison);
+
+      // Reloading original for following assertions.
+      document =
+          (HistorisedDocument) documentRepository.findDocumentById(session, sourcePk, language);
+      assertThat(document.getRepositoryPath(), is("/kmelia73/attachments/simpledoc_1"));
+      assertThat(document.getVersionMaster().getId(), is(not(doc.getVersionMaster().getId())));
+
+      // Version path pattern
+      masterUuid = doc.getVersionMaster().getId();
+      versionPathPattern = "/jcr:system/jcr:versionStorage/" + masterUuid.substring(0, 2) + "/" +
+          masterUuid.substring(2, 4) + "/" +
+          masterUuid.substring(4, 6) + "/" + masterUuid + "/%s/jcr:frozenNode";
+
+      // History
+      assertThat(doc.getHistory(), hasSize(1));
+      assertThat(doc.getFunctionalHistory(), hasSize(0));
+
+      for (SimpleDocumentVersion expectedVersion : document.getHistory()) {
+        expectedVersion.setVersionMaster(doc.getVersionMaster());
+      }
+      Iterator<SimpleDocumentVersion> resultHistoryIt = doc.getHistory().iterator();
+      int versionIndex = doc.getHistory().size();
+      for (SimpleDocumentVersion expectedVersion : document.getHistory()) {
+        SimpleDocumentVersion currentVersion = resultHistoryIt.next();
+        assertThat(currentVersion.getRepositoryPath(),
+            is(String.format(versionPathPattern, "1." + (--versionIndex))));
+        assertThat(currentVersion.getFullJcrPath(), is(doc.getFullJcrPath()));
+        assertThat(currentVersion.getPk(), not(sameInstance(currentVersion.getRealVersionPk())));
+        assertThat(currentVersion.getPk().getId(), is(currentVersion.getRealVersionPk().getId()));
+        assertThat(currentVersion.getPk().getComponentName(),
+            is(currentVersion.getRealVersionPk().getComponentName()));
+        assertThat(currentVersion.getPk().getOldSilverpeasId(),
+            is(currentVersion.getRealVersionPk().getOldSilverpeasId()));
+        assertThat(currentVersion.getForeignId(), is(targetForeignId));
+        assertThat(currentVersion.getForeignId(), is(currentVersion.getRealVersionForeignId()));
+        expectedVersion.setId(currentVersion.getId());
+        assertSimpleDocumentsAreEquals(currentVersion, expectedVersion,
+            ignoredBeanPropertiesInComparison);
+      }
+    } finally {
+      BasicDaoFactory.logout(session);
+    }
+  }
+
+  /**
+   * Test of copyDocument method, of class DocumentRepository.
+   *
+   * @throws Exception
+   */
+  @Test
+  public void testCopyDocumentWithHugeHistory() throws Exception {
+    Session session = BasicDaoFactory.getSystemSession();
+    try {
+      SimpleDocumentPK emptyId = new SimpleDocumentPK("-1", instanceId);
+      String language = "en";
+      ByteArrayInputStream content = new ByteArrayInputStream("This is a test".getBytes(
+          Charsets.UTF_8));
+      SimpleAttachment attachment = createEnglishVersionnedAttachment();
+      Date creationDate = attachment.getCreated();
+      String foreignId = "node78";
+      HistorisedDocument document = new HistorisedDocument(emptyId, foreignId, 0, attachment);
+      document.setContentType(MimeTypes.PDF_MIME_TYPE);
+      document.setPublicDocument(false);
+      createVersionedDocument(session, document, content);
+      SimpleDocumentPK sourcePk = document.getPk();
+      document = (HistorisedDocument) documentRepository
+          .findDocumentById(session, sourcePk, language);
+
+      // Version path pattern
+      String masterUuid = document.getVersionMaster().getId();
+      String versionPathPattern =
+          "/jcr:system/jcr:versionStorage/" + masterUuid.substring(0, 2) + "/" +
+              masterUuid.substring(2, 4) + "/" +
+              masterUuid.substring(4, 6) + "/" + masterUuid + "/%s/jcr:frozenNode";
+
+      assertThat(document, is(notNullValue()));
+      assertThat(document.getOrder(), is(0));
+      assertThat(document.getContentType(), is(MimeTypes.PDF_MIME_TYPE));
+      assertThat(document.getSize(), is(14L));
+      assertThat(document.getHistory(), is(notNullValue()));
+      assertThat(document.getHistory(), hasSize(0));
+      assertThat(document.getFunctionalHistory(), is(notNullValue()));
+      assertThat(document.getFunctionalHistory(), hasSize(0));
+      assertThat(document.getMajorVersion(), is(0));
+      assertThat(document.getMinorVersion(), is(1));
+      assertThat(document.getVersionIndex(), is(0));
+      assertThat(document.getRepositoryPath(), is("/kmelia73/attachments/simpledoc_1"));
+
+      document.setOrder(10);
+      documentRepository.setOrder(session, document);
+      document = (HistorisedDocument) documentRepository
+          .findDocumentById(session, sourcePk, language);
+
+      assertThat(document, is(notNullValue()));
+      assertThat(document.getOrder(), is(10));
+      assertThat(document.getContentType(), is(MimeTypes.PDF_MIME_TYPE));
+      assertThat(document.getSize(), is(14L));
+      assertThat(document.getHistory(), is(notNullValue()));
+      assertThat(document.getHistory(), hasSize(1));
+      assertThat(document.getFunctionalHistory(), is(notNullValue()));
+      assertThat(document.getFunctionalHistory(), hasSize(0));
+      assertThat(document.getMajorVersion(), is(0));
+      assertThat(document.getMinorVersion(), is(1));
+      assertThat(document.getVersionIndex(), is(1));
+      assertThat(document.getFullJcrPath(), is("/kmelia73/attachments/simpledoc_1"));
+      assertThat(document.getHistory().get(0).getRepositoryPath(),
+          is(String.format(versionPathPattern, "1.0")));
+
+      documentRepository.lock(session, document, document.getEditedBy());
+      documentRepository.updateDocument(session, document);
+      session.save();
+      documentRepository.unlock(session, document, false);
+      document = (HistorisedDocument) documentRepository
+          .findDocumentById(session, sourcePk, language);
+
+      assertThat(document, is(notNullValue()));
+      assertThat(document.getOrder(), is(10));
+      assertThat(document.getContentType(), is(MimeTypes.PDF_MIME_TYPE));
+      assertThat(document.getSize(), is(14L));
+      assertThat(document.getHistory(), is(notNullValue()));
+      assertThat(document.getHistory(), hasSize(2));
+      assertThat(document.getFunctionalHistory(), is(notNullValue()));
+      assertThat(document.getFunctionalHistory(), hasSize(1));
+      assertThat(document.getMajorVersion(), is(0));
+      assertThat(document.getMinorVersion(), is(2));
+      assertThat(document.getVersionIndex(), is(2));
+      assertThat(document.getRepositoryPath(), is("/kmelia73/attachments/simpledoc_1"));
+      assertThat(document.getHistory().get(0).getRepositoryPath(),
+          is(String.format(versionPathPattern, "1.1")));
+
+      document.setPublicDocument(true);
+      documentRepository.lock(session, document, document.getEditedBy());
+      documentRepository.updateDocument(session, document);
+      session.save();
+      documentRepository.unlock(session, document, false);
+      document = (HistorisedDocument) documentRepository
+          .findDocumentById(session, sourcePk, language);
+
+      assertThat(document, is(notNullValue()));
+      assertThat(document.getOrder(), is(10));
+      assertThat(document.getContentType(), is(MimeTypes.PDF_MIME_TYPE));
+      assertThat(document.getSize(), is(14L));
+      assertThat(document.getHistory(), is(notNullValue()));
+      assertThat(document.getHistory(), hasSize(3));
+      assertThat(document.getFunctionalHistory(), is(notNullValue()));
+      assertThat(document.getFunctionalHistory(), hasSize(2));
+      assertThat(document.getMajorVersion(), is(1));
+      assertThat(document.getMinorVersion(), is(0));
+      assertThat(document.getVersionIndex(), is(3));
+      assertThat(document.getRepositoryPath(), is("/kmelia73/attachments/simpledoc_1"));
+      assertThat(document.getHistory().get(0).getRepositoryPath(),
+          is(String.format(versionPathPattern, "1.2")));
+
+      document.setPublicDocument(false);
+      documentRepository.lock(session, document, document.getEditedBy());
+      documentRepository.updateDocument(session, document);
+      session.save();
+      documentRepository.unlock(session, document, false);
+      document = (HistorisedDocument) documentRepository
+          .findDocumentById(session, sourcePk, language);
+
+      assertThat(document, is(notNullValue()));
+      assertThat(document.getOrder(), is(10));
+      assertThat(document.getContentType(), is(MimeTypes.PDF_MIME_TYPE));
+      assertThat(document.getSize(), is(14L));
+      assertThat(document.getHistory(), is(notNullValue()));
+      assertThat(document.getHistory(), hasSize(4));
+      assertThat(document.getFunctionalHistory(), is(notNullValue()));
+      assertThat(document.getFunctionalHistory(), hasSize(3));
+      assertThat(document.getMajorVersion(), is(1));
+      assertThat(document.getMinorVersion(), is(1));
+      assertThat(document.getVersionIndex(), is(4));
+      assertThat(document.getRepositoryPath(), is("/kmelia73/attachments/simpledoc_1"));
+      assertThat(document.getHistory().get(0).getRepositoryPath(),
+          is(String.format(versionPathPattern, "1.3")));
+
+      document.setPublicDocument(false);
+      documentRepository.lock(session, document, document.getEditedBy());
+      documentRepository.updateDocument(session, document);
+      session.save();
+      documentRepository.unlock(session, document, false);
+      document = (HistorisedDocument) documentRepository
+          .findDocumentById(session, sourcePk, language);
+
+      assertThat(document, is(notNullValue()));
+      assertThat(document.getOrder(), is(10));
+      assertThat(document.getContentType(), is(MimeTypes.PDF_MIME_TYPE));
+      assertThat(document.getSize(), is(14L));
+      assertThat(document.getHistory(), is(notNullValue()));
+      assertThat(document.getHistory(), hasSize(5));
+      assertThat(document.getFunctionalHistory(), is(notNullValue()));
+      assertThat(document.getFunctionalHistory(), hasSize(4));
+      assertThat(document.getMajorVersion(), is(1));
+      assertThat(document.getMinorVersion(), is(2));
+      assertThat(document.getVersionIndex(), is(5));
+      assertThat(document.getRepositoryPath(), is("/kmelia73/attachments/simpledoc_1"));
+      assertThat(document.getHistory().get(0).getRepositoryPath(),
+          is(String.format(versionPathPattern, "1.4")));
+
+      document.setOrder(0);
+      documentRepository.setOrder(session, document);
+      document = (HistorisedDocument) documentRepository
+          .findDocumentById(session, sourcePk, language);
+
+      assertThat(document, is(notNullValue()));
+      assertThat(document.getOrder(), is(0));
+      assertThat(document.getContentType(), is(MimeTypes.PDF_MIME_TYPE));
+      assertThat(document.getSize(), is(14L));
+      assertThat(document.getHistory(), is(notNullValue()));
+      assertThat(document.getHistory(), hasSize(6));
+      assertThat(document.getFunctionalHistory(), is(notNullValue()));
+      assertThat(document.getFunctionalHistory(), hasSize(4));
+      assertThat(document.getMajorVersion(), is(1));
+      assertThat(document.getMinorVersion(), is(2));
+      assertThat(document.getVersionIndex(), is(6));
+      assertThat(document.getRepositoryPath(), is("/kmelia73/attachments/simpledoc_1"));
+      assertThat(document.getHistory().get(0).getRepositoryPath(),
+          is(String.format(versionPathPattern, "1.5")));
+
+      document.setPublicDocument(true);
+      documentRepository.lock(session, document, document.getEditedBy());
+      documentRepository.updateDocument(session, document);
+      session.save();
+      documentRepository.unlock(session, document, false);
+      document = (HistorisedDocument) documentRepository
+          .findDocumentById(session, sourcePk, language);
+
+      assertThat(document, is(notNullValue()));
+      assertThat(document.getOrder(), is(0));
+      assertThat(document.getContentType(), is(MimeTypes.PDF_MIME_TYPE));
+      assertThat(document.getSize(), is(14L));
+      assertThat(document.getHistory(), is(notNullValue()));
+      assertThat(document.getHistory(), hasSize(7));
+      assertThat(document.getFunctionalHistory(), is(notNullValue()));
+      assertThat(document.getFunctionalHistory(), hasSize(5));
+      assertThat(document.getMajorVersion(), is(2));
+      assertThat(document.getMinorVersion(), is(0));
+      assertThat(document.getVersionIndex(), is(7));
+      assertThat(document.getRepositoryPath(), is("/kmelia73/attachments/simpledoc_1"));
+      assertThat(document.getHistory().get(0).getRepositoryPath(),
+          is(String.format(versionPathPattern, "1.6")));
+
+      /*
+      History :
+      Technical   Functional  Action
+      1.0                     initialization
+      1.1         0.1         change order
+      1.2         0.1         update private
+      1.3         0.2         update public
+      1.4         1.0         update private
+      1.5         1.1         update private
+      1.6         1.1         change order
+      1.7         1.2         update public
+       */
+
+      String targetInstanceId = "kmelia26";
+      String targetForeignId = "node36";
+      SimpleDocumentPK result = documentRepository
+          .copyDocument(session, document, new ForeignPK(targetForeignId, targetInstanceId));
+      SimpleDocumentPK expResult = new SimpleDocumentPK(result.getId(), targetInstanceId);
+      expResult.setOldSilverpeasId(result.getOldSilverpeasId());
+      assertThat(result, is(expResult));
+      HistorisedDocument doc =
+          (HistorisedDocument) documentRepository.findDocumentById(session, expResult, language);
+      assertThat(doc, is(notNullValue()));
+      assertThat(doc.getOldSilverpeasId(), is(not(document.getOldSilverpeasId())));
+      assertThat(doc.getCreated(), is(creationDate));
+      document.setForeignId(targetForeignId);
+      document.setPK(result);
+      document.setNodeName(doc.getNodeName());
+      assertThat(doc, SimpleDocumentAttributesMatcher.matches(document));
+      checkEnglishSimpleDocument(doc);
+      assertThat(doc.getMajorVersion(), is(2));
+      assertThat(doc.getMinorVersion(), is(0));
+      assertThat(doc.getVersionIndex(), is(7));
+      assertThat(doc.getRepositoryPath(), is("/kmelia26/attachments/simpledoc_2"));
+
+      String[] ignoredBeanPropertiesInComparison =
+          new String[]{"history", "functionalHistory", "created", "updated", "repositoryPath",
+              "publicVersions", "lastPublicVersion", "versionMaster", "realVersionPk",
+              "realVersionForeignId", "previousVersion"};
+      assertSimpleDocumentsAreEquals(doc, document, ignoredBeanPropertiesInComparison);
+
+      // Reloading original for following assertions.
+      document =
+          (HistorisedDocument) documentRepository.findDocumentById(session, sourcePk, language);
+      assertThat(document.getRepositoryPath(), is("/kmelia73/attachments/simpledoc_1"));
+      assertThat(document.getVersionMaster().getId(), is(not(doc.getVersionMaster().getId())));
+
+      // Version path pattern
+      masterUuid = doc.getVersionMaster().getId();
+      versionPathPattern = "/jcr:system/jcr:versionStorage/" + masterUuid.substring(0, 2) + "/" +
+          masterUuid.substring(2, 4) + "/" +
+          masterUuid.substring(4, 6) + "/" + masterUuid + "/%s/jcr:frozenNode";
+
+      // History
+      assertThat(doc.getHistory(), hasSize(7));
+      assertThat(doc.getFunctionalHistory(), hasSize(5));
+
+      for (SimpleDocumentVersion expectedVersion : document.getHistory()) {
+        expectedVersion.setVersionMaster(doc.getVersionMaster());
+      }
+      Iterator<SimpleDocumentVersion> resultHistoryIt = doc.getHistory().iterator();
+      int versionIndex = doc.getHistory().size();
+      for (SimpleDocumentVersion expectedVersion : document.getHistory()) {
+        SimpleDocumentVersion currentVersion = resultHistoryIt.next();
+        assertThat(currentVersion.getRepositoryPath(),
+            is(String.format(versionPathPattern, "1." + (--versionIndex))));
+        assertThat(currentVersion.getFullJcrPath(), is(doc.getFullJcrPath()));
+        assertThat(currentVersion.getPk(), not(sameInstance(currentVersion.getRealVersionPk())));
+        assertThat(currentVersion.getPk().getId(), is(currentVersion.getRealVersionPk().getId()));
+        assertThat(currentVersion.getPk().getComponentName(),
+            is(currentVersion.getRealVersionPk().getComponentName()));
+        assertThat(currentVersion.getPk().getOldSilverpeasId(),
+            is(currentVersion.getRealVersionPk().getOldSilverpeasId()));
+        assertThat(currentVersion.getForeignId(), is(targetForeignId));
+        assertThat(currentVersion.getForeignId(), is(currentVersion.getRealVersionForeignId()));
+        expectedVersion.setId(currentVersion.getId());
+        assertSimpleDocumentsAreEquals(currentVersion, expectedVersion,
+            ignoredBeanPropertiesInComparison);
+      }
+    } finally {
+      BasicDaoFactory.logout(session);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private void assertSimpleDocumentsAreEquals(SimpleDocument result, SimpleDocument expected,
+      String... ignoredBeanProperties) throws Exception {
+
+    // SimpleDocument
+    Map<String, String> expectedBeanProperties = BeanUtils.describe(expected);
+    Map<String, String> resultBeanProperties = BeanUtils.describe(result);
+    String resultRepoPath = resultBeanProperties.get("repositoryPath");
+    List<String> toIgnoredBeanProperties = new ArrayList<String>();
+    Collections.addAll(toIgnoredBeanProperties, ignoredBeanProperties);
+    toIgnoredBeanProperties.add("file");
+    for (String keyToRemove : toIgnoredBeanProperties) {
+      expectedBeanProperties.remove(keyToRemove);
+      resultBeanProperties.remove(keyToRemove);
+    }
+    assertThat(resultBeanProperties.size(), is(expectedBeanProperties.size()));
+    for (Map.Entry<String, String> expectedEntry : expectedBeanProperties.entrySet()) {
+      assertThat("ResultRepoPath (simpledoc): " + resultRepoPath, resultBeanProperties,
+          hasEntry(expectedEntry.getKey(), expectedEntry.getValue()));
+    }
+
+    // Attachment
+    expectedBeanProperties = BeanUtils.describe(expected.getFile());
+    resultBeanProperties = BeanUtils.describe(result.getFile());
+    for (String keyToRemove : toIgnoredBeanProperties) {
+      expectedBeanProperties.remove(keyToRemove);
+      resultBeanProperties.remove(keyToRemove);
+    }
+    assertThat(resultBeanProperties.size(), is(expectedBeanProperties.size()));
+    for (Map.Entry<String, String> expectedEntry : expectedBeanProperties.entrySet()) {
+      assertThat("ResultRepoPath (attachment): " + resultRepoPath, resultBeanProperties,
+          hasEntry(expectedEntry.getKey(), expectedEntry.getValue()));
     }
   }
 
@@ -1255,6 +2607,10 @@ public class HistorisedDocumentRepositoryTest {
       assertThat(doc.getVersionIndex(), is(doc.getVersionMaster().getVersionIndex()));
       assertThat(doc.getForbiddenDownloadForRoles(),
           contains(SilverpeasRole.admin, SilverpeasRole.writer));
+      for (SimpleDocumentVersion version : doc.getHistory()) {
+        assertThat(version.getForbiddenDownloadForRoles(),
+            contains(SilverpeasRole.admin, SilverpeasRole.writer));
+      }
 
       document.addRolesForWhichDownloadIsAllowed(SilverpeasRole.writer, SilverpeasRole.admin);
       documentRepository.saveForbiddenDownloadForRoles(session, document);
@@ -1274,6 +2630,9 @@ public class HistorisedDocumentRepositoryTest {
       assertThat(doc.getVersionIndex(), is(4));
       assertThat(doc.getVersionIndex(), is(doc.getVersionMaster().getVersionIndex()));
       assertThat(doc.getForbiddenDownloadForRoles(), nullValue());
+      for (SimpleDocumentVersion version : doc.getHistory()) {
+        assertThat(version.getForbiddenDownloadForRoles(), nullValue());
+      }
 
     } finally {
       BasicDaoFactory.logout(session);
@@ -1318,6 +2677,7 @@ public class HistorisedDocumentRepositoryTest {
       assertThat(docCreated.getMinorVersion(), is(1));
       assertThat(docCreated.getVersionIndex(), is(0));
       assertThat(docCreated.getVersionIndex(), is(docCreated.getVersionMaster().getVersionIndex()));
+      assertThat(docCreated.getPreviousVersion(), nullValue());
 
       // Verifying data are ok
       String masterUuid = docCreated.getVersionMaster().getId();
@@ -1362,6 +2722,24 @@ public class HistorisedDocumentRepositoryTest {
 
       HistorisedDocument doc =
           (HistorisedDocument) documentRepository.findDocumentById(session, result, "fr");
+
+      List<String> publicDocumentsIdsFromLastToFirst = new ArrayList<String>();
+      VersionHistory versionHistory =
+          session.getWorkspace().getVersionManager().getVersionHistory(doc.getFullJcrPath());
+      NodeIterator frozenNodeIt = versionHistory.getAllFrozenNodes();
+      DocumentConverter converter = new DocumentConverter();
+      Version rootNode = versionHistory.getRootVersion();
+      while (frozenNodeIt.hasNext()) {
+        Node frozenNode = frozenNodeIt.nextNode();
+        if (!frozenNode.getPath().startsWith(rootNode.getPath())) {
+          SimpleDocument simpleDocument = converter.fillDocument(frozenNode, doc.getLanguage());
+          if (simpleDocument.isPublic()) {
+            publicDocumentsIdsFromLastToFirst.add(0, simpleDocument.getId());
+          }
+        }
+      }
+
+      // Testing the historised document.
       assertThat(doc, is(notNullValue()));
       assertThat(doc.getOrder(), is(15));
       assertThat(doc.getContentType(), is(MimeTypes.MIME_TYPE_OO_PRESENTATION));
@@ -1376,18 +2754,45 @@ public class HistorisedDocumentRepositoryTest {
       assertThat(doc.getVersionIndex(), is(1122));
       assertThat(doc.getVersionIndex(), is(doc.getVersionMaster().getVersionIndex()));
 
+      // Testing last public version.
+      Iterator<String> expectedPublicVersionIt = publicDocumentsIdsFromLastToFirst.iterator();
+      SimpleDocument lastPublicVersion = doc.getLastPublicVersion();
+      while (lastPublicVersion != null) {
+        assertThat(lastPublicVersion.getId(), is(expectedPublicVersionIt.next()));
+        expectedPublicVersionIt.remove();
+        assertThat(lastPublicVersion.getLastPublicVersion(), sameInstance(lastPublicVersion));
+        if (lastPublicVersion instanceof HistorisedDocument) {
+          lastPublicVersion =
+              ((HistorisedDocument) lastPublicVersion).getPreviousVersion().getLastPublicVersion();
+        } else {
+          lastPublicVersion = ((SimpleDocumentVersion) lastPublicVersion).getPreviousVersion()
+              .getLastPublicVersion();
+        }
+      }
+      assertThat(publicDocumentsIdsFromLastToFirst, hasSize(0));
+
+      // Testing technical version history.
+      assertThat(doc.getPreviousVersion(), is(doc.getHistory().get(0)));
       int versionIndexExpected = doc.getVersionIndex();
-      for (SimpleDocument documentInHistory : doc.getHistory()) {
+      SimpleDocumentVersion previousVersion = null;
+      for (SimpleDocumentVersion documentInHistory : doc.getHistory()) {
         assertThat(documentInHistory.getVersionMaster(), sameInstance(doc.getVersionMaster()));
         assertThat(documentInHistory.getVersionIndex(), is(--versionIndexExpected));
         assertThat(documentInHistory.getRepositoryPath(),
             is(String.format(versionPathPattern, "1." + (versionIndexExpected))));
+        assertThat(documentInHistory.getFullJcrPath(), is(doc.getFullJcrPath()));
+        if (previousVersion != null) {
+          assertThat(previousVersion, is(documentInHistory));
+        }
+        previousVersion = documentInHistory.getPreviousVersion();
       }
+      assertThat(previousVersion, nullValue());
 
+      // Testing functional version history.
       versionIndexExpected = 1071;
       int expectedMajorVersion = 4;
       int expectedMinorVersion = 1;
-      for (SimpleDocument documentInFunctionalHistory : doc.getFunctionalHistory()) {
+      for (SimpleDocumentVersion documentInFunctionalHistory : doc.getFunctionalHistory()) {
         assertThat(documentInFunctionalHistory.getVersionMaster(),
             sameInstance(doc.getVersionMaster()));
         assertThat(documentInFunctionalHistory.getVersion(),
@@ -1477,6 +2882,7 @@ public class HistorisedDocumentRepositoryTest {
     SimpleDocumentPK result = documentRepository.createDocument(session, document);
     documentRepository.storeContent(document, content);
     document.setPK(result);
+    session.save();
     documentRepository.unlock(session, document, false);
     return result;
   }

--- a/war-core/src/main/java/org/silverpeas/attachment/web/VersioningRequestRouter.java
+++ b/war-core/src/main/java/org/silverpeas/attachment/web/VersioningRequestRouter.java
@@ -52,7 +52,7 @@ public class VersioningRequestRouter extends ComponentRequestRouter<VersioningSe
   @Override
   public String getDestination(String function, VersioningSessionController versioningSC,
       HttpRequest request) {
-    String destination = "";
+    String destination;
     SilverTrace.info("versioningPeas", "VersioningRequestRouter.getDestination()",
         "root.MSG_GEN_PARAM_VALUE", "User=" + versioningSC.getUserId() + " Function=" + function);
     String rootDestination = "/versioningPeas/jsp/";
@@ -61,8 +61,11 @@ public class VersioningRequestRouter extends ComponentRequestRouter<VersioningSe
 
       // Handle the content language.
       String contentLanguage = request.getParameter("Language");
-      request.setAttribute("ContentLanguage",
-          (StringUtil.isDefined(contentLanguage) ? contentLanguage : null));
+      if (!StringUtil.isDefined(contentLanguage)) {
+        contentLanguage = null;
+      }
+      request.setAttribute("ContentLanguage", contentLanguage);
+      versioningSC.setContentLanguage(contentLanguage);
 
       request.setAttribute("Profile", flag);
       if ("ListPublicVersionsOfDocument".equals(function)) {

--- a/war-core/src/main/java/org/silverpeas/attachment/web/VersioningSessionController.java
+++ b/war-core/src/main/java/org/silverpeas/attachment/web/VersioningSessionController.java
@@ -43,9 +43,8 @@ import org.silverpeas.attachment.model.SimpleDocument;
 import org.silverpeas.attachment.model.SimpleDocumentPK;
 
 import java.rmi.RemoteException;
+import java.util.Collections;
 import java.util.List;
-
-import edu.emory.mathcs.backport.java.util.Collections;
 
 /**
  * @author Michael Nikolaenko
@@ -54,8 +53,8 @@ import edu.emory.mathcs.backport.java.util.Collections;
 public class VersioningSessionController extends AbstractComponentSessionController {
 
   private SimpleDocument document;
+  private String contentLanguage;
   private String nodeId = null;
-  private boolean topicRightsEnabled = false;
   private AdminController adminController = null;
   private String currentProfile = null;
   public static final String ADMIN = SilverpeasRole.admin.toString();
@@ -81,7 +80,7 @@ public class VersioningSessionController extends AbstractComponentSessionControl
   }
 
   private boolean isTopicRightsEnabled() {
-    return topicRightsEnabled;
+    return false;
   }
 
   /**
@@ -104,7 +103,8 @@ public class VersioningSessionController extends AbstractComponentSessionControl
    * @return SimpleDocument
    */
   public SimpleDocument getDocument(SimpleDocumentPK documentPK) {
-    return AttachmentServiceFactory.getAttachmentService().searchDocumentById(documentPK, null);
+    return AttachmentServiceFactory.getAttachmentService()
+        .searchDocumentById(documentPK, getContentLanguage());
   }
 
   /**
@@ -114,19 +114,19 @@ public class VersioningSessionController extends AbstractComponentSessionControl
    * @return List<SimpleDocument>
    */
   public List<SimpleDocument> getDocumentVersions(SimpleDocumentPK documentPK) {
-    return ((HistorisedDocument) AttachmentServiceFactory.getAttachmentService()
-        .searchDocumentById(documentPK, null)).getFunctionalHistory();
+    return (List)((HistorisedDocument) AttachmentServiceFactory.getAttachmentService()
+        .searchDocumentById(documentPK, getContentLanguage())).getFunctionalHistory();
   }
 
   /**
-   * To get only public versions of document.
+   * To get only public versions of document (according to the content language).
    *
    * @param documentPK
    * @return List<SimpleDocument>
    */
   public List<SimpleDocument> getPublicDocumentVersions(SimpleDocumentPK documentPK) {
     SimpleDocument currentDoc = AttachmentServiceFactory.getAttachmentService().searchDocumentById(
-        documentPK, null);
+        documentPK, getContentLanguage());
     if (currentDoc.isVersioned()) {
       return ((HistorisedDocument) currentDoc).getPublicVersions();
     }
@@ -140,6 +140,15 @@ public class VersioningSessionController extends AbstractComponentSessionControl
    */
   public void setEditingDocument(SimpleDocument document) {
     this.document = document;
+    setComponentId(document.getInstanceId());
+  }
+
+  public String getContentLanguage() {
+    return contentLanguage;
+  }
+
+  public void setContentLanguage(final String contentLanguage) {
+    this.contentLanguage = contentLanguage;
   }
 
   /**

--- a/war-core/src/main/java/org/silverpeas/servlets/GoToDocument.java
+++ b/war-core/src/main/java/org/silverpeas/servlets/GoToDocument.java
@@ -20,20 +20,20 @@
  */
 package org.silverpeas.servlets;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
+import com.silverpeas.accesscontrol.AccessControlContext;
+import com.silverpeas.accesscontrol.AccessControlOperation;
+import com.silverpeas.accesscontrol.AccessController;
+import com.silverpeas.accesscontrol.AccessControllerProvider;
+import com.silverpeas.peasUtil.GoTo;
+import com.silverpeas.util.StringUtil;
+import com.stratelia.silverpeas.peasCore.URLManager;
 import org.silverpeas.attachment.AttachmentServiceFactory;
 import org.silverpeas.attachment.model.SimpleDocument;
 import org.silverpeas.attachment.model.SimpleDocumentPK;
 import org.silverpeas.permalinks.PermalinkServiceFactory;
 
-import com.silverpeas.peasUtil.GoTo;
-import com.silverpeas.util.StringUtil;
-import com.silverpeas.util.security.ComponentSecurity;
-
-import com.stratelia.silverpeas.peasCore.URLManager;
-import com.stratelia.silverpeas.silvertrace.SilverTrace;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 public class GoToDocument extends GoTo {
 
@@ -48,13 +48,10 @@ public class GoToDocument extends GoTo {
           findVersionnedDocumentByOldId(Integer.parseInt(objectId));
     } else {
       document = AttachmentServiceFactory.getAttachmentService().searchDocumentById(
-          new SimpleDocumentPK(objectId), null);
+          new SimpleDocumentPK(objectId), getContentLanguage(req));
     }
     if (document != null) {
-      SimpleDocument version = document.getLastPublicVersion();
-      if (version != null) {
-        return redirectToFile(version, req, res);
-      }
+      return redirectToFile(document, req, res);
     }
     return null;
   }
@@ -68,28 +65,23 @@ public class GoToDocument extends GoTo {
       setGefSpaceId(req, componentId);
     }
     if (isLoggedIn) {
-      // L'utilisateur est déjà loggué
-      if (isUserAllowed(req, componentId)) {
-        // L'utilisateur a-t-il le droit de consulter le fichier/la publication
-        boolean isAccessAuthorized = true;
-        if (componentId.startsWith("kmelia")) {
-          try {
-            ComponentSecurity security = (ComponentSecurity) Class.forName(
-                "com.stratelia.webactiv.kmelia.KmeliaSecurity").newInstance();
-            isAccessAuthorized = security.isAccessAuthorized(componentId, getUserId(req), foreignId);
-          } catch (ClassNotFoundException e) {
-            SilverTrace.error("peasUtil", "GoToDocument.doPost", "root.EX_CLASS_NOT_INITIALIZED",
-                "com.stratelia.webactiv.kmelia.KmeliaSecurity", e);
-            return null;
+      AccessController<SimpleDocument> accessController =
+          AccessControllerProvider.getAccessController("simpleDocumentAccessController");
+      boolean isAccessAuthorized = accessController.isUserAuthorized(getUserId(req), version,
+          AccessControlContext.init().onOperationsOf(AccessControlOperation.download));
+      if (!isAccessAuthorized) {
+        SimpleDocument lastPublicVersion = version.getLastPublicVersion();
+        if (lastPublicVersion != null) {
+          isAccessAuthorized = accessController.isUserAuthorized(getUserId(req), lastPublicVersion,
+              AccessControlContext.init().onOperationsOf(AccessControlOperation.download));
+          if (isAccessAuthorized) {
+            return URLManager.getServerURL(req) + lastPublicVersion.getUniversalURL();
           }
         }
-
-        if (isAccessAuthorized) {
-          return URLManager.getServerURL(req) + version.getUniversalURL();
-        }
+      } else {
+        return URLManager.getServerURL(req) + version.getUniversalURL();
       }
     }
-    return "ComponentId=" + componentId + "&AttachmentId=" + version.getId()
-        + "&Mapping=Version&ForeignId=" + foreignId;
+    return null;
   }
 }

--- a/war-core/src/main/java/org/silverpeas/servlets/GoToFile.java
+++ b/war-core/src/main/java/org/silverpeas/servlets/GoToFile.java
@@ -20,27 +20,20 @@
  */
 package org.silverpeas.servlets;
 
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
+import com.silverpeas.peasUtil.GoTo;
+import com.silverpeas.util.security.ComponentSecurity;
+import com.stratelia.silverpeas.peasCore.URLManager;
+import com.stratelia.silverpeas.silvertrace.SilverTrace;
+import com.stratelia.webactiv.util.ClientBrowserUtil;
 import org.apache.commons.codec.CharEncoding;
-
 import org.silverpeas.attachment.AttachmentServiceFactory;
 import org.silverpeas.attachment.model.SimpleDocument;
 import org.silverpeas.attachment.model.SimpleDocumentPK;
 
-import com.silverpeas.peasUtil.GoTo;
-import com.silverpeas.util.StringUtil;
-import com.silverpeas.util.i18n.I18NHelper;
-import com.silverpeas.util.security.ComponentSecurity;
-
-import com.stratelia.silverpeas.peasCore.MainSessionController;
-import com.stratelia.silverpeas.peasCore.URLManager;
-import com.stratelia.silverpeas.silvertrace.SilverTrace;
-import com.stratelia.webactiv.util.ClientBrowserUtil;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 
 public class GoToFile extends GoTo {
 
@@ -50,16 +43,8 @@ public class GoToFile extends GoTo {
   @Override
   public String getDestination(String objectId, HttpServletRequest req,
       HttpServletResponse res) throws Exception {
-    MainSessionController mainSessionCtrl = util.getMainSessionController(req);
-    String language = I18NHelper.defaultLanguage;
-    if (mainSessionCtrl != null) {
-      language = mainSessionCtrl.getFavoriteLanguage();
-    }
-    if(StringUtil.isLong(objectId)) {
-      
-    }
     SimpleDocument attachment = AttachmentServiceFactory.getAttachmentService().
-        searchDocumentById(new SimpleDocumentPK(objectId), language);
+        searchDocumentById(new SimpleDocumentPK(objectId), getContentLanguage(req));
     if (attachment == null) {
       return null;
     }

--- a/war-core/src/main/java/org/silverpeas/servlets/GoToVersion.java
+++ b/war-core/src/main/java/org/silverpeas/servlets/GoToVersion.java
@@ -20,15 +20,14 @@
  */
 package org.silverpeas.servlets;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
+import com.silverpeas.util.StringUtil;
 import org.silverpeas.attachment.AttachmentServiceFactory;
 import org.silverpeas.attachment.model.SimpleDocument;
 import org.silverpeas.attachment.model.SimpleDocumentPK;
 import org.silverpeas.permalinks.PermalinkServiceFactory;
 
-import com.silverpeas.util.StringUtil;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 public class GoToVersion extends GoToDocument {
 
@@ -42,14 +41,11 @@ public class GoToVersion extends GoToDocument {
       document = PermalinkServiceFactory.getPermalinkCompatibilityService().
           findDocumentVersionByOldId(Integer.parseInt(objectId));
     } else {
-      document = AttachmentServiceFactory.getAttachmentService().searchDocumentById(
-          new SimpleDocumentPK(objectId), null);
+      document = AttachmentServiceFactory.getAttachmentService()
+          .searchDocumentById(new SimpleDocumentPK(objectId), getContentLanguage(req));
     }
     if (document != null) {
-      SimpleDocument version = document.getLastPublicVersion();
-      if (version != null) {
-        return redirectToFile(version, req, res);
-      }
+      return redirectToFile(document, req, res);
     }
     return null;
   }

--- a/war-core/src/main/webapp/attachment/jsp/publicVersions.jsp
+++ b/war-core/src/main/webapp/attachment/jsp/publicVersions.jsp
@@ -125,9 +125,7 @@
           publicVersion.isDownloadAllowedForRolesFrom(mainSessionCtrl.getCurrentUserDetail());
 
       arrayLine = arrayPane.addArrayLine(); // set a new line
-      String url =
-          FileServerUtils.getUrl(publicVersion.getInstanceId(), publicVersion.getFilename()) +
-              "&DocumentId=" + publicVersion.getId() + "&VersionId=" + publicVersion.getId();
+      String url = URLManager.getApplicationURL() + publicVersion.getAttachmentURL();
       if (fromAlias) {
         url = publicVersion.getAliasURL();
       }
@@ -150,9 +148,9 @@
       String permalink = "";
       if (canUserDownloadFile) {
         permalink =
-            " <a href=\"" + URLManager.getSimpleURL(URLManager.URL_VERSION, publicVersion.getId()) +
-                "\"><img src=\"" + URLManager.getApplicationURL() +
-                "/util/icons/link.gif\" border=\"0\" valign=\"absmiddle\" alt=\"" +
+            " <a href=\"" + publicVersion.getUniversalURL() + "\">" +
+                "<img src=\"" + URLManager.getApplicationURL() + "/util/icons/link.gif\"" +
+                "border=\"0\" valign=\"absmiddle\" alt=\"" +
                 messages.getString("versioning.CopyLink") + "\" title=\"" +
                 messages.getString("versioning.CopyLink") + "\" target=\"_blank\"></a> ";
       }

--- a/web-core/src/main/java/com/silverpeas/peasUtil/GoTo.java
+++ b/web-core/src/main/java/com/silverpeas/peasUtil/GoTo.java
@@ -21,27 +21,24 @@
 
 package com.silverpeas.peasUtil;
 
-import java.io.IOException;
-import java.io.OutputStream;
+import com.silverpeas.look.LookHelper;
+import com.silverpeas.util.StringUtil;
+import com.silverpeas.util.i18n.I18NHelper;
+import com.stratelia.silverpeas.peasCore.MainSessionController;
+import com.stratelia.silverpeas.peasCore.SilverpeasWebUtil;
+import com.stratelia.silverpeas.peasCore.URLManager;
+import com.stratelia.silverpeas.silvertrace.SilverTrace;
+import com.stratelia.webactiv.util.viewGenerator.html.GraphicElementFactory;
+import org.apache.commons.io.IOUtils;
+import org.silverpeas.util.Charsets;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
-
-import org.silverpeas.util.Charsets;
-
-import com.silverpeas.look.LookHelper;
-import com.silverpeas.util.StringUtil;
-
-import com.stratelia.silverpeas.peasCore.MainSessionController;
-import com.stratelia.silverpeas.peasCore.SilverpeasWebUtil;
-import com.stratelia.silverpeas.peasCore.URLManager;
-import com.stratelia.silverpeas.silvertrace.SilverTrace;
-import com.stratelia.webactiv.util.viewGenerator.html.GraphicElementFactory;
-
-import org.apache.commons.io.IOUtils;
+import java.io.IOException;
+import java.io.OutputStream;
 
 public abstract class GoTo extends HttpServlet {
 
@@ -163,5 +160,14 @@ public abstract class GoTo extends HttpServlet {
         gef.setSpaceId(helperSpaceId);
       }
     }
+  }
+
+  /**
+   * Gets the content language specified into the request.
+   * @param request
+   * @return
+   */
+  protected String getContentLanguage(HttpServletRequest request) {
+    return util.getContentLanguage(request);
   }
 }

--- a/web-core/src/main/java/com/stratelia/silverpeas/peasCore/SilverpeasWebUtil.java
+++ b/web-core/src/main/java/com/stratelia/silverpeas/peasCore/SilverpeasWebUtil.java
@@ -27,6 +27,8 @@ package com.stratelia.silverpeas.peasCore;
 
 import javax.servlet.http.HttpServletRequest;
 
+import com.silverpeas.util.StringUtil;
+import com.silverpeas.util.i18n.I18NHelper;
 import org.silverpeas.core.admin.OrganisationController;
 import org.silverpeas.core.admin.OrganisationControllerFactory;
 
@@ -130,5 +132,27 @@ public class SilverpeasWebUtil {
           getComponentId(request)[1]);
     }
     return ArrayUtil.EMPTY_STRING_ARRAY;
+  }
+
+  /**
+   * Gets the content language specified into the request.
+   * @param request
+   * @return
+   */
+  public String getContentLanguage(HttpServletRequest request) {
+    String contentLanguage = (String) request.getAttribute("ContentLanguage");
+    if (StringUtil.isNotDefined(contentLanguage)) {
+      contentLanguage = request.getParameter("ContentLanguage");
+    }
+    if (StringUtil.isNotDefined(contentLanguage)) {
+      contentLanguage = I18NHelper.defaultLanguage;
+    }
+    if (StringUtil.isNotDefined(contentLanguage)) {
+      MainSessionController mainSessionCtrl = getMainSessionController(request);
+      if (mainSessionCtrl != null) {
+        contentLanguage = mainSessionCtrl.getFavoriteLanguage();
+      }
+    }
+    return contentLanguage;
   }
 }

--- a/web-core/src/main/java/org/silverpeas/accesscontrol/SimpleDocumentAccessController.java
+++ b/web-core/src/main/java/org/silverpeas/accesscontrol/SimpleDocumentAccessController.java
@@ -145,6 +145,11 @@ public class SimpleDocumentAccessController extends AbstractAccessController<Sim
     boolean authorized = true;
     boolean isRoleVerificationRequired = false;
 
+    // Checking the versions
+    if (object.isVersioned() && !object.isPublic()) {
+      isRoleVerificationRequired = true;
+    }
+
     // Verifying download is possible
     if (context.getOperations().contains(AccessControlOperation.download) &&
         !object.isDownloadAllowedForReaders()) {


### PR DESCRIPTION
- fixing the case of the copy that did not work too (history of versions was not respected, i18n was not supported, date of a version was not the one of the original but the date of the copy action !)
- fixing the case of the move
- upgrading the simple document access controller in order to take in account the versions of attachments
- improving the mechanism of universal link associated to attachments
- handling the language content for versioned attachments

Don't forget to check https://github.com/Silverpeas/Silverpeas-Components/pull/304
