### PR TITLE
Bug #6677, fixing two problems.

### DIFF
--- a/ejb-core/comment/src/main/java/com/silverpeas/comment/dao/jdbc/JDBCCommentRequester.java
+++ b/ejb-core/comment/src/main/java/com/silverpeas/comment/dao/jdbc/JDBCCommentRequester.java
@@ -445,14 +445,19 @@ public class JDBCCommentRequester {
       clause = "AND ";
     }
     if (listInstanceId != null) {
-      query.append(clause).append("instanceId IN (");
-      clause = "";
-      for (String instanceId : listInstanceId) {
-        query.append(clause).append("?");
-        clause = ", ";
-        params.add(instanceId);
+      if (listInstanceId.isEmpty()) {
+        // This empty list indicates that the requester has no component access.
+        query.append(clause).append("instanceId IN ('noComponentInstanceId') ");
+      } else {
+        query.append(clause).append("instanceId IN (");
+        clause = "";
+        for (String instanceId : listInstanceId) {
+          query.append(clause).append("?");
+          clause = ", ";
+          params.add(instanceId);
+        }
+        query.append(") ");
       }
-      query.append(") ");
       clause = "AND ";
     }
     if (period != null && period.isValid()) {

--- a/lib-core/src/main/java/com/stratelia/webactiv/beans/admin/dao/ComponentDAO.java
+++ b/lib-core/src/main/java/com/stratelia/webactiv/beans/admin/dao/ComponentDAO.java
@@ -32,6 +32,7 @@ import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
@@ -139,6 +140,18 @@ public class ComponentDAO {
       int userId, String componentName) throws SQLException {
     Set<String> componentIds = new HashSet<String>();
     componentIds.addAll(getAllPublicComponentIds(con));
+
+    // Public component instance ids must be filtered in case when a component name filter is
+    // defined.
+    if (StringUtil.isDefined(componentName)) {
+      Iterator<String> componentIdsIt = componentIds.iterator();
+      while (componentIdsIt.hasNext()) {
+        if (!componentIdsIt.next().startsWith(componentName)) {
+          componentIdsIt.remove();
+        }
+      }
+    }
+
     if (groupIds != null && groupIds.size() > 0) {
       componentIds.addAll(getAllAvailableComponentIds(con, groupIds, componentName));
     }


### PR DESCRIPTION
- the public component instance identifiers were not filtered according to a specified and defined component name (but unfortunately, this point can not functionnally be verified because it will just increase Silverpeas performances)
- sometimes a comment search is filtered on component instance identifiers that the user can access. When no component instance identifier was accessible to the user, the SQL query built in order to get comments was malformed