### PR TITLE
Fix bug 6937

### DIFF
--- a/lib-core/src/main/java/com/stratelia/silverpeas/notificationManager/NotificationSender.java
+++ b/lib-core/src/main/java/com/stratelia/silverpeas/notificationManager/NotificationSender.java
@@ -217,7 +217,7 @@ public class NotificationSender implements java.io.Serializable {
     OrganisationController orgaController = OrganisationControllerFactory.
         getOrganisationController();
     Group group = orgaController.getGroup(groupId);
-    int nbUsers = group.getNbUsers();
+    int nbUsers = group.getTotalNbUsers();
     boolean res1 = settings.getBoolean("notif.receiver.displayGroup", false);
     boolean res2 = StringUtil.isDefined(threshold);
     boolean res3 = StringUtil.isInteger(threshold);

--- a/lib-core/src/main/java/com/stratelia/webactiv/beans/admin/Admin.java
+++ b/lib-core/src/main/java/com/stratelia/webactiv/beans/admin/Admin.java
@@ -5198,7 +5198,7 @@ public final class Admin {
   }
 
   /**
-   * For use in userPanel : return the total number of users recursivly contained in a group
+   * For use in userPanel : return the total number of users recursively contained in a group
    */
   public int getAllSubUsersNumber(String sGroupId) throws AdminException {
     DomainDriverManager domainDriverManager = DomainDriverManagerFactory
@@ -5208,15 +5208,7 @@ public final class Admin {
       return userManager.getUserNumber(domainDriverManager);
     } else {
 
-      // add users directly in this group
-      int nb = groupManager.getNBUsersDirectlyInGroup(sGroupId);
-
-      // add users in sub groups
-      List<String> groupIds = groupManager.getAllSubGroupIdsRecursively(sGroupId);
-      for (String groupId : groupIds) {
-        nb += groupManager.getNBUsersDirectlyInGroup(groupId);
-      }
-      return nb;
+      return groupManager.getTotalUserCountInGroup("", sGroupId);
     }
   }
 

--- a/lib-core/src/main/java/com/stratelia/webactiv/beans/admin/Group.java
+++ b/lib-core/src/main/java/com/stratelia/webactiv/beans/admin/Group.java
@@ -239,6 +239,12 @@ public class Group implements Serializable, Comparable<Group> {
     return (rule != null && rule.trim().length() > 0);
   }
 
+  /**
+   * Gets the number of direct users in this group; the users from its subgroups aren't counted. To
+   * count also the users in its subgroups, please use the
+   * {@code com.stratelia.webactiv.beans.admin.Group#getTotalNbUsers} method instead.
+   * @return the number of direct users.
+   */
   public int getNbUsers() {
     if (nbUsers == -1) {
       return getUserIds().length;
@@ -247,22 +253,15 @@ public class Group implements Serializable, Comparable<Group> {
   }
 
   /**
-   * Gets the total number of users in this group and in its subgroups.
-   * @return the total number of users.
+   * Gets the total number of users in this group and in its subgroups. Users that are in several
+   * groups are counted only once.
+   * @return the total number of distinct users in its group and subgroups.
    */
   public int getTotalNbUsers() {
     if (nbTotalUsers < 0) {
       nbTotalUsers = getOrganisationController().getAllSubUsersNumber(getId());
     }
     return nbTotalUsers;
-  }
-
-  public void setNbUsers(int nbUsers) {
-    this.nbUsers = nbUsers;
-  }
-
-  public void setTotalNbUsers(int count) {
-    this.nbTotalUsers = count;
   }
 
   protected static OrganisationController getOrganisationController() {

--- a/lib-core/src/main/java/com/stratelia/webactiv/beans/admin/dao/UserDAO.java
+++ b/lib-core/src/main/java/com/stratelia/webactiv/beans/admin/dao/UserDAO.java
@@ -115,7 +115,7 @@ public class UserDAO {
    * Gets the number of users that match the specified criteria. The criteria are provided by an
    * UserSearchCriteriaBuilder instance that was used to create them.
    *
-   * @param connection the connetion with a data source to use.
+   * @param connection the connexion with a data source to use.
    * @param criteria a builder with which the criteria the user profiles must satisfy has been
    * built.
    * @return the number of users that match the specified criteria.
@@ -125,7 +125,7 @@ public class UserDAO {
     PreparedStatement statement = null;
     ResultSet resultSet = null;
     try {
-      String query = criteria.toSQLQuery("COUNT(*)");
+      String query = criteria.toSQLQuery("COUNT(DISTINCT id)");
       statement = connection.prepareStatement(query);
       resultSet = statement.executeQuery();
       resultSet.next();

--- a/lib-core/src/main/java/org/silverpeas/core/admin/OrganisationController.java
+++ b/lib-core/src/main/java/org/silverpeas/core/admin/OrganisationController.java
@@ -221,7 +221,7 @@ public interface OrganisationController extends java.io.Serializable {
   Group[] searchGroups(Group modelGroup, boolean isAnd);
 
   /**
-   * For use in userPanel : return the total number of users recursivly contained in a group
+   * Returns the total number of distinct users recursively contained in the specified group
    */
   int getAllSubUsersNumber(String sGroupId);
 

--- a/war-core/src/main/webapp/jobDomainPeas/jsp/domainContent.jsp
+++ b/war-core/src/main/webapp/jobDomainPeas/jsp/domainContent.jsp
@@ -214,8 +214,8 @@ out.println(window.printBefore());
 	        	  groupIcon.setProperties(resource.getIcon("JDP.group"), resource.getString("GML.groupe"), "");
 	          }
 	          arrayLine.addArrayCellIconPane(iconPane1);
-	          arrayLine.addArrayCellLink(EncodeHelper.javaStringToHtmlString(group.getName()), (String)request.getAttribute("myComponentURL")+"groupContent?Idgroup="+group.getId());
-	          arrayLine.addArrayCellText(group.getNbUsers());
+	          arrayLine.addArrayCellLink(EncodeHelper.javaStringToHtmlString(group.getName()), request.getAttribute("myComponentURL")+"groupContent?Idgroup="+group.getId());
+	          arrayLine.addArrayCellText(group.getTotalNbUsers());
 	          arrayLine.addArrayCellText(EncodeHelper.javaStringToHtmlString(group.getDescription()));
     	  }
       }

--- a/war-core/src/main/webapp/jobDomainPeas/jsp/groupContent.jsp
+++ b/war-core/src/main/webapp/jobDomainPeas/jsp/groupContent.jsp
@@ -188,7 +188,7 @@ if (showTabs) {
 			        	groupIcon.setProperties(resource.getIcon("JDP.group"), resource.getString("GML.groupe"), "");
 					arrayLine.addArrayCellIconPane(iconPane1);
 					arrayLine.addArrayCellLink(EncodeHelper.javaStringToHtmlString(group.getName()), (String)request.getAttribute("myComponentURL")+"groupContent?Idgroup="+group.getId());
-			        arrayLine.addArrayCellText(group.getNbUsers());
+			        arrayLine.addArrayCellText(group.getTotalNbUsers());
 			        arrayLine.addArrayCellText(EncodeHelper.javaStringToHtmlString(group.getDescription()));
 		    	}
 			}

--- a/web-core/src/main/java/com/silverpeas/jobDomainPeas/control/JobDomainPeasSessionController.java
+++ b/web-core/src/main/java/com/silverpeas/jobDomainPeas/control/JobDomainPeasSessionController.java
@@ -1280,12 +1280,6 @@ public class JobDomainPeasSessionController extends AbstractComponentSessionCont
     if (isOnlyGroupManager() && !isGroupManagerOnCurrentGroup()) {
       groups = filterGroupsToGroupManager(groups);
     }
-    for (Group group : groups) {
-      if (group != null) {
-        group.setNbUsers(getOrganisationController().getAllSubUsersNumber(
-            group.getId()));
-      }
-    }
     return groups;
   }
 

--- a/web-core/src/main/java/com/silverpeas/profile/web/UserGroupProfileEntity.java
+++ b/web-core/src/main/java/com/silverpeas/profile/web/UserGroupProfileEntity.java
@@ -184,11 +184,6 @@ public class UserGroupProfileEntity extends Group implements Exposable {
   }
 
   @Override
-  public void setNbUsers(int nbUsers) {
-    this.group.setNbUsers(nbUsers);
-  }
-
-  @Override
   @XmlElement
   public String getDomainId() {
     return this.group.getDomainId();

--- a/web-core/src/test/java/com/silverpeas/profile/web/UserProfileTestResources.java
+++ b/web-core/src/test/java/com/silverpeas/profile/web/UserProfileTestResources.java
@@ -349,12 +349,12 @@ public class UserProfileTestResources extends TestResources {
     Group[] groups = mock.getAllGroups();
     for (Group group : groups) {
       when(mock.getAllUsersOfGroup(group.getId())).thenReturn(new UserDetail[0]);
-      group.setTotalNbUsers(1);
+      //group.setTotalNbUsers(1);
     }
     Group internalGroup = mock.getGroup("1");
     UserDetail[] users = getAllExistingUsers();
     internalGroup.setUserIds(getUserIds(users));
-    internalGroup.setTotalNbUsers(users.length);
+    //internalGroup.setTotalNbUsers(users.length);
 
     for (int i = 0; i <= 1; i++) {
       String domainId = String.valueOf(i);


### PR DESCRIPTION
The use of the Group#setNbUsers(int) isn't consistent among the code. Some codes use it to set the direct number of users in the group as expected (in Admin) whereas others use it to set the total number of users in the group (by taking into account the subgroups). This part was cleaned and in order to avoid this misuse the Group#setNbUsers(int) and Group#setTotalNbUsers(int) are now removed.

Up to now, the method Group#getNbUsers() computes the number of direct users from the size of the array of users' identifiers that was set to the group by the GroupManager (it is always set when returning one or more groups), so there is no need to let external code to set the direct user count.
In the other side, up to now, the method Group#getTotalNbUsers() computes recursively the number of users in the group by invoking the corresponding method of OrganizationController (id est OrganizationController#getAllSubUsersNumber(groupId)). There is then no need to let external code to set the direct user count.

Fix the computation of the total number of users in a group (by taking recursively into account the subgroups) by using now the new method GroupManager#getTotalUserCountInGroup(domainId, groupId). This method counts distinctively the users in a group and its subgroups. 

Don't forget to merge also the PR [#398](https://github.com/Silverpeas/Silverpeas-Components/pull/398)