### PR TITLE
[Admin] Fixing bug 8688

### DIFF
--- a/lib-core/src/main/java/com/stratelia/webactiv/beans/admin/Admin.java
+++ b/lib-core/src/main/java/com/stratelia/webactiv/beans/admin/Admin.java
@@ -2465,7 +2465,7 @@ public class Admin {
   }
 
   private String spaceRole2ComponentRole(String spaceRole, String componentName) {
-    return roleMapping.getString(componentName + "_" + spaceRole, spaceRole);
+    return roleMapping.getString(componentName + "_" + spaceRole);
   }
 
   private List<String> componentRole2SpaceRoles(String componentRole,


### PR DESCRIPTION
Default behavior change : Now, if a component is not declared into roleMapping.properties, inheritance is ignored.