### PR TITLE
Feature #6519: the sender is now removed from the receivers only if the notification concerns a subscription.

### DIFF
--- a/config-core/src/main/config/properties/org/silverpeas/notificationManager/settings/notificationManagerSettings.properties
+++ b/config-core/src/main/config/properties/org/silverpeas/notificationManager/settings/notificationManagerSettings.properties
@@ -74,3 +74,6 @@ cronDelayedNotificationSending = 30 0 * * *
 # Si la valeur est un entier positif, alors la limitation est active.
 # Sinon, il n'y a pas de limitation (cas par d\u00e9faut).
 notif.manual.receiver.limit = 0
+
+# If enabled, the sender must be removed from the list of receivers of a subscription notification.
+notification.subscription.removeSenderFromReceivers.enabled = true

--- a/lib-core/src/main/java/com/silverpeas/notification/builder/AbstractUserNotificationBuilder.java
+++ b/lib-core/src/main/java/com/silverpeas/notification/builder/AbstractUserNotificationBuilder.java
@@ -24,9 +24,11 @@
 package com.silverpeas.notification.builder;
 
 import com.silverpeas.util.CollectionUtil;
+import com.silverpeas.util.StringUtil;
 import com.silverpeas.util.i18n.I18NHelper;
 import com.stratelia.silverpeas.notificationManager.ExternalRecipient;
 import com.stratelia.silverpeas.notificationManager.GroupRecipient;
+import com.stratelia.silverpeas.notificationManager.NotificationManagerSettings;
 import com.stratelia.silverpeas.notificationManager.NotificationMetaData;
 import com.stratelia.silverpeas.notificationManager.UserRecipient;
 import com.stratelia.silverpeas.notificationManager.constant.NotifAction;
@@ -36,7 +38,6 @@ import com.stratelia.webactiv.util.ResourceLocator;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.Collection;
-import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -196,6 +197,13 @@ public abstract class AbstractUserNotificationBuilder implements UserNotificatio
       for (final String userId : userIdsToExcludeFromNotifying) {
         getNotificationMetaData().addUserRecipientToExclude(new UserRecipient(userId));
       }
+    }
+    if (this instanceof UserSubscriptionNotificationBehavior &&
+        NotificationManagerSettings.isRemoveSenderFromSubscriptionNotificationReceiversEnabled() &&
+        StringUtil.isInteger(getSender())) {
+      // The sender must be excluded from receivers when the notification concerns a subscription
+      // and if it is enabled from the global parameter.
+      getNotificationMetaData().addUserRecipientToExclude(new UserRecipient(getSender()));
     }
 
     if (CollectionUtil.isNotEmpty(groupIdsToNotify)) {

--- a/lib-core/src/main/java/com/silverpeas/notification/builder/UserSubscriptionNotificationBehavior.java
+++ b/lib-core/src/main/java/com/silverpeas/notification/builder/UserSubscriptionNotificationBehavior.java
@@ -36,6 +36,6 @@ public interface UserSubscriptionNotificationBehavior {
    * HTTP parameter that permits to indicate to the server that the subscription notification
    * sending must be skipped.
    */
-  public static final String SKIP_SUBSCRIPTION_NOTIFICATION_SENDING_HTTP_PARAM =
+  String SKIP_SUBSCRIPTION_NOTIFICATION_SENDING_HTTP_PARAM =
       "SKIP_SUBSCRIPTION_NOTIFICATION_SENDING";
 }

--- a/lib-core/src/main/java/com/silverpeas/notification/jms/SilverpeasMessageListener.java
+++ b/lib-core/src/main/java/com/silverpeas/notification/jms/SilverpeasMessageListener.java
@@ -29,7 +29,6 @@ import com.silverpeas.notification.NotificationSubscriber;
 import com.silverpeas.notification.NotificationTopic;
 import com.silverpeas.notification.PublishingException;
 import com.silverpeas.notification.SilverpeasNotification;
-import com.silverpeas.notification.builder.UserSubscriptionNotificationBehavior;
 import com.silverpeas.notification.builder.UserSubscriptionNotificationSendingHandler;
 
 /**

--- a/lib-core/src/main/java/com/stratelia/silverpeas/notificationManager/NotificationManagerSettings.java
+++ b/lib-core/src/main/java/com/stratelia/silverpeas/notificationManager/NotificationManagerSettings.java
@@ -191,4 +191,13 @@ public class NotificationManagerSettings {
     }
     return mediaIds;
   }
+
+  /**
+   * Indicates if the sender must be removed from the list of receivers of a subscription
+   * notification.
+   * @return true if enabled, false otherwise.
+   */
+  public static boolean isRemoveSenderFromSubscriptionNotificationReceiversEnabled() {
+    return settings.getBoolean("notification.subscription.removeSenderFromReceivers.enabled", true);
+  }
 }

