### PR TITLE
Fix Support #7477

### DIFF
--- a/war-core/src/main/webapp/selection/jsp/userpanel.jsp
+++ b/war-core/src/main/webapp/selection/jsp/userpanel.jsp
@@ -759,6 +759,8 @@
           } catch (e) {
             // to prevent errors according to cross browser compatibility
           }
+		  
+		 autoresizeUserGroupFilters();
 
           $(window).resize(function() {
             autoresizeUserGroupFilters();


### PR DESCRIPTION
il manquait l'ascenseur quand la liste des groupes est trop nombreuse. Il n'apparaissait qu'au resize et pour cause le calcule de la taille n'était fait que sur l’événement resize.