### PR TITLE
[i18n] Fixing bug 7226

### DIFF
--- a/lib-core/src/main/java/com/silverpeas/form/displayers/WysiwygFCKFieldDisplayer.java
+++ b/lib-core/src/main/java/com/silverpeas/form/displayers/WysiwygFCKFieldDisplayer.java
@@ -451,7 +451,7 @@ public class WysiwygFCKFieldDisplayer extends AbstractFieldDisplayer<TextField> 
             setContentIntoFile(pageContext.getComponentId(), pageContext.getObjectId(),
                 template.getFieldName(), newValue, contentLanguage);
 
-        field.setValue(dbKey + fileName, pageContext.getLanguage());
+        field.setValue(dbKey + fileName, contentLanguage);
       } catch (FormException e) {
         throw new FormException("WysiwygFCKFieldDisplayer.update", "form.EX_NOT_CORRECT_VALUE", e);
       }

--- a/lib-core/src/main/java/com/silverpeas/form/form/XmlForm.java
+++ b/lib-core/src/main/java/com/silverpeas/form/form/XmlForm.java
@@ -90,6 +90,9 @@ public class XmlForm extends AbstractForm {
     SilverTrace.info("form", "XmlForm.display", "root.MSG_GEN_ENTER_METHOD");
     String language = pageContext.getLanguage();
 
+    // content language is the one of the record
+    pageContext.setContentLanguage(record.getLanguage());
+
     String mode = "";
     if (pageContext.isDesignMode()) {
       mode = "mode-design";

--- a/lib-core/src/main/java/com/silverpeas/form/record/GenericRecordSet.java
+++ b/lib-core/src/main/java/com/silverpeas/form/record/GenericRecordSet.java
@@ -109,9 +109,6 @@ public class GenericRecordSet implements RecordSet, Serializable {
    */
   @Override
   public DataRecord getRecord(String objectId, String language) throws FormException {
-    if (!I18NHelper.isI18nContentActivated || I18NHelper.isDefaultLanguage(language)) {
-      language = null;
-    }
     return getGenericRecordSetManager().getRecord(recordTemplate, objectId, language);
   }
 

--- a/lib-core/src/main/java/com/silverpeas/form/record/GenericRecordSetManager.java
+++ b/lib-core/src/main/java/com/silverpeas/form/record/GenericRecordSetManager.java
@@ -285,20 +285,38 @@ public class GenericRecordSetManager {
     return getRecord(template, objectId, null);
   }
 
-  public DataRecord getRecord(IdentifiedRecordTemplate template,
-      String objectId, String language) throws FormException {
+  /**
+   * Return the DataRecord registered by the tuple (templateId, objectId, language). If language
+   * does not match, fallback to other languages is done.
+   * @param template the definition of the form template the record belongs to.
+   * @param objectId the ID of the resource attached to form record.
+   * @return the form record in given language or in next language or <code>null</code> if not
+   * found.
+   * @throws FormException if the (templateId, recordId) pair is unknown.
+   */
+  public DataRecord getRecord(IdentifiedRecordTemplate template, String objectId, String language)
+      throws FormException {
 
-    SilverTrace.debug("form", "GenericRecordSetManager.getRecord",
-        "root.MSG_GEN_PARAM_VALUE", "objectId = " + objectId + ", language = "
-        + language);
+    SilverTrace.debug("form", "GenericRecordSetManager.getRecord", "root.MSG_GEN_PARAM_VALUE",
+        "objectId = " + objectId + ", language = " + language);
 
     Connection con = null;
-    GenericDataRecord record = null;
-
     try {
       con = getConnection();
-      record = selectRecordRow(con, template, objectId, language);
-
+      GenericDataRecord record = selectRecordRow(con, template, objectId, language);
+      if (record != null) {
+        record.setLanguage(language);
+      } else if (I18NHelper.isI18nContentEnabled()) {
+        List<String> languages = new ArrayList<String>(I18NHelper.getAllSupportedLanguages());
+        languages.remove(language);
+        for (String lang : languages) {
+          record = selectRecordRow(con, template, objectId, lang);
+          if (record != null) {
+            record.setLanguage(lang);
+            break;
+          }
+        }
+      }
       if (record != null) {
         try {
           selectFieldRows(con, template, record);


### PR DESCRIPTION
Fallback on all managed languages when getting a form content (same behavior as WYSIWYG content)

Do not omit to check out corresponding PR on Silverpeas-Components...