### PR TITLE
Feature 8017 

### DIFF
--- a/core-api/src/main/java/org/silverpeas/core/calendar/Calendar.java
+++ b/core-api/src/main/java/org/silverpeas/core/calendar/Calendar.java
@@ -44,6 +44,8 @@ import java.time.YearMonth;
 import java.util.List;
 import java.util.Optional;
 
+import static java.time.Month.DECEMBER;
+
 /**
  * A calendar is a particular system for scheduling and organizing events and activities that occur
  * at different times or on different dates throughout the years.
@@ -111,6 +113,19 @@ public class Calendar extends SilverpeasJpaEntity<Calendar, UuidIdentifier> impl
   }
 
   /**
+   * Gets a calendar window of time defined between the two specified dates and from which the
+   * events occurring in the given period can be requested.
+   * @param start the start date of the period.
+   * @param end the end date of the period.
+   * @return a window of time that includes all the calendar events occurring in its specified
+   * period of time.
+   */
+  public static CalendarTimeWindow getTimeWindowBetween(final LocalDate start,
+      final LocalDate end) {
+    return new CalendarTimeWindow(start, end);
+  }
+
+  /**
    * Gets the identifier of the component instance which the calendar is attached.
    * @return the identifier of the component instance which the calendar is attached.
    */
@@ -153,45 +168,45 @@ public class Calendar extends SilverpeasJpaEntity<Calendar, UuidIdentifier> impl
   }
 
   /**
-   * Gets a time window according to the specified period into which occurrences of events are
-   * requested.
-   * @param year the year during which the events occur.
-   * @return the initialized time window.
+   * Gets a window of time on this calendar defined by the specified period. The window of time
+   * will include only the events in this calendar that occur in the specified period.
+   * @param year the year during which the events in this calendar occur.
+   * @return the window of time including the events in this calendar occurring in the given period.
    */
   public CalendarTimeWindow in(final Year year) {
-    return new CalendarTimeWindow(this, year);
+    return between(year.atDay(1), year.atMonth(DECEMBER).atEndOfMonth());
   }
 
   /**
-   * Gets a time window according to the specified period into which occurrences of events are
-   * requested.
-   * @param yearMonth the month and year during which the events occur.
-   * @return the initialized time window.
+   * Gets a window of time on this calendar defined by the specified period. The window of time
+   * will include only the events in this calendar that occur in the specified period.
+   * @param yearMonth the month and year during which the events in this calendar occur.
+   * @return the window of time including the events in this calendar occurring in the given period.
    */
   public CalendarTimeWindow in(final YearMonth yearMonth) {
-    return new CalendarTimeWindow(this, yearMonth);
+    return between(yearMonth.atDay(1), yearMonth.atEndOfMonth());
   }
 
   /**
-   * Gets a time window according to the specified period into which occurrences of events are
-   * requested.
-   * @param day day during which the events occur.
-   * @return the initialized time window.
+   * Gets a window of time on this calendar defined by the specified period. The window of time
+   * will include only the events in this calendar that occur in the specified period.
+   * @param day day during which the events in this calendar occur.
+   * @return the window of time including the events in this calendar occurring in the given period.
    */
   public CalendarTimeWindow in(final LocalDate day) {
-    return new CalendarTimeWindow(this, day);
+    return between(day, day);
   }
 
   /**
-   * Gets a time window according to the specified period into which occurrences of events are
-   * requested.
+   * Gets a window of time on this calendar defined by the specified period. The window of time
+   * will include only the events in this calendar that occur in the specified period.
    * @param start the start date of the period.
    * @param end the end date of the period.
-   * @return the initialized time window.
+   * @return the window of time including the events in this calendar occurring in the given period.
    */
   public CalendarTimeWindow between(final LocalDate start, final LocalDate end) {
     verifyCalendarIsPersisted();
-    return new CalendarTimeWindow(this, start, end);
+    return Calendar.getTimeWindowBetween(start, end).filter(f -> f.onCalendar(this));
   }
 
   private void verifyCalendarIsPersisted() {
@@ -238,4 +253,5 @@ public class Calendar extends SilverpeasJpaEntity<Calendar, UuidIdentifier> impl
     CalendarEventRepository repository = CalendarEventRepository.get();
     return repository.size(this) == 0;
   }
