### PR TITLE
Bug #5329 : adding a new rule around WYSIWYG attachment management.

### DIFF
--- a/lib-core/src/main/java/com/silverpeas/util/i18n/I18NHelper.java
+++ b/lib-core/src/main/java/com/silverpeas/util/i18n/I18NHelper.java
@@ -35,6 +35,7 @@ import javax.servlet.http.HttpServletRequest;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -46,7 +47,7 @@ public class I18NHelper {
   // "fr" - List of I18NLanguage : all available languages in french
   // "en" - List of I18NLanguage : all available languages in english
   public final static Map<String, List<I18NLanguage>> allLanguages =
-      new HashMap<String, List<I18NLanguage>>();
+      new LinkedHashMap<String, List<I18NLanguage>>();
 
   private static int nbLanguages = 0;
   public static boolean isI18N = false;

--- a/lib-core/src/main/java/org/silverpeas/attachment/AttachmentService.java
+++ b/lib-core/src/main/java/org/silverpeas/attachment/AttachmentService.java
@@ -23,22 +23,21 @@
  */
 package org.silverpeas.attachment;
 
+import com.silverpeas.util.ForeignPK;
+import com.stratelia.webactiv.util.WAPrimaryKey;
+import org.silverpeas.attachment.model.DocumentType;
+import org.silverpeas.attachment.model.SimpleDocument;
+import org.silverpeas.attachment.model.SimpleDocumentPK;
+import org.silverpeas.attachment.model.UnlockContext;
+import org.silverpeas.attachment.util.SimpleDocumentList;
+import org.silverpeas.search.indexEngine.model.FullIndexEntry;
+
 import java.io.File;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
-
-import org.silverpeas.attachment.model.DocumentType;
-import org.silverpeas.attachment.model.SimpleDocument;
-import org.silverpeas.attachment.model.SimpleDocumentPK;
-import org.silverpeas.attachment.model.UnlockContext;
-import org.silverpeas.search.indexEngine.model.FullIndexEntry;
-
-import com.silverpeas.util.ForeignPK;
-
-import com.stratelia.webactiv.util.WAPrimaryKey;
 
 /**
  *
@@ -69,6 +68,18 @@ public interface AttachmentService {
    * @param lang the language of the content.
    */
   void getBinaryContent(OutputStream output, SimpleDocumentPK pk, String lang);
+
+  /**
+   * Writes the binary content contained between begin and end indexes into the specified
+   * OutputStream.
+   * @param output the stream where the content is to be written.
+   * @param pk the id of the document.
+   * @param lang the language of the content.
+   * @param contentOffset number of bytes to skip from input content before copying into output.
+   * @param contentLength number of bytes to copy.
+   */
+  void getBinaryContent(OutputStream output, SimpleDocumentPK pk, String lang, long contentOffset,
+      long contentLength);
 
   void addXmlForm(SimpleDocumentPK pk, String language, String xmlFormName);
 
@@ -259,7 +270,8 @@ public interface AttachmentService {
    * @return the list of attached documents.
    * @throws AttachmentException when is impossible to search
    */
-  List<SimpleDocument> listDocumentsByForeignKey(WAPrimaryKey foreignKey, String lang);
+  SimpleDocumentList<SimpleDocument> listDocumentsByForeignKey(WAPrimaryKey foreignKey,
+      String lang);
 
   /**
    * Search all documents (files, xmlform content, wysiwyg) attached to a foreign object.
@@ -269,7 +281,8 @@ public interface AttachmentService {
    * @return the list of attached documents.
    * @throws AttachmentException when is impossible to search
    */
-  List<SimpleDocument> listAllDocumentsByForeignKey(WAPrimaryKey foreignKey, String lang);
+  SimpleDocumentList<SimpleDocument> listAllDocumentsByForeignKey(WAPrimaryKey foreignKey,
+      String lang);
 
   /**
    * Search all file attached to a foreign object.
@@ -280,8 +293,8 @@ public interface AttachmentService {
    * @return the list of attached documents.
    * @throws AttachmentException when is impossible to search
    */
-  List<SimpleDocument> listDocumentsByForeignKeyAndType(WAPrimaryKey foreignKey, DocumentType type,
-      String lang);
+  SimpleDocumentList<SimpleDocument> listDocumentsByForeignKeyAndType(WAPrimaryKey foreignKey,
+      DocumentType type, String lang);
 
   void unindexAttachmentsOfExternalObject(WAPrimaryKey foreignKey);
 

--- a/lib-core/src/main/java/org/silverpeas/attachment/repository/DocumentConverter.java
+++ b/lib-core/src/main/java/org/silverpeas/attachment/repository/DocumentConverter.java
@@ -34,6 +34,7 @@ import org.silverpeas.attachment.model.HistorisedDocumentVersion;
 import org.silverpeas.attachment.model.SimpleAttachment;
 import org.silverpeas.attachment.model.SimpleDocument;
 import org.silverpeas.attachment.model.SimpleDocumentPK;
+import org.silverpeas.attachment.util.SimpleDocumentList;
 import org.silverpeas.attachment.model.SimpleDocumentVersion;
 import org.silverpeas.util.jcr.AbstractJcrConverter;
 
@@ -159,9 +160,10 @@ class DocumentConverter extends AbstractJcrConverter {
    * @return a collection of SimpleDocument.
    * @throws RepositoryException
    */
-  public List<SimpleDocument> convertNodeIterator(NodeIterator iter, String language) throws
-      RepositoryException {
-    List<SimpleDocument> result = new ArrayList<SimpleDocument>((int) iter.getSize());
+  public SimpleDocumentList<SimpleDocument> convertNodeIterator(NodeIterator iter, String language)
+      throws RepositoryException {
+    SimpleDocumentList<SimpleDocument> result =
+        new SimpleDocumentList<SimpleDocument>((int) iter.getSize()).setQueryLanguage(language);
     while (iter.hasNext()) {
       result.add(convertNode(iter.nextNode(), language));
     }
@@ -224,9 +226,16 @@ class DocumentConverter extends AbstractJcrConverter {
   }
 
   public void fillNode(SimpleDocument document, Node documentNode) throws RepositoryException {
+    fillNode(document, documentNode, false);
+  }
+
+  public void fillNode(SimpleDocument document, Node documentNode, boolean skipAttachmentContent)
+      throws RepositoryException {
     setDocumentNodeProperties(document, documentNode);
-    Node attachmentNode = getAttachmentNode(document.getFile().getNodeName(), documentNode);
-    attachmentConverter.fillNode(document.getFile(), attachmentNode);
+    if (!skipAttachmentContent) {
+      Node attachmentNode = getAttachmentNode(document.getFile().getNodeName(), documentNode);
+      attachmentConverter.fillNode(document.getFile(), attachmentNode);
+    }
   }
 
   private void setDocumentNodeProperties(SimpleDocument document, Node documentNode) throws

--- a/lib-core/src/main/java/org/silverpeas/attachment/repository/DocumentRepository.java
+++ b/lib-core/src/main/java/org/silverpeas/attachment/repository/DocumentRepository.java
@@ -37,6 +37,7 @@ import org.silverpeas.attachment.model.HistorisedDocument;
 import org.silverpeas.attachment.model.SimpleAttachment;
 import org.silverpeas.attachment.model.SimpleDocument;
 import org.silverpeas.attachment.model.SimpleDocumentPK;
+import org.silverpeas.attachment.util.SimpleDocumentList;
 import org.silverpeas.util.jcr.NodeIterable;
 import org.silverpeas.util.jcr.PropertyIterable;
 
@@ -103,7 +104,6 @@ public class DocumentRepository {
   }
 
   /**
-   * /**
    * Create file attached to an object who is identified by "PK" SimpleDocument object contains an
    * attribute who identifie the link by a foreign key.
    *
@@ -543,8 +543,8 @@ public class DocumentRepository {
    * @return an ordered list of the documents.
    * @throws RepositoryException
    */
-  public List<SimpleDocument> listDocumentsByForeignId(Session session, String instanceId,
-      String foreignId, String language) throws RepositoryException {
+  public SimpleDocumentList<SimpleDocument> listDocumentsByForeignId(Session session,
+      String instanceId, String foreignId, String language) throws RepositoryException {
     NodeIterator iter = selectDocumentsByForeignIdAndType(session, instanceId, foreignId,
         DocumentType.attachment);
     return converter.convertNodeIterator(iter, language);
@@ -560,8 +560,8 @@ public class DocumentRepository {
    * @return an ordered list of the documents.
    * @throws RepositoryException
    */
-  public List<SimpleDocument> listAllDocumentsByForeignId(Session session, String instanceId,
-      String foreignId, String language) throws RepositoryException {
+  public SimpleDocumentList<SimpleDocument> listAllDocumentsByForeignId(Session session,
+      String instanceId, String foreignId, String language) throws RepositoryException {
     NodeIterator iter = selectDocumentsByForeignId(session, instanceId, foreignId);
     return converter.convertNodeIterator(iter, language);
   }
@@ -577,8 +577,9 @@ public class DocumentRepository {
    * @return an ordered list of the documents.
    * @throws RepositoryException
    */
-  public List<SimpleDocument> listDocumentsByForeignIdAndType(Session session, String instanceId,
-      String foreignId, DocumentType type, String language) throws RepositoryException {
+  public SimpleDocumentList<SimpleDocument> listDocumentsByForeignIdAndType(Session session,
+      String instanceId, String foreignId, DocumentType type, String language)
+      throws RepositoryException {
     NodeIterator iter = selectDocumentsByForeignIdAndType(session, instanceId, foreignId, type);
     return converter.convertNodeIterator(iter, language);
   }
@@ -940,28 +941,33 @@ public class DocumentRepository {
       language = I18NHelper.defaultLanguage;
     }
     SimpleDocument document = converter.fillDocument(docNode, language);
-    return new BufferedInputStream(FileUtils.openInputStream(new File(document.getAttachmentPath())));
+    return new BufferedInputStream(
+        FileUtils.openInputStream(new File(document.getAttachmentPath())));
   }
 
   /**
    * Remove the content for the specified language.
+   * If no other content exists, then the document node is deleted.
    *
    * @param session the current JCR session.
    * @param documentPk the document which content is to be removed.
    * @param language the language of the content which is to be removed.
+   * @return false if the document has no child node after the content remove, true otherwise.
    * @throws RepositoryException
    */
-  public void removeContent(Session session, SimpleDocumentPK documentPk, String language) throws
-      RepositoryException {
+  public boolean removeContent(Session session, SimpleDocumentPK documentPk, String language)
+      throws RepositoryException {
     Node documentNode = session.getNodeByIdentifier(documentPk.getId());
     if (converter.isVersionedMaster(documentNode) && !documentNode.isCheckedOut()) {
       checkoutNode(documentNode, null);
     }
     converter.removeAttachment(documentNode, language);
     documentNode = session.getNodeByIdentifier(documentPk.getId());
-    if (!documentNode.hasNodes()) {
+    boolean existsOtherContents = documentNode.hasNodes();
+    if (!existsOtherContents) {
       deleteDocumentNode(documentNode);
     }
+    return existsOtherContents;
   }
 
   /**
@@ -986,16 +992,48 @@ public class DocumentRepository {
   }
 
   /**
-   * Unlock a document if it is versionned to create a new version.
+   * Unlock a document if it is versionned to create a new version or to restore a previous one.
+   * By using this method, the metadata of the content are always updated.
    *
-   * @param session
-   * @param document
-   * @param restore
-   * @return
+   * @param session the current JCR open session to perform actions.
+   * @param document the document data from which all needed identifiers are retrieved.
+   * @param restore true to restore the previous version if any.
+   * @return the result of {@link #unlock(Session, SimpleDocument, boolean, boolean)} execution.
    * @throws RepositoryException
    */
   public SimpleDocument unlock(Session session, SimpleDocument document, boolean restore)
       throws RepositoryException {
+    return unlock(session, document, restore, false);
+  }
+
+  /**
+   * Unlock a document if it is versionned from a context into which a language content has just
+   * been deleted. This method does not update the metadata of the content in order to obtain an
+   * efficient content deletion.
+   *
+   * @param session the current JCR open session to perform actions.
+   * @param document the document data from which all needed identifiers are retrieved.
+   * @return the result of {@link #unlock(Session, SimpleDocument, boolean, boolean)} execution.
+   * @throws RepositoryException
+   */
+  public SimpleDocument unlockFromContentDeletion(Session session, SimpleDocument document)
+      throws RepositoryException {
+    return unlock(session, document, false, true);
+  }
+
+  /**
+   * Unlock a document if it is versionned to create a new version or to restore a previous one.
+   *
+   * @param session the current JCR open session to perform actions.
+   * @param document the document data from which all needed identifiers are retrieved.
+   * @param restore true to restore the previous version if any.
+   * @param skipContentMetadataUpdate false to update the metadata of the content {@link
+   * SimpleDocument#getFile()}.
+   * @return the document updated.
+   * @throws RepositoryException
+   */
+  private SimpleDocument unlock(Session session, SimpleDocument document, boolean restore,
+      boolean skipContentMetadataUpdate) throws RepositoryException {
     Node documentNode;
     try {
       documentNode = session.getNodeByIdentifier(document.getId());
@@ -1016,11 +1054,11 @@ public class DocumentRepository {
           return converter.convertNode(lastVersion.getFrozenNode(), document.getLanguage());
         }
       }
-      converter.fillNode(document, documentNode);
+      converter.fillNode(document, documentNode, skipContentMetadataUpdate);
       return checkinNode(documentNode, document.getLanguage(), document.isPublic());
     }
     if (!document.isVersioned()) {
-      converter.fillNode(document, documentNode);
+      converter.fillNode(document, documentNode, skipContentMetadataUpdate);
       converter.releaseDocumentNode(documentNode, document.getLanguage());
       return converter.convertNode(documentNode, document.getLanguage());
     }

--- a/lib-core/src/main/java/org/silverpeas/attachment/util/AttachmentSettings.java
+++ b/lib-core/src/main/java/org/silverpeas/attachment/util/AttachmentSettings.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2000 - 2014 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception. You should have recieved a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "http://www.silverpeas.org/docs/core/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.silverpeas.attachment.util;
+
+import com.silverpeas.util.StringUtil;
+import com.stratelia.webactiv.util.ResourceLocator;
+
+import javax.inject.Inject;
+
+/**
+ * The aim of this class is to expose at the rest of application the settings around attachments.
+ * Its implementation allows to manage the attachment parameters easily into unit tests. It assures
+ * also less problems around setting regressions.
+ * @author: Yohann Chastagnier
+ */
+public class AttachmentSettings {
+
+  private static final AttachmentSettings instance = new AttachmentSettings();
+
+  @Inject
+  private Provider provider;
+
+  /**
+   * Indicates if obsolete wysiwyg content must be ignored.
+   * This method returns always false if {@link #getObsoleteWysiwygContentIgnoredMark()} returns
+   * a not defined value.
+   * False by default (attachment.wysiwyg.content.inspection.obsolete.ignore).
+   * @return true if wysiwyg content must be ignored, false otherwise.
+   */
+  public static boolean isObsoleteWysiwygContentIgnored() {
+    return getInstance().getProvider()
+        .getBoolean("attachment.wysiwyg.content.inspection.obsolete.ignore", false) &&
+        StringUtil.isDefined(getObsoleteWysiwygContentIgnoredMark());
+  }
+
+  /**
+   * Gets the strict mark to fill at start of a wysiwyg file to mark it as ignored.
+   * If the mark exists into the file, but not at beginning, it is not taken into account.
+   * (defined in properties by attachment.wysiwyg.content.inspection.obsolete.ignore.mark)
+   * @return the mark if defined, empty string otherwise.
+   */
+  public static String getObsoleteWysiwygContentIgnoredMark() {
+    return getInstance().getProvider()
+        .getString("attachment.wysiwyg.content.inspection.obsolete.ignore.mark", "");
+  }
+
+  /**
+   * Gets the provider.
+   * @return
+   */
+  private ResourceLocator getProvider() {
+    if (provider == null) {
+      provider = new Provider();
+    }
+    return provider;
+  }
+
+  /**
+   * @return a AttachmentSettings instance.
+   */
+  public static AttachmentSettings getInstance() {
+    return instance;
+  }
+
+  /**
+   * This internal class provides the settings.
+   * Implementing by this way the settings access is very useful for maintenance and unit tests.
+   */
+  public static class Provider extends ResourceLocator {
+    private static final long serialVersionUID = -2626681960886868011L;
+
+    public Provider() {
+      super("org.silverpeas.util.attachment.Attachment", "");
+    }
+  }
+}

--- a/lib-core/src/main/java/org/silverpeas/attachment/util/SimpleDocumentList.java
+++ b/lib-core/src/main/java/org/silverpeas/attachment/util/SimpleDocumentList.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright (C) 2000 - 2014 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception. You should have recieved a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "http://www.silverpeas.org/docs/core/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.silverpeas.attachment.util;
+
+import com.silverpeas.util.ArrayUtil;
+import com.silverpeas.util.StringUtil;
+import com.silverpeas.util.comparator.AbstractComplexComparator;
+import com.silverpeas.util.i18n.I18NHelper;
+import org.apache.commons.lang.NotImplementedException;
+import org.silverpeas.attachment.model.SimpleDocument;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+/**
+ * This list provides some additional useful behaviors around simple documents.
+ * @author: Yohann Chastagnier
+ * @param <SIMPLE_DOCUMENT> the type of simple document that the list contains.
+ */
+public class SimpleDocumentList<SIMPLE_DOCUMENT extends SimpleDocument>
+    extends ArrayList<SIMPLE_DOCUMENT> {
+  private static final long serialVersionUID = 4986827710138035170L;
+
+  private static final String[] ALL_LANGUAGES_BY_PRIORITY =
+      I18NHelper.getAllSupportedLanguages().toArray(new String[I18NHelper.getNumberOfLanguages()]);
+
+  private String queryLanguage = null;
+
+  public SimpleDocumentList(final int initialCapacity) {
+    super(initialCapacity);
+  }
+
+  public SimpleDocumentList() {
+    super();
+  }
+
+  public SimpleDocumentList(final Collection<? extends SIMPLE_DOCUMENT> c) {
+    super(c);
+  }
+
+  /**
+   * Gets the language used to perform the JCR query in order to load the current list.
+   * @return the language is defined, null value otherwise.
+   */
+  public String getQueryLanguage() {
+    return queryLanguage;
+  }
+
+  /**
+   * Sets the language used to perform the JCR query in order to load the current list.
+   * @param queryLanguage the language used to perform the JCR query in order to load the list.
+   * @return itself.
+   */
+  public SimpleDocumentList<SIMPLE_DOCUMENT> setQueryLanguage(final String queryLanguage) {
+    if (StringUtil.isDefined(queryLanguage)) {
+      this.queryLanguage = queryLanguage;
+    } else {
+      this.queryLanguage = null;
+    }
+    return this;
+  }
+
+  /**
+   * Removes from the current list all documents which content is in an other language than the one
+   * returned by {@link #getQueryLanguage()}.
+   * If {@link #getQueryLanguage()} returns null or an unknown languague, nothing is done.
+   * @return itself.
+   */
+  public SimpleDocumentList<SIMPLE_DOCUMENT> removeLanguageFallbacks() {
+    if (!isEmpty()) {
+      String language = I18NHelper.checkLanguage(getQueryLanguage());
+      if (language.equals(getQueryLanguage())) {
+        Iterator<SIMPLE_DOCUMENT> it = iterator();
+        while (it.hasNext()) {
+          SIMPLE_DOCUMENT document = it.next();
+          if (!language.equals(document.getLanguage())) {
+            it.remove();
+          }
+        }
+      }
+    }
+    return this;
+  }
+
+  /**
+   * Orders the list by descending priority of the language and descending last update date.
+   * By default, if no language priority is given, then the language priority of the platform is
+   * taken into account. If a language priority is specified, then the language priorities of the
+   * platform are overridden.
+   * @param languageOrderedByPriority manual language priority definition ​​from the highest to the
+   * lowest.
+   * @return itself.
+   */
+  public SimpleDocumentList<SIMPLE_DOCUMENT> orderByLanguageAndLastUpdate(
+      String... languageOrderedByPriority) {
+    if (size() > 1) {
+      Collections.sort(this, new LanguageAndLastUpdateComparator(languageOrderedByPriority,
+          ORDER_BY.LANGUAGE_PRIORITY_DESC, ORDER_BY.LAST_UPDATE_DATE_DESC));
+    }
+    return this;
+  }
+
+  /**
+   * Order by definitions.
+   */
+  private enum ORDER_BY {
+    LANGUAGE_PRIORITY_DESC(false),
+    LAST_UPDATE_DATE_DESC(false);
+
+    private final boolean ascending;
+
+    ORDER_BY(final boolean ascending) {
+      this.ascending = ascending;
+    }
+
+    public boolean isAscending() {
+      return ascending;
+    }
+  }
+
+  /**
+   * Comparator class that permits to order a list of simple documents by a language priority and
+   * descending update date.
+   */
+  private class LanguageAndLastUpdateComparator extends AbstractComplexComparator<SIMPLE_DOCUMENT> {
+
+    private Map<String, Integer> languagePriorityCache =
+        new HashMap<String, Integer>(I18NHelper.getNumberOfLanguages());
+    private final ORDER_BY[] orderBies;
+
+    /**
+     * Default constructor.
+     * @param languageOrderedByPriority languages ​​from the highest to the lowest.
+     * @param orderBies the order by directives.
+     */
+    private LanguageAndLastUpdateComparator(final String[] languageOrderedByPriority,
+        ORDER_BY... orderBies) {
+      this.orderBies = orderBies;
+      if (ArrayUtil.contains(orderBies, ORDER_BY.LANGUAGE_PRIORITY_DESC)) {
+        for (String language : ALL_LANGUAGES_BY_PRIORITY) {
+          languagePriorityCache
+              .put(language, (languagePriorityCache.size() + ALL_LANGUAGES_BY_PRIORITY.length + 1));
+        }
+        int i = 0;
+        for (String language : languageOrderedByPriority) {
+          languagePriorityCache.put(language, i++);
+        }
+        languagePriorityCache
+            .put(null, (languagePriorityCache.size() + ALL_LANGUAGES_BY_PRIORITY.length + 1));
+      }
+    }
+
+    @Override
+    protected ValueBuffer getValuesToCompare(final SIMPLE_DOCUMENT simpleDocument) {
+      ValueBuffer valueBuffer = new ValueBuffer();
+      for (ORDER_BY orderBy : orderBies) {
+        switch (orderBy) {
+          case LANGUAGE_PRIORITY_DESC:
+            valueBuffer.append(getLanguagePriorityIndex(simpleDocument), orderBy.isAscending());
+            break;
+          case LAST_UPDATE_DATE_DESC:
+            valueBuffer.append((simpleDocument.getUpdated() != null ? simpleDocument.getUpdated() :
+                simpleDocument.getCreated()), orderBy.isAscending());
+            break;
+          default:
+            throw new NotImplementedException();
+        }
+      }
+      return valueBuffer;
+    }
+
+    /**
+     * Gets the priority index of the language content of the document.
+     * @param simpleDocument the document data.
+     * @return the priority index of the language content, 0 is the highest priority and the less
+     * the index decreases the less is the language priority
+     */
+    private int getLanguagePriorityIndex(final SIMPLE_DOCUMENT simpleDocument) {
+      return languagePriorityCache.get(simpleDocument.getLanguage()) * -1;
+    }
+  }
+}

--- a/lib-core/src/main/java/org/silverpeas/wysiwyg/control/WysiwygController.java
+++ b/lib-core/src/main/java/org/silverpeas/wysiwyg/control/WysiwygController.java
@@ -34,6 +34,24 @@ import com.stratelia.webactiv.util.exception.SilverpeasException;
 import com.stratelia.webactiv.util.exception.SilverpeasRuntimeException;
 import com.stratelia.webactiv.util.exception.UtilException;
 import com.stratelia.webactiv.util.fileFolder.FileFolderManager;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.CharEncoding;
+import org.apache.commons.lang3.tuple.Pair;
+import org.silverpeas.attachment.AttachmentException;
+import org.silverpeas.attachment.AttachmentServiceFactory;
+import org.silverpeas.attachment.model.DocumentType;
+import org.silverpeas.attachment.model.SimpleAttachment;
+import org.silverpeas.attachment.model.SimpleDocument;
+import org.silverpeas.attachment.model.SimpleDocumentPK;
+import org.silverpeas.attachment.model.UnlockContext;
+import org.silverpeas.attachment.util.SimpleDocumentList;
+import org.silverpeas.core.admin.OrganisationController;
+import org.silverpeas.core.admin.OrganisationControllerFactory;
+import org.silverpeas.search.indexEngine.model.FullIndexEntry;
+import org.silverpeas.util.Charsets;
+import org.silverpeas.wysiwyg.WysiwygException;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -47,21 +65,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.CharEncoding;
-import org.silverpeas.attachment.AttachmentException;
-import org.silverpeas.attachment.AttachmentServiceFactory;
-import org.silverpeas.attachment.model.DocumentType;
-import org.silverpeas.attachment.model.SimpleAttachment;
-import org.silverpeas.attachment.model.SimpleDocument;
-import org.silverpeas.attachment.model.SimpleDocumentPK;
-import org.silverpeas.attachment.model.UnlockContext;
-import org.silverpeas.core.admin.OrganisationController;
-import org.silverpeas.core.admin.OrganisationControllerFactory;
-import org.silverpeas.search.indexEngine.model.FullIndexEntry;
-import org.silverpeas.util.Charsets;
-import org.silverpeas.wysiwyg.WysiwygException;
 
 /**
  * Central service to manage Wysiwyg.
@@ -88,7 +91,7 @@ public class WysiwygController {
       wysiwygFile = new File(getLegacyWysiwygPath(WYSIWYG_CONTEXT, foreignPK.getInstanceId()),
           getOldWysiwygFileName(foreignPK.getId()));
     }
-    String content = "";
+    String content = null;
     if (wysiwygFile.exists() && wysiwygFile.isFile()) {
       content = FileUtils.readFileToString(wysiwygFile);
     }
@@ -496,29 +499,33 @@ public class WysiwygController {
    * This method must be synchronized. Quick wysiwyg's saving can generate problems without
    * synchronization !!!
    *
-   *
    * @param textHtml
    * @param foreignKey the id of object to which is attached the wysiwyg.
-   * @param context
    * @param userId
    */
-  private static void saveFile(String textHtml, WAPrimaryKey foreignKey, DocumentType context,
-      String userId, String language, boolean indexIt) {
+  private static void saveFile(String textHtml, WAPrimaryKey foreignKey, String userId,
+      String language, boolean indexIt) {
+    DocumentType wysiwygType = DocumentType.wysiwyg;
     String fileName = getWysiwygFileName(foreignKey.getId(), language);
     SilverTrace.info("wysiwyg", "WysiwygController.updateFileAndAttachment()",
-        "root.MSG_GEN_PARAM_VALUE", "fileName=" + fileName + " context=" + context + "objectId="
-        + foreignKey.getId());
-    SimpleDocument document = searchAttachmentDetail(foreignKey, context, language);
+        "root.MSG_GEN_PARAM_VALUE",
+        "fileName=" + fileName + " context=" + wysiwygType + "objectId=" + foreignKey.getId());
+    SimpleDocument document = searchAttachmentDetail(foreignKey, wysiwygType, language);
     if (document != null) {
       document.setLanguage(I18NHelper.checkLanguage(language));
       document.setSize(textHtml.getBytes(Charsets.UTF_8).length);
-      document.setDocumentType(context);
+      document.setDocumentType(wysiwygType);
       document.setUpdatedBy(userId);
-      AttachmentServiceFactory.getAttachmentService().updateAttachment(document,
-          new ByteArrayInputStream(textHtml.getBytes(Charsets.UTF_8)), indexIt, false);
-      invokeCallback(userId, foreignKey);
+      if (document.getSize() > 0) {
+        AttachmentServiceFactory.getAttachmentService()
+            .updateAttachment(document, new ByteArrayInputStream(textHtml.getBytes(Charsets.UTF_8)),
+                indexIt, false);
+        invokeCallback(userId, foreignKey);
+      } else {
+        AttachmentServiceFactory.getAttachmentService().removeContent(document, language, true);
+      }
     } else {
-      createFileAndAttachment(textHtml, foreignKey, context, userId, language, indexIt, true);
+      createFileAndAttachment(textHtml, foreignKey, wysiwygType, userId, language, indexIt, true);
     }
   }
 
@@ -538,14 +545,12 @@ public class WysiwygController {
 
   public static void updateFileAndAttachment(String textHtml, String componentId,
       String objectId, String userId, String language, boolean indexIt) {
-    saveFile(textHtml, new ForeignPK(objectId, componentId), DocumentType.wysiwyg, userId, language,
-        indexIt);
+    saveFile(textHtml, new ForeignPK(objectId, componentId), userId, language, indexIt);
   }
 
   public static void save(String textHtml, String componentId, String objectId, String userId,
       String language, boolean indexIt) {
-    saveFile(textHtml, new ForeignPK(objectId, componentId), DocumentType.wysiwyg, userId, language,
-        indexIt);
+    saveFile(textHtml, new ForeignPK(objectId, componentId), userId, language, indexIt);
   }
 
   /**
@@ -599,34 +604,41 @@ public class WysiwygController {
     }
   }
 
-  /**
-   * Loads the content of a Wysiwyg as a String.
-   *
-   * @param foreignPk
-   * @param context
-   * @param lang
-   * @return
-   */
-  public static String loadFileAndAttachment(ForeignPK foreignPk, DocumentType context, String lang) {
-    SimpleDocument document = searchAttachmentDetail(foreignPk, context, lang);
-    if (document != null) {
-      return loadContent(document, lang);
+  private static String loadContent(SimpleDocument document, String lang) {
+    if (isEmptyWysiwygContent(document, lang)) {
+      return "";
     }
-    return "";
-  }
-
-  public static String loadContent(SimpleDocument doc, String lang) {
-    return loadContent(doc.getPk(), lang);
-  }
-
-  private static String loadContent(SimpleDocumentPK pk, String lang) {
     ByteArrayOutputStream buffer = new ByteArrayOutputStream();
     try {
-      AttachmentServiceFactory.getAttachmentService().getBinaryContent(buffer, pk, lang);
+      AttachmentServiceFactory.getAttachmentService()
+          .getBinaryContent(buffer, document.getPk(), lang);
       return new String(buffer.toByteArray(), Charsets.UTF_8);
     } finally {
       IOUtils.closeQuietly(buffer);
     }
+  }
+
+  /**
+   * Indicates for the specified document and the specified language if the related content is
+   * empty.
+   * @param document the simple document to verify.
+   * @param lang the language of the content to verify.
+   * @return true if the specified content is empty, false otherwise.
+   */
+  private static boolean isEmptyWysiwygContent(SimpleDocument document, String lang) {
+    if (document.getDocumentType() == DocumentType.wysiwyg) {
+      ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+      try {
+        AttachmentServiceFactory.getAttachmentService()
+            .getBinaryContent(buffer, document.getPk(), lang, 0, 1);
+        if (buffer.size() == 0) {
+          return true;
+        }
+      } finally {
+        IOUtils.closeQuietly(buffer);
+      }
+    }
+    return false;
   }
 
   /**
@@ -638,18 +650,56 @@ public class WysiwygController {
    * @return text : the contents of the file attached.
    */
   public static String load(String componentId, String objectId, String language) {
-    String currentLanguage = I18NHelper.checkLanguage(language);
-    String content = loadFileAndAttachment(new ForeignPK(objectId, componentId),
-        DocumentType.wysiwyg, currentLanguage);
-    if (!StringUtil.isDefined(content)) {
-      try {
-        content = loadFromFileSystemDirectly(new ForeignPK(objectId, componentId), currentLanguage);
-      } catch (IOException ex) {
-        SilverTrace.error("wysiwyg", "WysiwygController.load()", "Error loading content", ex);
+    String content = internalLoad(componentId, objectId, language);
+    if (I18NHelper.isI18nActivated() && content != null && StringUtil.isNotDefined(content)) {
+      List<String> languages = new ArrayList<String>(I18NHelper.getAllSupportedLanguages());
+      languages.remove(language);
+      for (String lang : languages) {
+        content = internalLoad(componentId, objectId, lang);
+        if (content == null || StringUtil.isDefined(content)) {
+          break;
+        }
       }
     }
     if (content == null) {
       content = "";
+    }
+    return content;
+  }
+
+  /**
+   * Load wysiwyg content.
+   * @param componentId String : the id of component.
+   * @param objectId String : for example the id of the publication.
+   * @param language the language of the content.
+   * @return not empty string if a content exists, "" if it is empty, 
+   * null if empty guessed on language fallback.
+   */
+  private static String internalLoad(String componentId, String objectId, String language) {
+    String currentLanguage = I18NHelper.checkLanguage(language);
+    String finalLanguage = currentLanguage;
+    String content = "";
+    SimpleDocument document =
+        searchAttachmentDetail(new ForeignPK(objectId, componentId), DocumentType.wysiwyg,
+            currentLanguage);
+    if (document != null) {
+      content = loadContent(document, currentLanguage);
+      finalLanguage = document.getLanguage();
+    }
+    if (!StringUtil.isDefined(content)) {
+      try {
+        String contentFromSystem =
+            loadFromFileSystemDirectly(new ForeignPK(objectId, componentId), currentLanguage);
+        if (StringUtil.isDefined(contentFromSystem)) {
+          content = contentFromSystem;
+          finalLanguage = currentLanguage;
+        }
+      } catch (IOException ex) {
+        SilverTrace.error("wysiwyg", "WysiwygController.load()", "Error loading content", ex);
+      }
+    }
+    if (StringUtil.isNotDefined(content) && !finalLanguage.equals(currentLanguage)) {
+      content = null;
     }
     return content;
   }
@@ -706,14 +756,7 @@ public class WysiwygController {
 
   public static boolean haveGotWysiwygToDisplay(String componentId, String objectId,
       String language) {
-    String wysiwygContent = load(componentId, objectId, language);
-    if (!StringUtil.isDefined(wysiwygContent) && I18NHelper.isI18N) {
-      Iterator<String> iter = I18NHelper.getLanguages();
-      while (iter.hasNext() && !StringUtil.isDefined(wysiwygContent)) {
-        wysiwygContent = load(componentId, objectId, iter.next());
-      }
-    }
-    return StringUtil.isDefined(wysiwygContent);
+    return haveGotWysiwyg(componentId, objectId, language);
   }
 
   public static boolean haveGotWysiwyg(String componentId, String objectId, String language) {
@@ -728,13 +771,13 @@ public class WysiwygController {
    * @param context String : for example wysiwyg.
    * @return SimpleDocument
    */
-  private static SimpleDocument searchAttachmentDetail(WAPrimaryKey foreignKey, DocumentType context,
-      String lang) {
+  private static SimpleDocument searchAttachmentDetail(WAPrimaryKey foreignKey,
+      DocumentType context, String lang) {
     String language = I18NHelper.checkLanguage(lang);
-    List<SimpleDocument> documents = AttachmentServiceFactory.getAttachmentService()
+    SimpleDocumentList<SimpleDocument> documents = AttachmentServiceFactory.getAttachmentService()
         .listDocumentsByForeignKeyAndType(foreignKey, context, language);
     if (!documents.isEmpty()) {
-      return documents.get(0);
+      return documents.orderByLanguageAndLastUpdate(lang).get(0);
     }
     return null;
   }
@@ -776,9 +819,6 @@ public class WysiwygController {
 
   /**
    * Method declaration
-   *
-   *
-   *
    * @param oldComponentId
    * @param oldObjectId
    * @param componentId
@@ -786,33 +826,58 @@ public class WysiwygController {
    * @param userId
    * @see
    */
-  public static Map<String, String> copy(String oldComponentId, String oldObjectId, String componentId,
-      String objectId, String userId) {
+  public static Map<String, String> copy(String oldComponentId, String oldObjectId,
+      String componentId, String objectId, String userId) {
     SilverTrace.info("wysiwyg", "WysiwygController.copy()", "root.MSG_GEN_ENTER_METHOD");
     ForeignPK foreignKey = new ForeignPK(oldObjectId, oldComponentId);
-    List<SimpleDocument> documents = AttachmentServiceFactory.getAttachmentService().
-        listDocumentsByForeignKeyAndType(foreignKey, DocumentType.wysiwyg, null);
     ForeignPK targetPk = new ForeignPK(objectId, componentId);
+    SimpleDocument copy = null;
+    List<Pair<SimpleDocumentPK, SimpleDocumentPK>> oldNewImagePkMapping =
+        new ArrayList<Pair<SimpleDocumentPK, SimpleDocumentPK>>();
     Map<String, String> fileIds = new HashMap<String, String>();
-    for (SimpleDocument doc : documents) {
-      doc.getFile().setCreatedBy(userId);
-      SimpleDocumentPK pk = AttachmentServiceFactory.getAttachmentService().copyDocument(doc,
-          targetPk);
-      SimpleDocument copy = AttachmentServiceFactory.getAttachmentService().searchDocumentById(pk,
-          doc.getLanguage());
-      String content = replaceInternalImagesPath(loadContent(copy, doc.getLanguage()),
-          oldComponentId, oldObjectId, componentId, objectId);
-
-      List<SimpleDocument> images = AttachmentServiceFactory.getAttachmentService().
-          listDocumentsByForeignKeyAndType(foreignKey, DocumentType.image, null);
-      for (SimpleDocument image : images) {
-        SimpleDocumentPK imageCopyPk = AttachmentServiceFactory.getAttachmentService().copyDocument(
-            image, targetPk);
-        fileIds.put(image.getId(), imageCopyPk.getId());
-        content = replaceInternalImageId(content, image.getPk(), imageCopyPk);
+    List<String> languagesWithEmptyContent = new ArrayList<String>();
+    for (String language : I18NHelper.getAllSupportedLanguages()) {
+      SimpleDocumentList<SimpleDocument> documents =
+          AttachmentServiceFactory.getAttachmentService().
+              listDocumentsByForeignKeyAndType(foreignKey, DocumentType.wysiwyg, language)
+              .removeLanguageFallbacks();
+      for (SimpleDocument doc : documents) {
+        if (!isEmptyWysiwygContent(doc, doc.getLanguage())) {
+          doc.getFile().setCreatedBy(userId);
+          if (copy == null) {
+            SimpleDocumentPK pk =
+                AttachmentServiceFactory.getAttachmentService().copyDocument(doc, targetPk);
+            copy = AttachmentServiceFactory.getAttachmentService()
+                .searchDocumentById(pk, doc.getLanguage());
+            List<SimpleDocument> images = AttachmentServiceFactory.getAttachmentService().
+                listDocumentsByForeignKeyAndType(foreignKey, DocumentType.image, null);
+            for (SimpleDocument image : images) {
+              SimpleDocumentPK imageCopyPk =
+                  AttachmentServiceFactory.getAttachmentService().copyDocument(image, targetPk);
+              fileIds.put(image.getId(), imageCopyPk.getId());
+              oldNewImagePkMapping.add(Pair.of(image.getPk(), imageCopyPk));
+            }
+          }
+          copy.setLanguage(language);
+          String content =
+              replaceInternalImagesPath(loadContent(copy, doc.getLanguage()), oldComponentId,
+                  oldObjectId, componentId, objectId);
+          for (Pair<SimpleDocumentPK, SimpleDocumentPK> oldNewPk : oldNewImagePkMapping) {
+            content = replaceInternalImageId(content, oldNewPk.getLeft(), oldNewPk.getRight());
+          }
+          AttachmentServiceFactory.getAttachmentService()
+              .updateAttachment(copy, new ByteArrayInputStream(content.getBytes(Charsets.UTF_8)),
+                  true, true);
+        } else {
+          languagesWithEmptyContent.add(language);
+        }
       }
-      AttachmentServiceFactory.getAttachmentService().updateAttachment(copy,
-          new ByteArrayInputStream(content.getBytes(Charsets.UTF_8)), true, true);
+    }
+    if (copy != null) {
+      for (String languageWithEmptyContent : languagesWithEmptyContent) {
+        AttachmentServiceFactory.getAttachmentService()
+            .removeContent(copy, languageWithEmptyContent, false);
+      }
     }
     return fileIds;
   }
@@ -934,27 +999,29 @@ public class WysiwygController {
 
   public static void wysiwygPlaceHaveChanged(String oldComponentId, String oldObjectId,
       String newComponentId, String newObjectId) {
-    ForeignPK foreignKey = new ForeignPK(oldObjectId, newComponentId);
-    List<SimpleDocument> documents = AttachmentServiceFactory.getAttachmentService().
-        listDocumentsByForeignKeyAndType(foreignKey, DocumentType.wysiwyg, null);
-    if (documents != null && !documents.isEmpty()) {
+    ForeignPK foreignKey = new ForeignPK(newObjectId, newComponentId);
+    List<SimpleDocument> images = null;
+    for (String language : I18NHelper.getAllSupportedLanguages()) {
+      List<SimpleDocument> documents = AttachmentServiceFactory.getAttachmentService().
+          listDocumentsByForeignKeyAndType(foreignKey, DocumentType.wysiwyg, language)
+          .removeLanguageFallbacks();
       for (SimpleDocument document : documents) {
-        for (String language : I18NHelper.getAllSupportedLanguages()) {
-          String wysiwyg = load(newComponentId, newObjectId, language);
-          if (StringUtil.isDefined(wysiwyg)) {
-            List<SimpleDocument> images = AttachmentServiceFactory.getAttachmentService().
+        String wysiwyg = loadContent(document, language);
+        if (StringUtil.isDefined(wysiwyg)) {
+          wysiwyg = replaceInternalImagesPath(wysiwyg, oldComponentId, oldObjectId, newComponentId,
+              newObjectId);
+          if (images == null) {
+            images = AttachmentServiceFactory.getAttachmentService().
                 listDocumentsByForeignKeyAndType(foreignKey, DocumentType.image, null);
-            for (SimpleDocument image : images) {
-              wysiwyg = replaceInternalImagesPath(wysiwyg, oldComponentId, oldObjectId,
-                  newComponentId, newObjectId);
-              image.getPk().setComponentName(oldComponentId);
-              SimpleDocumentPK imageCopyPk = new SimpleDocumentPK(image.getId(), newComponentId);
-              imageCopyPk.setOldSilverpeasId(image.getOldSilverpeasId());
-              wysiwyg = replaceInternalImageId(wysiwyg, image.getPk(), imageCopyPk);
-            }
-            AttachmentServiceFactory.getAttachmentService().updateAttachment(document,
-                new ByteArrayInputStream(wysiwyg.getBytes(Charsets.UTF_8)), true, true);
           }
+          for (SimpleDocument image : images) {
+            image.getPk().setComponentName(oldComponentId);
+            SimpleDocumentPK imageCopyPk = new SimpleDocumentPK(image.getId(), newComponentId);
+            imageCopyPk.setOldSilverpeasId(image.getOldSilverpeasId());
+            wysiwyg = replaceInternalImageId(wysiwyg, image.getPk(), imageCopyPk);
+          }
+          AttachmentServiceFactory.getAttachmentService().updateAttachment(document,
+              new ByteArrayInputStream(wysiwyg.getBytes(Charsets.UTF_8)), true, true);
         }
       }
     }

--- a/lib-core/src/test/java/org/silverpeas/attachment/AttachmentServiceTest.java
+++ b/lib-core/src/test/java/org/silverpeas/attachment/AttachmentServiceTest.java
@@ -308,9 +308,59 @@ public class AttachmentServiceTest {
     assertThat(content, is(notNullValue()));
     assertThat(content.length, is("This is a test".getBytes(Charsets.UTF_8).length));
     assertThat(new String(content, Charsets.UTF_8), is("This is a test"));
+
     out = new ByteArrayOutputStream();
     lang = "fr";
     instance.getBinaryContent(out, pk, lang);
+    assertThat(out, is(notNullValue()));
+    content = out.toByteArray();
+    assertThat(content, is(notNullValue()));
+    assertThat(content.length, is(14));
+    assertThat(new String(content, Charsets.UTF_8), is("This is a test"));
+
+    out = new ByteArrayOutputStream();
+    instance.getBinaryContent(out, pk, lang, 0, -1);
+    assertThat(out, is(notNullValue()));
+    content = out.toByteArray();
+    assertThat(content, is(notNullValue()));
+    assertThat(content.length, is(14));
+    assertThat(new String(content, Charsets.UTF_8), is("This is a test"));
+
+    out = new ByteArrayOutputStream();
+    instance.getBinaryContent(out, pk, lang, 0, 0);
+    assertThat(out, is(notNullValue()));
+    content = out.toByteArray();
+    assertThat(content, is(notNullValue()));
+    assertThat(content.length, is(0));
+    assertThat(new String(content, Charsets.UTF_8), is(""));
+
+    long length = "This".length();
+    out = new ByteArrayOutputStream();
+    instance.getBinaryContent(out, pk, lang, -10, length);
+    assertThat(out, is(notNullValue()));
+    content = out.toByteArray();
+    assertThat(content, is(notNullValue()));
+    assertThat(content.length, is(4));
+    assertThat(new String(content, Charsets.UTF_8), is("This"));
+
+    out = new ByteArrayOutputStream();
+    instance.getBinaryContent(out, pk, lang, 0, length);
+    assertThat(out, is(notNullValue()));
+    content = out.toByteArray();
+    assertThat(content, is(notNullValue()));
+    assertThat(content.length, is(4));
+    assertThat(new String(content, Charsets.UTF_8), is("This"));
+
+    out = new ByteArrayOutputStream();
+    instance.getBinaryContent(out, pk, lang, 5, length);
+    assertThat(out, is(notNullValue()));
+    content = out.toByteArray();
+    assertThat(content, is(notNullValue()));
+    assertThat(content.length, is(4));
+    assertThat(new String(content, Charsets.UTF_8), is("is a"));
+
+    out = new ByteArrayOutputStream();
+    instance.getBinaryContent(out, pk, lang, 0, 500000000);
     assertThat(out, is(notNullValue()));
     content = out.toByteArray();
     assertThat(content, is(notNullValue()));
@@ -523,9 +573,14 @@ public class AttachmentServiceTest {
   public void testRemoveContent() {
     SimpleDocument document = instance.searchDocumentById(existingFrDoc, "fr");
     checkFrenchSimpleDocument(document);
+    File pathToVerify = new File(document.getAttachmentPath()).getParentFile();
+    assertThat(pathToVerify.exists(), is(true));
     instance.removeContent(document, "fr", false);
     document = instance.searchDocumentById(existingFrDoc, "fr");
     assertThat(document, is(nullValue()));
+    assertThat(pathToVerify.exists(), is(false));
+    assertThat(pathToVerify.getParentFile().getParentFile().exists(), is(false));
+    assertThat(pathToVerify.getParentFile().getParentFile().getParentFile().exists(), is(true));
 
     document = instance.searchDocumentById(existingEnDoc, "en");
     checkEnglishSimpleDocument(document);

--- a/lib-core/src/test/java/org/silverpeas/attachment/mock/AttachmentServiceMockWrapper.java
+++ b/lib-core/src/test/java/org/silverpeas/attachment/mock/AttachmentServiceMockWrapper.java
@@ -25,12 +25,6 @@ package org.silverpeas.attachment.mock;
 
 import com.silverpeas.util.ForeignPK;
 import com.stratelia.webactiv.util.WAPrimaryKey;
-import java.io.File;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
 import org.mockito.Mockito;
 import org.silverpeas.attachment.AttachmentException;
 import org.silverpeas.attachment.AttachmentService;
@@ -38,7 +32,15 @@ import org.silverpeas.attachment.model.DocumentType;
 import org.silverpeas.attachment.model.SimpleDocument;
 import org.silverpeas.attachment.model.SimpleDocumentPK;
 import org.silverpeas.attachment.model.UnlockContext;
+import org.silverpeas.attachment.util.SimpleDocumentList;
 import org.silverpeas.search.indexEngine.model.FullIndexEntry;
+
+import java.io.File;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
 
 /**
  * A wrapper of a mock of an {@code AttachmentService} instance dedicated to the tests. This wrapper
@@ -63,6 +65,12 @@ public class AttachmentServiceMockWrapper implements AttachmentService {
   @Override
   public void getBinaryContent(OutputStream output, SimpleDocumentPK pk, String lang) {
     mock.getBinaryContent(output, pk, lang);
+  }
+
+  @Override
+  public void getBinaryContent(final OutputStream output, final SimpleDocumentPK pk,
+      final String lang, final long contentOffset, final long contentLength) {
+    mock.getBinaryContent(output, pk, lang, contentOffset, contentLength);
   }
 
   @Override
@@ -173,18 +181,20 @@ public class AttachmentServiceMockWrapper implements AttachmentService {
   }
 
   @Override
-  public List<SimpleDocument> listDocumentsByForeignKey(WAPrimaryKey foreignKey, String lang) {
+  public SimpleDocumentList<SimpleDocument> listDocumentsByForeignKey(WAPrimaryKey foreignKey,
+      String lang) {
     return mock.listDocumentsByForeignKey(foreignKey, lang);
   }
 
   @Override
-  public List<SimpleDocument> listAllDocumentsByForeignKey(WAPrimaryKey foreignKey, String lang) {
+  public SimpleDocumentList<SimpleDocument> listAllDocumentsByForeignKey(WAPrimaryKey foreignKey,
+      String lang) {
     return mock.listAllDocumentsByForeignKey(foreignKey, lang);
   }
 
   @Override
-  public List<SimpleDocument> listDocumentsByForeignKeyAndType(WAPrimaryKey foreignKey,
-      DocumentType type, String lang) {
+  public SimpleDocumentList<SimpleDocument> listDocumentsByForeignKeyAndType(
+      WAPrimaryKey foreignKey, DocumentType type, String lang) {
     return mock.listDocumentsByForeignKeyAndType(foreignKey, type, lang);
   }
 

--- a/lib-core/src/test/java/org/silverpeas/attachment/util/JcrTest.java
+++ b/lib-core/src/test/java/org/silverpeas/attachment/util/JcrTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2000 - 2014 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception. You should have recieved a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "http://www.silverpeas.org/docs/core/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.silverpeas.attachment.util;
+
+import com.silverpeas.jcrutil.BasicDaoFactory;
+import com.silverpeas.jcrutil.model.SilverpeasRegister;
+import com.stratelia.webactiv.util.FileRepositoryManager;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.apache.jackrabbit.api.JackrabbitRepository;
+import org.silverpeas.attachment.repository.DocumentRepository;
+import org.silverpeas.util.Charsets;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+
+import java.io.File;
+import java.io.InputStreamReader;
+import java.io.Reader;
+
+/**
+ * This class handle a JCR test with using a String context.
+ * @author: Yohann Chastagnier
+ */
+public abstract class JcrTest {
+
+  private ClassPathXmlApplicationContext appContext;
+
+  private DocumentRepository documentRepository = new DocumentRepository();
+
+  public ClassPathXmlApplicationContext getAppContext() {
+    return appContext;
+  }
+
+  public void setAppContext(final ClassPathXmlApplicationContext appContext) {
+    this.appContext = appContext;
+  }
+
+  public DocumentRepository getDocumentRepository() {
+    return documentRepository;
+  }
+
+  public JackrabbitRepository getRepository() {
+    return ((JackrabbitRepository) getAppContext().getBean(BasicDaoFactory.JRC_REPOSITORY));
+  }
+
+  public abstract void run() throws Exception;
+
+
+  /**
+   * Execute the test with its context.
+   * @throws Exception
+   */
+  public void execute() throws Exception {
+    setAppContext(new ClassPathXmlApplicationContext("/spring-pure-memory-jcr.xml"));
+    Reader reader = new InputStreamReader(
+        JcrTest.class.getClassLoader().getResourceAsStream("silverpeas-jcr.txt"), Charsets.UTF_8);
+    File file = new File(FileRepositoryManager.getAbsolutePath(""));
+    FileUtils.deleteQuietly(file);
+    try {
+      try {
+        SilverpeasRegister.registerNodeTypes(reader);
+      } finally {
+        IOUtils.closeQuietly(reader);
+      }
+      run();
+    } finally {
+      file = new File(FileRepositoryManager.getAbsolutePath(""));
+      FileUtils.deleteQuietly(file);
+      getRepository().shutdown();
+      getAppContext().close();
+    }
+  }
+}

--- a/lib-core/src/test/java/org/silverpeas/attachment/util/SimpleDocumentListTest.java
+++ b/lib-core/src/test/java/org/silverpeas/attachment/util/SimpleDocumentListTest.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright (C) 2000 - 2014 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception. You should have recieved a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "http://www.silverpeas.org/docs/core/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.silverpeas.attachment.util;
+
+import org.junit.Test;
+import org.silverpeas.attachment.model.HistorisedDocument;
+import org.silverpeas.attachment.model.SimpleAttachment;
+import org.silverpeas.attachment.model.SimpleDocument;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasSize;
+
+public class SimpleDocumentListTest {
+
+  @Test
+  public void removeLanguageFallbacksOnEmptyList() {
+    new SimpleDocumentList().setQueryLanguage("en").removeLanguageFallbacks();
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void removeLanguageFallbacksOnListWithOneElement() {
+    //noinspection MismatchedQueryAndUpdateOfCollection
+    SimpleDocumentList<SimpleDocument> test =
+        new SimpleDocumentList<SimpleDocument>().setQueryLanguage("en");
+    test.add(new SimpleDocument());
+    test.removeLanguageFallbacks();
+  }
+
+  @Test
+  public void removeLanguageFallbacksOnListWithOneElementButNoLanguageSet() {
+    //noinspection MismatchedQueryAndUpdateOfCollection
+    SimpleDocumentList<SimpleDocument> test =
+        new SimpleDocumentList<SimpleDocument>().setQueryLanguage("");
+    test.add(new SimpleDocument());
+    test.removeLanguageFallbacks();
+    assertThat(test, hasSize(1));
+  }
+
+  @Test
+  public void removeLanguageFallbacksOnListWithSeveralElementsButNoLanguageSet() {
+    //noinspection MismatchedQueryAndUpdateOfCollection
+    SimpleDocumentList<SimpleDocument> test =
+        new SimpleDocumentList<SimpleDocument>().setQueryLanguage(null);
+    int i = 1;
+    // i = number of the month of the last update date...
+    test.add(createDocument(i++, "en", createDate("2014-01-01")));
+    test.add(createDocument(i++, "fr", createDate("2014-01-02")));
+    test.add(createDocument(i++, "de", createDate("2014-01-03")));
+    test.add(createDocument(i++, "fr", createDate("2014-01-04")));
+    test.add(createDocument(i++, "en", createDate("2014-01-05")));
+    test.add(createDocument(i++, "en", createDate("2014-01-06")));
+    test.add(createDocument(i++, "fr", createDate("2014-01-07")));
+    test.add(createDocument(i++, "en", createDate("2014-01-08")));
+    test.add(createDocument(i++, "en", createDate("2014-01-09")));
+    test.add(createDocument(i++, "fr", createDate("2014-01-10")));
+    test.add(createDocument(i++, "en", createDate("2014-01-11")));
+    test.add(createDocument(i, "en", createDate("2014-01-12")));
+    List<Integer> ids = extractIds(test);
+    assertThat(ids, contains(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12));
+    test.removeLanguageFallbacks();
+    ids = extractIds(test);
+    assertThat(ids, contains(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12));
+  }
+
+  @Test
+  public void removeLanguageFallbacksOnListWithSeveralElements() {
+    //noinspection MismatchedQueryAndUpdateOfCollection
+    SimpleDocumentList<SimpleDocument> test =
+        new SimpleDocumentList<SimpleDocument>().setQueryLanguage("en");
+    int i = 1;
+    // i = number of the month of the last update date...
+    test.add(createDocument(i++, "en", createDate("2014-01-01")));
+    test.add(createDocument(i++, "fr", createDate("2014-01-02")));
+    test.add(createDocument(i++, "de", createDate("2014-01-03")));
+    test.add(createDocument(i++, "fr", createDate("2014-01-04")));
+    test.add(createDocument(i++, "en", createDate("2014-01-05")));
+    test.add(createDocument(i++, "en", createDate("2014-01-06")));
+    test.add(createDocument(i++, "fr", createDate("2014-01-07")));
+    test.add(createDocument(i++, "en", createDate("2014-01-08")));
+    test.add(createDocument(i++, "en", createDate("2014-01-09")));
+    test.add(createDocument(i++, "fr", createDate("2014-01-10")));
+    test.add(createDocument(i++, "en", createDate("2014-01-11")));
+    test.add(createDocument(i, "en", createDate("2014-01-12")));
+    List<Integer> ids = extractIds(test);
+    assertThat(ids, contains(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12));
+    test.removeLanguageFallbacks();
+    ids = extractIds(test);
+    assertThat(ids, contains(1, 5, 6, 8, 9, 11, 12));
+  }
+
+  @Test
+  public void orderByLanguageAndLastUpdateOnEmptyList() {
+    new SimpleDocumentList().orderByLanguageAndLastUpdate("fr", "en");
+  }
+
+  @Test
+  public void orderByLanguageAndLastUpdateOnListWithOneElement() {
+    //noinspection MismatchedQueryAndUpdateOfCollection
+    SimpleDocumentList<SimpleDocument> test = new SimpleDocumentList<SimpleDocument>();
+    test.add(new SimpleDocument());
+    test.orderByLanguageAndLastUpdate("fr", "en");
+  }
+
+  /**
+   * This method is to prove that nothing is ordered when it exists only one element in the list.
+   * @see #orderByLanguageAndLastUpdateOnListWithOneElement()
+   */
+  @Test(expected = NullPointerException.class)
+  public void orderByLanguageAndLastUpdateOnListWithTwoElements() {
+    //noinspection MismatchedQueryAndUpdateOfCollection
+    SimpleDocumentList<SimpleDocument> test = new SimpleDocumentList<SimpleDocument>();
+    test.add(new SimpleDocument());
+    test.add(new SimpleDocument());
+    test.orderByLanguageAndLastUpdate("fr", "en");
+  }
+
+  /**
+   * Default platform language priorities : fr, en, de
+   */
+  @Test
+  public void orderByLanguageAndLastUpdateOnListWithSeveralElements() {
+    //noinspection MismatchedQueryAndUpdateOfCollection
+    SimpleDocumentList<SimpleDocument> test = new SimpleDocumentList<SimpleDocument>();
+    int i = 1;
+    // i = number of the month of the last update date...
+    test.add(createDocument(i++, "en", createDate("2014-01-01")));
+    test.add(createDocument(i++, "fr", createDate("2014-01-02")));
+    test.add(createDocument(i++, "de", createDate("2014-01-03")));
+    test.add(createDocument(i++, "fr", createDate("2014-01-04")));
+    test.add(createDocument(i++, "en", createDate("2014-01-05")));
+    test.add(createDocument(i++, "en", createDate("2014-01-06")));
+    test.add(createDocument(i++, "fr", createDate("2014-01-07")));
+    test.add(createDocument(i++, "en", createDate("2014-01-08")));
+    test.add(createDocument(i++, "en", createDate("2014-01-09")));
+    test.add(createDocument(i++, "fr", createDate("2014-01-10")));
+    test.add(createDocument(i++, "en", createDate("2014-01-11")));
+    test.add(createDocument(i, "en", createDate("2014-01-12")));
+    List<Integer> ids = extractIds(test);
+    assertThat(ids, contains(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12));
+
+    test.orderByLanguageAndLastUpdate();
+    ids = extractIds(test);
+    assertThat(ids, contains(10, 7, 4, 2, 12, 11, 9, 8, 6, 5, 1, 3));
+
+    test.orderByLanguageAndLastUpdate("de");
+    ids = extractIds(test);
+    assertThat(ids, contains(3, 10, 7, 4, 2, 12, 11, 9, 8, 6, 5, 1));
+
+    test.orderByLanguageAndLastUpdate("en", "de", "fr");
+    ids = extractIds(test);
+    assertThat(ids, contains(12, 11, 9, 8, 6, 5, 1, 3, 10, 7, 4, 2));
+  }
+
+  private static List<Integer> extractIds(List<SimpleDocument> list) {
+    List<Integer> ids = new ArrayList<Integer>(list.size());
+    for (SimpleDocument document : list) {
+      ids.add(Integer.valueOf(document.getId()));
+    }
+    return ids;
+  }
+
+  /**
+   * Creates a date from the given pattern.
+   * @param datePattern the pattern of the date to take into account.
+   * @return the date according to the specified date pattern.
+   */
+  private Date createDate(String datePattern) {
+    return java.sql.Date.valueOf(datePattern);
+  }
+
+  /**
+   * Creates a document.
+   * @return
+   */
+  private SimpleDocument createDocument(final int id, String language, Date lastUpdateDate) {
+    final SimpleDocument document;
+    if (id % 2 == 0) {
+      document = new HistorisedDocument();
+    } else {
+      document = new SimpleDocument();
+    }
+    document.setId(String.valueOf(id));
+    document.setFile(new SimpleAttachment());
+    document.setLanguage(language);
+    if (id % 5 == 0) {
+      document.setUpdated(lastUpdateDate);
+    } else {
+      document.setCreated(lastUpdateDate);
+    }
+    return document;
+  }
+}

--- a/lib-core/src/test/java/org/silverpeas/wysiwyg/control/WysiwygControllerTest.java
+++ b/lib-core/src/test/java/org/silverpeas/wysiwyg/control/WysiwygControllerTest.java
@@ -20,36 +20,33 @@
  */
 package org.silverpeas.wysiwyg.control;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.Reader;
-import java.util.List;
-
-import javax.jcr.RepositoryException;
-
+import com.silverpeas.util.ForeignPK;
+import com.silverpeas.util.MimeTypes;
+import com.silverpeas.util.i18n.I18NHelper;
+import com.stratelia.webactiv.util.FileRepositoryManager;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.junit.Test;
 import org.silverpeas.attachment.AttachmentServiceFactory;
+import org.silverpeas.attachment.model.DocumentType;
+import org.silverpeas.attachment.model.HistorisedDocument;
+import org.silverpeas.attachment.model.SimpleAttachment;
 import org.silverpeas.attachment.model.SimpleDocument;
 import org.silverpeas.attachment.model.SimpleDocumentPK;
-import org.silverpeas.util.Charsets;
+import org.silverpeas.attachment.util.JcrTest;
+import org.silverpeas.attachment.util.SimpleDocumentList;
 
-import com.silverpeas.jcrutil.BasicDaoFactory;
-import com.silverpeas.jcrutil.model.SilverpeasRegister;
-import com.silverpeas.util.ForeignPK;
-
-import org.apache.commons.io.IOUtils;
-import org.apache.jackrabbit.api.JackrabbitRepository;
-import org.apache.jackrabbit.commons.cnd.ParseException;
-import org.junit.Test;
-import org.springframework.context.support.ClassPathXmlApplicationContext;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Date;
+import java.util.List;
 
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
 
 public class WysiwygControllerTest {
-
-  public WysiwygControllerTest() {
-  }
 
   /**
    * Test of finNode method, of class WysiwygController.
@@ -111,8 +108,8 @@ public class WysiwygControllerTest {
     String componentId = "webSites45";
     String result = WysiwygController.getNodePath(currentPath, componentId);
     assertThat(result, is("/home/ehugonnet/programs/silverpeas/data/web/website.war/webSites45/1"));
-    currentPath
-        = "/home/ehugonnet/programs/silverpeas/data/web/website.war/webSites45/1/repertoire1/repertoire2/";
+    currentPath = "/home/ehugonnet/programs/silverpeas/data/web/website" +
+        ".war/webSites45/1/repertoire1/repertoire2/";
     result = WysiwygController.getNodePath(currentPath, componentId);
     assertThat(result, is("/home/ehugonnet/programs/silverpeas/data/web/website.war/webSites45/1"));
   }
@@ -187,38 +184,1825 @@ public class WysiwygControllerTest {
   }
 
   /**
-   * Test of ignoreAntiSlash method, of class WysiwygController.
+   * Test of copy method, of class WysiwygController.
    */
   @Test
-  public void testCreateWysiwyg() throws RepositoryException, IOException, ParseException {
+  public void testCopyWysiwygThatExistsOnlyInEN() throws Exception {
+    new JcrTest() {
+      @Override
+      public void run() {
+        String componentId = "blog974";
+        String messageId = "18";
+        String expectedContent = "<mark>EN_Content_FileServer_ComponentId=blog974";
+        String userId = "7";
+        String language = "en";
+        WysiwygController.save(expectedContent, componentId, messageId, userId, language, false);
 
-    ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext(
-        "/spring-pure-memory-jcr.xml");
-    Reader reader = new InputStreamReader(this.getClass().getClassLoader().getResourceAsStream(
-        "silverpeas-jcr.txt"), Charsets.UTF_8);
-    try {
-      SilverpeasRegister.registerNodeTypes(reader);
-    } finally {
-      IOUtils.closeQuietly(reader);
-    }
-    try {
-      String componentId = "blog974";
-      String messageId = "18";
-      String expectedContent = "Hello World";
-      String userId = "7";
-      String language = "en";
-      WysiwygController.createFileAndAttachment(expectedContent, new ForeignPK(messageId,
-          componentId), userId, language);
-      String content = WysiwygController.load(componentId, messageId, language);
-      assertThat(content, is(expectedContent));
-      List<SimpleDocument> lockedFiles = AttachmentServiceFactory.getAttachmentService()
-          .listDocumentsLockedByUser(userId, null);
-      assertThat(lockedFiles, is(notNullValue()));
-      assertThat(lockedFiles, hasSize(0));
-    } finally {
-      ((JackrabbitRepository) context.getBean(BasicDaoFactory.JRC_REPOSITORY)).shutdown();
-      context.close();
-    }
+        ForeignPK resourceSrcTestPK = new ForeignPK(messageId, componentId);
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceSrcTestPK, "fr"), hasSize(0));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceSrcTestPK, "en"), hasSize(1));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceSrcTestPK, "de"), hasSize(0));
+
+        String destComponentId = "kmelia26";
+        String destMessageId = "38";
+        ForeignPK resourceDestTestPK = new ForeignPK(destMessageId, destComponentId);
+        assertThat(listWysiwygs(resourceDestTestPK), hasSize(0));
+
+        assertThat(WysiwygController.load(componentId, messageId, "fr"),
+            is("<mark>EN_Content_FileServer_ComponentId=blog974"));
+        assertThat(WysiwygController.load(componentId, messageId, "en"),
+            is("<mark>EN_Content_FileServer_ComponentId=blog974"));
+        assertThat(WysiwygController.load(destComponentId, destMessageId, "fr"), is(""));
+        assertThat(WysiwygController.load(destComponentId, destMessageId, "en"), is(""));
+
+        WysiwygController.copy(componentId, messageId, destComponentId, destMessageId, "26");
+
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceSrcTestPK, "fr"), hasSize(0));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceSrcTestPK, "en"), hasSize(1));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceSrcTestPK, "de"), hasSize(0));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceDestTestPK, "fr"), hasSize(0));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceDestTestPK, "en"), hasSize(1));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceDestTestPK, "de"), hasSize(0));
+
+        assertThat(WysiwygController.load(componentId, messageId, "fr"),
+            is("<mark>EN_Content_FileServer_ComponentId=blog974"));
+        assertThat(WysiwygController.load(componentId, messageId, "en"),
+            is("<mark>EN_Content_FileServer_ComponentId=blog974"));
+        assertThat(WysiwygController.load(destComponentId, destMessageId, "fr"),
+            is("<mark>EN_Content_FileServer_ComponentId=kmelia26"));
+        assertThat(WysiwygController.load(destComponentId, destMessageId, "en"),
+            is("<mark>EN_Content_FileServer_ComponentId=kmelia26"));
+      }
+    }.execute();
+  }
+
+  /**
+   * Test of copy method, of class WysiwygController.
+   */
+  @Test
+  public void testCopyWysiwygFRENNoImageInJcr() throws Exception {
+    new JcrTest() {
+      @Override
+      public void run() throws Exception {
+        String componentId = "blog974";
+        String messageId = "18";
+        String expectedContent =
+            "<mark>EN_Content_FileServer_ComponentId=blog974_/componentId/blog974/attachmentId/18/";
+        String userId = "7";
+        String language = "en";
+        WysiwygController.save(expectedContent, componentId, messageId, userId, language, false);
+        language = "fr";
+        expectedContent =
+            "<mark>FR_Content_FileServer_ComponentId=blog974_/componentId/blog974/attachmentId/18/";
+        WysiwygController.save(expectedContent, componentId, messageId, userId, language, false);
+
+
+        ForeignPK resourceSrcTestPK = new ForeignPK(messageId, componentId);
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceSrcTestPK, "fr"), hasSize(1));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceSrcTestPK, "en"), hasSize(1));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceSrcTestPK, "de"), hasSize(0));
+        String destComponentId = "kmelia26";
+        String destMessageId = "38";
+        ForeignPK resourceDestTestPK = new ForeignPK(destMessageId, destComponentId);
+        assertThat(listWysiwygs(resourceDestTestPK), hasSize(0));
+
+        // No image
+        assertThat(listImages(resourceSrcTestPK), hasSize(0));
+
+        assertThat(WysiwygController.load(componentId, messageId, "fr"),
+            is("<mark>FR_Content_FileServer_ComponentId=blog974_" +
+                "/componentId/blog974/attachmentId/18/")
+        );
+        assertThat(WysiwygController.load(componentId, messageId, "en"),
+            is("<mark>EN_Content_FileServer_ComponentId=blog974_" +
+                "/componentId/blog974/attachmentId/18/")
+        );
+        assertThat(WysiwygController.load(destComponentId, destMessageId, "fr"), is(""));
+        assertThat(WysiwygController.load(destComponentId, destMessageId, "en"), is(""));
+
+        WysiwygController.copy(componentId, messageId, destComponentId, destMessageId, "26");
+
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceSrcTestPK, "fr"), hasSize(1));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceSrcTestPK, "en"), hasSize(1));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceSrcTestPK, "de"), hasSize(0));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceDestTestPK, "fr"), hasSize(1));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceDestTestPK, "en"), hasSize(1));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceDestTestPK, "de"), hasSize(0));
+
+        // No image
+        assertThat(listImages(resourceSrcTestPK), hasSize(0));
+        assertThat(listImages(resourceDestTestPK), hasSize(0));
+
+        assertThat(WysiwygController.load(componentId, messageId, "fr"),
+            is("<mark>FR_Content_FileServer_ComponentId=blog974_" +
+                "/componentId/blog974/attachmentId/18/")
+        );
+        assertThat(WysiwygController.load(componentId, messageId, "en"),
+            is("<mark>EN_Content_FileServer_ComponentId=blog974_" +
+                "/componentId/blog974/attachmentId/18/")
+        );
+        assertThat(WysiwygController.load(destComponentId, destMessageId, "fr"),
+            is("<mark>FR_Content_FileServer_ComponentId=kmelia26_" +
+                "/componentId/blog974/attachmentId/18/")
+        );
+        assertThat(WysiwygController.load(destComponentId, destMessageId, "en"),
+            is("<mark>EN_Content_FileServer_ComponentId=kmelia26_" +
+                "/componentId/blog974/attachmentId/18/")
+        );
+      }
+    }.execute();
+  }
+
+  /**
+   * Test of copy method, of class WysiwygController.
+   */
+  @Test
+  public void testCopyWysiwygFRENWithImageInJcr() throws Exception {
+    new JcrTest() {
+      @Override
+      public void run() throws Exception {
+        String componentId = "blog974";
+        String messageId = "18";
+        SimpleDocument image = createImageContent(componentId, messageId);
+        String expectedContent =
+            "<mark>EN_Content_FileServer_ComponentId=blog974_/componentId/blog974/attachmentId/" +
+                image.getId() + "/";
+        String userId = "7";
+        String language = "en";
+        WysiwygController.save(expectedContent, componentId, messageId, userId, language, false);
+        language = "fr";
+        expectedContent =
+            "<mark>FR_Content_FileServer_ComponentId=blog974_/componentId/blog974/attachmentId/" +
+                image.getId() + "/";
+        WysiwygController.save(expectedContent, componentId, messageId, userId, language, false);
+
+        ForeignPK resourceSrcTestPK = new ForeignPK(messageId, componentId);
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceSrcTestPK, "fr"), hasSize(1));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceSrcTestPK, "en"), hasSize(1));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceSrcTestPK, "de"), hasSize(0));
+
+        String destComponentId = "kmelia26";
+        String destMessageId = "38";
+        ForeignPK resourceDestTestPK = new ForeignPK(destMessageId, destComponentId);
+        assertThat(listWysiwygs(resourceDestTestPK), hasSize(0));
+
+        // One image
+        for (String lang : I18NHelper.getAllSupportedLanguages()) {
+          assertThat(listImagesWithNoLanguageFallback(resourceSrcTestPK, lang),
+              hasSize(I18NHelper.defaultLanguage.equals(lang) ? 1 : 0));
+          assertThat(listImagesWithNoLanguageFallback(resourceDestTestPK, lang), hasSize(0));
+        }
+
+        assertThat(WysiwygController.load(componentId, messageId, "fr"),
+            is("<mark>FR_Content_FileServer_ComponentId=blog974_" +
+                "/componentId/blog974/attachmentId/" + image.getId() + "/")
+        );
+        assertThat(WysiwygController.load(componentId, messageId, "en"),
+            is("<mark>EN_Content_FileServer_ComponentId=blog974_" +
+                "/componentId/blog974/attachmentId/" + image.getId() + "/")
+        );
+        assertThat(WysiwygController.load(destComponentId, destMessageId, "fr"), is(""));
+        assertThat(WysiwygController.load(destComponentId, destMessageId, "en"), is(""));
+
+        WysiwygController.copy(componentId, messageId, destComponentId, destMessageId, "26");
+
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceSrcTestPK, "fr"), hasSize(1));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceSrcTestPK, "en"), hasSize(1));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceSrcTestPK, "de"), hasSize(0));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceDestTestPK, "fr"), hasSize(1));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceDestTestPK, "en"), hasSize(1));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceDestTestPK, "de"), hasSize(0));
+
+        // One image
+        assertThat(listImages(resourceSrcTestPK), hasSize(1));
+        SimpleDocumentList<SimpleDocument> copiedImages = listImages(resourceDestTestPK);
+        assertThat(copiedImages, hasSize(1));
+        for (String lang : I18NHelper.getAllSupportedLanguages()) {
+          assertThat(listImagesWithNoLanguageFallback(resourceSrcTestPK, lang),
+              hasSize(I18NHelper.defaultLanguage.equals(lang) ? 1 : 0));
+          assertThat(listImagesWithNoLanguageFallback(resourceDestTestPK, lang),
+              hasSize(I18NHelper.defaultLanguage.equals(lang) ? 1 : 0));
+        }
+
+        assertThat(WysiwygController.load(componentId, messageId, "fr"),
+            is("<mark>FR_Content_FileServer_ComponentId=blog974_" +
+                "/componentId/blog974/attachmentId/" + image.getId() + "/")
+        );
+        assertThat(WysiwygController.load(componentId, messageId, "en"),
+            is("<mark>EN_Content_FileServer_ComponentId=blog974_" +
+                "/componentId/blog974/attachmentId/" + image.getId() + "/")
+        );
+        assertThat(WysiwygController.load(destComponentId, destMessageId, "fr"),
+            is("<mark>FR_Content_FileServer_ComponentId=kmelia26_" +
+                "/componentId/kmelia26/attachmentId/" + copiedImages.get(0).getId() + "/")
+        );
+        assertThat(WysiwygController.load(destComponentId, destMessageId, "en"),
+            is("<mark>EN_Content_FileServer_ComponentId=kmelia26_" +
+                "/componentId/kmelia26/attachmentId/" + copiedImages.get(0).getId() + "/")
+        );
+      }
+    }.execute();
+  }
+
+  /**
+   * Test of copy method, of class WysiwygController.
+   */
+  @Test
+  public void testCopyWysiwygFRThatIsEmptyENWithImageInJcr() throws Exception {
+    new JcrTest() {
+      @Override
+      public void run() throws Exception {
+        String componentId = "blog974";
+        String messageId = "18";
+        SimpleDocument image = createImageContent(componentId, messageId);
+        String expectedContent =
+            "EN_Content_FileServer_ComponentId=blog974_/componentId/blog974/attachmentId/" +
+                image.getId() + "/";
+        String userId = "7";
+        String language = "en";
+        WysiwygController.save(expectedContent, componentId, messageId, userId, language, false);
+        language = "fr";
+        expectedContent = "empty";
+        WysiwygController.save(expectedContent, componentId, messageId, userId, language, false);
+        // Empty FR wysiwyg ...
+        ForeignPK resourceSrcTestPK = new ForeignPK(messageId, componentId);
+        File frWysiwygFile = new File(
+            listWysiwygsWithNoLanguageFallback(resourceSrcTestPK, "fr").get(0).getAttachmentPath());
+        assertThat(frWysiwygFile.length(), greaterThan(0L));
+        FileUtils.write(frWysiwygFile, "");
+        assertThat(frWysiwygFile.length(), is(0L));
+
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceSrcTestPK, "fr"), hasSize(1));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceSrcTestPK, "en"), hasSize(1));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceSrcTestPK, "de"), hasSize(0));
+
+        String destComponentId = "kmelia26";
+        String destMessageId = "38";
+        ForeignPK resourceDestTestPK = new ForeignPK(destMessageId, destComponentId);
+        SimpleDocumentList<SimpleDocument> wysiwygs = listWysiwygs(resourceDestTestPK);
+        assertThat(wysiwygs, hasSize(0));
+
+        // One image
+        for (String lang : I18NHelper.getAllSupportedLanguages()) {
+          assertThat(listImagesWithNoLanguageFallback(resourceSrcTestPK, lang),
+              hasSize(I18NHelper.defaultLanguage.equals(lang) ? 1 : 0));
+          assertThat(listImagesWithNoLanguageFallback(resourceDestTestPK, lang), hasSize(0));
+        }
+
+        assertThat(WysiwygController.load(componentId, messageId, "fr"),
+            is("EN_Content_FileServer_ComponentId=blog974_" +
+                "/componentId/blog974/attachmentId/" + image.getId() + "/")
+        );
+        assertThat(WysiwygController.load(componentId, messageId, "en"),
+            is("EN_Content_FileServer_ComponentId=blog974_" +
+                "/componentId/blog974/attachmentId/" + image.getId() + "/")
+        );
+        assertThat(WysiwygController.load(destComponentId, destMessageId, "fr"), is(""));
+        assertThat(WysiwygController.load(destComponentId, destMessageId, "en"), is(""));
+
+        WysiwygController.copy(componentId, messageId, destComponentId, destMessageId, "26");
+
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceSrcTestPK, "fr"), hasSize(1));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceSrcTestPK, "en"), hasSize(1));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceSrcTestPK, "de"), hasSize(0));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceDestTestPK, "fr"), hasSize(0));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceDestTestPK, "en"), hasSize(1));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceDestTestPK, "de"), hasSize(0));
+
+        // One image
+        assertThat(listImages(resourceSrcTestPK), hasSize(1));
+        SimpleDocumentList<SimpleDocument> copiedImages = listImages(resourceDestTestPK);
+        assertThat(copiedImages, hasSize(1));
+        for (String lang : I18NHelper.getAllSupportedLanguages()) {
+          assertThat(listImagesWithNoLanguageFallback(resourceSrcTestPK, lang),
+              hasSize(I18NHelper.defaultLanguage.equals(lang) ? 1 : 0));
+          assertThat(listImagesWithNoLanguageFallback(resourceDestTestPK, lang),
+              hasSize(I18NHelper.defaultLanguage.equals(lang) ? 1 : 0));
+        }
+
+        assertThat(WysiwygController.load(componentId, messageId, "fr"),
+            is("EN_Content_FileServer_ComponentId=blog974_" +
+                "/componentId/blog974/attachmentId/" + image.getId() + "/")
+        );
+        assertThat(WysiwygController.load(componentId, messageId, "en"),
+            is("EN_Content_FileServer_ComponentId=blog974_" +
+                "/componentId/blog974/attachmentId/" + image.getId() + "/")
+        );
+        assertThat(WysiwygController.load(destComponentId, destMessageId, "fr"),
+            is("EN_Content_FileServer_ComponentId=kmelia26_" +
+                "/componentId/kmelia26/attachmentId/" + copiedImages.get(0).getId() + "/")
+        );
+        assertThat(WysiwygController.load(destComponentId, destMessageId, "en"),
+            is("EN_Content_FileServer_ComponentId=kmelia26_" +
+                "/componentId/kmelia26/attachmentId/" + copiedImages.get(0).getId() + "/")
+        );
+      }
+    }.execute();
+  }
+
+  /**
+   * Test of copy method, of class WysiwygController.
+   */
+  @Test
+  public void testCopyWysiwygFRThatIsEmptyENThatIsEmptyWithImageInJcr() throws Exception {
+    new JcrTest() {
+      @Override
+      public void run() throws Exception {
+        String componentId = "blog974";
+        String messageId = "18";
+        SimpleDocument image = createImageContent(componentId, messageId);
+        String expectedContent =
+            "<mark>EN_Content_FileServer_ComponentId=blog974_/componentId/blog974/attachmentId/" +
+                image.getId() + "/";
+        String userId = "7";
+        String language = "en";
+        WysiwygController.save(expectedContent, componentId, messageId, userId, language, false);
+        language = "fr";
+        expectedContent =
+            "<mark>FR_Content_FileServer_ComponentId=blog974_/componentId/blog974/attachmentId/" +
+                image.getId() + "/";
+        WysiwygController.save(expectedContent, componentId, messageId, userId, language, false);
+        // Empty FR wysiwyg ...
+        ForeignPK resourceSrcTestPK = new ForeignPK(messageId, componentId);
+        File frWysiwygFile = new File(
+            listWysiwygsWithNoLanguageFallback(resourceSrcTestPK, "fr").get(0).getAttachmentPath());
+        assertThat(frWysiwygFile.length(), greaterThan(0L));
+        FileUtils.write(frWysiwygFile, "");
+        assertThat(frWysiwygFile.length(), is(0L));
+        // Empty EN wysiwyg ...
+        File enWysiwygFile = new File(
+            listWysiwygsWithNoLanguageFallback(resourceSrcTestPK, "en").get(0).getAttachmentPath());
+        assertThat(enWysiwygFile.length(), greaterThan(0L));
+        FileUtils.write(enWysiwygFile, "");
+        assertThat(enWysiwygFile.length(), is(0L));
+
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceSrcTestPK, "fr"), hasSize(1));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceSrcTestPK, "en"), hasSize(1));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceSrcTestPK, "de"), hasSize(0));
+
+        String destComponentId = "kmelia26";
+        String destMessageId = "38";
+        ForeignPK resourceDestTestPK = new ForeignPK(destMessageId, destComponentId);
+        SimpleDocumentList<SimpleDocument> wysiwygs = listWysiwygs(resourceDestTestPK);
+        assertThat(wysiwygs, hasSize(0));
+
+        // One image
+        for (String lang : I18NHelper.getAllSupportedLanguages()) {
+          assertThat(listImagesWithNoLanguageFallback(resourceSrcTestPK, lang),
+              hasSize(I18NHelper.defaultLanguage.equals(lang) ? 1 : 0));
+          assertThat(listImagesWithNoLanguageFallback(resourceDestTestPK, lang), hasSize(0));
+        }
+
+        assertThat(WysiwygController.load(componentId, messageId, "fr"), is(""));
+        assertThat(WysiwygController.load(componentId, messageId, "en"), is(""));
+        assertThat(WysiwygController.load(destComponentId, destMessageId, "fr"), is(""));
+        assertThat(WysiwygController.load(destComponentId, destMessageId, "en"), is(""));
+
+        WysiwygController.copy(componentId, messageId, destComponentId, destMessageId, "26");
+
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceSrcTestPK, "fr"), hasSize(1));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceSrcTestPK, "en"), hasSize(1));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceSrcTestPK, "de"), hasSize(0));
+        // Finally no copy done
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceDestTestPK, "fr"), hasSize(0));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceDestTestPK, "en"), hasSize(0));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceDestTestPK, "de"), hasSize(0));
+
+        // No image copied
+        for (String lang : I18NHelper.getAllSupportedLanguages()) {
+          assertThat(listImagesWithNoLanguageFallback(resourceSrcTestPK, lang),
+              hasSize(I18NHelper.defaultLanguage.equals(lang) ? 1 : 0));
+          assertThat(listImagesWithNoLanguageFallback(resourceDestTestPK, lang), hasSize(0));
+        }
+
+        assertThat(WysiwygController.load(componentId, messageId, "fr"), is(""));
+        assertThat(WysiwygController.load(componentId, messageId, "en"), is(""));
+        assertThat(WysiwygController.load(destComponentId, destMessageId, "fr"), is(""));
+        assertThat(WysiwygController.load(destComponentId, destMessageId, "en"), is(""));
+      }
+    }.execute();
+  }
+
+  /**
+   * Test of move method, of class WysiwygController.
+   */
+  @Test
+  public void testMoveWysiwygThatExistsOnlyInEN() throws Exception {
+    new JcrTest() {
+      @Override
+      public void run() {
+        String componentId = "blog974";
+        String messageId = "18";
+        String expectedContent = "<mark>EN_Content_FileServer_ComponentId=blog974";
+        String userId = "7";
+        String language = "en";
+        WysiwygController.save(expectedContent, componentId, messageId, userId, language, false);
+
+        ForeignPK resourceSrcTestPK = new ForeignPK(messageId, componentId);
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceSrcTestPK, "fr"), hasSize(0));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceSrcTestPK, "en"), hasSize(1));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceSrcTestPK, "de"), hasSize(0));
+
+        String destComponentId = "kmelia26";
+        String destMessageId = "38";
+        ForeignPK resourceDestTestPK = new ForeignPK(destMessageId, destComponentId);
+        assertThat(listWysiwygs(resourceDestTestPK), hasSize(0));
+
+        assertThat(WysiwygController.load(componentId, messageId, "fr"),
+            is("<mark>EN_Content_FileServer_ComponentId=blog974"));
+        assertThat(WysiwygController.load(componentId, messageId, "en"),
+            is("<mark>EN_Content_FileServer_ComponentId=blog974"));
+        assertThat(WysiwygController.load(destComponentId, destMessageId, "fr"), is(""));
+        assertThat(WysiwygController.load(destComponentId, destMessageId, "en"), is(""));
+
+        WysiwygController.move(componentId, messageId, destComponentId, destMessageId);
+
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceSrcTestPK, "fr"), hasSize(0));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceSrcTestPK, "en"), hasSize(0));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceSrcTestPK, "de"), hasSize(0));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceDestTestPK, "fr"), hasSize(0));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceDestTestPK, "en"), hasSize(1));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceDestTestPK, "de"), hasSize(0));
+
+        assertThat(WysiwygController.load(componentId, messageId, "fr"), is(""));
+        assertThat(WysiwygController.load(componentId, messageId, "en"), is(""));
+        assertThat(WysiwygController.load(destComponentId, destMessageId, "fr"),
+            is("<mark>EN_Content_FileServer_ComponentId=kmelia26"));
+        assertThat(WysiwygController.load(destComponentId, destMessageId, "en"),
+            is("<mark>EN_Content_FileServer_ComponentId=kmelia26"));
+      }
+    }.execute();
+  }
+
+  /**
+   * Test of move method, of class WysiwygController.
+   */
+  @Test
+  public void testMoveWysiwygFRENNoImageInJcr() throws Exception {
+    new JcrTest() {
+      @Override
+      public void run() throws Exception {
+        String componentId = "blog974";
+        String messageId = "18";
+        String expectedContent =
+            "<mark>EN_Content_FileServer_ComponentId=blog974_/componentId/blog974/attachmentId/18/";
+        String userId = "7";
+        String language = "en";
+        WysiwygController.save(expectedContent, componentId, messageId, userId, language, false);
+        language = "fr";
+        expectedContent =
+            "<mark>FR_Content_FileServer_ComponentId=blog974_/componentId/blog974/attachmentId/18/";
+        WysiwygController.save(expectedContent, componentId, messageId, userId, language, false);
+
+
+        ForeignPK resourceSrcTestPK = new ForeignPK(messageId, componentId);
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceSrcTestPK, "fr"), hasSize(1));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceSrcTestPK, "en"), hasSize(1));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceSrcTestPK, "de"), hasSize(0));
+        String destComponentId = "kmelia26";
+        String destMessageId = "38";
+        ForeignPK resourceDestTestPK = new ForeignPK(destMessageId, destComponentId);
+        assertThat(listWysiwygs(resourceDestTestPK), hasSize(0));
+
+        // No image
+        assertThat(listImages(resourceSrcTestPK), hasSize(0));
+
+        assertThat(WysiwygController.load(componentId, messageId, "fr"),
+            is("<mark>FR_Content_FileServer_ComponentId=blog974_" +
+                "/componentId/blog974/attachmentId/18/")
+        );
+        assertThat(WysiwygController.load(componentId, messageId, "en"),
+            is("<mark>EN_Content_FileServer_ComponentId=blog974_" +
+                "/componentId/blog974/attachmentId/18/")
+        );
+        assertThat(WysiwygController.load(destComponentId, destMessageId, "fr"), is(""));
+        assertThat(WysiwygController.load(destComponentId, destMessageId, "en"), is(""));
+
+        WysiwygController.move(componentId, messageId, destComponentId, destMessageId);
+
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceSrcTestPK, "fr"), hasSize(0));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceSrcTestPK, "en"), hasSize(0));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceSrcTestPK, "de"), hasSize(0));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceDestTestPK, "fr"), hasSize(1));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceDestTestPK, "en"), hasSize(1));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceDestTestPK, "de"), hasSize(0));
+
+        // No image
+        assertThat(listImages(resourceSrcTestPK), hasSize(0));
+        assertThat(listImages(resourceDestTestPK), hasSize(0));
+
+        assertThat(WysiwygController.load(componentId, messageId, "fr"), is(""));
+        assertThat(WysiwygController.load(componentId, messageId, "en"), is(""));
+        assertThat(WysiwygController.load(destComponentId, destMessageId, "fr"),
+            is("<mark>FR_Content_FileServer_ComponentId=kmelia26_" +
+                "/componentId/blog974/attachmentId/18/")
+        );
+        assertThat(WysiwygController.load(destComponentId, destMessageId, "en"),
+            is("<mark>EN_Content_FileServer_ComponentId=kmelia26_" +
+                "/componentId/blog974/attachmentId/18/")
+        );
+      }
+    }.execute();
+  }
+
+  /**
+   * Test of move method, of class WysiwygController.
+   */
+  @Test
+  public void testMoveWysiwygFRENWithImageInJcr() throws Exception {
+    new JcrTest() {
+      @Override
+      public void run() throws Exception {
+        String componentId = "blog974";
+        String messageId = "18";
+        SimpleDocument image = createImageContent(componentId, messageId);
+        String expectedContent =
+            "<mark>EN_Content_FileServer_ComponentId=blog974_/componentId/blog974/attachmentId/" +
+                image.getId() + "/";
+        String userId = "7";
+        String language = "en";
+        WysiwygController.save(expectedContent, componentId, messageId, userId, language, false);
+        language = "fr";
+        expectedContent =
+            "<mark>FR_Content_FileServer_ComponentId=blog974_/componentId/blog974/attachmentId/" +
+                image.getId() + "/";
+        WysiwygController.save(expectedContent, componentId, messageId, userId, language, false);
+
+        ForeignPK resourceSrcTestPK = new ForeignPK(messageId, componentId);
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceSrcTestPK, "fr"), hasSize(1));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceSrcTestPK, "en"), hasSize(1));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceSrcTestPK, "de"), hasSize(0));
+
+        String destComponentId = "kmelia26";
+        String destMessageId = "38";
+        ForeignPK resourceDestTestPK = new ForeignPK(destMessageId, destComponentId);
+        assertThat(listWysiwygs(resourceDestTestPK), hasSize(0));
+
+        // One image
+        for (String lang : I18NHelper.getAllSupportedLanguages()) {
+          assertThat(listImagesWithNoLanguageFallback(resourceSrcTestPK, lang),
+              hasSize(I18NHelper.defaultLanguage.equals(lang) ? 1 : 0));
+          assertThat(listImagesWithNoLanguageFallback(resourceDestTestPK, lang), hasSize(0));
+        }
+
+        assertThat(WysiwygController.load(componentId, messageId, "fr"),
+            is("<mark>FR_Content_FileServer_ComponentId=blog974_" +
+                "/componentId/blog974/attachmentId/" + image.getId() + "/")
+        );
+        assertThat(WysiwygController.load(componentId, messageId, "en"),
+            is("<mark>EN_Content_FileServer_ComponentId=blog974_" +
+                "/componentId/blog974/attachmentId/" + image.getId() + "/")
+        );
+        assertThat(WysiwygController.load(destComponentId, destMessageId, "fr"), is(""));
+        assertThat(WysiwygController.load(destComponentId, destMessageId, "en"), is(""));
+
+        WysiwygController.move(componentId, messageId, destComponentId, destMessageId);
+
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceSrcTestPK, "fr"), hasSize(0));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceSrcTestPK, "en"), hasSize(0));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceSrcTestPK, "de"), hasSize(0));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceDestTestPK, "fr"), hasSize(1));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceDestTestPK, "en"), hasSize(1));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceDestTestPK, "de"), hasSize(0));
+
+        // One image
+        for (String lang : I18NHelper.getAllSupportedLanguages()) {
+          assertThat(listImagesWithNoLanguageFallback(resourceSrcTestPK, lang), hasSize(0));
+          assertThat(listImagesWithNoLanguageFallback(resourceDestTestPK, lang),
+              hasSize(I18NHelper.defaultLanguage.equals(lang) ? 1 : 0));
+        }
+
+        assertThat(WysiwygController.load(componentId, messageId, "fr"), is(""));
+        assertThat(WysiwygController.load(componentId, messageId, "en"), is(""));
+        assertThat(WysiwygController.load(destComponentId, destMessageId, "fr"),
+            is("<mark>FR_Content_FileServer_ComponentId=kmelia26_" +
+                "/componentId/kmelia26/attachmentId/" + image.getId() + "/")
+        );
+        assertThat(WysiwygController.load(destComponentId, destMessageId, "en"),
+            is("<mark>EN_Content_FileServer_ComponentId=kmelia26_" +
+                "/componentId/kmelia26/attachmentId/" + image.getId() + "/")
+        );
+      }
+    }.execute();
+  }
+
+  /**
+   * Test of move method, of class WysiwygController.
+   */
+  @Test
+  public void testMoveWysiwygFRThatIsEmptyENWithImageInJcr() throws Exception {
+    new JcrTest() {
+      @Override
+      public void run() throws Exception {
+        String componentId = "blog974";
+        String messageId = "18";
+        SimpleDocument image = createImageContent(componentId, messageId);
+        String expectedContent =
+            "EN_Content_FileServer_ComponentId=blog974_/componentId/blog974/attachmentId/" +
+                image.getId() + "/";
+        String userId = "7";
+        String language = "en";
+        WysiwygController.save(expectedContent, componentId, messageId, userId, language, false);
+        language = "fr";
+        expectedContent =
+            "<mark>FR_Content_FileServer_ComponentId=blog974_/componentId/blog974/attachmentId/" +
+                image.getId() + "/";
+        WysiwygController.save(expectedContent, componentId, messageId, userId, language, false);
+        // Empty FR wysiwyg ...
+        ForeignPK resourceSrcTestPK = new ForeignPK(messageId, componentId);
+        File frWysiwygFile = new File(
+            listWysiwygsWithNoLanguageFallback(resourceSrcTestPK, "fr").get(0).getAttachmentPath());
+        assertThat(frWysiwygFile.length(), greaterThan(0L));
+        FileUtils.write(frWysiwygFile, "");
+        assertThat(frWysiwygFile.length(), is(0L));
+
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceSrcTestPK, "fr"), hasSize(1));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceSrcTestPK, "en"), hasSize(1));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceSrcTestPK, "de"), hasSize(0));
+
+        String destComponentId = "kmelia26";
+        String destMessageId = "38";
+        ForeignPK resourceDestTestPK = new ForeignPK(destMessageId, destComponentId);
+        SimpleDocumentList<SimpleDocument> wysiwygs = listWysiwygs(resourceDestTestPK);
+        assertThat(wysiwygs, hasSize(0));
+
+        // One image
+        for (String lang : I18NHelper.getAllSupportedLanguages()) {
+          assertThat(listImagesWithNoLanguageFallback(resourceSrcTestPK, lang),
+              hasSize(I18NHelper.defaultLanguage.equals(lang) ? 1 : 0));
+          assertThat(listImagesWithNoLanguageFallback(resourceDestTestPK, lang), hasSize(0));
+        }
+
+        assertThat(WysiwygController.load(componentId, messageId, "fr"),
+            is("EN_Content_FileServer_ComponentId=blog974_" +
+                "/componentId/blog974/attachmentId/" + image.getId() + "/")
+        );
+        assertThat(WysiwygController.load(componentId, messageId, "en"),
+            is("EN_Content_FileServer_ComponentId=blog974_" +
+                "/componentId/blog974/attachmentId/" + image.getId() + "/")
+        );
+        assertThat(WysiwygController.load(destComponentId, destMessageId, "fr"), is(""));
+        assertThat(WysiwygController.load(destComponentId, destMessageId, "en"), is(""));
+
+        WysiwygController.move(componentId, messageId, destComponentId, destMessageId);
+
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceSrcTestPK, "fr"), hasSize(0));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceSrcTestPK, "en"), hasSize(0));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceSrcTestPK, "de"), hasSize(0));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceDestTestPK, "fr"), hasSize(1));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceDestTestPK, "en"), hasSize(1));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceDestTestPK, "de"), hasSize(0));
+
+        // One image
+        for (String lang : I18NHelper.getAllSupportedLanguages()) {
+          assertThat(listImagesWithNoLanguageFallback(resourceSrcTestPK, lang), hasSize(0));
+          assertThat(listImagesWithNoLanguageFallback(resourceDestTestPK, lang),
+              hasSize(I18NHelper.defaultLanguage.equals(lang) ? 1 : 0));
+        }
+
+        assertThat(WysiwygController.load(componentId, messageId, "fr"), is(""));
+        assertThat(WysiwygController.load(componentId, messageId, "en"), is(""));
+        assertThat(WysiwygController.load(destComponentId, destMessageId, "fr"),
+            is("EN_Content_FileServer_ComponentId=kmelia26_" +
+                "/componentId/kmelia26/attachmentId/" + image.getId() + "/")
+        );
+        assertThat(WysiwygController.load(destComponentId, destMessageId, "en"),
+            is("EN_Content_FileServer_ComponentId=kmelia26_" +
+                "/componentId/kmelia26/attachmentId/" + image.getId() + "/")
+        );
+      }
+    }.execute();
+  }
+
+  /**
+   * Test of move method, of class WysiwygController.
+   */
+  @Test
+  public void testMoveWysiwygFRThatIsEmptyENThatIsEmptyWithImageInJcr() throws Exception {
+    new JcrTest() {
+      @Override
+      public void run() throws Exception {
+        String componentId = "blog974";
+        String messageId = "18";
+        SimpleDocument image = createImageContent(componentId, messageId);
+        String expectedContent =
+            "<mark>EN_Content_FileServer_ComponentId=blog974_/componentId/blog974/attachmentId/" +
+                image.getId() + "/";
+        String userId = "7";
+        String language = "en";
+        WysiwygController.save(expectedContent, componentId, messageId, userId, language, false);
+        language = "fr";
+        expectedContent =
+            "<mark>FR_Content_FileServer_ComponentId=blog974_/componentId/blog974/attachmentId/" +
+                image.getId() + "/";
+        WysiwygController.save(expectedContent, componentId, messageId, userId, language, false);
+        // Empty FR wysiwyg ...
+        ForeignPK resourceSrcTestPK = new ForeignPK(messageId, componentId);
+        File frWysiwygFile = new File(
+            listWysiwygsWithNoLanguageFallback(resourceSrcTestPK, "fr").get(0).getAttachmentPath());
+        assertThat(frWysiwygFile.length(), greaterThan(0L));
+        FileUtils.write(frWysiwygFile, "");
+        assertThat(frWysiwygFile.length(), is(0L));
+        // Empty EN wysiwyg ...
+        File enWysiwygFile = new File(
+            listWysiwygsWithNoLanguageFallback(resourceSrcTestPK, "en").get(0).getAttachmentPath());
+        assertThat(enWysiwygFile.length(), greaterThan(0L));
+        FileUtils.write(enWysiwygFile, "");
+        assertThat(enWysiwygFile.length(), is(0L));
+
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceSrcTestPK, "fr"), hasSize(1));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceSrcTestPK, "en"), hasSize(1));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceSrcTestPK, "de"), hasSize(0));
+
+        String destComponentId = "kmelia26";
+        String destMessageId = "38";
+        ForeignPK resourceDestTestPK = new ForeignPK(destMessageId, destComponentId);
+        SimpleDocumentList<SimpleDocument> wysiwygs = listWysiwygs(resourceDestTestPK);
+        assertThat(wysiwygs, hasSize(0));
+
+        // One image
+        for (String lang : I18NHelper.getAllSupportedLanguages()) {
+          assertThat(listImagesWithNoLanguageFallback(resourceSrcTestPK, lang),
+              hasSize(I18NHelper.defaultLanguage.equals(lang) ? 1 : 0));
+          assertThat(listImagesWithNoLanguageFallback(resourceDestTestPK, lang), hasSize(0));
+        }
+
+        assertThat(WysiwygController.load(componentId, messageId, "fr"), is(""));
+        assertThat(WysiwygController.load(componentId, messageId, "en"), is(""));
+        assertThat(WysiwygController.load(destComponentId, destMessageId, "fr"), is(""));
+        assertThat(WysiwygController.load(destComponentId, destMessageId, "en"), is(""));
+
+        WysiwygController.move(componentId, messageId, destComponentId, destMessageId);
+
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceSrcTestPK, "fr"), hasSize(0));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceSrcTestPK, "en"), hasSize(0));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceSrcTestPK, "de"), hasSize(0));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceDestTestPK, "fr"), hasSize(1));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceDestTestPK, "en"), hasSize(1));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceDestTestPK, "de"), hasSize(0));
+
+        // Images moved
+        for (String lang : I18NHelper.getAllSupportedLanguages()) {
+          assertThat(listImagesWithNoLanguageFallback(resourceSrcTestPK, lang), hasSize(0));
+          assertThat(listImagesWithNoLanguageFallback(resourceDestTestPK, lang),
+              hasSize(I18NHelper.defaultLanguage.equals(lang) ? 1 : 0));
+        }
+
+        assertThat(WysiwygController.load(componentId, messageId, "fr"), is(""));
+        assertThat(WysiwygController.load(componentId, messageId, "en"), is(""));
+        assertThat(WysiwygController.load(destComponentId, destMessageId, "fr"), is(""));
+        assertThat(WysiwygController.load(destComponentId, destMessageId, "en"), is(""));
+      }
+    }.execute();
+  }
+
+  /**
+   * Test of load method, of class WysiwygController.
+   */
+  @Test
+  public void testLoadWysiwygThatExistsOnlyInEN() throws Exception {
+    new JcrTest() {
+      @Override
+      public void run() {
+        String componentId = "blog974";
+        String messageId = "18";
+        String expectedContent = "<mark>EN_Content";
+        String userId = "7";
+        String language = "en";
+        WysiwygController.save(expectedContent, componentId, messageId, userId, language, false);
+        // Jcr State
+        ForeignPK resourceTestPK = new ForeignPK(messageId, componentId);
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "fr"), hasSize(0));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "en"), hasSize(1));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "de"), hasSize(0));
+        // Tests
+        assertThat(WysiwygController.load(componentId, messageId, "fr"), is("<mark>EN_Content"));
+        assertThat(WysiwygController.load(componentId, messageId, "en"), is("<mark>EN_Content"));
+      }
+    }.execute();
+  }
+
+  /**
+   * Test of load method, of class WysiwygController.
+   */
+  @Test
+  public void testLoadWysiwygThatDoesNotExist() throws Exception {
+    new JcrTest() {
+      @Override
+      public void run() {
+        String componentId = "blog974";
+        String messageId = "18";
+        // Jcr State
+        ForeignPK resourceTestPK = new ForeignPK(messageId, componentId);
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "fr"), hasSize(0));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "en"), hasSize(0));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "de"), hasSize(0));
+        // Tests
+        assertThat(WysiwygController.load(componentId, messageId, "fr"), is(""));
+        assertThat(WysiwygController.load(componentId, messageId, "en"), is(""));
+      }
+    }.execute();
+  }
+
+  /**
+   * Test of load method, of class WysiwygController.
+   */
+  @Test
+  public void testLoadLegacyFRWysiwyg() throws Exception {
+    new JcrTest() {
+      @Override
+      public void run() throws Exception {
+        String componentId = "blog974";
+        String messageId = "18";
+        createLegacyWysiwygContent(componentId, messageId, "fr", "<mark>LegacyContent");
+        // Jcr State
+        ForeignPK resourceTestPK = new ForeignPK(messageId, componentId);
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "fr"), hasSize(0));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "en"), hasSize(0));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "de"), hasSize(0));
+        // Tests
+        assertThat(WysiwygController.load(componentId, messageId, "fr"), is("<mark>LegacyContent"));
+        assertThat(WysiwygController.load(componentId, messageId, "en"), is("<mark>LegacyContent"));
+      }
+    }.execute();
+  }
+
+
+  /**
+   * Test of load method, of class WysiwygController.
+   */
+  @Test
+  public void testLoadLegacyEmptyFRWysiwyg() throws Exception {
+    new JcrTest() {
+      @Override
+      public void run() throws Exception {
+        String componentId = "blog974";
+        String messageId = "18";
+        createLegacyWysiwygContent(componentId, messageId, "fr", "");
+        // Jcr State
+        ForeignPK resourceTestPK = new ForeignPK(messageId, componentId);
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "fr"), hasSize(0));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "en"), hasSize(0));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "de"), hasSize(0));
+        // Tests
+        assertThat(WysiwygController.load(componentId, messageId, "fr"), is(""));
+        assertThat(WysiwygController.load(componentId, messageId, "en"), is(""));
+      }
+    }.execute();
+  }
+
+  /**
+   * Test of load method, of class WysiwygController.
+   */
+  @Test
+  public void testLoadLegacyEmptyFRWysiwygAndJcrENwysiwyg() throws Exception {
+    new JcrTest() {
+      @Override
+      public void run() throws Exception {
+        String componentId = "blog974";
+        String messageId = "18";
+        WysiwygController.save("ENContent", componentId, messageId, "26", "en", false);
+        createLegacyWysiwygContent(componentId, messageId, "fr", "");
+        // Jcr State
+        ForeignPK resourceTestPK = new ForeignPK(messageId, componentId);
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "fr"), hasSize(0));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "en"), hasSize(1));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "de"), hasSize(0));
+        // Tests
+        /*
+        This test shows that if a not empty document exists into the JCR,
+        then legacy content is never loaded.
+         */
+        assertThat(WysiwygController.load(componentId, messageId, "fr"), is("ENContent"));
+        assertThat(WysiwygController.load(componentId, messageId, "en"), is("ENContent"));
+      }
+    }.execute();
+  }
+
+  /**
+   * Test of load method, of class WysiwygController.
+   */
+  @Test
+  public void testLoadLegacyFRWysiwygAndJcrEmptyENwysiwyg() throws Exception {
+    new JcrTest() {
+      @Override
+      public void run() throws Exception {
+        String componentId = "blog974";
+        String messageId = "18";
+        WysiwygController.save("<mark>ENContent", componentId, messageId, "26", "en", false);
+        createLegacyWysiwygContent(componentId, messageId, "fr", "LegacyContent");
+        // Empty EN wysiwyg ...
+        ForeignPK resourceTestPK = new ForeignPK(messageId, componentId);
+        File enWysiwygFile = new File(
+            listWysiwygsWithNoLanguageFallback(resourceTestPK, "en").get(0).getAttachmentPath());
+        assertThat(enWysiwygFile.length(), greaterThan(0L));
+        FileUtils.write(enWysiwygFile, "");
+        assertThat(enWysiwygFile.length(), is(0L));
+        // Jcr State
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "fr"), hasSize(0));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "en"), hasSize(1));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "de"), hasSize(0));
+        // Tests
+        assertThat(WysiwygController.load(componentId, messageId, "fr"), is("LegacyContent"));
+        assertThat(WysiwygController.load(componentId, messageId, "en"), is("LegacyContent"));
+      }
+    }.execute();
+  }
+
+  /**
+   * Test of load method, of class WysiwygController.
+   */
+  @Test
+  public void testLoadLegacyEmptyFRWysiwygAndJcrEmptyENwysiwyg() throws Exception {
+    new JcrTest() {
+      @Override
+      public void run() throws Exception {
+        String componentId = "blog974";
+        String messageId = "18";
+        WysiwygController.save("<mark>ENContent", componentId, messageId, "26", "en", false);
+        createLegacyWysiwygContent(componentId, messageId, "fr", "");
+        // Empty EN wysiwyg ...
+        ForeignPK resourceTestPK = new ForeignPK(messageId, componentId);
+        File enWysiwygFile = new File(
+            listWysiwygsWithNoLanguageFallback(resourceTestPK, "en").get(0).getAttachmentPath());
+        assertThat(enWysiwygFile.length(), greaterThan(0L));
+        FileUtils.write(enWysiwygFile, "");
+        assertThat(enWysiwygFile.length(), is(0L));
+        // Jcr State
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "fr"), hasSize(0));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "en"), hasSize(1));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "de"), hasSize(0));
+        // Tests
+        assertThat(WysiwygController.load(componentId, messageId, "fr"), is(""));
+        assertThat(WysiwygController.load(componentId, messageId, "en"), is(""));
+      }
+    }.execute();
+  }
+
+  /**
+   * Test of load method, of class WysiwygController.
+   */
+  @Test
+  public void testLoadWysiwyg() throws Exception {
+    new JcrTest() {
+      @Override
+      public void run() {
+        String componentId = "blog974";
+        String messageId = "18";
+        String expectedContent = "EN_Content";
+        String userId = "7";
+        String language = "en";
+        WysiwygController.save(expectedContent, componentId, messageId, userId, language, false);
+        expectedContent = "<mark>FR_Content";
+        language = "fr";
+        WysiwygController.save(expectedContent, componentId, messageId, userId, language, false);
+        // Jcr State
+        ForeignPK resourceTestPK = new ForeignPK(messageId, componentId);
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "fr"), hasSize(1));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "en"), hasSize(1));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "de"), hasSize(0));
+        // Tests
+        assertThat(WysiwygController.load(componentId, messageId, "fr"), is("<mark>FR_Content"));
+        assertThat(WysiwygController.load(componentId, messageId, "en"), is("EN_Content"));
+      }
+    }.execute();
+  }
+
+  /**
+   * Test of load method, of class WysiwygController.
+   */
+  @Test
+  public void testLoadEmptyWysiwygFRAndEmptyENWysiwyg() throws Exception {
+    new JcrTest() {
+      @Override
+      public void run() throws IOException {
+        String componentId = "blog974";
+        String messageId = "18";
+        String expectedContent = "EN_Content";
+        String userId = "7";
+        String language = "en";
+        WysiwygController.save(expectedContent, componentId, messageId, userId, language, false);
+        expectedContent = "<mark>FR_Content";
+        language = "fr";
+        WysiwygController.save(expectedContent, componentId, messageId, userId, language, false);
+        // Empty FR wysiwyg ...
+        ForeignPK resourceTestPK = new ForeignPK(messageId, componentId);
+        File frWysiwygFile = new File(
+            listWysiwygsWithNoLanguageFallback(resourceTestPK, "fr").get(0).getAttachmentPath());
+        assertThat(frWysiwygFile.length(), greaterThan(0L));
+        FileUtils.write(frWysiwygFile, "");
+        assertThat(frWysiwygFile.length(), is(0L));
+        // Empty EN wysiwyg ...
+        File enWysiwygFile = new File(
+            listWysiwygsWithNoLanguageFallback(resourceTestPK, "en").get(0).getAttachmentPath());
+        assertThat(enWysiwygFile.length(), greaterThan(0L));
+        FileUtils.write(enWysiwygFile, "");
+        assertThat(enWysiwygFile.length(), is(0L));
+        // Jcr State
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "fr"), hasSize(1));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "en"), hasSize(1));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "de"), hasSize(0));
+        // Tests
+        assertThat(WysiwygController.load(componentId, messageId, "fr"), is(""));
+        assertThat(WysiwygController.load(componentId, messageId, "en"), is(""));
+      }
+    }.execute();
+  }
+
+  /**
+   * Test of haveGotWysiwygToDisplay method, of class WysiwygController.
+   */
+  @Test
+  public void testHavegotwysiwygtodisplayWysiwygThatExistsOnlyInEN() throws Exception {
+    new JcrTest() {
+      @Override
+      public void run() {
+        String componentId = "blog974";
+        String messageId = "18";
+        String expectedContent = "<mark>EN_Content";
+        String userId = "7";
+        String language = "en";
+        WysiwygController.save(expectedContent, componentId, messageId, userId, language, false);
+        // Jcr State
+        ForeignPK resourceTestPK = new ForeignPK(messageId, componentId);
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "fr"), hasSize(0));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "en"), hasSize(1));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "de"), hasSize(0));
+        // Tests
+        assertThat(WysiwygController.haveGotWysiwygToDisplay(componentId, messageId, "fr"), is(true));
+        assertThat(WysiwygController.haveGotWysiwygToDisplay(componentId, messageId, "en"), is(true));
+      }
+    }.execute();
+  }
+
+  /**
+   * Test of haveGotWysiwygToDisplay method, of class WysiwygController.
+   */
+  @Test
+  public void testHavegotwysiwygtodisplayWysiwygThatDoesNotExist() throws Exception {
+    new JcrTest() {
+      @Override
+      public void run() {
+        String componentId = "blog974";
+        String messageId = "18";
+        // Jcr State
+        ForeignPK resourceTestPK = new ForeignPK(messageId, componentId);
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "fr"), hasSize(0));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "en"), hasSize(0));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "de"), hasSize(0));
+        // Tests
+        assertThat(WysiwygController.haveGotWysiwygToDisplay(componentId, messageId, "fr"), is(false));
+        assertThat(WysiwygController.haveGotWysiwygToDisplay(componentId, messageId, "en"), is(false));
+      }
+    }.execute();
+  }
+
+  /**
+   * Test of haveGotWysiwygToDisplay method, of class WysiwygController.
+   */
+  @Test
+  public void testHavegotwysiwygtodisplayLegacyFRWysiwyg() throws Exception {
+    new JcrTest() {
+      @Override
+      public void run() throws Exception {
+        String componentId = "blog974";
+        String messageId = "18";
+        createLegacyWysiwygContent(componentId, messageId, "fr", "<mark>LegacyContent");
+        // Jcr State
+        ForeignPK resourceTestPK = new ForeignPK(messageId, componentId);
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "fr"), hasSize(0));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "en"), hasSize(0));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "de"), hasSize(0));
+        // Tests
+        assertThat(WysiwygController.haveGotWysiwygToDisplay(componentId, messageId, "fr"), is(true));
+        assertThat(WysiwygController.haveGotWysiwygToDisplay(componentId, messageId, "en"), is(true));
+      }
+    }.execute();
+  }
+
+
+  /**
+   * Test of haveGotWysiwygToDisplay method, of class WysiwygController.
+   */
+  @Test
+  public void testHavegotwysiwygtodisplayLegacyEmptyFRWysiwyg() throws Exception {
+    new JcrTest() {
+      @Override
+      public void run() throws Exception {
+        String componentId = "blog974";
+        String messageId = "18";
+        createLegacyWysiwygContent(componentId, messageId, "fr", "");
+        // Jcr State
+        ForeignPK resourceTestPK = new ForeignPK(messageId, componentId);
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "fr"), hasSize(0));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "en"), hasSize(0));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "de"), hasSize(0));
+        // Tests
+        assertThat(WysiwygController.haveGotWysiwygToDisplay(componentId, messageId, "fr"), is(false));
+        assertThat(WysiwygController.haveGotWysiwygToDisplay(componentId, messageId, "en"), is(false));
+      }
+    }.execute();
+  }
+
+  /**
+   * Test of haveGotWysiwygToDisplay method, of class WysiwygController.
+   */
+  @Test
+  public void testHavegotwysiwygtodisplayLegacyEmptyFRWysiwygAndJcrENwysiwyg() throws Exception {
+    new JcrTest() {
+      @Override
+      public void run() throws Exception {
+        String componentId = "blog974";
+        String messageId = "18";
+        WysiwygController.save("ENContent", componentId, messageId, "26", "en", false);
+        createLegacyWysiwygContent(componentId, messageId, "fr", "");
+        // Jcr State
+        ForeignPK resourceTestPK = new ForeignPK(messageId, componentId);
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "fr"), hasSize(0));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "en"), hasSize(1));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "de"), hasSize(0));
+        // Tests
+        /*
+        This test shows that if a not empty document exists into the JCR,
+        then legacy content is never haveGotWysiwygToDisplayed.
+         */
+        assertThat(WysiwygController.haveGotWysiwygToDisplay(componentId, messageId, "fr"), is(true));
+        assertThat(WysiwygController.haveGotWysiwygToDisplay(componentId, messageId, "en"), is(true));
+      }
+    }.execute();
+  }
+
+  /**
+   * Test of haveGotWysiwygToDisplay method, of class WysiwygController.
+   */
+  @Test
+  public void testHavegotwysiwygtodisplayLegacyFRWysiwygAndJcrEmptyENwysiwyg() throws Exception {
+    new JcrTest() {
+      @Override
+      public void run() throws Exception {
+        String componentId = "blog974";
+        String messageId = "18";
+        WysiwygController.save("<mark>ENContent", componentId, messageId, "26", "en", false);
+        createLegacyWysiwygContent(componentId, messageId, "fr", "LegacyContent");
+        // Empty EN wysiwyg ...
+        ForeignPK resourceTestPK = new ForeignPK(messageId, componentId);
+        File enWysiwygFile = new File(
+            listWysiwygsWithNoLanguageFallback(resourceTestPK, "en").get(0).getAttachmentPath());
+        assertThat(enWysiwygFile.length(), greaterThan(0L));
+        FileUtils.write(enWysiwygFile, "");
+        assertThat(enWysiwygFile.length(), is(0L));
+        // Jcr State
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "fr"), hasSize(0));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "en"), hasSize(1));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "de"), hasSize(0));
+        // Tests
+        assertThat(WysiwygController.haveGotWysiwygToDisplay(componentId, messageId, "fr"), is(true));
+        assertThat(WysiwygController.haveGotWysiwygToDisplay(componentId, messageId, "en"), is(true));
+      }
+    }.execute();
+  }
+
+  /**
+   * Test of haveGotWysiwygToDisplay method, of class WysiwygController.
+   */
+  @Test
+  public void testHavegotwysiwygtodisplayLegacyEmptyFRWysiwygAndJcrEmptyENwysiwyg() throws Exception {
+    new JcrTest() {
+      @Override
+      public void run() throws Exception {
+        String componentId = "blog974";
+        String messageId = "18";
+        WysiwygController.save("<mark>ENContent", componentId, messageId, "26", "en", false);
+        createLegacyWysiwygContent(componentId, messageId, "fr", "");
+        // Empty EN wysiwyg ...
+        ForeignPK resourceTestPK = new ForeignPK(messageId, componentId);
+        File enWysiwygFile = new File(
+            listWysiwygsWithNoLanguageFallback(resourceTestPK, "en").get(0).getAttachmentPath());
+        assertThat(enWysiwygFile.length(), greaterThan(0L));
+        FileUtils.write(enWysiwygFile, "");
+        assertThat(enWysiwygFile.length(), is(0L));
+        // Jcr State
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "fr"), hasSize(0));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "en"), hasSize(1));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "de"), hasSize(0));
+        // Tests
+        assertThat(WysiwygController.haveGotWysiwygToDisplay(componentId, messageId, "fr"), is(false));
+        assertThat(WysiwygController.haveGotWysiwygToDisplay(componentId, messageId, "en"), is(false));
+      }
+    }.execute();
+  }
+
+  /**
+   * Test of haveGotWysiwygToDisplay method, of class WysiwygController.
+   */
+  @Test
+  public void testHavegotwysiwygtodisplayWysiwyg() throws Exception {
+    new JcrTest() {
+      @Override
+      public void run() {
+        String componentId = "blog974";
+        String messageId = "18";
+        String expectedContent = "EN_Content";
+        String userId = "7";
+        String language = "en";
+        WysiwygController.save(expectedContent, componentId, messageId, userId, language, false);
+        expectedContent = "<mark>FR_Content";
+        language = "fr";
+        WysiwygController.save(expectedContent, componentId, messageId, userId, language, false);
+        // Jcr State
+        ForeignPK resourceTestPK = new ForeignPK(messageId, componentId);
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "fr"), hasSize(1));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "en"), hasSize(1));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "de"), hasSize(0));
+        // Tests
+        assertThat(WysiwygController.haveGotWysiwygToDisplay(componentId, messageId, "fr"), is(true));
+        assertThat(WysiwygController.haveGotWysiwygToDisplay(componentId, messageId, "en"), is(true));
+      }
+    }.execute();
+  }
+
+  /**
+   * Test of haveGotWysiwygToDisplay method, of class WysiwygController.
+   */
+  @Test
+  public void testHavegotwysiwygtodisplayEmptyWysiwygFRAndEmptyENWysiwyg() throws Exception {
+    new JcrTest() {
+      @Override
+      public void run() throws IOException {
+        String componentId = "blog974";
+        String messageId = "18";
+        String expectedContent = "EN_Content";
+        String userId = "7";
+        String language = "en";
+        WysiwygController.save(expectedContent, componentId, messageId, userId, language, false);
+        expectedContent = "<mark>FR_Content";
+        language = "fr";
+        WysiwygController.save(expectedContent, componentId, messageId, userId, language, false);
+        // Empty FR wysiwyg ...
+        ForeignPK resourceTestPK = new ForeignPK(messageId, componentId);
+        File frWysiwygFile = new File(
+            listWysiwygsWithNoLanguageFallback(resourceTestPK, "fr").get(0).getAttachmentPath());
+        assertThat(frWysiwygFile.length(), greaterThan(0L));
+        FileUtils.write(frWysiwygFile, "");
+        assertThat(frWysiwygFile.length(), is(0L));
+        // Empty EN wysiwyg ...
+        File enWysiwygFile = new File(
+            listWysiwygsWithNoLanguageFallback(resourceTestPK, "en").get(0).getAttachmentPath());
+        assertThat(enWysiwygFile.length(), greaterThan(0L));
+        FileUtils.write(enWysiwygFile, "");
+        assertThat(enWysiwygFile.length(), is(0L));
+        // Jcr State
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "fr"), hasSize(1));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "en"), hasSize(1));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "de"), hasSize(0));
+        // Tests
+        assertThat(WysiwygController.haveGotWysiwygToDisplay(componentId, messageId, "fr"), is(false));
+        assertThat(WysiwygController.haveGotWysiwygToDisplay(componentId, messageId, "en"), is(false));
+      }
+    }.execute();
+  }
+
+  /**
+   * Test of haveGotWysiwyg method, of class WysiwygController.
+   */
+  @Test
+  public void testHavegotwysiwygWysiwygThatExistsOnlyInEN() throws Exception {
+    new JcrTest() {
+      @Override
+      public void run() {
+        String componentId = "blog974";
+        String messageId = "18";
+        String expectedContent = "<mark>EN_Content";
+        String userId = "7";
+        String language = "en";
+        WysiwygController.save(expectedContent, componentId, messageId, userId, language, false);
+        // Jcr State
+        ForeignPK resourceTestPK = new ForeignPK(messageId, componentId);
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "fr"), hasSize(0));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "en"), hasSize(1));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "de"), hasSize(0));
+        // Tests
+        assertThat(WysiwygController.haveGotWysiwyg(componentId, messageId, "fr"), is(true));
+        assertThat(WysiwygController.haveGotWysiwyg(componentId, messageId, "en"), is(true));
+      }
+    }.execute();
+  }
+
+  /**
+   * Test of haveGotWysiwyg method, of class WysiwygController.
+   */
+  @Test
+  public void testHavegotwysiwygWysiwygThatDoesNotExist() throws Exception {
+    new JcrTest() {
+      @Override
+      public void run() {
+        String componentId = "blog974";
+        String messageId = "18";
+        // Jcr State
+        ForeignPK resourceTestPK = new ForeignPK(messageId, componentId);
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "fr"), hasSize(0));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "en"), hasSize(0));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "de"), hasSize(0));
+        // Tests
+        assertThat(WysiwygController.haveGotWysiwyg(componentId, messageId, "fr"), is(false));
+        assertThat(WysiwygController.haveGotWysiwyg(componentId, messageId, "en"), is(false));
+      }
+    }.execute();
+  }
+
+  /**
+   * Test of haveGotWysiwyg method, of class WysiwygController.
+   */
+  @Test
+  public void testHavegotwysiwygLegacyFRWysiwyg() throws Exception {
+    new JcrTest() {
+      @Override
+      public void run() throws Exception {
+        String componentId = "blog974";
+        String messageId = "18";
+        createLegacyWysiwygContent(componentId, messageId, "fr", "<mark>LegacyContent");
+        // Jcr State
+        ForeignPK resourceTestPK = new ForeignPK(messageId, componentId);
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "fr"), hasSize(0));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "en"), hasSize(0));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "de"), hasSize(0));
+        // Tests
+        assertThat(WysiwygController.haveGotWysiwyg(componentId, messageId, "fr"), is(true));
+        assertThat(WysiwygController.haveGotWysiwyg(componentId, messageId, "en"), is(true));
+      }
+    }.execute();
+  }
+
+
+  /**
+   * Test of haveGotWysiwyg method, of class WysiwygController.
+   */
+  @Test
+  public void testHavegotwysiwygLegacyEmptyFRWysiwyg() throws Exception {
+    new JcrTest() {
+      @Override
+      public void run() throws Exception {
+        String componentId = "blog974";
+        String messageId = "18";
+        createLegacyWysiwygContent(componentId, messageId, "fr", "");
+        // Jcr State
+        ForeignPK resourceTestPK = new ForeignPK(messageId, componentId);
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "fr"), hasSize(0));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "en"), hasSize(0));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "de"), hasSize(0));
+        // Tests
+        assertThat(WysiwygController.haveGotWysiwyg(componentId, messageId, "fr"), is(false));
+        assertThat(WysiwygController.haveGotWysiwyg(componentId, messageId, "en"), is(false));
+      }
+    }.execute();
+  }
+
+  /**
+   * Test of haveGotWysiwyg method, of class WysiwygController.
+   */
+  @Test
+  public void testHavegotwysiwygLegacyEmptyFRWysiwygAndJcrENwysiwyg() throws Exception {
+    new JcrTest() {
+      @Override
+      public void run() throws Exception {
+        String componentId = "blog974";
+        String messageId = "18";
+        WysiwygController.save("ENContent", componentId, messageId, "26", "en", false);
+        createLegacyWysiwygContent(componentId, messageId, "fr", "");
+        // Jcr State
+        ForeignPK resourceTestPK = new ForeignPK(messageId, componentId);
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "fr"), hasSize(0));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "en"), hasSize(1));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "de"), hasSize(0));
+        // Tests
+        /*
+        This test shows that if a not empty document exists into the JCR,
+        then legacy content is never haveGotWysiwyged.
+         */
+        assertThat(WysiwygController.haveGotWysiwyg(componentId, messageId, "fr"), is(true));
+        assertThat(WysiwygController.haveGotWysiwyg(componentId, messageId, "en"), is(true));
+      }
+    }.execute();
+  }
+
+  /**
+   * Test of haveGotWysiwyg method, of class WysiwygController.
+   */
+  @Test
+  public void testHavegotwysiwygLegacyFRWysiwygAndJcrEmptyENwysiwyg() throws Exception {
+    new JcrTest() {
+      @Override
+      public void run() throws Exception {
+        String componentId = "blog974";
+        String messageId = "18";
+        WysiwygController.save("<mark>ENContent", componentId, messageId, "26", "en", false);
+        createLegacyWysiwygContent(componentId, messageId, "fr", "LegacyContent");
+        // Empty EN wysiwyg ...
+        ForeignPK resourceTestPK = new ForeignPK(messageId, componentId);
+        File enWysiwygFile = new File(
+            listWysiwygsWithNoLanguageFallback(resourceTestPK, "en").get(0).getAttachmentPath());
+        assertThat(enWysiwygFile.length(), greaterThan(0L));
+        FileUtils.write(enWysiwygFile, "");
+        assertThat(enWysiwygFile.length(), is(0L));
+        // Jcr State
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "fr"), hasSize(0));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "en"), hasSize(1));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "de"), hasSize(0));
+        // Tests
+        assertThat(WysiwygController.haveGotWysiwyg(componentId, messageId, "fr"), is(true));
+        assertThat(WysiwygController.haveGotWysiwyg(componentId, messageId, "en"), is(true));
+      }
+    }.execute();
+  }
+
+  /**
+   * Test of haveGotWysiwyg method, of class WysiwygController.
+   */
+  @Test
+  public void testHavegotwysiwygLegacyEmptyFRWysiwygAndJcrEmptyENwysiwyg() throws Exception {
+    new JcrTest() {
+      @Override
+      public void run() throws Exception {
+        String componentId = "blog974";
+        String messageId = "18";
+        WysiwygController.save("<mark>ENContent", componentId, messageId, "26", "en", false);
+        createLegacyWysiwygContent(componentId, messageId, "fr", "");
+        // Empty EN wysiwyg ...
+        ForeignPK resourceTestPK = new ForeignPK(messageId, componentId);
+        File enWysiwygFile = new File(
+            listWysiwygsWithNoLanguageFallback(resourceTestPK, "en").get(0).getAttachmentPath());
+        assertThat(enWysiwygFile.length(), greaterThan(0L));
+        FileUtils.write(enWysiwygFile, "");
+        assertThat(enWysiwygFile.length(), is(0L));
+        // Jcr State
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "fr"), hasSize(0));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "en"), hasSize(1));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "de"), hasSize(0));
+        // Tests
+        assertThat(WysiwygController.haveGotWysiwyg(componentId, messageId, "fr"), is(false));
+        assertThat(WysiwygController.haveGotWysiwyg(componentId, messageId, "en"), is(false));
+      }
+    }.execute();
+  }
+
+  /**
+   * Test of haveGotWysiwyg method, of class WysiwygController.
+   */
+  @Test
+  public void testHavegotwysiwygWysiwyg() throws Exception {
+    new JcrTest() {
+      @Override
+      public void run() {
+        String componentId = "blog974";
+        String messageId = "18";
+        String expectedContent = "EN_Content";
+        String userId = "7";
+        String language = "en";
+        WysiwygController.save(expectedContent, componentId, messageId, userId, language, false);
+        expectedContent = "<mark>FR_Content";
+        language = "fr";
+        WysiwygController.save(expectedContent, componentId, messageId, userId, language, false);
+        // Jcr State
+        ForeignPK resourceTestPK = new ForeignPK(messageId, componentId);
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "fr"), hasSize(1));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "en"), hasSize(1));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "de"), hasSize(0));
+        // Tests
+        assertThat(WysiwygController.haveGotWysiwyg(componentId, messageId, "fr"), is(true));
+        assertThat(WysiwygController.haveGotWysiwyg(componentId, messageId, "en"), is(true));
+      }
+    }.execute();
+  }
+
+  /**
+   * Test of haveGotWysiwyg method, of class WysiwygController.
+   */
+  @Test
+  public void testHavegotwysiwygEmptyWysiwygFRAndEmptyENWysiwyg() throws Exception {
+    new JcrTest() {
+      @Override
+      public void run() throws IOException {
+        String componentId = "blog974";
+        String messageId = "18";
+        String expectedContent = "EN_Content";
+        String userId = "7";
+        String language = "en";
+        WysiwygController.save(expectedContent, componentId, messageId, userId, language, false);
+        expectedContent = "<mark>FR_Content";
+        language = "fr";
+        WysiwygController.save(expectedContent, componentId, messageId, userId, language, false);
+        // Empty FR wysiwyg ...
+        ForeignPK resourceTestPK = new ForeignPK(messageId, componentId);
+        File frWysiwygFile = new File(
+            listWysiwygsWithNoLanguageFallback(resourceTestPK, "fr").get(0).getAttachmentPath());
+        assertThat(frWysiwygFile.length(), greaterThan(0L));
+        FileUtils.write(frWysiwygFile, "");
+        assertThat(frWysiwygFile.length(), is(0L));
+        // Empty EN wysiwyg ...
+        File enWysiwygFile = new File(
+            listWysiwygsWithNoLanguageFallback(resourceTestPK, "en").get(0).getAttachmentPath());
+        assertThat(enWysiwygFile.length(), greaterThan(0L));
+        FileUtils.write(enWysiwygFile, "");
+        assertThat(enWysiwygFile.length(), is(0L));
+        // Jcr State
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "fr"), hasSize(1));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "en"), hasSize(1));
+        assertThat(listWysiwygsWithNoLanguageFallback(resourceTestPK, "de"), hasSize(0));
+        // Tests
+        assertThat(WysiwygController.haveGotWysiwyg(componentId, messageId, "fr"), is(false));
+        assertThat(WysiwygController.haveGotWysiwyg(componentId, messageId, "en"), is(false));
+      }
+    }.execute();
+  }
+
+  private void createLegacyWysiwygContent(String componentId, String resourceId, String language,
+      String content) throws Exception {
+    File legacyWysiwyg = FileUtils
+        .getFile(FileRepositoryManager.getAbsolutePath(componentId), "Attachment", "wysiwyg",
+            resourceId + "wysiwyg_" + language + ".txt");
+    FileUtils.write(legacyWysiwyg, content);
+  }
+
+  private SimpleDocument createImageContent(String componentId, String resourceId)
+      throws Exception {
+    SimpleDocument image =
+        new SimpleDocument(new SimpleDocumentPK("-1", componentId), resourceId, 0, false,
+            new SimpleAttachment("imageFileName", I18NHelper.defaultLanguage, "imageTitle",
+                "imageDescription", 0, MimeTypes.PLAIN_TEXT_MIME_TYPE, "1", new Date(), null)
+        );
+    image.setDocumentType(DocumentType.image);
+    return AttachmentServiceFactory.getAttachmentService()
+        .createAttachment(image, new ByteArrayInputStream("ImageContent".getBytes()));
+  }
+
+  /**
+   * Test of createFileAndAttachment method, of class WysiwygController.
+   */
+  @Test
+  public void testCreateWysiwyg() throws Exception {
+    new JcrTest() {
+      @Override
+      public void run() {
+        String componentId = "blog974";
+        String messageId = "18";
+        String expectedContent = "EN_Content";
+        String userId = "7";
+        String language = "en";
+        ForeignPK resourceTestPK = new ForeignPK(messageId, componentId);
+        List<SimpleDocument> wysiwygs = listWysiwygs(resourceTestPK);
+        assertThat(wysiwygs, hasSize(0));
+        assertThat(WysiwygController.load(componentId, messageId, language), isEmptyString());
+        WysiwygController
+            .createFileAndAttachment(expectedContent, resourceTestPK, userId, language);
+        String content = WysiwygController.load(componentId, messageId, language);
+        assertThat(content, is(expectedContent));
+        List<SimpleDocument> lockedFiles =
+            AttachmentServiceFactory.getAttachmentService().listDocumentsLockedByUser(userId, null);
+        assertThat(lockedFiles, is(notNullValue()));
+        assertThat(lockedFiles, hasSize(0));
+
+        wysiwygs = listWysiwygs(resourceTestPK);
+        assertThat(wysiwygs, hasSize(1));
+
+        expectedContent = "FR_Content";
+        language = "fr";
+        WysiwygController
+            .createFileAndAttachment(expectedContent, resourceTestPK, userId, language);
+
+        wysiwygs = listWysiwygs(resourceTestPK);
+        assertThat(wysiwygs, hasSize(2));
+        assertThat(WysiwygController.load(componentId, messageId, "fr"), is("FR_Content"));
+        assertThat(WysiwygController.load(componentId, messageId, "en"), is("EN_Content"));
+      }
+    }.execute();
+  }
+
+  private SimpleDocumentList<SimpleDocument> listWysiwygs(ForeignPK foreignPK) {
+    return AttachmentServiceFactory.getAttachmentService()
+        .listDocumentsByForeignKeyAndType(foreignPK, DocumentType.wysiwyg, null);
+  }
+
+  private SimpleDocumentList<SimpleDocument> listImages(ForeignPK foreignPK) {
+    return AttachmentServiceFactory.getAttachmentService()
+        .listDocumentsByForeignKeyAndType(foreignPK, DocumentType.image, null);
+  }
+
+  private SimpleDocumentList<SimpleDocument> listWysiwygsWithNoLanguageFallback(ForeignPK foreignPK,
+      String language) {
+    return AttachmentServiceFactory.getAttachmentService()
+        .listDocumentsByForeignKeyAndType(foreignPK, DocumentType.wysiwyg, language)
+        .removeLanguageFallbacks();
+  }
+
+  private SimpleDocumentList<SimpleDocument> listImagesWithNoLanguageFallback(ForeignPK foreignPK,
+      String language) {
+    return AttachmentServiceFactory.getAttachmentService()
+        .listDocumentsByForeignKeyAndType(foreignPK, DocumentType.image, language)
+        .removeLanguageFallbacks();
+  }
+
+  /**
+   * Test of save method, of class WysiwygController.
+   */
+  @Test
+  public void testSaveWysiwyg() throws Exception {
+    new JcrTest() {
+      @Override
+      public void run() {
+        String componentId = "blog974";
+        String messageId = "18";
+        String expectedContent = "EN_Content";
+        String userId = "7";
+        String language = "en";
+        ForeignPK resourceTestPK = new ForeignPK(messageId, componentId);
+        List<SimpleDocument> wysiwygs = listWysiwygs(resourceTestPK);
+        assertThat(wysiwygs, hasSize(0));
+        assertThat(WysiwygController.load(componentId, messageId, language), isEmptyString());
+        WysiwygController.save(expectedContent, componentId, messageId, userId, language, false);
+        String content = WysiwygController.load(componentId, messageId, language);
+        assertThat(content, is(expectedContent));
+        List<SimpleDocument> lockedFiles =
+            AttachmentServiceFactory.getAttachmentService().listDocumentsLockedByUser(userId, null);
+        assertThat(lockedFiles, is(notNullValue()));
+        assertThat(lockedFiles, hasSize(0));
+
+        wysiwygs = listWysiwygs(resourceTestPK);
+        assertThat(wysiwygs, hasSize(1));
+
+        expectedContent = "FR_Content";
+        language = "fr";
+        WysiwygController.save(expectedContent, componentId, messageId, userId, language, false);
+
+        wysiwygs = listWysiwygs(resourceTestPK);
+        assertThat(wysiwygs, hasSize(1));
+        assertThat(WysiwygController.load(componentId, messageId, "fr"), is("FR_Content"));
+        assertThat(WysiwygController.load(componentId, messageId, "en"), is("EN_Content"));
+      }
+    }.execute();
+  }
+
+  /**
+   * Test of save method, of class WysiwygController.
+   */
+  @Test
+  public void testSaveEmptyWysiwyg() throws Exception {
+    new JcrTest() {
+      @Override
+      public void run() {
+        String componentId = "blog974";
+        String messageId = "18";
+        String expectedContent = "";
+        String userId = "7";
+        String language = "en";
+        WysiwygController.save(expectedContent, componentId, messageId, userId, language, false);
+
+        expectedContent = "";
+        language = "fr";
+        WysiwygController.save(expectedContent, componentId, messageId, userId, language, false);
+
+        ForeignPK resourceTestPK = new ForeignPK(messageId, componentId);
+        List<SimpleDocument> wysiwygs = listWysiwygs(resourceTestPK);
+        assertThat(wysiwygs, hasSize(0));
+        assertThat(WysiwygController.load(componentId, messageId, "fr"), is(""));
+        assertThat(WysiwygController.load(componentId, messageId, "en"), is(""));
+      }
+    }.execute();
+  }
+
+  /**
+   * Test of save method, of class WysiwygController.
+   */
+  @Test
+  public void testSaveWysiwygThenUpdateIt() throws Exception {
+    new JcrTest() {
+      @Override
+      public void run() {
+        String componentId = "blog974";
+        String messageId = "18";
+        String expectedContent = "EN_Content";
+        String userId = "7";
+        String language = "en";
+        WysiwygController.save(expectedContent, componentId, messageId, userId, language, false);
+
+        expectedContent = "FR_Content";
+        language = "fr";
+        WysiwygController.save(expectedContent, componentId, messageId, userId, language, false);
+
+        ForeignPK resourceTestPK = new ForeignPK(messageId, componentId);
+        List<SimpleDocument> wysiwygs = listWysiwygs(resourceTestPK);
+        assertThat(wysiwygs, hasSize(1));
+        assertThat(WysiwygController.load(componentId, messageId, "fr"), is("FR_Content"));
+        assertThat(WysiwygController.load(componentId, messageId, "en"), is("EN_Content"));
+
+        WysiwygController
+            .save(expectedContent + "_updated", componentId, messageId, userId, language, false);
+        wysiwygs = listWysiwygs(resourceTestPK);
+        assertThat(wysiwygs, hasSize(1));
+        assertThat(WysiwygController.load(componentId, messageId, "fr"), is("FR_Content_updated"));
+        assertThat(WysiwygController.load(componentId, messageId, "en"), is("EN_Content"));
+      }
+    }.execute();
+  }
+
+  /**
+   * Test of save method, of class WysiwygController.
+   */
+  @Test
+  public void testSaveWysiwygThenUpdateItWithEmptyOne() throws Exception {
+    new JcrTest() {
+      @Override
+      public void run() {
+        String componentId = "blog974";
+        String messageId = "18";
+        String expectedContent = "EN_Content";
+        String userId = "7";
+        String language = "en";
+        WysiwygController.save(expectedContent, componentId, messageId, userId, language, false);
+
+        expectedContent = "FR_Content";
+        language = "fr";
+        WysiwygController.save(expectedContent, componentId, messageId, userId, language, false);
+
+        ForeignPK resourceTestPK = new ForeignPK(messageId, componentId);
+        List<SimpleDocument> wysiwygs = listWysiwygs(resourceTestPK);
+        assertThat(wysiwygs, hasSize(1));
+        assertThat(WysiwygController.load(componentId, messageId, "fr"), is("FR_Content"));
+        assertThat(WysiwygController.load(componentId, messageId, "en"), is("EN_Content"));
+
+        WysiwygController.save("", componentId, messageId, userId, language, false);
+        wysiwygs = listWysiwygs(resourceTestPK);
+        assertThat(wysiwygs, hasSize(1));
+        assertThat(WysiwygController.load(componentId, messageId, "fr"), is("EN_Content"));
+        assertThat(WysiwygController.load(componentId, messageId, "en"), is("EN_Content"));
+
+        language = "en";
+        WysiwygController.save("", componentId, messageId, userId, language, false);
+        wysiwygs = listWysiwygs(resourceTestPK);
+        assertThat(wysiwygs, hasSize(0));
+        assertThat(WysiwygController.load(componentId, messageId, "fr"), is(""));
+        assertThat(WysiwygController.load(componentId, messageId, "en"), is(""));
+      }
+    }.execute();
+  }
+
+  /**
+   * Test of save method, of class WysiwygController.
+   */
+  @Test
+  public void testSaveVersionedWysiwygThenUpdateItWithEmptyOne() throws Exception {
+    new JcrTest() {
+      @Override
+      public void run() {
+        String componentId = "blog974";
+        String messageId = "18";
+        String expectedContent = "EN_Content";
+        String userId = "7";
+        String language = "en";
+        WysiwygController.save(expectedContent, componentId, messageId, userId, language, false);
+
+        expectedContent = "FR_Content";
+        language = "fr";
+        WysiwygController.save(expectedContent, componentId, messageId, userId, language, false);
+
+        ForeignPK resourceTestPK = new ForeignPK(messageId, componentId);
+        List<SimpleDocument> wysiwygs = listWysiwygs(resourceTestPK);
+        assertThat(wysiwygs, hasSize(1));
+        assertThat(WysiwygController.load(componentId, messageId, "fr"), is("FR_Content"));
+        assertThat(WysiwygController.load(componentId, messageId, "en"), is("EN_Content"));
+
+        AttachmentServiceFactory.getAttachmentService()
+            .changeVersionState(wysiwygs.get(0).getPk(), "Versioned test");
+
+        expectedContent = "FR_Content_updated";
+        language = "fr";
+        WysiwygController.save(expectedContent, componentId, messageId, userId, language, false);
+
+        expectedContent = "EN_Content_updated";
+        language = "en";
+        WysiwygController.save(expectedContent, componentId, messageId, userId, language, false);
+
+        wysiwygs = listWysiwygs(resourceTestPK);
+        assertThat(wysiwygs, hasSize(1));
+        assertThat(wysiwygs.get(0), instanceOf(HistorisedDocument.class));
+        assertThat(WysiwygController.load(componentId, messageId, "fr"), is("FR_Content_updated"));
+        assertThat(WysiwygController.load(componentId, messageId, "en"), is("EN_Content_updated"));
+
+        language = "fr";
+        WysiwygController.save("", componentId, messageId, userId, language, false);
+        wysiwygs = listWysiwygs(resourceTestPK);
+        assertThat(wysiwygs, hasSize(1));
+        assertThat(wysiwygs.get(0), instanceOf(HistorisedDocument.class));
+        assertThat(WysiwygController.load(componentId, messageId, "fr"), is("EN_Content_updated"));
+        assertThat(WysiwygController.load(componentId, messageId, "en"), is("EN_Content_updated"));
+
+        language = "en";
+        WysiwygController.save("", componentId, messageId, userId, language, false);
+        wysiwygs = listWysiwygs(resourceTestPK);
+        assertThat(wysiwygs, hasSize(0));
+        assertThat(WysiwygController.load(componentId, messageId, "fr"), is(""));
+        assertThat(WysiwygController.load(componentId, messageId, "en"), is(""));
+      }
+    }.execute();
   }
 
   @Test
