### PR TITLE
Fix a bug about the unlocking of a process instance in a workflow

### DIFF
--- a/ejb-core/formtemplate/src/main/java/com/silverpeas/workflow/engine/instance/ProcessInstanceImpl.java
+++ b/ejb-core/formtemplate/src/main/java/com/silverpeas/workflow/engine/instance/ProcessInstanceImpl.java
@@ -1589,6 +1589,7 @@ public class ProcessInstanceImpl implements UpdatableProcessInstance {
     } else {
       this.unLock(state.getName(), user);
     }
+    this.setLockedByAdmin(false);
   }
 
   /**


### PR DESCRIPTION
Fix the bug with the solution provided by Etienne in redmine (https://tracker.silverpeas.org/issues/5992)