+
 }

--- a/core-api/src/main/java/org/silverpeas/core/calendar/CalendarEventFilter.java
+++ b/core-api/src/main/java/org/silverpeas/core/calendar/CalendarEventFilter.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2000 - 2016 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "http://www.silverpeas.org/docs/core/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.silverpeas.core.calendar;
+
+import org.silverpeas.core.admin.user.model.User;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * A filter to apply on the calendar events that occur in a given window of time.
+ * @author mmoquillon
+ */
+public class CalendarEventFilter {
+
+  private List<Calendar> calendars = new ArrayList<>();
+  private List<User> participants = new ArrayList<>();
+
+  CalendarEventFilter() {
+
+  }
+
+  /**
+   * Filters on the specified calendars.
+   * @param calendars one or several calendars in which the events will have to be fetched.
+   * @return itself.
+   */
+  public CalendarEventFilter onCalendar(Calendar... calendars) {
+    return onCalendar(Arrays.asList(calendars));
+  }
+
+  /**
+   * Filters on the specified calendars.
+   * @param calendars one or several calendars in which the events will have to be fetched.
+   * @return itself.
+   */
+  public CalendarEventFilter onCalendar(List<Calendar> calendars) {
+    this.calendars.addAll(calendars);
+    return this;
+  }
+
+  /**
+   * Filters on the specified participants for an event. A participant can be the author or an
+   * attendee of an event.
+   * @param users the users in Silverpeas that participate for at least one event.
+   * @return itself.
+   */
+  public CalendarEventFilter onParticipants(User... users) {
+    return onParticipants(Arrays.asList(users));
+  }
+
+  /**
+   * Filters on the specified participants for an event. A participant can be the author or an
+   * attendee of an event.
+   * @param users the users in Silverpeas that participate for at least one event.
+   * @return itself.
+   */
+  public CalendarEventFilter onParticipants(List<User> users) {
+    this.participants.addAll(users);
+    return this;
+  }
+
+  /**
+   * Gets a list of calendars on which the events to filter must be planned.
+   * @return a list of calendars or an empty list if there is no filter on calendars.
+   */
+  public List<Calendar> getCalendars() {
+    return calendars;
+  }
+
+  /**
+   * Gets a list of participants that should be concerned by the events to filter. A participant
+   * is a Silverpeas user that is the author or an attendee for an event.
+   * @return a list of users participating for at least one event or an empty list if there is no
+   * filter on participants.
+   */
+  public List<User> getParticipants() {
+    return participants;
+  }
+}
+  

