### PR TITLE
[Search] updating feature 3840 and closing partially feature 8172

### DIFF
--- a/core-api/src/main/java/org/silverpeas/core/util/DateUtil.java
+++ b/core-api/src/main/java/org/silverpeas/core/util/DateUtil.java
@@ -34,6 +34,7 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.LocalDate;
 import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
@@ -68,6 +69,9 @@ public class DateUtil {
   public static final FastDateFormat ICALDATE_FORMATTER;
   public static final FastDateFormat ICALUTCDATE_FORMATTER;
   public static final FastDateFormat ISO8601_FORMATTER;
+  private static final DateTimeFormatter CUSTOM_FORMATTER =
+      DateTimeFormatter.ofPattern("yyyy/MM/dd");
+
   /**
    * Format and parse dates.
    */
@@ -346,6 +350,10 @@ public class DateUtil {
     synchronized (DATE_PARSER) {
       return DATE_PARSER.parse(date);
     }
+  }
+
+  public static LocalDate toLocalDate(String date) {
+    return LocalDate.parse(date, CUSTOM_FORMATTER);
   }
 
   /**

--- a/core-configuration/src/main/config/properties/org/silverpeas/pdcPeas/multilang/pdcBundle.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/pdcPeas/multilang/pdcBundle.properties
@@ -282,3 +282,4 @@ pdcPeas.predefined.update.allowed.true=Le contributeur doit valider et peut modi
 pdcPeas.predefined.update.allowed.false=Le contributeur ne doit pas valider le classement par d\u00e9faut
 
 pdcPeas.MustContainsText = doit \u00eatre renseign\u00e9
+pdcPeas.facet.lastUpdate=Dernière modification

--- a/core-configuration/src/main/config/properties/org/silverpeas/pdcPeas/multilang/pdcBundle_de.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/pdcPeas/multilang/pdcBundle_de.properties
@@ -277,3 +277,4 @@ pdcPeas.predefined.update.allowed.true=Der Teilnehmer muss genehmigen und kann d
 pdcPeas.predefined.update.allowed.false=Der Beitrag darf nicht die Standardklassifikation genehmigen
 
 pdcPeas.MustContainsText = muss eingegeben werden
+pdcPeas.facet.lastUpdate=Last update

--- a/core-configuration/src/main/config/properties/org/silverpeas/pdcPeas/multilang/pdcBundle_en.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/pdcPeas/multilang/pdcBundle_en.properties
@@ -289,3 +289,4 @@ pdcPeas.predefined.update.allowed.true=The contributor must approve and may modi
 pdcPeas.predefined.update.allowed.false=The contributor must not approve the default classification
 
 pdcPeas.MustContainsText = must be completed
+pdcPeas.facet.lastUpdate=Last update

--- a/core-configuration/src/main/config/properties/org/silverpeas/pdcPeas/multilang/pdcBundle_fr.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/pdcPeas/multilang/pdcBundle_fr.properties
@@ -245,6 +245,7 @@ pdcPeas.facet.author= Auteur
 pdcPeas.facet.service= Application
 pdcPeas.facet.datatype= Type de contribution
 pdcPeas.facet.filetype= Type de fichier
+pdcPeas.facet.lastUpdate= Dernière modification
 pdcPeas.facet.tooltip.enable= Cliquer pour affiner la recherche sur {0}
 pdcPeas.facet.tooltip.disable= Cliquer pour supprimer le filtre sur {0}
 pdcPeas.facet.toggle.show = Tout afficher

--- a/core-library/src/main/java/org/silverpeas/core/contribution/content/form/record/GenericRecordSet.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/content/form/record/GenericRecordSet.java
@@ -166,8 +166,16 @@ public class GenericRecordSet implements RecordSet, Serializable {
                   fieldType, fieldDisplayerName);
               if (fieldDisplayer != null) {
                 String key = formName + "$$" + fieldName;
-                fieldDisplayer.index(indexEntry, key, fieldName, field, language,
-                    fieldTemplate.isUsedAsFacet());
+                if (fieldTemplate.isRepeatable()) {
+                  for (int i=0; i<fieldTemplate.getMaximumNumberOfOccurrences(); i++) {
+                    field.setStringValue(data.getField(fieldName, i).getStringValue());
+                    fieldDisplayer.index(indexEntry, key, fieldName, field, language,
+                        fieldTemplate.isUsedAsFacet());
+                  }
+                } else {
+                  fieldDisplayer.index(indexEntry, key, fieldName, field, language,
+                      fieldTemplate.isUsedAsFacet());
+                }
               }
             } catch (Exception e) {
               SilverTrace.error("form", "AbstractForm.update",

--- a/core-library/src/main/java/org/silverpeas/core/index/indexing/DateFormatter.java
+++ b/core-library/src/main/java/org/silverpeas/core/index/indexing/DateFormatter.java
@@ -29,9 +29,9 @@ import java.util.Date;
 
 public class DateFormatter {
 
-  private static final SimpleDateFormat indexFormatter = new SimpleDateFormat("yyyyMMdd");
-  public final static String nullBeginDate = "00000000";
-  public final static String nullEndDate = "99999999";
+  private static final SimpleDateFormat indexFormatter = new SimpleDateFormat("yyyy/MM/dd");
+  public final static String nullBeginDate = "0000/00/00";
+  public final static String nullEndDate = "9999/99/99";
 
   public synchronized static String date2IndexFormat(Date date) {
     return indexFormatter.format(date);

--- a/core-library/src/main/java/org/silverpeas/core/index/indexing/model/FieldDescription.java
+++ b/core-library/src/main/java/org/silverpeas/core/index/indexing/model/FieldDescription.java
@@ -49,6 +49,9 @@ public class FieldDescription implements Serializable {
     this.lang = I18NHelper.checkLanguage(lang);
     this.fieldName = fieldName;
     this.stored = false;
+    this.basedOnDates = false;
+    this.startDate = null;
+    this.endDate = null;
   }
 
   public FieldDescription(String fieldName, String content, String lang, boolean stored) {
@@ -56,24 +59,23 @@ public class FieldDescription implements Serializable {
     this.lang = I18NHelper.checkLanguage(lang);
     this.fieldName = fieldName;
     this.stored = stored;
+    this.basedOnDates = false;
+    this.startDate = null;
+    this.endDate = null;
   }
 
   public FieldDescription(String fieldName, Date begin, Date end, String lang) {
-    String content = "";
-    if (begin != null && end != null)
-      content = "[" + DateFormatter.date2IndexFormat(begin) + " TO "
-          + DateFormatter.date2IndexFormat(end) + "]";
-    else if (begin != null && end == null)
-      content = "[" + DateFormatter.date2IndexFormat(begin) + " TO "
-          + DateFormatter.nullEndDate + "]";
-    else if (begin == null && end != null)
-      content = "[" + DateFormatter.nullBeginDate + " TO "
-          + DateFormatter.date2IndexFormat(end) + "]";
-
-    this.content = content;
+    this.content = "";
     this.lang = I18NHelper.checkLanguage(lang);
     this.fieldName = fieldName;
     this.stored = false;
+    this.basedOnDates = true;
+    this.startDate = begin;
+    this.endDate = end;
+  }
+
+  public boolean isBasedOnDate() {
+    return basedOnDates;
   }
 
   /**
@@ -101,6 +103,14 @@ public class FieldDescription implements Serializable {
     return stored;
   }
 
+  public Date getStartDate() {
+    return startDate;
+  }
+
+  public Date getEndDate() {
+    return endDate;
+  }
+
   /**
    * All the attributes are private and final.
    */
@@ -108,4 +118,7 @@ public class FieldDescription implements Serializable {
   private final String lang;
   private final String fieldName;
   private final boolean stored;
+  private final boolean basedOnDates;
+  private final Date startDate;
+  private final Date endDate;
 }

--- a/core-library/src/main/java/org/silverpeas/core/index/indexing/model/FieldDescription.java
+++ b/core-library/src/main/java/org/silverpeas/core/index/indexing/model/FieldDescription.java
@@ -24,11 +24,10 @@
 
 package org.silverpeas.core.index.indexing.model;
 
+import org.silverpeas.core.i18n.I18NHelper;
+
 import java.io.Serializable;
 import java.util.Date;
-
-import org.silverpeas.core.index.indexing.DateFormatter;
-import org.silverpeas.core.i18n.I18NHelper;
 
 /**
  * A FieldDescription pack all the needed information to parse and index a generic field (xml field,
@@ -43,6 +42,17 @@ import org.silverpeas.core.i18n.I18NHelper;
 public class FieldDescription implements Serializable {
 
   private static final long serialVersionUID = -475049855423827178L;
+
+  /**
+   * All the attributes are private and final.
+   */
+  private final String content;
+  private final String lang;
+  private final String fieldName;
+  private final boolean stored;
+  private final boolean basedOnDates;
+  private final Date startDate;
+  private final Date endDate;
 
   public FieldDescription(String fieldName, String content, String lang) {
     this.content = content;
@@ -110,15 +120,4 @@ public class FieldDescription implements Serializable {
   public Date getEndDate() {
     return endDate;
   }
-
-  /**
-   * All the attributes are private and final.
-   */
-  private final String content;
-  private final String lang;
-  private final String fieldName;
-  private final boolean stored;
-  private final boolean basedOnDates;
-  private final Date startDate;
-  private final Date endDate;
 }

--- a/core-library/src/main/java/org/silverpeas/core/index/indexing/model/FullIndexEntry.java
+++ b/core-library/src/main/java/org/silverpeas/core/index/indexing/model/FullIndexEntry.java
@@ -118,20 +118,6 @@ public class FullIndexEntry extends IndexEntry implements Serializable, Cloneabl
     }
   }
 
