### PR TITLE
Feature #6519 (5.14.x): roll-backing the treatment of notification to previous version about the remove of the sender from the receivers (see REDMINE #6073).

### DIFF
--- a/lib-core/src/main/java/com/stratelia/silverpeas/notificationManager/NotificationSender.java
+++ b/lib-core/src/main/java/com/stratelia/silverpeas/notificationManager/NotificationSender.java
@@ -115,12 +115,6 @@ public class NotificationSender implements java.io.Serializable {
     // Then exclude users that don't have to be notified
     usersSet.removeAll(metaData.getUserRecipientsToExclude());
 
-    // Finally exclude the sender from the container of receivers (usersSet)
-    String senderId = metaData.getSender();
-    if (StringUtil.isInteger(senderId) && Integer.parseInt(senderId) > 0) {
-      usersSet.remove(new UserRecipient(senderId));
-    }
-
     Set<String> languages = metaData.getLanguages();
     Map<String, String> usersLanguage = new HashMap<String, String>(usersSet.size());
     for (UserRecipient user : usersSet) {


### PR DESCRIPTION
This commit is only compatible with 5.14.x branch. Do not report to another one.