--- a/core-api/src/main/java/org/silverpeas/core/calendar/event/CalendarEventOccurrenceGenerator.java
+++ b/core-api/src/main/java/org/silverpeas/core/calendar/event/CalendarEventOccurrenceGenerator.java
@@ -47,7 +47,7 @@ public interface CalendarEventOccurrenceGenerator {
   }
 
   /**
-   * Generates the occurrences of the specified events and that occur at the specified day.
+   * Generates the occurrences of the calendar events that occur in the specified window of time.
    * @param timeWindow the time window in which the events occur.
    * @return a set of event occurrences that occur in the specified window of time sorted by the
    * date and time at which they start.

--- a/core-api/src/main/java/org/silverpeas/core/calendar/event/view/CalendarEventParticipationView.java
+++ b/core-api/src/main/java/org/silverpeas/core/calendar/event/view/CalendarEventParticipationView.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2000 - 2016 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "http://www.silverpeas.org/docs/core/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.silverpeas.core.calendar.event.view;
+
+import org.silverpeas.core.admin.user.model.User;
+import org.silverpeas.core.calendar.event.CalendarEventOccurrence;
+import org.silverpeas.core.calendar.event.InternalAttendee;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A view in which the occurrences of calendar events are grouped by their participants.
+ * A participant is either an author or an attendee for an event.
+ * The events occurrences are grouped by participant and for each participant the occurrences are
+ * sorted by calendar identifier and by date time.
+ * @author mmoquillon
+ */
+public class CalendarEventParticipationView implements CalendarEventView {
+
+  @Override
+  public Map<String, List<CalendarEventOccurrence>> apply(
+      final List<CalendarEventOccurrence> occurrences) {
+    Map<String, List<CalendarEventOccurrence>> view = new HashMap<>();
+    for (CalendarEventOccurrence occurrence : occurrences) {
+      add(view, occurrence.getCalendarEvent().getCreatedBy(), occurrence);
+      occurrence.getCalendarEvent()
+          .getAttendees()
+          .stream()
+          .filter(a -> a instanceof InternalAttendee)
+          .forEach(a -> {
+            add(view, a.getId(), occurrence);
+          });
+    }
+    return view;
+  }
+
+  private void add(Map<String, List<CalendarEventOccurrence>> view, String participant,
+      CalendarEventOccurrence occurrence) {
+    List<CalendarEventOccurrence> occurrences =
+        view.computeIfAbsent(participant, (u -> new LinkedList<>()));
+    occurrences.add(occurrence);
+    Collections.sort(occurrences, (o1, o2) -> {
+      int c = o1.getCalendarEvent()
+          .getCalendar()
+          .getId()
+          .compareTo(o2.getCalendarEvent().getCalendar().getId());
+      return c == 0 ? o1.getStartDateTime().compareTo(o2.getStartDateTime()) : c;
+    });
+  }
+
+}
+  

--- a/core-api/src/main/java/org/silverpeas/core/calendar/event/view/CalendarEventView.java
+++ b/core-api/src/main/java/org/silverpeas/core/calendar/event/view/CalendarEventView.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2000 - 2016 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "http://www.silverpeas.org/docs/core/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.silverpeas.core.calendar.event.view;
+
+import org.silverpeas.core.calendar.event.CalendarEventOccurrence;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A view in which the occurrences of the calendar events are grouped by a given event
+ * or occurrence property.
+ * @author mmoquillon
+ */
+@FunctionalInterface
+public interface CalendarEventView {
+
+  /**
+   * Applies this view on the specified list of calendar event occurrences. The occurrences will
+   * be grouped by a specific property.
+   * @param occurrences a list of calendar event occurrences.
+   * @return a map in which the occurrences are grouped by a specific property.
+   */
+  Map<?, List<CalendarEventOccurrence>> apply(final List<CalendarEventOccurrence> occurrences);
+}
+  

--- a/core-api/src/main/java/org/silverpeas/core/calendar/event/view/package-info.java
+++ b/core-api/src/main/java/org/silverpeas/core/calendar/event/view/package-info.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2000 - 2016 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "http://www.silverpeas.org/docs/core/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/**
+ * @author mmoquillon
+ */
+/**
+ * Provides a set of useful different views on the occurrences of calendar events in order to
+ * easily handle them by some specific properties.
+ */
+package org.silverpeas.core.calendar.event.view;

--- a/core-api/src/main/java/org/silverpeas/core/calendar/repository/CalendarEventRepository.java
+++ b/core-api/src/main/java/org/silverpeas/core/calendar/repository/CalendarEventRepository.java
@@ -24,7 +24,9 @@
 
 package org.silverpeas.core.calendar.repository;
 
+import org.silverpeas.core.admin.user.model.User;
 import org.silverpeas.core.calendar.Calendar;
+import org.silverpeas.core.calendar.CalendarEventFilter;
 import org.silverpeas.core.calendar.event.CalendarEvent;
 import org.silverpeas.core.persistence.datasource.repository.EntityRepository;
 import org.silverpeas.core.util.ServiceProvider;