-  /**
-   * @deprecated use addField(String fieldName, String value) instead
-   */
-  public void addXMLField(String fieldName, String value) {
-    addXMLField(fieldName, value, null);
-  }
-
-  /**
-   * @deprecated use addField(String fieldName, String value, String language) instead
-   */
-  public void addXMLField(String fieldName, String value, String language) {
-    getFields().add(new FieldDescription(fieldName, value, language, false));
-  }
-
   public void addField(String fieldName, String value) {
     addField(fieldName, value, null, false);
   }
@@ -169,13 +155,6 @@ public class FullIndexEntry extends IndexEntry implements Serializable, Cloneabl
    */
   public List<FileDescription> getLinkedFileContentList() {
     return getLinkedFileList();
-  }
-
-  /**
-   * @deprecated use getFields() instead
-   */
-  public List<FieldDescription> getXmlFields() {
-    return getFields();
   }
 
   private List<TextDescription> getTextList() {

--- a/core-library/src/main/java/org/silverpeas/core/index/search/model/IndexSearcher.java
+++ b/core-library/src/main/java/org/silverpeas/core/index/search/model/IndexSearcher.java
@@ -575,12 +575,15 @@ public class IndexSearcher {
       return null;
     }
 
-    if (!StringUtil.isDefined(beginDate)) {
-      beginDate = IndexEntry.STARTDATE_DEFAULT;
+    String start = beginDate;
+    if (!StringUtil.isDefined(start)) {
+      start = IndexEntry.STARTDATE_DEFAULT;
     }
-    if (!StringUtil.isDefined(endDate)) {
-      endDate = IndexEntry.ENDDATE_DEFAULT;
+
+    String end = endDate;
+    if (!StringUtil.isDefined(end)) {
+      end = IndexEntry.ENDDATE_DEFAULT;
     }
-    return new TermRangeQuery(fieldName, beginDate, endDate, true, true);
+    return new TermRangeQuery(fieldName, start, end, true, true);
   }
 }

--- a/core-library/src/main/java/org/silverpeas/core/index/search/model/IndexSearcher.java
+++ b/core-library/src/main/java/org/silverpeas/core/index/search/model/IndexSearcher.java
@@ -335,11 +335,19 @@ public class IndexSearcher {
 
       List<FieldDescription> fieldQueries = query.getMultiFieldQuery();
       for (FieldDescription fieldQuery : fieldQueries) {
-        Query fieldI18NQuery =
-            getQuery(fieldQuery.getFieldName(), fieldQuery.getContent(), languages, analyzer);
-        booleanQuery.add(fieldI18NQuery, BooleanClause.Occur.MUST);
+        if (fieldQuery.isBasedOnDate()) {
+          TermRangeQuery rangeQuery = getTermRangeQuery(fieldQuery.getFieldName(),
+              DateUtil.date2SQLDate(fieldQuery.getStartDate()),
+              DateUtil.date2SQLDate(fieldQuery.getEndDate()));
+          if (rangeQuery != null) {
+            booleanQuery.add(rangeQuery, BooleanClause.Occur.MUST);
+          }
+        } else {
+          Query fieldI18NQuery =
+              getQuery(fieldQuery.getFieldName(), fieldQuery.getContent(), languages, analyzer);
+          booleanQuery.add(fieldI18NQuery, BooleanClause.Occur.MUST);
+        }
       }
-
 
       return booleanQuery;
     } catch (ParseException e) {
@@ -537,32 +545,13 @@ public class IndexSearcher {
   protected TermRangeQuery getRangeQueryOnCreationDate(QueryDescription query) {
     String beginDate = query.getRequestedCreatedAfter();
     String endDate = query.getRequestedCreatedBefore();
-    if (!StringUtil.isDefined(beginDate) && !StringUtil.isDefined(endDate)) {
-      return null;
-    }
-    if (!StringUtil.isDefined(beginDate)) {
-      beginDate = IndexEntry.STARTDATE_DEFAULT;
-    }
-    if (!StringUtil.isDefined(endDate)) {
-      endDate = IndexEntry.ENDDATE_DEFAULT;
-    }
-    return new TermRangeQuery(IndexManager.CREATIONDATE, beginDate, endDate, true, true);
+    return getTermRangeQuery(IndexManager.CREATIONDATE, beginDate, endDate);
   }
 
   protected TermRangeQuery getRangeQueryOnLastUpdateDate(QueryDescription query) {
     String beginDate = query.getRequestedUpdatedAfter();
     String endDate = query.getRequestedUpdatedBefore();
-    if (!StringUtil.isDefined(beginDate) && !StringUtil.isDefined(endDate)) {
-      return null;
-    }
-
-    if (!StringUtil.isDefined(beginDate)) {
-      beginDate = IndexEntry.STARTDATE_DEFAULT;
-    }
-    if (!StringUtil.isDefined(endDate)) {
-      endDate = IndexEntry.ENDDATE_DEFAULT;
-    }
-    return new TermRangeQuery(IndexManager.LASTUPDATEDATE, beginDate, endDate, true, true);
+    return getTermRangeQuery(IndexManager.LASTUPDATEDATE, beginDate, endDate);
   }
 
   protected TermQuery getTermQueryOnAuthor(QueryDescription query) {
@@ -579,5 +568,19 @@ public class IndexSearcher {
     }
     Term term = new Term(IndexManager.PATH, query.getRequestedFolder());
     return new PrefixQuery(term);
+  }
+
+  private TermRangeQuery getTermRangeQuery(String fieldName, String beginDate, String endDate) {
+    if (!StringUtil.isDefined(beginDate) && !StringUtil.isDefined(endDate)) {
+      return null;
+    }
+
+    if (!StringUtil.isDefined(beginDate)) {
+      beginDate = IndexEntry.STARTDATE_DEFAULT;
+    }
+    if (!StringUtil.isDefined(endDate)) {
+      endDate = IndexEntry.ENDDATE_DEFAULT;
+    }
+    return new TermRangeQuery(fieldName, beginDate, endDate, true, true);
   }
 }

--- a/core-war/src/main/java/org/silverpeas/web/pdc/control/PdcSearchSessionController.java
+++ b/core-war/src/main/java/org/silverpeas/web/pdc/control/PdcSearchSessionController.java
@@ -614,11 +614,6 @@ public class PdcSearchSessionController extends AbstractComponentSessionControll
     return form.getRecordTemplate().getFieldTemplate(fieldName);
   }
 
-  private String getFieldLabel(String formName, String fieldName)
-      throws PublicationTemplateException, FormException {
-    return getFieldTemplate(formName, fieldName).getLabel(getLanguage());
-  }
-
   private String getFieldValue(String formName, String fieldName, String fieldValue)
       throws PublicationTemplateException, FormException {
     FieldTemplate fieldTemplate = getFieldTemplate(formName, fieldName);

--- a/core-war/src/main/java/org/silverpeas/web/pdc/servlets/PdcSearchRequestRouter.java
+++ b/core-war/src/main/java/org/silverpeas/web/pdc/servlets/PdcSearchRequestRouter.java
@@ -402,6 +402,7 @@ public class PdcSearchRequestRouter extends ComponentRequestRouter<PdcSearchSess
     String instanceId = request.getParameter("componentFilter");
     String datatype = request.getParameter("datatypeFilter");
     String filetype = request.getParameter("filetypeFilter");
+    String lastUpdate = request.getParameter("lastUpdateFilter");
 
     ResultFilterVO filter = new ResultFilterVO();
 
@@ -417,6 +418,9 @@ public class PdcSearchRequestRouter extends ComponentRequestRouter<PdcSearchSess
     }
     if (StringUtil.isDefined(filetype)) {
       filter.setFiletype(filetype);
+    }
+    if (StringUtil.isDefined(lastUpdate)) {
+      filter.setLastUpdate(lastUpdate);
     }
 
     // check form field facets

--- a/core-war/src/main/java/org/silverpeas/web/pdc/vo/FacetOnDates.java
+++ b/core-war/src/main/java/org/silverpeas/web/pdc/vo/FacetOnDates.java
@@ -1,0 +1,27 @@
+package org.silverpeas.web.pdc.vo;
+
+import org.silverpeas.core.util.DateUtil;
+
+import java.time.LocalDate;
+
+/**
+ * Created by Nicolas on 11/01/2017.
+ */
+public class FacetOnDates extends Facet {
+
+  public FacetOnDates(String id, String name) {
+    super(id, name);
+  }
+
+  public FacetEntryVO addEntry(String d) {
+    return addEntry(DateUtil.toLocalDate(d));
+  }
+
+  public FacetEntryVO addEntry(LocalDate date) {
+    String year = String.valueOf(date.getYear());
+    FacetEntryVO entry = new FacetEntryVO(year, year);
+    super.addEntry(entry);
+    return entry;
+  }
+
+}

--- a/core-war/src/main/java/org/silverpeas/web/pdc/vo/ResultFilterVO.java
+++ b/core-war/src/main/java/org/silverpeas/web/pdc/vo/ResultFilterVO.java
@@ -34,7 +34,8 @@ public class ResultFilterVO {
   private String componentId = null;
   private String datatype = null;
   private String filetype = null;
-  private String year = null;
+  private String lastUpdate = null;
+
   private Map<String, String> formFieldFacets;
 
   /**
@@ -60,12 +61,12 @@ public class ResultFilterVO {
     this.componentId = componentId;
   }
 
-  public String getYear() {
-    return year;
+  public String getLastUpdate() {
+    return lastUpdate;
   }
 
-  public void setYear(String year) {
-    this.year = year;
+  public void setLastUpdate(final String lastUpdate) {
+    this.lastUpdate = lastUpdate;
   }
 
   public void addFormFieldSelectedFacetEntry(String facetId, String value) {
@@ -91,7 +92,8 @@ public class ResultFilterVO {
 
   public boolean isEmpty() {
     return !StringUtil.isDefined(authorId) && !StringUtil.isDefined(componentId) &&
-        !StringUtil.isDefined(datatype) && !StringUtil.isDefined(filetype) && isSelectedFormFieldFacetsEmpty();
+        !StringUtil.isDefined(datatype) && !StringUtil.isDefined(filetype) &&
+        !StringUtil.isDefined(lastUpdate) && isSelectedFormFieldFacetsEmpty();
   }
 
   public Map<String, String> getFormFieldSelectedFacetEntries() {

--- a/core-war/src/main/java/org/silverpeas/web/pdc/vo/ResultGroupFilter.java
+++ b/core-war/src/main/java/org/silverpeas/web/pdc/vo/ResultGroupFilter.java
@@ -29,12 +29,12 @@ import java.util.Comparator;
 import java.util.List;
 
 public class ResultGroupFilter {
-  private List<String> year = null;
 
   private Facet authorFacet = null;
   private Facet componentFacet = null;
   private Facet datatypeFacet = null;
   private Facet filetypeFacet = null;
+  private Facet lastUpdateFacet = null;
 
   private List<Facet> formfieldFacets;
 
@@ -43,14 +43,6 @@ public class ResultGroupFilter {
    */
   public ResultGroupFilter() {
     super();
-  }
-
-  public List<String> getYear() {
-    return year;
-  }
-
-  public void setYear(List<String> year) {
-    this.year = year;
   }
 
   public Facet getAuthorFacet() {
@@ -79,13 +71,19 @@ public class ResultGroupFilter {
 
   public void sortFacetsEntries() {
     EntryComparator comparator = new EntryComparator();
+    YearComparator yearComparator = new YearComparator();
     Collections.sort(authorFacet.getEntries(), comparator);
     Collections.sort(componentFacet.getEntries(), comparator);
     Collections.sort(datatypeFacet.getEntries(), comparator);
     Collections.sort(filetypeFacet.getEntries(), comparator);
+    Collections.sort(lastUpdateFacet.getEntries(), yearComparator);
 
     for (Facet formFieldFacet : formfieldFacets) {
-      Collections.sort(formFieldFacet.getEntries(), comparator);
+      if (formFieldFacet instanceof FacetOnDates) {
+        Collections.sort(formFieldFacet.getEntries(), yearComparator);
+      } else {
+        Collections.sort(formFieldFacet.getEntries(), comparator);
+      }
     }
   }
 
@@ -105,6 +103,14 @@ public class ResultGroupFilter {
     this.filetypeFacet = filetypeFacet;
   }
 
+  public Facet getLastUpdateFacet() {
+    return lastUpdateFacet;
+  }
+
+  public void setLastUpdateFacet(Facet lastUpdateFacet) {
+    this.lastUpdateFacet = lastUpdateFacet;
+  }
+
   private class EntryComparator implements Comparator<FacetEntryVO>{
     @Override
     public int compare(FacetEntryVO o1, FacetEntryVO o2) {
@@ -114,6 +120,13 @@ public class ResultGroupFilter {
       }
       // sort same weight entries according to alphabetical order
       return o1.getName().compareTo(o2.getName());
+    }
+  }
+
+  private class YearComparator implements Comparator<FacetEntryVO>{
+    @Override
+    public int compare(FacetEntryVO o1, FacetEntryVO o2) {
+      return o2.getName().compareTo(o1.getName());
     }
   }
 

--- a/core-war/src/main/webapp/pdcPeas/jsp/globalResult.jsp
+++ b/core-war/src/main/webapp/pdcPeas/jsp/globalResult.jsp
@@ -648,6 +648,7 @@ function viewFile(target, attachmentId, versioned, componentId) {
 	<div id="facetSearchDivId">
 	<%
 	displayFacet(facets.getAuthorFacet(), resource, out);
+	displayFacet(facets.getLastUpdateFacet(), resource, out);
 
 	List<Facet> fieldFacets = facets.getFormFieldFacets();
 	for (Facet facet : fieldFacets) {

--- a/core-war/src/main/webapp/templateDesigner/jsp/includeParamsField.jsp
+++ b/core-war/src/main/webapp/templateDesigner/jsp/includeParamsField.jsp
@@ -15,7 +15,7 @@ String usedAsFacet = "";
 boolean nameDisabled = false;
 String actionForm = "AddField";
 Map<String, String> parameters = null;
-boolean showFacetParam = "listbox".equals(displayer) || "radio".equals(displayer) || "checkbox".equals(displayer);
+boolean showFacetParam = "date".equals(displayer) || "listbox".equals(displayer) || "radio".equals(displayer) || "checkbox".equals(displayer);
 boolean showMultiValuesParam = "text".equals(displayer) || "textarea".equals(displayer) || "url".equals(displayer) || "file".equals(displayer) || "image".equals(displayer) || "video".equals(displayer);
 boolean shownInNewWindow = "pdc".equals(displayer);
 String checked = "checked=\"checked\"";

--- a/core-web/src/main/java/org/silverpeas/core/webapi/search/ResultEntity.java
+++ b/core-web/src/main/java/org/silverpeas/core/webapi/search/ResultEntity.java
@@ -4,6 +4,7 @@ import org.silverpeas.core.index.search.model.SearchResult;
 import org.silverpeas.core.util.StringUtil;
 
 import javax.xml.bind.annotation.XmlElement;
+import java.util.Map;
 
 /**
  * @author Nicolas Eysseric
@@ -34,6 +35,9 @@ public class ResultEntity {
   @XmlElement
   private String thumbnailURL;
 
+  @XmlElement
+  private Map<String, String> fieldsForFacets;
+
   private ResultEntity(SearchResult gsr) {
     this.name = gsr.getName();
     this.description = gsr.getDescription();
@@ -49,6 +53,8 @@ public class ResultEntity {
     if (StringUtil.isDefined(gsr.getThumbnailURL())) {
       this.thumbnailURL = gsr.getThumbnailURL().replaceFirst("/FileServer/", "/OnlineFileServer/");
     }
+
+    this.fieldsForFacets = gsr.getFormFieldsForFacets();
   }
 
   public static ResultEntity fromSearchResult(SearchResult gsr) {
@@ -109,6 +115,10 @@ public class ResultEntity {
 
   public void setThumbnailURL(final String thumbnailURL) {
     this.thumbnailURL = thumbnailURL;
+  }
+
+  public Map<String, String> getFieldsForFacets() {
+    return fieldsForFacets;
   }
 
   @Override

--- a/core-web/src/main/java/org/silverpeas/core/webapi/search/SearchResource.java
+++ b/core-web/src/main/java/org/silverpeas/core/webapi/search/SearchResource.java
@@ -1,10 +1,13 @@
 package org.silverpeas.core.webapi.search;
 
+import org.apache.commons.collections.EnumerationUtils;
 import org.silverpeas.core.annotation.RequestScoped;
 import org.silverpeas.core.annotation.Service;
+import org.silverpeas.core.index.indexing.model.FieldDescription;
 import org.silverpeas.core.index.search.model.QueryDescription;
 import org.silverpeas.core.index.search.model.SearchResult;
 import org.silverpeas.core.search.SearchService;
+import org.silverpeas.core.util.DateUtil;
 import org.silverpeas.core.util.StringUtil;
 import org.silverpeas.core.util.logging.SilverLogger;
 import org.silverpeas.core.webapi.base.RESTWebService;
@@ -17,10 +20,11 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import java.time.Instant;
-import java.time.ZoneId;
+import java.text.ParseException;
+import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 
 /**
@@ -39,14 +43,14 @@ public class SearchResource extends RESTWebService {
   public List<ResultEntity> search(@QueryParam("query") String query,
       @QueryParam("taxonomyPosition") String position,
       @QueryParam("spaceId") String spaceId, @QueryParam("appId") String appId,
-      @QueryParam("startDate") String startDate, @QueryParam("endDate") String endDate) {
+      @QueryParam("startDate") String startDate, @QueryParam("endDate") String endDate,
+      @QueryParam("form") String form) {
     QueryDescription queryDescription = new QueryDescription(query);
     queryDescription.setTaxonomyPosition(position);
 
     if (StringUtil.isDefined(startDate)) {
       try {
-        String date = Instant.ofEpochMilli(Long.valueOf(startDate)).atZone(ZoneId.systemDefault())
-            .toLocalDate().format(formatter);
+        String date = LocalDate.parse(startDate).format(formatter);
         queryDescription.setRequestedCreatedAfter(date);
       } catch (Exception e) {
         SilverLogger.getLogger(this).info("Can't parse start date as Long : {0}",
@@ -56,9 +60,7 @@ public class SearchResource extends RESTWebService {
 
     if (StringUtil.isDefined(endDate)) {
       try {
-        String date =
-            Instant.ofEpochMilli(Long.valueOf(endDate)).atZone(ZoneId.systemDefault()).toLocalDate()
-                .format(formatter);
+        String date = LocalDate.parse(endDate).format(formatter);
         queryDescription.setRequestedCreatedBefore(date);
       } catch (Exception e) {
         SilverLogger.getLogger(this).info("Can't parse end date as Long : {0}",
@@ -68,6 +70,40 @@ public class SearchResource extends RESTWebService {
 
     // determine where to search
     setComponents(queryDescription, spaceId, appId);
+
+    // add query parameters about form
+    if (StringUtil.isDefined(form)) {
+      List<String> paramNames = EnumerationUtils.toList(getHttpRequest().getParameterNames());
+      List<FieldDescription> formQuery = new ArrayList<>();
+      for (String paramName : paramNames) {
+        if (paramName.startsWith("field_")) {
+          String fieldName = paramName.replace("field_", "");
+          String value = getHttpRequest().getParameter(paramName);
+          formQuery.add(new FieldDescription(form+"$$"+fieldName, value, "fr"));
+        } else if (paramName.startsWith("fieldDate_")) {
+          String fieldName = paramName.replace("fieldDate_", "");
+          String value = getHttpRequest().getParameter(paramName);
+          String sDate = value.substring(0, value.indexOf(","));
+          String eDate = value.substring(value.indexOf(",")+1);
+          Date fromDate = null;
+          Date toDate = null;
+          try {
+            fromDate = DateUtil.parseISO8601Date(sDate);
+          } catch (ParseException e) {
+            // ignore unparsable date
+          }
+          try {
+            toDate = DateUtil.parseISO8601Date(eDate);
+          } catch (ParseException e) {
+            // ignore unparsable date
+          }
+          if (fromDate != null || toDate != null) {
+            formQuery.add(new FieldDescription(form+"$$"+fieldName, fromDate, toDate, "fr"));
+          }
+        }
+      }
+      queryDescription.setFieldQueries(formQuery);
+    }
 
     SearchService searchService = SearchService.get();
     List<ResultEntity> entities = new ArrayList<>();


### PR DESCRIPTION
This PR is a duplicate of [PR #786](https://github.com/Silverpeas/Silverpeas-Core/pull/786) in order to have a control on it for fixing any problems coming from the build.

Updating feature #3840, now :
- Repeatable form fields are well indexed (all values and not only the first one),
- REST API allows to querying on desired form fields,
- Results contain data from stored fields,
- Form field of type 'date' can be used as facet.

Closing partially feature #8172. First version of 'Last update' facet is here (one entry per year for the moment).