### PR TITLE
Feature #7102: adding a parameter into Attachment.properties in order to enable or not the use of file metadata for attachment data (title & description).

### DIFF
--- a/config-core/src/main/config/properties/org/silverpeas/util/attachment/Attachment.properties
+++ b/config-core/src/main/config/properties/org/silverpeas/util/attachment/Attachment.properties
@@ -88,3 +88,7 @@ attachment.onlineEditing.customProtocol = false
 # Turn off this parameter if you don't want a popin alerts user to download and install
 # the necessary external program
 attachment.onlineEditing.customProtocol.alert = true
+
+# Turn on this parameter if metadata of a file must be used to fill data (title & description) of
+# an attachment. By default metadata are not used.
+attachment.data.fromMetadata = false

--- a/lib-core/src/main/java/org/silverpeas/attachment/util/AttachmentSettings.java
+++ b/lib-core/src/main/java/org/silverpeas/attachment/util/AttachmentSettings.java
@@ -23,75 +23,23 @@
  */
 package org.silverpeas.attachment.util;
 
-import com.silverpeas.util.StringUtil;
 import com.stratelia.webactiv.util.ResourceLocator;
 
-import javax.inject.Inject;
-
 /**
- * The aim of this class is to expose at the rest of application the settings around attachments.
- * Its implementation allows to manage the attachment parameters easily into unit tests. It assures
- * also less problems around setting regressions.
+ * Handled the settings around the attachments.
  * @author: Yohann Chastagnier
  */
 public class AttachmentSettings {
 
-  private static final AttachmentSettings instance = new AttachmentSettings();
-
-  @Inject
-  private Provider provider;
+  private static ResourceLocator settings =
+      new ResourceLocator("org.silverpeas.util.attachment.Attachment", "");
 
   /**
-   * Indicates if obsolete wysiwyg content must be ignored.
-   * This method returns always false if {@link #getObsoleteWysiwygContentIgnoredMark()} returns
-   * a not defined value.
-   * False by default (attachment.wysiwyg.content.inspection.obsolete.ignore).
-   * @return true if wysiwyg content must be ignored, false otherwise.
+   * Indicates if metadata of a file, if any, can be used to fill data (title & description) of an
+   * attachment. (defined in properties by attachment.data.fromMetadata)
+   * @return true if they must be used, false otherwise.
    */
-  public static boolean isObsoleteWysiwygContentIgnored() {
-    return getInstance().getProvider()
-        .getBoolean("attachment.wysiwyg.content.inspection.obsolete.ignore", false) &&
-        StringUtil.isDefined(getObsoleteWysiwygContentIgnoredMark());
-  }
-
-  /**
-   * Gets the strict mark to fill at start of a wysiwyg file to mark it as ignored.
-   * If the mark exists into the file, but not at beginning, it is not taken into account.
-   * (defined in properties by attachment.wysiwyg.content.inspection.obsolete.ignore.mark)
-   * @return the mark if defined, empty string otherwise.
-   */
-  public static String getObsoleteWysiwygContentIgnoredMark() {
-    return getInstance().getProvider()
-        .getString("attachment.wysiwyg.content.inspection.obsolete.ignore.mark", "");
-  }
-
-  /**
-   * Gets the provider.
-   * @return
-   */
-  private ResourceLocator getProvider() {
-    if (provider == null) {
-      provider = new Provider();
-    }
-    return provider;
-  }
-
-  /**
-   * @return a AttachmentSettings instance.
-   */
-  public static AttachmentSettings getInstance() {
-    return instance;
-  }
-
-  /**
-   * This internal class provides the settings.
-   * Implementing by this way the settings access is very useful for maintenance and unit tests.
-   */
-  public static class Provider extends ResourceLocator {
-    private static final long serialVersionUID = -2626681960886868011L;
-
-    public Provider() {
-      super("org.silverpeas.util.attachment.Attachment", "");
-    }
+  public static boolean isUseFileMetadataForAttachmentDataEnabled() {
+    return settings.getBoolean("attachment.data.fromMetadata", false);
   }
 }

--- a/lib-core/src/main/java/org/silverpeas/upload/UploadedFile.java
+++ b/lib-core/src/main/java/org/silverpeas/upload/UploadedFile.java
@@ -32,16 +32,17 @@ import com.stratelia.webactiv.beans.admin.UserDetail;
 import com.stratelia.webactiv.util.DateUtil;
 import com.stratelia.webactiv.util.FileRepositoryManager;
 import com.stratelia.webactiv.util.WAPrimaryKey;
-import org.apache.commons.io.FileUtils;
 import org.silverpeas.attachment.AttachmentServiceFactory;
 import org.silverpeas.attachment.model.HistorisedDocument;
 import org.silverpeas.attachment.model.SimpleAttachment;
 import org.silverpeas.attachment.model.SimpleDocument;
 import org.silverpeas.attachment.model.SimpleDocumentPK;
+import org.silverpeas.attachment.util.AttachmentSettings;
 
 import javax.servlet.http.HttpServletRequest;
 import java.io.File;
 
+import static com.silverpeas.util.StringUtil.defaultStringIfNotDefined;
 import static com.silverpeas.util.StringUtil.getBooleanValue;
 import static org.silverpeas.attachment.AttachmentService.VERSION_MODE;
 import static org.silverpeas.core.admin.OrganisationControllerFactory.getOrganisationController;
@@ -184,24 +185,19 @@ public class UploadedFile {
     String lang = I18NHelper.checkLanguage(contributionLanguage);
 
     // Title and description
-    String title = getTitle();
-    String description = getDescription();
-    if (!StringUtil.isDefined(title)) {
+    String title = defaultStringIfNotDefined(getTitle());
+    String description = defaultStringIfNotDefined(getDescription());
+    if (AttachmentSettings.isUseFileMetadataForAttachmentDataEnabled() &&
+        !StringUtil.isDefined(title)) {
       MetadataExtractor extractor = MetadataExtractor.getInstance();
       MetaData metadata = extractor.extractMetadata(getFile());
       if (StringUtil.isDefined(metadata.getTitle())) {
         title = metadata.getTitle();
-      } else {
-        title = "";
       }
       if (!StringUtil.isDefined(description) && StringUtil.isDefined(metadata.getSubject())) {
         description = metadata.getSubject();
       }
     }
-    if (!StringUtil.isDefined(description)) {
-      description = "";
-    }
-
     // Simple document PK
     SimpleDocumentPK pk = new SimpleDocumentPK(null, resourcePk);
 

--- a/web-core/src/main/java/com/silverpeas/importExport/control/PublicationImportExport.java
+++ b/web-core/src/main/java/com/silverpeas/importExport/control/PublicationImportExport.java
@@ -53,7 +53,6 @@ import org.apache.commons.lang.StringUtils;
 
 public class PublicationImportExport {
 
-  final static MetadataExtractor metadataExtractor = MetadataExtractor.getInstance();
   final static ResourceLocator multilang = new ResourceLocator(
       "org.silverpeas.importExport.multilang.importExportBundle", "fr");
 
@@ -116,7 +115,7 @@ public class PublicationImportExport {
         MetaData metaData = null;
         if (settings.isPoiUsed()) {
           // extract title, subject and keywords
-          metaData = metadataExtractor.extractMetadata(file.getAbsolutePath());
+          metaData = MetadataExtractor.getInstance().extractMetadata(file.getAbsolutePath());
           if (StringUtil.isDefined(metaData.getTitle())) {
             nomPub = metaData.getTitle();
           }
@@ -131,7 +130,7 @@ public class PublicationImportExport {
         if (settings.useFileDates()) {
           // extract creation and last modification dates
           if (metaData == null) {
-            metaData = metadataExtractor.extractMetadata(file.getAbsolutePath());
+            metaData = MetadataExtractor.getInstance().extractMetadata(file.getAbsolutePath());
           }
           if (metaData.getCreationDate() != null) {
             creationDate = metaData.getCreationDate();

--- a/web-core/src/main/java/com/silverpeas/importExport/control/PublicationsTypeManager.java
+++ b/web-core/src/main/java/com/silverpeas/importExport/control/PublicationsTypeManager.java
@@ -62,6 +62,7 @@ import org.apache.commons.io.FileUtils;
 import org.silverpeas.attachment.AttachmentServiceFactory;
 import org.silverpeas.attachment.model.SimpleDocument;
 import org.silverpeas.attachment.model.SimpleDocumentPK;
+import org.silverpeas.attachment.util.AttachmentSettings;
 import org.silverpeas.core.admin.OrganisationControllerFactory;
 import org.silverpeas.importExport.attachment.AttachmentDetail;
 import org.silverpeas.importExport.attachment.AttachmentImportExport;
@@ -89,8 +90,6 @@ import static java.io.File.separator;
  * @author sdevolder
  */
 public class PublicationsTypeManager {
-
-  final static MetadataExtractor metadataExtractor = MetadataExtractor.getInstance();
 
   /**
    * Méthode métier du moteur d'importExport créant une exportation pour toutes les publications
@@ -183,7 +182,7 @@ public class PublicationsTypeManager {
         if (wysiwygContent != null) {
           wysiwygText = exportWysiwygContent(pubId, publicationDetail.getInstanceId(), gedIE,
               exportPublicationRelativePath, exportPublicationPath, wysiwygContent, publicationType.
-              getPublicationDetail().getLanguage());
+                  getPublicationDetail().getLanguage());
         } else if (xmlModel != null) {
           exportXmlForm(new PublicationPK(pubId, publicationDetail.getInstanceId()),
               exportPublicationRelativePath, exportPublicationPath, xmlModel);
@@ -747,9 +746,11 @@ public class PublicationsTypeManager {
                     unitReport.setError(UnitReport.ERROR_FILE_SIZE_EXCEEDS_LIMIT);
                   } else {
                     MetaData metaData = null;
-                    if (settings.isPoiUsed()) {
+                    if (AttachmentSettings.isUseFileMetadataForAttachmentDataEnabled() &&
+                        settings.isPoiUsed()) {
                       // extract title, subject and keywords
-                      metaData = metadataExtractor.extractMetadata(attdetail.getAttachmentPath());
+                      metaData = MetadataExtractor.getInstance()
+                          .extractMetadata(attdetail.getAttachmentPath());
                       if (!StringUtil.isDefined(attdetail.getTitle()) && StringUtil.isDefined(
                           metaData.getTitle())) {
                         attdetail.setTitle(metaData.getTitle());
@@ -759,10 +760,12 @@ public class PublicationsTypeManager {
                         attdetail.setInfo(metaData.getSubject());
                       }
                     }
-                    if (settings.useFileDates()) {
+                    if (AttachmentSettings.isUseFileMetadataForAttachmentDataEnabled() &&
+                        settings.useFileDates()) {
                       // extract creation date
                       if (metaData == null) {
-                        metaData = metadataExtractor.extractMetadata(attdetail.getAttachmentPath());
+                        metaData = MetadataExtractor.getInstance()
+                            .extractMetadata(attdetail.getAttachmentPath());
                       }
                       if (metaData.getCreationDate() != null) {
                         attdetail.setCreationDate(metaData.getCreationDate());

--- a/web-core/src/main/java/com/silverpeas/importExport/control/RepositoriesTypeManager.java
+++ b/web-core/src/main/java/com/silverpeas/importExport/control/RepositoriesTypeManager.java
@@ -55,6 +55,7 @@ import org.silverpeas.attachment.model.SimpleDocument;
 import org.silverpeas.attachment.model.SimpleDocumentPK;
 import org.silverpeas.attachment.model.UnlockContext;
 import org.silverpeas.attachment.model.UnlockOption;
+import org.silverpeas.attachment.util.AttachmentSettings;
 import org.silverpeas.core.admin.OrganisationControllerFactory;
 import org.silverpeas.importExport.attachment.AttachmentDetail;
 import org.silverpeas.importExport.attachment.AttachmentImportExport;
@@ -304,9 +305,8 @@ public class RepositoriesTypeManager {
                 currentUser.getId(), creationDate, null));
       }
       document.setDocumentType(documentType);
+      setMetadata(document, file);
     }
-
-    setMetadata(document, file);
 
     if (needCreation) {
       boolean notifying = !document.isVersioned() || publicVersion;
@@ -338,11 +338,13 @@ public class RepositoriesTypeManager {
    * @param file the physical file.
    */
   private static void setMetadata(SimpleDocument document, File file) {
-    final MetadataExtractor extractor = MetadataExtractor.getInstance();
-    final MetaData metadata = extractor.extractMetadata(file);
-    document.setSize(file.length());
-    document.setTitle(metadata.getTitle());
-    document.setDescription(metadata.getSubject());
+    if (AttachmentSettings.isUseFileMetadataForAttachmentDataEnabled()) {
+      final MetadataExtractor extractor = MetadataExtractor.getInstance();
+      final MetaData metadata = extractor.extractMetadata(file);
+      document.setSize(file.length());
+      document.setTitle(metadata.getTitle());
+      document.setDescription(metadata.getSubject());
+    }
   }
 
   private void processMailContent(PublicationDetail pubDetail, File file,

--- a/web-core/src/main/java/org/silverpeas/attachment/web/SimpleDocumentResourceCreator.java
+++ b/web-core/src/main/java/org/silverpeas/attachment/web/SimpleDocumentResourceCreator.java
@@ -42,6 +42,7 @@ import org.silverpeas.attachment.model.SimpleDocument;
 import org.silverpeas.attachment.model.SimpleDocumentPK;
 import org.silverpeas.attachment.model.UnlockContext;
 import org.silverpeas.attachment.model.UnlockOption;
+import org.silverpeas.attachment.util.AttachmentSettings;
 import org.silverpeas.importExport.versioning.DocumentVersion;
 import org.silverpeas.servlet.RequestParameterDecoder;
 
@@ -60,6 +61,7 @@ import java.io.InputStream;
 import java.net.URI;
 import java.util.Date;
 
+import static com.silverpeas.util.StringUtil.defaultStringIfNotDefined;
 import static org.silverpeas.web.util.IFrameAjaxTransportUtil.*;
 
 /**
@@ -136,22 +138,18 @@ public class SimpleDocumentResourceCreator extends AbstractSimpleDocumentResourc
         checkUploadedFile(tempFile);
 
         String lang = I18NHelper.checkLanguage(uploadData.getLanguage());
-        String title = uploadData.getTitle();
-        String description = uploadData.getDescription();
-        if (!StringUtil.isDefined(title)) {
+        String title = defaultStringIfNotDefined(uploadData.getTitle());
+        String description = defaultStringIfNotDefined(uploadData.getDescription());
+        if (AttachmentSettings.isUseFileMetadataForAttachmentDataEnabled() &&
+            !StringUtil.isDefined(title)) {
           MetadataExtractor extractor = MetadataExtractor.getInstance();
           MetaData metadata = extractor.extractMetadata(tempFile);
           if (StringUtil.isDefined(metadata.getTitle())) {
             title = metadata.getTitle();
-          } else {
-            title = "";
           }
           if (!StringUtil.isDefined(description) && StringUtil.isDefined(metadata.getSubject())) {
             description = metadata.getSubject();
           }
-        }
-        if (!StringUtil.isDefined(description)) {
-          description = "";
         }
 
         DocumentType attachmentContext;


### PR DESCRIPTION
Fixing also a little problem on the update of an attachment from D&D which was updating the title and the description with the metadata of the file.
Cleaning the code.

https://tracker.silverpeas.org/issues/7102