### PR TITLE
Fix bug 6937 for 5.15

### DIFF
--- a/lib-core/src/main/java/com/stratelia/silverpeas/notificationManager/NotificationSender.java
+++ b/lib-core/src/main/java/com/stratelia/silverpeas/notificationManager/NotificationSender.java
@@ -144,8 +144,6 @@ public class NotificationSender implements java.io.Serializable {
         "root.MSG_GEN_EXIT_METHOD");
   }
 
-  
-
   /**
    * Saving the notification into history if users have been notified.
    * @param metaData

--- a/lib-core/src/main/java/com/stratelia/webactiv/beans/admin/Admin.java
+++ b/lib-core/src/main/java/com/stratelia/webactiv/beans/admin/Admin.java
@@ -5218,7 +5218,7 @@ public final class Admin {
   }
 
   /**
-   * For use in userPanel : return the total number of users recursivly contained in a group
+   * For use in userPanel : return the total number of users recursively contained in a group
    */
   public int getAllSubUsersNumber(String sGroupId) throws AdminException {
     DomainDriverManager domainDriverManager = DomainDriverManagerFactory
@@ -5228,15 +5228,7 @@ public final class Admin {
       return userManager.getUserNumber(domainDriverManager);
     } else {
 
-      // add users directly in this group
-      int nb = groupManager.getNBUsersDirectlyInGroup(sGroupId);
-
-      // add users in sub groups
-      List<String> groupIds = groupManager.getAllSubGroupIdsRecursively(sGroupId);
-      for (String groupId : groupIds) {
-        nb += groupManager.getNBUsersDirectlyInGroup(groupId);
-      }
-      return nb;
+      return groupManager.getTotalUserCountInGroup("", sGroupId);
     }
   }
 

--- a/lib-core/src/main/java/com/stratelia/webactiv/beans/admin/Group.java
+++ b/lib-core/src/main/java/com/stratelia/webactiv/beans/admin/Group.java
@@ -239,6 +239,12 @@ public class Group implements Serializable, Comparable<Group> {
     return (rule != null && rule.trim().length() > 0);
   }
 