--- a/lib-core/src/main/java/com/stratelia/silverpeas/notificationManager/NotificationMetaData.java
+++ b/lib-core/src/main/java/com/stratelia/silverpeas/notificationManager/NotificationMetaData.java
@@ -708,15 +708,6 @@ public class NotificationMetaData implements java.io.Serializable {
         updateInternalUserRecipientsToExclude ? getUserRecipientsToExclude() :
             new HashSet<UserRecipient>(getUserRecipientsToExclude());
 
-    if (!isManualUserOne()) {
-      // If sender exists, it is excluded
-      String senderId = getSender();
-      if (StringUtil.isInteger(senderId) && Integer.parseInt(senderId) > 0) {
-        UserRecipient senderUserRecipient = new UserRecipient(senderId);
-        userRecipientsToExclude.add(senderUserRecipient);
-      }
-    }
-
     // First get direct users
     allUniqueUserRecipients.addAll(userRecipients);
 

--- a/lib-core/src/test/java/com/stratelia/silverpeas/notificationManager/NotificationMetaDataTest.java
+++ b/lib-core/src/test/java/com/stratelia/silverpeas/notificationManager/NotificationMetaDataTest.java
@@ -216,8 +216,9 @@ public class NotificationMetaDataTest {
     current.addGroupRecipient(new GroupRecipient("GU"));
 
     assertThat(current.getAllUserRecipients(),
-        containsInAnyOrder(new UserRecipient("26"), new UserRecipient("38"),
-            new UserRecipient("GU_1"), new UserRecipient("GU_2"), new UserRecipient("GU_3")));
+        containsInAnyOrder(new UserRecipient(USER_SENDER), new UserRecipient("26"),
+            new UserRecipient("38"), new UserRecipient("GU_1"), new UserRecipient("GU_2"),
+            new UserRecipient("GU_3")));
     assertThat(current.getUserRecipientsToExclude(), empty());
   }
 
@@ -232,9 +233,10 @@ public class NotificationMetaDataTest {
     current.addGroupRecipient(new GroupRecipient("GU"));
 
     assertThat(current.getAllUserRecipients(true),
-        containsInAnyOrder(new UserRecipient("26"), new UserRecipient("38"),
-            new UserRecipient("GU_1"), new UserRecipient("GU_2"), new UserRecipient("GU_3")));
-    assertThat(current.getUserRecipientsToExclude(), contains(new UserRecipient(USER_SENDER)));
+        containsInAnyOrder(new UserRecipient(USER_SENDER), new UserRecipient("26"),
+            new UserRecipient("38"), new UserRecipient("GU_1"), new UserRecipient("GU_2"),
+            new UserRecipient("GU_3")));
+    assertThat(current.getUserRecipientsToExclude(), empty());
   }
 
   @Test
@@ -248,8 +250,9 @@ public class NotificationMetaDataTest {
     current.addGroupRecipient(new GroupRecipient("GU"));
 
     assertThat(current.getAllUserRecipients(),
-        containsInAnyOrder(new UserRecipient("26"), new UserRecipient("38"),
-            new UserRecipient("GU_1"), new UserRecipient("GU_2"), new UserRecipient("GU_3")));
+        containsInAnyOrder(new UserRecipient(USER_SENDER), new UserRecipient("26"),
+            new UserRecipient("38"), new UserRecipient("GU_1"), new UserRecipient("GU_2"),
+            new UserRecipient("GU_3")));
     assertThat(current.getUserRecipientsToExclude(), contains(new UserRecipient("Excluded")));
   }
 