@@ -57,17 +59,18 @@ public interface CalendarEventRepository extends EntityRepository<CalendarEvent>
   long size(final Calendar calendar);
 
   /**
-   * Gets all the events belonging to the specified calendar that occur between the two specified
-   * date and times.
-   * @param calendar the calendar with with events must be linked to.
-   * @param startDateTime the inclusive date and time in UTC/Greenwich at which begins the period in
-   * which the events are get.
+   * Gets all the events matching the specified filter and that occur between the two specified date
+   * and times.
+   * @param filter a filter to apply on the calendar events to return. The filter can be empty and
+   * then no filtering will be applied on the requested calendar events.
+   * @param startDateTime the inclusive date and time in UTC/Greenwich at which begins the period
+   * in which the events are get.
    * @param endDateTime the inclusive date and time in UTC/Greenwich at which ends the period in
    * which the events are get.
-   * @return a list of events that occur between the two date times or an empty list if there
-   * is no events in the specified calendar between the two date times.
+   * @return a list of events filtering by the given filter and that occur between the two date
+   * times or an empty list if there is no events matching the specified arguments.
    */
-  List<CalendarEvent> getAllBetween(final Calendar calendar, OffsetDateTime startDateTime,
+  List<CalendarEvent> getAllBetween(CalendarEventFilter filter, OffsetDateTime startDateTime,
       OffsetDateTime endDateTime);
 
 }

--- a/core-api/src/test/java/org/silverpeas/core/calendar/event/TestCalendarEventOccurrenceBuilder.java
+++ b/core-api/src/test/java/org/silverpeas/core/calendar/event/TestCalendarEventOccurrenceBuilder.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2000 - 2016 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "http://www.silverpeas.org/docs/core/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.silverpeas.core.calendar.event;
+
+import org.mockito.Mockito;
+import org.silverpeas.core.calendar.Calendar;
+import org.silverpeas.core.calendar.Recurrence;
+import org.silverpeas.core.date.Period;
+import org.silverpeas.core.date.TimeUnit;
+
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Supplier;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.silverpeas.core.test.TestUserProvider.aUser;
+
+/**
+ * A builder of a list of event occurrences dedicated for unit tests.
+ * @author mmoquillon
+ */
+public class TestCalendarEventOccurrenceBuilder {
+
+  private static final String EVENT_TITLE = "an event title";
+  private static final String EVENT_DESCRIPTION = "a short event description";
+
+  /**
+   * Builds a list of different occurrences of events.
+   * @return a list of calendar event occurrences.
+   */
+  public static List<CalendarEventOccurrence> build() {
+    List<CalendarEventOccurrence> occurrences = new ArrayList<>();
+    final OffsetDateTime now = OffsetDateTime.now();
+
+    Calendar calendar = mock(Calendar.class);
+    when(calendar.getId()).thenReturn("ID_1");
+    when(calendar.getComponentInstanceId()).thenReturn("Kal32");
+
+    CalendarEvent event = CalendarEvent.on(Period.between(now, now.plusHours(2)))
+        .createdBy(aUser("1"))
+        .withTitle(EVENT_TITLE)
+        .withDescription(EVENT_DESCRIPTION)
+        .withAttendee(aUser("0"))
+        .withAttendee(aUser("2"))
+        .withAttendee("titi@chez-les-duponts.fr")
+        .recur(Recurrence.every(1, TimeUnit.DAY).upTo(3));
+    event.setCalendar(calendar);
+    occurrences.add(new CalendarEventOccurrence(event, now, now.plusHours(2)));
+    occurrences.add(
+        new CalendarEventOccurrence(event, now.plusDays(1), now.plusDays(1).plusHours(2)));
+    occurrences.add(
+        new CalendarEventOccurrence(event, now.plusDays(2), now.plusDays(2).plusHours(2)));
+
+    calendar = mock(Calendar.class);
+    when(calendar.getId()).thenReturn("ID_2");
+    when(calendar.getComponentInstanceId()).thenReturn("Kal32");
+    event = CalendarEvent.on(now.toLocalDate())
+        .createdBy(aUser("0"))
+        .withAttendee("toto@chez-les-duponts.fr")
+        .withTitle(EVENT_TITLE)
+        .withDescription(EVENT_DESCRIPTION);
+    event.setCalendar(calendar);
+    occurrences.add(
+        new CalendarEventOccurrence(event, event.getStartDateTime(), event.getEndDateTime()));
+
+    calendar = mock(Calendar.class);
+    when(calendar.getId()).thenReturn("ID_3");
+    when(calendar.getComponentInstanceId()).thenReturn("Kal12");
+    event = CalendarEvent.on(Period.between(now, now.plusHours(3)))
+        .createdBy(aUser("0"))
+        .withAttendee(aUser("1"))
+        .withTitle(EVENT_TITLE)
+        .withDescription(EVENT_DESCRIPTION);
+    event.setCalendar(calendar);
+    occurrences.add(
+        new CalendarEventOccurrence(event, event.getStartDateTime(), event.getEndDateTime()));
+
+    return occurrences;
+  }
+
+}
+  