@@ -228,11 +2012,11 @@ public class WysiwygControllerTest {
     try {
       String content = IOUtils.toString(in);
       String result = IOUtils.toString(resultIn);
-      SimpleDocumentPK oldPk = new SimpleDocumentPK("dd99f10b-0640-40d3-9ef4-8b84d29a7c85",
-          "kmelia1");
+      SimpleDocumentPK oldPk =
+          new SimpleDocumentPK("dd99f10b-0640-40d3-9ef4-8b84d29a7c85", "kmelia1");
       oldPk.setOldSilverpeasId(34L);
-      SimpleDocumentPK newPk = new SimpleDocumentPK("f2eb803f-cb46-4988-b89d-045c4e846da4",
-          "kmelia1");
+      SimpleDocumentPK newPk =
+          new SimpleDocumentPK("f2eb803f-cb46-4988-b89d-045c4e846da4", "kmelia1");
       newPk.setOldSilverpeasId(41L);
       String move = WysiwygController.replaceInternalImageId(content, oldPk, newPk);
       assertThat(move, is(result));
@@ -249,11 +2033,11 @@ public class WysiwygControllerTest {
     try {
       String content = IOUtils.toString(in);
       String result = IOUtils.toString(resultIn);
-      SimpleDocumentPK oldPk = new SimpleDocumentPK("359d2924-b6c6-461c-a459-2eef38f12c3c",
-          "kmelia1");
+      SimpleDocumentPK oldPk =
+          new SimpleDocumentPK("359d2924-b6c6-461c-a459-2eef38f12c3c", "kmelia1");
       oldPk.setOldSilverpeasId(34L);
-      SimpleDocumentPK newPk = new SimpleDocumentPK("f2eb803f-cb46-4988-b89d-045c4e846da4",
-          "kmelia18");
+      SimpleDocumentPK newPk =
+          new SimpleDocumentPK("f2eb803f-cb46-4988-b89d-045c4e846da4", "kmelia18");
       newPk.setOldSilverpeasId(41L);
       String move = WysiwygController.replaceInternalImageId(content, oldPk, newPk);
       assertThat(move, is(result));

--- a/web-core/src/test/java/org/silverpeas/attachment/web/MockBinaryAttachmentService.java
+++ b/web-core/src/test/java/org/silverpeas/attachment/web/MockBinaryAttachmentService.java
@@ -23,6 +23,20 @@
  */
 package org.silverpeas.attachment.web;
 
+import com.silverpeas.util.ForeignPK;
+import com.silverpeas.util.MimeTypes;
+import com.stratelia.webactiv.util.WAPrimaryKey;
+import org.apache.commons.io.IOUtils;
+import org.silverpeas.attachment.AttachmentException;
+import org.silverpeas.attachment.AttachmentService;
+import org.silverpeas.attachment.model.DocumentType;
+import org.silverpeas.attachment.model.SimpleAttachment;
+import org.silverpeas.attachment.model.SimpleDocument;
+import org.silverpeas.attachment.model.SimpleDocumentPK;
+import org.silverpeas.attachment.model.UnlockContext;
+import org.silverpeas.attachment.util.SimpleDocumentList;
+import org.silverpeas.search.indexEngine.model.FullIndexEntry;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -32,22 +46,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
-import org.silverpeas.attachment.AttachmentException;
-import org.silverpeas.attachment.AttachmentService;
-import org.silverpeas.attachment.model.DocumentType;
-import org.silverpeas.attachment.model.SimpleAttachment;
-import org.silverpeas.attachment.model.SimpleDocument;
-import org.silverpeas.attachment.model.SimpleDocumentPK;
-import org.silverpeas.attachment.model.UnlockContext;
-import org.silverpeas.search.indexEngine.model.FullIndexEntry;
-
-import com.silverpeas.util.ForeignPK;
-import com.silverpeas.util.MimeTypes;
-
-import com.stratelia.webactiv.util.WAPrimaryKey;
-
-import org.apache.commons.io.IOUtils;
 
 /**
  *
@@ -76,6 +74,16 @@ public class MockBinaryAttachmentService implements AttachmentService {
   public void getBinaryContent(OutputStream output, SimpleDocumentPK pk, String lang) {
     try {
       IOUtils.write("Ceci est un test et ca marche", output);
+    } catch (IOException ex) {
+      Logger.getLogger(MockBinaryAttachmentService.class.getName()).log(Level.SEVERE, null, ex);
+    }
+  }
+
+  @Override
+  public void getBinaryContent(final OutputStream output, final SimpleDocumentPK pk,
+      final String lang, final long contentOffset, final long contentLength) {
+    try {
+      IOUtils.write("Ceci est un test et ca ne marche pas", output);
     } catch (IOException ex) {
       Logger.getLogger(MockBinaryAttachmentService.class.getName()).log(Level.SEVERE, null, ex);
     }
@@ -173,7 +181,8 @@ public class MockBinaryAttachmentService implements AttachmentService {
   }
 
   @Override
-  public List<SimpleDocument> listDocumentsByForeignKey(WAPrimaryKey foreignKey, String lang) {
+  public SimpleDocumentList<SimpleDocument> listDocumentsByForeignKey(WAPrimaryKey foreignKey,
+      String lang) {
     throw new UnsupportedOperationException("Not supported yet.");
   }
 
@@ -229,8 +238,8 @@ public class MockBinaryAttachmentService implements AttachmentService {
   }
 
   @Override
-  public List<SimpleDocument> listDocumentsByForeignKeyAndType(WAPrimaryKey foreignKey,
-      DocumentType type, String lang) {
+  public SimpleDocumentList<SimpleDocument> listDocumentsByForeignKeyAndType(
+      WAPrimaryKey foreignKey, DocumentType type, String lang) {
     throw new UnsupportedOperationException("Not supported yet.");
   }
 
@@ -250,7 +259,8 @@ public class MockBinaryAttachmentService implements AttachmentService {
   }
 
   @Override
-  public List<SimpleDocument> listAllDocumentsByForeignKey(WAPrimaryKey foreignKey, String lang) {
+  public SimpleDocumentList<SimpleDocument> listAllDocumentsByForeignKey(WAPrimaryKey foreignKey,
+      String lang) {
     throw new UnsupportedOperationException("Not supported yet.");
   }
 

--- a/ws-test-core/src/main/java/org/silverpeas/attachment/mock/SimpleDocumentServiceWrapper.java
+++ b/ws-test-core/src/main/java/org/silverpeas/attachment/mock/SimpleDocumentServiceWrapper.java
@@ -23,30 +23,27 @@
  */
 package org.silverpeas.attachment.mock;
 
-import java.io.File;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
-
-import javax.inject.Named;
-
+import com.silverpeas.annotation.Service;
+import com.silverpeas.util.Default;
+import com.silverpeas.util.ForeignPK;
+import com.stratelia.webactiv.util.WAPrimaryKey;
+import org.mockito.Mockito;
 import org.silverpeas.attachment.AttachmentException;
 import org.silverpeas.attachment.AttachmentService;
 import org.silverpeas.attachment.model.DocumentType;
 import org.silverpeas.attachment.model.SimpleDocument;
 import org.silverpeas.attachment.model.SimpleDocumentPK;
 import org.silverpeas.attachment.model.UnlockContext;
+import org.silverpeas.attachment.util.SimpleDocumentList;
 import org.silverpeas.search.indexEngine.model.FullIndexEntry;
 
-import com.silverpeas.annotation.Service;
-import com.silverpeas.util.Default;
-import com.silverpeas.util.ForeignPK;
-
-import com.stratelia.webactiv.util.WAPrimaryKey;
-
-import org.mockito.Mockito;
+import javax.inject.Named;
+import java.io.File;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
 
 @Default
 @Service
@@ -80,6 +77,12 @@ public class SimpleDocumentServiceWrapper implements AttachmentService {
   @Override
   public void getBinaryContent(OutputStream output, SimpleDocumentPK pk, String lang) {
     realService.getBinaryContent(output, pk, lang);
+  }
+
+  @Override
+  public void getBinaryContent(final OutputStream output, final SimpleDocumentPK pk,
+      final String lang, final long contentOffset, final long contentLength) {
+    realService.getBinaryContent(output, pk, lang, contentOffset, contentLength);
   }
 
   @Override
@@ -153,7 +156,8 @@ public class SimpleDocumentServiceWrapper implements AttachmentService {
   }
 
   @Override
-  public List<SimpleDocument> listDocumentsByForeignKey(WAPrimaryKey foreignKey, String lang) {
+  public SimpleDocumentList<SimpleDocument> listDocumentsByForeignKey(WAPrimaryKey foreignKey,
+      String lang) {
     return realService.listDocumentsByForeignKey(foreignKey, lang);
   }
 
@@ -242,8 +246,8 @@ public class SimpleDocumentServiceWrapper implements AttachmentService {
   }
 
   @Override
-  public List<SimpleDocument> listDocumentsByForeignKeyAndType(WAPrimaryKey foreignKey,
-      DocumentType type, String lang) {
+  public SimpleDocumentList<SimpleDocument> listDocumentsByForeignKeyAndType(
+      WAPrimaryKey foreignKey, DocumentType type, String lang) {
     return realService.listDocumentsByForeignKeyAndType(foreignKey, type, lang);
   }
 
@@ -263,7 +267,8 @@ public class SimpleDocumentServiceWrapper implements AttachmentService {
   }
 
   @Override
-  public List<SimpleDocument> listAllDocumentsByForeignKey(WAPrimaryKey foreignKey, String lang) {
+  public SimpleDocumentList<SimpleDocument> listAllDocumentsByForeignKey(WAPrimaryKey foreignKey,
+      String lang) {
     return realService.listAllDocumentsByForeignKey(foreignKey, lang);
   }
 


### PR DESCRIPTION
When updating a WYSIWYG attachment for a language with an empty content, the content for language is not saved but deleted. After that, if no content for any language exists for the attachment, then it is deleted from the JCR.
(adding some unit tests around the WYSIWYG controller)
(adding a List Object for SimpleDocument to centralize common behaviors)

It could be useful to integrate in a first time https://github.com/Silverpeas/Silverpeas-Core/pull/506 PR before this one, because of all fixes it brings around the versioning management, especially around multi-lingual content.

There will be a manual merge operation into the master version of Silverpeas-Core around the WysiwygController class. Indeed, the class has been deeply modified during the developments made for the new application: suggestion box. Thank you so to not hesitate to get back to me in case of difficulties.
