### PR TITLE
Fixed bug #5845

### DIFF
--- a/war-core/src/main/webapp/util/styleSheets/fieldset.css
+++ b/war-core/src/main/webapp/util/styleSheets/fieldset.css
@@ -106,7 +106,6 @@ fieldset.skinFieldset {
 	position:relative;
 	clear: both;
 	height:100%;
-	width:100%;
 }
 
 .field {
@@ -194,4 +193,19 @@ input.inputHour{
 .skinFieldset .champs .wysiwyg-fileStorage {
 	width:90%;
 	background-color:#FFF;
+}
+
+/* fieldset & Formulaire */
+
+.skinFieldset .forms .fields > li {
+	float:none;
+}
+
+.skinFieldset .forms .fields .fieldInput {
+    display: block;
+	margin-left: 195px;
+}
+
+.skinFieldset .forms .fields .fieldInput select{
+  max-width:200px;
 }


### PR DESCRIPTION
Il faut borner la largeur des menus déroulant, dans le cas où un libellé trop long nécessite une largeur supérieur à la place qu'il y a.