+  /**
+   * Gets the number of direct users in this group; the users from its subgroups aren't counted. To
+   * count also the users in its subgroups, please use the
+   * {@code com.stratelia.webactiv.beans.admin.Group#getTotalNbUsers} method instead.
+   * @return the number of direct users.
+   */
   public int getNbUsers() {
     if (nbUsers == -1) {
       return getUserIds().length;
@@ -247,8 +253,13 @@ public class Group implements Serializable, Comparable<Group> {
   }
 
   /**
-   * Gets the total number of users in this group and in its subgroups.
-   * @return the total number of users.
+   * Gets the total number of users in this group and in its subgroups. Users that are in several
+   * groups are counted only once.
+   * </p>
+   * Depending on the requester, the total number of users can omit some users by their state
+   * (usually the users whose their account is deactivated). By default, all the users whose
+   * the account is deleted aren't taken into account.
+   * @return the total number of distinct users in its group and subgroups.
    */
   public int getTotalNbUsers() {
     if (nbTotalUsers < 0) {
@@ -257,12 +268,8 @@ public class Group implements Serializable, Comparable<Group> {
     return nbTotalUsers;
   }
 
-  public void setNbUsers(int nbUsers) {
-    this.nbUsers = nbUsers;
-  }
-
-  public void setTotalNbUsers(int count) {
-    this.nbTotalUsers = count;
+  protected void setTotalNbUsers(int nbUsers) {
+    this.nbTotalUsers = nbUsers;
   }
 
   protected static OrganisationController getOrganisationController() {

--- a/lib-core/src/main/java/com/stratelia/webactiv/beans/admin/GroupManager.java
+++ b/lib-core/src/main/java/com/stratelia/webactiv/beans/admin/GroupManager.java
@@ -102,6 +102,35 @@ public class GroupManager {
   }
 
   /**
+   * Gets the total number of users in the specified group, that is to say the number of distinct
+   * users in the specified group and in its subgroups.
+   * @param domainId the unique identifier to which the group belong.
+   * @param groupId the unique identifier of the group.
+   * @return the total users count in the specified group.
+   * @throws AdminException if an error occurs while computing the user count.
+   */
+  public int getTotalUserCountInGroup(String domainId, String groupId) throws AdminException {
+    Connection connection = null;
+    try {
+      connection = DBUtil.makeConnection(JNDINames.ADMIN_DATASOURCE);
+      SearchCriteriaDAOFactory factory = SearchCriteriaDAOFactory.getFactory();
+      List<String> groupIds = getAllSubGroupIdsRecursively(groupId);
+      groupIds.add(groupId);
+      UserSearchCriteriaForDAO criteriaOnUsers = factory.getUserSearchCriteriaDAO();
+      int userCount = userDao.getUserCountByCriteria(connection, criteriaOnUsers.
+          onDomainId(domainId).
+          and().
+          onGroupIds(groupIds.toArray(new String[groupIds.size()])));
+      return userCount;
+    } catch (SQLException e) {
+      throw new AdminException("GroupManager.getGroupsMatchingCriteria",
+          SilverpeasException.ERROR, "admin.EX_ERR_GET_USER_GROUPS", e);
+    } finally {
+      DBUtil.close(connection);
+    }
+  }
+
+  /**
    * Add a user to a group
    *
    * @param ddManager

--- a/lib-core/src/main/java/com/stratelia/webactiv/beans/admin/UserDetailsSearchCriteria.java
+++ b/lib-core/src/main/java/com/stratelia/webactiv/beans/admin/UserDetailsSearchCriteria.java
@@ -89,13 +89,13 @@ public class UserDetailsSearchCriteria implements SearchCriteria {
   }
 
   @Override
-  public SearchCriteria onAccessLevels(final UserAccessLevel... accessLevels) {
+  public UserDetailsSearchCriteria onAccessLevels(final UserAccessLevel... accessLevels) {
     criteria.put(USER_ACCESS_LEVELS, accessLevels);
     return this;
   }
 
   @Override
-  public SearchCriteria onUserStatesToExclude(final UserState... userStates) {
+  public UserDetailsSearchCriteria onUserStatesToExclude(final UserState... userStates) {
     criteria.put(USER_STATES_TO_EXCLUDE, userStates);
     return null;
   }
@@ -260,22 +260,22 @@ public class UserDetailsSearchCriteria implements SearchCriteria {
   }
 
   /**
-   * Useless as by default the criteria forms a conjonction.
+   * Useless as by default the criteria forms a conjunction.
    *
    * @return itself.
    */
   @Override
-  public SearchCriteria and() {
+  public UserDetailsSearchCriteria and() {
     return this;
   }
 
   /**
-   * Not supported. By default, the criteria form a conjonction.
+   * Not supported. By default, the criteria form a conjunction.
    *
    * @return nothing, thrown an UnsupportedOperationException exception.
    */
   @Override
-  public SearchCriteria or() {
+  public UserDetailsSearchCriteria or() {
     throw new UnsupportedOperationException("Not supported yet.");
   }
 
@@ -285,7 +285,7 @@ public class UserDetailsSearchCriteria implements SearchCriteria {
   }
 
   @Override
-  public SearchCriteria onPagination(PaginationPage page) {
+  public UserDetailsSearchCriteria onPagination(PaginationPage page) {
     criteria.put(PAGINATION, page);
     return this;
   }

--- a/lib-core/src/main/java/com/stratelia/webactiv/beans/admin/dao/UserDAO.java
+++ b/lib-core/src/main/java/com/stratelia/webactiv/beans/admin/dao/UserDAO.java
@@ -114,7 +114,7 @@ public class UserDAO {
    * Gets the number of users that match the specified criteria. The criteria are provided by an
    * UserSearchCriteriaBuilder instance that was used to create them.
    *
-   * @param connection the connetion with a data source to use.
+   * @param connection the connexion with a data source to use.
    * @param criteria a builder with which the criteria the user profiles must satisfy has been
    * built.
    * @return the number of users that match the specified criteria.
@@ -124,7 +124,7 @@ public class UserDAO {
     PreparedStatement statement = null;
     ResultSet resultSet = null;
     try {
-      String query = criteria.toSQLQuery("COUNT(*)");
+      String query = criteria.toSQLQuery("COUNT(DISTINCT id)");
       statement = connection.prepareStatement(query);
       resultSet = statement.executeQuery();
       resultSet.next();

--- a/lib-core/src/main/java/org/silverpeas/core/admin/OrganisationController.java
+++ b/lib-core/src/main/java/org/silverpeas/core/admin/OrganisationController.java
@@ -221,7 +221,7 @@ public interface OrganisationController extends java.io.Serializable {
   Group[] searchGroups(Group modelGroup, boolean isAnd);
 
   /**
-   * For use in userPanel : return the total number of users recursivly contained in a group
+   * Returns the total number of distinct users recursively contained in the specified group
    */
   int getAllSubUsersNumber(String sGroupId);
 

--- a/lib-core/src/test/java/com/stratelia/silverpeas/notificationManager/NotificationMetaDataTest.java
+++ b/lib-core/src/test/java/com/stratelia/silverpeas/notificationManager/NotificationMetaDataTest.java
@@ -71,7 +71,7 @@ public class NotificationMetaDataTest {
       public Group answer(final InvocationOnMock invocation) throws Throwable {
         Group group = new Group();
         group.setId((String) invocation.getArguments()[0]);
-        group.setNbUsers(5);
+        group.setUserIds(new String[] {"1", "2", "3", "4", "5"});
         return group;
       }
     });

--- a/war-core/src/main/webapp/jobDomainPeas/jsp/domainContent.jsp
+++ b/war-core/src/main/webapp/jobDomainPeas/jsp/domainContent.jsp
@@ -214,8 +214,8 @@ out.println(window.printBefore());
 	        	  groupIcon.setProperties(resource.getIcon("JDP.group"), resource.getString("GML.groupe"), "");
 	          }
 	          arrayLine.addArrayCellIconPane(iconPane1);
-	          arrayLine.addArrayCellLink(EncodeHelper.javaStringToHtmlString(group.getName()), (String)request.getAttribute("myComponentURL")+"groupContent?Idgroup="+group.getId());
-	          arrayLine.addArrayCellText(group.getNbUsers());
+	          arrayLine.addArrayCellLink(EncodeHelper.javaStringToHtmlString(group.getName()), request.getAttribute("myComponentURL")+"groupContent?Idgroup="+group.getId());
+	          arrayLine.addArrayCellText(group.getTotalNbUsers());
 	          arrayLine.addArrayCellText(EncodeHelper.javaStringToHtmlString(group.getDescription()));
     	  }
       }

--- a/war-core/src/main/webapp/jobDomainPeas/jsp/groupContent.jsp
+++ b/war-core/src/main/webapp/jobDomainPeas/jsp/groupContent.jsp
@@ -188,7 +188,7 @@ if (showTabs) {
 			        	groupIcon.setProperties(resource.getIcon("JDP.group"), resource.getString("GML.groupe"), "");
 					arrayLine.addArrayCellIconPane(iconPane1);
 					arrayLine.addArrayCellLink(EncodeHelper.javaStringToHtmlString(group.getName()), (String)request.getAttribute("myComponentURL")+"groupContent?Idgroup="+group.getId());
-			        arrayLine.addArrayCellText(group.getNbUsers());
+			        arrayLine.addArrayCellText(group.getTotalNbUsers());
 			        arrayLine.addArrayCellText(EncodeHelper.javaStringToHtmlString(group.getDescription()));
 		    	}
 			}

--- a/war-core/src/main/webapp/util/javaScript/angularjs/services/silverpeas-profile.js
+++ b/war-core/src/main/webapp/util/javaScript/angularjs/services/silverpeas-profile.js
@@ -81,7 +81,7 @@
             });
           } else {
             window.console &&
-            window.console.log('User profile - ERROR - getting extended user data whithout specifying its id ...');
+            window.console.log('User profile - ERROR - getting extended user data without specifying its id ...');
             return {};
           }
         };

--- a/web-core/src/main/java/com/silverpeas/jobDomainPeas/control/JobDomainPeasSessionController.java
+++ b/web-core/src/main/java/com/silverpeas/jobDomainPeas/control/JobDomainPeasSessionController.java
@@ -1245,12 +1245,6 @@ public class JobDomainPeasSessionController extends AbstractComponentSessionCont
     if (isOnlyGroupManager() && !isGroupManagerOnCurrentGroup()) {
       groups = filterGroupsToGroupManager(groups);
     }
-    for (Group group : groups) {
-      if (group != null) {
-        group.setNbUsers(getOrganisationController().getAllSubUsersNumber(
-            group.getId()));
-      }
-    }
     return groups;
   }
 

--- a/web-core/src/main/java/com/silverpeas/profile/web/UserGroupProfileEntity.java
+++ b/web-core/src/main/java/com/silverpeas/profile/web/UserGroupProfileEntity.java
@@ -184,11 +184,6 @@ public class UserGroupProfileEntity extends Group implements Exposable {
   }
 
   @Override
-  public void setNbUsers(int nbUsers) {
-    this.group.setNbUsers(nbUsers);
-  }
-
-  @Override
   @XmlElement
   public String getDomainId() {
     return this.group.getDomainId();

--- a/web-core/src/test/java/com/silverpeas/profile/web/UserProfileTestResources.java
+++ b/web-core/src/test/java/com/silverpeas/profile/web/UserProfileTestResources.java
@@ -349,12 +349,12 @@ public class UserProfileTestResources extends TestResources {
     Group[] groups = mock.getAllGroups();
     for (Group group : groups) {
       when(mock.getAllUsersOfGroup(group.getId())).thenReturn(new UserDetail[0]);
-      group.setTotalNbUsers(1);
+      //group.setTotalNbUsers(1);
     }
     Group internalGroup = mock.getGroup("1");
     UserDetail[] users = getAllExistingUsers();
     internalGroup.setUserIds(getUserIds(users));
-    internalGroup.setTotalNbUsers(users.length);
+    //internalGroup.setTotalNbUsers(users.length);
 
     for (int i = 0; i <= 1; i++) {
       String domainId = String.valueOf(i);


### PR DESCRIPTION
The total number of users in a group counts users that are in several subgroups only once. This count is now centralized into one method Admin#getAllSubUsersNumber(groupId) that invokes the GroupManager#groupManager.getTotalUserCountInGroup(domainId, groupId) method when the groupId is specified (otherwise it invokes the UserManager#getUserNumber(domainDriverManager) method). In the case only some users whose the account isn't in a given state must be taken into account, the method Admin#searchUsers(UserDetailsSearchCriteria) should be used instead. The groups that are returned by Admin#searchGroups(GroupsSearchCriteria) take already into account of this contrain for the total users number. In the other side, the number of direct users in a group is directly computed from the size of the users in the group (the users are set by GroupManager when returning one or more groups groupId), there is no need to expose anymore methods to set this number of users; the call is now performed by invoking directly Group#getNbUsers().

The fix comes from cherry-picking the commits in 5.14.x
Conflicts:
	lib-core/src/main/java/com/stratelia/silverpeas/notificationManager/NotificationSender.java
	lib-core/src/main/java/com/stratelia/webactiv/beans/admin/GroupManager.java

Don't forget to merge also the [PR #401](https://github.com/Silverpeas/Silverpeas-Components/pull/401) in Silverpeas-Components