@@ -265,10 +268,68 @@ public class NotificationMetaDataTest {
     current.addGroupRecipient(new GroupRecipient("GU"));
 
     assertThat(current.getAllUserRecipients(true),
-        containsInAnyOrder(new UserRecipient("26"), new UserRecipient("38"),
-            new UserRecipient("GU_1"), new UserRecipient("GU_2"), new UserRecipient("GU_3")));
+        containsInAnyOrder(new UserRecipient(USER_SENDER), new UserRecipient("26"),
+            new UserRecipient("38"), new UserRecipient("GU_1"), new UserRecipient("GU_2"),
+            new UserRecipient("GU_3")));
     assertThat(current.getUserRecipientsToExclude(),
-        containsInAnyOrder(new UserRecipient("Excluded"), new UserRecipient(USER_SENDER)));
+        containsInAnyOrder(new UserRecipient("Excluded")));
+  }
+
+  @Test
+  public void getAllUserRecipientsInSendContextForVerifyingExclusionWithDefaultSettings()
+      throws Exception {
+    current.setSender(USER_SENDER);
+    current.addUserRecipientToExclude(new UserRecipient("Excluded"));
+    current.addUserRecipient(new UserRecipient(USER_SENDER));
+    current.addUserRecipient(new UserRecipient("26"));
+
+    assertThat(current.getAllUserRecipients(true),
+        containsInAnyOrder(new UserRecipient(USER_SENDER), new UserRecipient("26")));
+    assertThat(current.getUserRecipientsToExclude(),
+        containsInAnyOrder(new UserRecipient("Excluded")));
+  }
+
+  @Test
+  public void getAllUserRecipientsInSendContextForVerifyingSenderExclusion()
+      throws Exception {
+    current.setSender(USER_SENDER);
+    current.addUserRecipientToExclude(new UserRecipient("Excluded"));
+    current.addUserRecipient(new UserRecipient(USER_SENDER));
+    current.addUserRecipient(new UserRecipient("26"));
+
+    assertThat(current.getAllUserRecipients(true),
+        containsInAnyOrder(new UserRecipient(USER_SENDER), new UserRecipient("26")));
+    assertThat(current.getUserRecipientsToExclude(),
+        containsInAnyOrder(new UserRecipient("Excluded")));
+  }
+
+  @Test
+  public void getAllUserRecipientsInSendContextForVerifyingSenderExclusionWithForceKeepingSender()
+      throws Exception {
+    current.setSender(USER_SENDER);
+    current.addUserRecipientToExclude(new UserRecipient("Excluded"));
+    current.addUserRecipient(new UserRecipient(USER_SENDER));
+    current.addUserRecipient(new UserRecipient("26"));
+
+    assertThat(current.getAllUserRecipients(true),
+        containsInAnyOrder(new UserRecipient(USER_SENDER), new UserRecipient("26")));
+    assertThat(current.getUserRecipientsToExclude(),
+        containsInAnyOrder(new UserRecipient("Excluded")));
+  }
+
+  @Test
+  public void getAllUserRecipientsInSendContextForVerifyingSenderExclusionWithManualNotification()
+      throws Exception {
+    current.setSender(USER_SENDER);
+    current.addUserRecipientToExclude(new UserRecipient("Excluded"));
+    current.addUserRecipient(new UserRecipient(USER_SENDER));
+    current.addUserRecipient(new UserRecipient("26"));
+    current.manualUserNotification();
+
+    assertThat(current.getAllUserRecipients(true),
+        containsInAnyOrder(new UserRecipient(USER_SENDER), new UserRecipient("26")));
+    assertThat(current.getUserRecipientsToExclude(),
+        containsInAnyOrder(new UserRecipient("Excluded")));
   }
 
   /*

--- a/war-core/src/main/java/com/stratelia/silverpeas/notificationUser/control/NotificationUserSessionController.java
+++ b/war-core/src/main/java/com/stratelia/silverpeas/notificationUser/control/NotificationUserSessionController.java
@@ -93,7 +93,7 @@ public class NotificationUserSessionController extends AbstractComponentSessionC
   }
 
   /**
-   * @param Notification
+   * @param notification
    * @throws NotificationManagerException
    */
   public void sendMessage(Notification notification) throws NotificationManagerException {
@@ -101,12 +101,15 @@ public class NotificationUserSessionController extends AbstractComponentSessionC
     NotificationMetaData notifMetaData = notification.toNotificationMetaData();
     notifMetaData.setSender(getUserId());
     notifMetaData.setSource(getString("manualNotification"));
-    if (sel.getSelectedUserLimit() > 0) {
-      // A limitation has been set when the selection screen has been initialized.
+    if (StringUtil.isDefined(sel.getFirstSelectedElement()) ||
+        StringUtil.isDefined(sel.getFirstSelectedSet())) {
+      // The selection container has been set from the user panel, so the notification must be
+      // tagged as a manuel one.
       notifMetaData.manualUserNotification();
     } else {
-      // The user panel has not been displayed, so the notification is not tagged as a manual one
-      // in order to skip centralized verifications.
+      // The user panel has not been displayed and the receiver container has been set
+      // automatically, so the notification is not tagged as a manual one (and centralized
+      // verifications will be skipped).
     }
 
     notifSender.notifyUser(notification.getChannel(), notifMetaData);


### PR DESCRIPTION
Adding a new parameter that permits to enable/disable this removing.
So, roll-backing the treatment of notification sending to previous version about the remove of the sender from the receivers (see REDMINE #6073).
This commit is only compatible with 5.15.x version and the next one. Do not report to previous one.