### PR TITLE
Fixing bug 7228

### DIFF
--- a/lib-core/src/main/java/org/silverpeas/wysiwyg/control/WysiwygManager.java
+++ b/lib-core/src/main/java/org/silverpeas/wysiwyg/control/WysiwygManager.java
@@ -872,7 +872,7 @@ public class WysiwygManager {
           }
           AttachmentServiceFactory.getAttachmentService()
               .updateAttachment(copy, new ByteArrayInputStream(content.getBytes(Charsets.UTF_8)),
-                  true, true);
+                  false, false);
         } else {
           languagesWithEmptyContent.add(language);
         }


### PR DESCRIPTION
Changing behavior when copying Wysiwyg content. Do not index or invoke callback when copying... Main contribution is responsible of indexation.

Do not forget to checkout corresponding PR on Silverpeas-Components...