--- a/core-api/src/test/java/org/silverpeas/core/calendar/event/view/CalendarEventParticipationViewTest.java
+++ b/core-api/src/test/java/org/silverpeas/core/calendar/event/view/CalendarEventParticipationViewTest.java
@@ -1,0 +1,92 @@
+package org.silverpeas.core.calendar.event.view;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.silverpeas.core.admin.user.service.UserProvider;
+import org.silverpeas.core.calendar.event.CalendarEventOccurrence;
+import org.silverpeas.core.calendar.event.TestCalendarEventOccurrenceBuilder;
+import org.silverpeas.core.test.TestUserProvider;
+import org.silverpeas.core.test.rule.CommonAPI4Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * Unit test on the view applying on a list of calendar event occurrences.
+ * @author mmoquillon
+ */
+public class CalendarEventParticipationViewTest {
+
+  @Rule
+  public CommonAPI4Test commonAPI4Test = new CommonAPI4Test();
+  private CalendarEventParticipationView view = new CalendarEventParticipationView();
+
+  @Before
+  public void setUpUsers() {
+    UserProvider userProvider = TestUserProvider.withoutCurrentRequester();
+    commonAPI4Test.injectIntoMockedBeanContainer(userProvider);
+  }
+
+  @Test
+  public void applyOnAnEmptyListShouldDoesNothing() {
+    Map<String, List<CalendarEventOccurrence>> byUser = view.apply(new ArrayList<>());
+    assertThat(byUser.isEmpty(), is(true));
+  }
+
+  @Test
+  public void applyOnAListWithOccurrences() {
+    List<CalendarEventOccurrence> occurrences = TestCalendarEventOccurrenceBuilder.build();
+    Map<String, List<CalendarEventOccurrence>> byUser = view.apply(occurrences);
+
+    assertThat(byUser.isEmpty(), is(false));
+    for (Map.Entry<String, List<CalendarEventOccurrence>> entry : byUser.entrySet()) {
+      List<CalendarEventOccurrence> ocs;
+      switch (entry.getKey()) {
+        case "0":
+          ocs = entry.getValue();
+          assertThat(ocs.size(), is(5));
+          assertThat(isSorted(ocs), is(true));
+          break;
+        case "1":
+          ocs = entry.getValue();
+          assertThat(ocs.size(), is(4));
+          assertThat(isSorted(ocs), is(true));
+          break;
+        case "2":
+          ocs = entry.getValue();
+          assertThat(ocs.size(), is(3));
+          assertThat(isSorted(ocs), is(true));
+          break;
+        default:
+          fail("Unknown user with id " + entry.getKey());
+      }
+    }
+  }
+
+  private boolean isSorted(final List<CalendarEventOccurrence> occurrences) {
+    for (int i = 0; i < occurrences.size() - 1; i++) {
+      int result = occurrences.get(i)
+          .getCalendarEvent()
+          .getCalendar()
+          .getId()
+          .compareTo(occurrences.get(i + 1).getCalendarEvent().getCalendar().getId());
+      if (result == 0) {
+        if (occurrences.get(i)
+            .getStartDateTime()
+            .isAfter(occurrences.get(i + 1).getStartDateTime())) {
+          return false;
+        }
+      } else if (result > 0) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+}

--- a/core-api/src/test/java/org/silverpeas/core/test/TestUserProvider.java
+++ b/core-api/src/test/java/org/silverpeas/core/test/TestUserProvider.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2000 - 2016 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "http://www.silverpeas.org/docs/core/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.silverpeas.core.test;
+
+import org.silverpeas.core.admin.user.model.User;
+import org.silverpeas.core.admin.user.service.UserProvider;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * A provider of {@link User} dedicated to unit tests that works on users or that implies some
+ * users.
+ * @author mmoquillon
+ */
+public class TestUserProvider implements UserProvider {
+
+  private User currentRequester;
+
+  private TestUserProvider(String currentRequesterId) {
+    this.currentRequester = aUser(currentRequesterId);
+  }
+
+  private TestUserProvider(final User currentRequester) {
+    this.currentRequester = currentRequester;
+  }
+
+  public static TestUserProvider withAsCurrentRequester(String requesterId) {
+    return new TestUserProvider(requesterId);
+  }
+
+  public static TestUserProvider withAsCurrentRequester(final User requester) {
+    return new TestUserProvider(requester);
+  }
+
+  public static TestUserProvider withoutCurrentRequester() {
+    return new TestUserProvider((User) null);
+  }
+
+  public static User aUser(final String userId) {
+    User user = mock(User.class);
+    when(user.getId()).thenReturn(userId);
+    return user;
+  }
+
+  @Override
+  public User getUser(final String userId) {
+    return aUser(userId);
+  }
+
+  @Override
+  public User getCurrentRequester() {
+    return currentRequester;
+  }
+
+}
+  

--- a/core-library/src/integration-test/java/org/silverpeas/core/calendar/CalendarEventOccurrenceFilteringIntegrationTest.java
+++ b/core-library/src/integration-test/java/org/silverpeas/core/calendar/CalendarEventOccurrenceFilteringIntegrationTest.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright (C) 2000 - 2016 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "http://www.silverpeas.org/docs/core/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.silverpeas.core.calendar;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.silverpeas.core.admin.user.model.User;
+import org.silverpeas.core.calendar.event.CalendarEventOccurrence;
+import org.silverpeas.core.test.CalendarWarBuilder;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * This integration test is on the filtering of the occurrences of calendar events according to some
+ * peculiar criteria. The occurrences can be for events planned on different calendars and for
+ * which participate some given users.
+ * @author mmoquillon
+ */
+@RunWith(Arquillian.class)
+public class CalendarEventOccurrenceFilteringIntegrationTest extends BaseCalendarTest {
+
+  @Deployment
+  public static Archive<?> createTestArchive() {
+    return CalendarWarBuilder.onWarForTestClass(
+        CalendarEventOccurrenceFilteringIntegrationTest.class)
+        .addAsResource(BaseCalendarTest.TABLE_CREATION_SCRIPT.substring(1))
+        .addAsResource(INITIALIZATION_SCRIPT.substring(1))
+        .build();
+  }
+
+  /**
+   * Whatever the calendars, get the occurrences of events in which participate some given users
+   * and in a given period of time.
+   * <p>
+   * Input: users that participate to some events and a period of time without any occurrences of
+   * events.
+   * Output: no occurrences.
+   */
+  @Test
+  public void getNoOccurrencesWithGivenParticipantsInAnEmptyPeriod() {
+    List<CalendarEventOccurrence> occurrences =
+        Calendar.getTimeWindowBetween(LocalDate.now(), LocalDate.now().plusWeeks(1))
+            .filter(f -> f.onParticipants(User.getById("0"), User.getById("1"), User.getById("2")))
+            .getEventOccurrences();
+    assertThat(occurrences.isEmpty(), is(true));
+  }
+
+  /**
+   * Whatever the calendars, get the occurrences of events in which participate some given users
+   * and in a given period of time.
+   * <p>
+   * Input: users that don't participate to the events in the given a period of time.
+   * Output: no occurrences.
+   */
+  @Test
+  public void getNoOccurrencesWithNotMatchingParticipants() {
+    List<CalendarEventOccurrence> occurrences =
+        Calendar.getTimeWindowBetween(LocalDate.of(2016, 1, 8), LocalDate.of(2016, 2, 27))
+            .filter(f -> f.onParticipants(User.getById("2")))
+            .getEventOccurrences();
+    assertThat(occurrences.isEmpty(), is(true));
+  }
+
+  /**
+   * Whatever the calendars, get the occurrences of events in which participate some given users
+   * and in a given period of time.
+   * <p>
+   * Input: the author of the events that occur in the given a period of time.
+   * Output: the expected occurrences.
+   */
+  @Test
+  public void getOccurrencesForAGivenAuthor() {
+    List<CalendarEventOccurrence> occurrences =
+        Calendar.getTimeWindowBetween(LocalDate.of(2016, 1, 1), LocalDate.of(2016, 1, 8))
+            .filter(f -> f.onParticipants(User.getById("0")))
+            .getEventOccurrences();
+
+    assertThat(occurrences.size(), is(4));
+    assertThat(occurrences.get(0).getCalendarEvent().getId(), is("ID_E_4"));
+    assertThat(occurrences.get(1).getCalendarEvent().getId(), is("ID_E_2"));
+    assertThat(occurrences.get(2).getCalendarEvent().getId(), is("ID_E_1"));
+    assertThat(occurrences.get(3).getCalendarEvent().getId(), is("ID_E_3"));
+  }
+
+  /**
+   * Whatever the calendars, get the occurrences of events in which participate some given users
+   * and in a given period of time.
+   * <p>
+   * Input: an attendee in some events that occur in the given a period of time.
+   * Output: the expected occurrences.
+   */
+  @Test
+  public void getOccurrencesForAGivenAttendee() {
+    List<CalendarEventOccurrence> occurrences =
+        Calendar.getTimeWindowBetween(LocalDate.of(2016, 1, 1), LocalDate.of(2016, 1, 8))
+            .filter(f -> f.onParticipants(User.getById("1")))
+            .getEventOccurrences();
+
+    assertThat(occurrences.size(), is(1));
+    assertThat(occurrences.get(0).getCalendarEvent().getId(), is("ID_E_1"));
+  }
+
+  /**
+   * Whatever the calendars, get the occurrences of events in which participate some given users
+   * and in a given period of time.
+   * <p>
+   * Input: an author in some both non-recurring and recurring events that occur in a given a
+   * period of time.
+   * Output: the expected occurrences.
+   */
+  @Test
+  public void getOccurrencesFromRecurrentEventsWithGivenParticipants() {
+    List<CalendarEventOccurrence> occurrences =
+        Calendar.getTimeWindowBetween(LocalDate.of(2016, 1, 9), LocalDate.of(2016, 1, 23))
+            .filter(f -> f.onParticipants(User.getById("0")))
+            .getEventOccurrences();
+
+    assertThat(occurrences.size(), is(6));
+    assertThat(occurrences.get(0).getCalendarEvent().getId(), is("ID_E_4"));
+    assertThat(occurrences.get(1).getCalendarEvent().getId(), is("ID_E_2"));
+    assertThat(occurrences.get(2).getCalendarEvent().getId(), is("ID_E_1"));
+    assertThat(occurrences.get(3).getCalendarEvent().getId(), is("ID_E_3"));
+    assertThat(occurrences.get(4).getCalendarEvent().getId(), is("ID_E_5"));
+    assertThat(occurrences.get(5).getCalendarEvent().getId(), is("ID_E_5"));
+    assertThat(occurrences.get(4).getStartDateTime().toLocalDate(), is(LocalDate.of(2016, 1, 9)));
+    assertThat(occurrences.get(5).getStartDateTime().toLocalDate(), is(LocalDate.of(2016, 1, 23)));
+  }
+
+  /**
+   * Get the occurrences of events that were planned on some calendars in a given period of time.
+   * <p>
+   * Input: two calendars.
+   * Output: the expected occurrences.
+   */
+  @Test
+  public void getOccurrencesFromSeveralCalendars() {
+    List<CalendarEventOccurrence> occurrences =
+        Calendar.getTimeWindowBetween(LocalDate.of(2016, 1, 1), LocalDate.of(2016, 1, 8))
+            .filter(f -> f.onCalendar(Calendar.getById("ID_3"), Calendar.getById("ID_2")))
+            .getEventOccurrences();
+
+    assertThat(occurrences.size(), is(3));
+    assertThat(occurrences.get(0).getCalendarEvent().getId(), is("ID_E_4"));
+    assertThat(occurrences.get(1).getCalendarEvent().getId(), is("ID_E_2"));
+    assertThat(occurrences.get(2).getCalendarEvent().getId(), is("ID_E_1"));
+  }
+}
+  

--- a/core-library/src/main/java/org/silverpeas/core/calendar/repository/DefaultCalendarEventRepository.java
+++ b/core-library/src/main/java/org/silverpeas/core/calendar/repository/DefaultCalendarEventRepository.java
@@ -24,7 +24,9 @@
 
 package org.silverpeas.core.calendar.repository;
 
+import org.silverpeas.core.admin.user.model.User;
 import org.silverpeas.core.calendar.Calendar;
+import org.silverpeas.core.calendar.CalendarEventFilter;
 import org.silverpeas.core.calendar.event.CalendarEvent;
 import org.silverpeas.core.persistence.datasource.repository.jpa.NamedParameters;
 import org.silverpeas.core.persistence.datasource.repository.jpa.SilverpeasJpaEntityRepository;
@@ -32,6 +34,7 @@ import org.silverpeas.core.persistence.datasource.repository.jpa.SilverpeasJpaEn
 import javax.inject.Singleton;
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * @author Yohann Chastagnier
@@ -48,14 +51,23 @@ public class DefaultCalendarEventRepository extends SilverpeasJpaEntityRepositor
   }
 
   @Override
-  public List<CalendarEvent> getAllBetween(final Calendar calendar,
-      final OffsetDateTime startDateTime,
-      final OffsetDateTime endDateTime) {
-    NamedParameters params = newNamedParameters()
-        .add("startDateTime", startDateTime)
-        .add("endDateTime", endDateTime)
-        .add("calendar", calendar);
-    return findByNamedQuery("calendarEventsByPeriod", params);
+  public List<CalendarEvent> getAllBetween(final CalendarEventFilter filter,
+      final OffsetDateTime startDateTime, final OffsetDateTime endDateTime) {
+    String namedQuery = "calendarEvents";
+    NamedParameters parameters = newNamedParameters();
+    if (!filter.getCalendars().isEmpty()) {
+      parameters.add("calendars", filter.getCalendars());
+      namedQuery += "ByCalendar";
+    }
+    if (!filter.getParticipants().isEmpty()) {
+      parameters.add("participantIds",
+          filter.getParticipants().stream().map(User::getId).collect(Collectors.toList()));
+      namedQuery += "ByParticipants";
+    }
+
+    namedQuery += "ByPeriod";
+    parameters.add("startDateTime", startDateTime).add("endDateTime", endDateTime);
+    return findByNamedQuery(namedQuery, parameters);
   }
 
   @Override


### PR DESCRIPTION
Refine the CalendarWindowTime to represent a window of time for calendar events whatever the concerned calendars. The CalendarWindowTime provides now the method 'filter' with which the events or their occurrences can be filtered according to one or more properties. The filters are defined in the CalendarEventFilter class and two filters are defined: one to filter the events or their occurrences by their participants (Silverpeas users that are the creator or an attendee for an event) and another one to filter the events or their occurrences by the calendars on which they are planned.

In order to facilitate the handling of event occurrences, a new class hierarchy is defined to represent a view on the event occurrences. A view provides a given point of view on the occurrences; this point of view being a property of an event or an occurrence by which the occurrences can be grouped. A view CalendarEventParticipationView is provided to group the event occurrences by their participants (authors and attendees for the events), and each list of occurrences per participant is ordered by the calendar on which they are planned and by their starting date time.