### PR TITLE
Bug #5861 getString on a file causes out of memory

### DIFF
--- a/war-core/src/main/java/org/silverpeas/attachment/web/DragAndDrop.java
+++ b/war-core/src/main/java/org/silverpeas/attachment/web/DragAndDrop.java
@@ -106,8 +106,7 @@ public class DragAndDrop extends HttpServlet {
       for (FileItem item : items) {
         SilverTrace.info("attachment", "DragAndDrop.doPost", "root.MSG_GEN_PARAM_VALUE", "item = "
             + item.getFieldName());
-        SilverTrace.info("attachment", "DragAndDrop.doPost", "root.MSG_GEN_PARAM_VALUE", "item = "
-            + item.getName() + "; " + item.getString(CharEncoding.UTF_8));
+        SilverTrace.info("attachment", "DragAndDrop.doPost", "root.MSG_GEN_PARAM_VALUE", "item = " + item.getName());
 
         if (!item.isFormField()) {
           String fileName = item.getName();


### PR DESCRIPTION
For big files uploaded, it causes out of memory.. getString on the fileitem object removed.
