### PR TITLE
Use of the HTTP Bearer authorization scheme instead of the previous custom mechanism for token-based authorization

### DIFF
--- a/core-api/src/main/java/org/silverpeas/core/security/token/persistent/PersistentResourceToken.java
+++ b/core-api/src/main/java/org/silverpeas/core/security/token/persistent/PersistentResourceToken.java
@@ -178,7 +178,7 @@ public class PersistentResourceToken
   }
 
   /**
-   * Indicates if the token is well registred
+   * Indicates if the token is well registered
    *
    * @return a boolean indicating if this token exists in the data source.
    */

--- a/core-library/src/integration-test/java/org/silverpeas/core/admin/StubbedAdministration.java
+++ b/core-library/src/integration-test/java/org/silverpeas/core/admin/StubbedAdministration.java
@@ -532,7 +532,7 @@ public class StubbedAdministration implements Administration {
   }
 
   @Override
-  public String getUserIdByAuthenticationKey(final String authenticationKey) throws Exception {
+  public String getUserIdByAuthenticationKey(final String authenticationKey) throws AdminException {
     return null;
   }
 

--- a/core-library/src/main/java/org/silverpeas/core/admin/service/Admin.java
+++ b/core-library/src/main/java/org/silverpeas/core/admin/service/Admin.java
@@ -2179,7 +2179,7 @@ class Admin implements Administration {
   }
 
   @Override
-  public String getUserIdByAuthenticationKey(String authenticationKey) throws Exception {
+  public String getUserIdByAuthenticationKey(String authenticationKey) throws AdminException {
     Map<String, String> userParameters = domainDriverManager.authenticate(authenticationKey);
     String login = userParameters.get("login");
     String domainId = userParameters.get("domainId");

--- a/core-library/src/main/java/org/silverpeas/core/admin/service/Administration.java
+++ b/core-library/src/main/java/org/silverpeas/core/admin/service/Administration.java
@@ -596,7 +596,7 @@ public interface Administration {
    * @return The user id corresponding to the authentication key.
    * @throws Exception
    */
-  String getUserIdByAuthenticationKey(String authenticationKey) throws Exception;
+  String getUserIdByAuthenticationKey(String authenticationKey) throws AdminException;
 
   /**
    * Get the user corresponding to the given user Id (only infos in cache table)

--- a/core-library/src/main/java/org/silverpeas/core/security/authentication/verifier/UserCanLoginVerifier.java
+++ b/core-library/src/main/java/org/silverpeas/core/security/authentication/verifier/UserCanLoginVerifier.java
@@ -48,6 +48,8 @@ public class UserCanLoginVerifier extends AbstractAuthenticationVerifier {
   public static final String ERROR_INCORRECT_LOGIN_PWD_DOMAIN = "6";
   public static final String ERROR_USER_ACCOUNT_BLOCKED = "Error_UserAccountBlocked";
   public static final String ERROR_USER_ACCOUNT_DEACTIVATED = "Error_UserAccountDeactivated";
+  public static final String VERIFIER = "UserCanLoginVerifier.verify()";
+  public static final String CANNOT_LOGIN = "authentication.EX_VERIFY_USER_CAN_LOGIN";
 
   /**
    * Default constructor.
@@ -93,18 +95,18 @@ public class UserCanLoginVerifier extends AbstractAuthenticationVerifier {
   public void verify() throws AuthenticationException {
     if(getUser() == null) {
       // Authentication failed
-      throw new AuthenticationBadCredentialException("UserCanLoginVerifier.verify()",
-          SilverpeasException.ERROR, "authentication.EX_VERIFY_USER_CAN_LOGIN");
+      throw new AuthenticationBadCredentialException(VERIFIER,
+          SilverpeasException.ERROR, CANNOT_LOGIN);
     } else if (!isUserStateValid()) {
       // For now, if user is not valid (BLOCKED, DEACTIVATED, EXPIRED, DELETED, UNKNOWN) he is
       // considered as BLOCKED.
       if (getUser().isDeactivatedState()) {
-        throw new AuthenticationUserAccountDeactivatedException("UserCanLoginVerifier.verify()",
-            SilverpeasException.ERROR, "authentication.EX_VERIFY_USER_CAN_LOGIN",
+        throw new AuthenticationUserAccountDeactivatedException(VERIFIER,
+            SilverpeasException.ERROR, CANNOT_LOGIN,
             "Login=" + getUser().getLogin());
       }
-      throw new AuthenticationUserAccountBlockedException("UserCanLoginVerifier.verify()",
-          SilverpeasException.ERROR, "authentication.EX_VERIFY_USER_CAN_LOGIN",
+      throw new AuthenticationUserAccountBlockedException(VERIFIER,
+          SilverpeasException.ERROR, CANNOT_LOGIN,
           "Login=" + getUser().getLogin());
     }
   }

--- a/core-web-test/src/main/java/org/silverpeas/web/ResourceCreationTest.java
+++ b/core-web-test/src/main/java/org/silverpeas/web/ResourceCreationTest.java
@@ -68,8 +68,8 @@ import static org.silverpeas.core.util.StringUtil.isDefined;
 public abstract class ResourceCreationTest extends RESTWebServiceTest
     implements WebResourceTesting {
 
-  private static String withAsSessionKey(String sessionKey) {
-    return sessionKey;
+  private static String withAsApiToken(String apiTokenValue) {
+    return apiTokenValue;
   }
 
   /**
@@ -89,12 +89,12 @@ public abstract class ResourceCreationTest extends RESTWebServiceTest
    * @return the response of the post.
    */
   public <C> Response post(final C entity, String atURI) {
-    return post(entity, atURI, withAsSessionKey(getTokenKey()));
+    return post(entity, atURI, withAsApiToken(getAPITokenValue()));
   }
 
   @Test
   public void creationOfANewResourceByANonAuthenticatedUser() {
-    Response response = post(aResource(), at(aResourceURI()), withAsSessionKey(null));
+    Response response = post(aResource(), at(aResourceURI()), withAsApiToken(null));
     int receivedStatus = response.getStatus();
     int unauthorized = Status.UNAUTHORIZED.getStatusCode();
     assertThat(receivedStatus, is(unauthorized));
@@ -103,7 +103,7 @@ public abstract class ResourceCreationTest extends RESTWebServiceTest
   @Test
   public void creationOfANewResourceWithADeprecatedSession() {
     Response response =
-        post(aResource(), at(aResourceURI()), withAsSessionKey(UUID.randomUUID().toString()));
+        post(aResource(), at(aResourceURI()), withAsApiToken(UUID.randomUUID().toString()));
     int receivedStatus = response.getStatus();
     int unauthorized = Status.UNAUTHORIZED.getStatusCode();
     assertThat(receivedStatus, is(unauthorized));
@@ -127,7 +127,7 @@ public abstract class ResourceCreationTest extends RESTWebServiceTest
     assertThat(receivedStatus, is(badRequest));
   }
 
-  private <C> Response post(final C entity, String atURI, String withSessionKey) {
+  private <C> Response post(final C entity, String atURI, String apiTokenValue) {
     String thePath = atURI;
     String queryParams = "";
     WebTarget resource = resource();
@@ -138,8 +138,9 @@ public abstract class ResourceCreationTest extends RESTWebServiceTest
     }
     Invocation.Builder resourcePoster = applyQueryParameters(queryParams, resource.path(thePath))
         .request(MediaType.APPLICATION_JSON);
-    if (isDefined(withSessionKey)) {
-      resourcePoster = resourcePoster.header(HTTP_SESSIONKEY, withSessionKey);
+    if (isDefined(apiTokenValue)) {
+      resourcePoster =
+          resourcePoster.header(API_TOKEN_HTTP_HEADER, encodesAPITokenValue(apiTokenValue));
     }
     return resourcePoster.post(Entity.entity(entity, MediaType.APPLICATION_JSON));
   }

--- a/core-web-test/src/main/java/org/silverpeas/web/ResourceDeletionTest.java
+++ b/core-web-test/src/main/java/org/silverpeas/web/ResourceDeletionTest.java
@@ -72,7 +72,7 @@ public abstract class ResourceDeletionTest extends RESTWebServiceTest
    */
   public void deleteAt(String uri) {
     resource().path(uri).request(MediaType.APPLICATION_JSON).
-        header(HTTP_SESSIONKEY, getTokenKey()).
+        header(API_TOKEN_HTTP_HEADER, encodesAPITokenValue(getAPITokenValue())).
         delete();
   }
 
@@ -85,7 +85,7 @@ public abstract class ResourceDeletionTest extends RESTWebServiceTest
    */
   public <C> C deleteAt(String uri, Class<C> c) {
     return resource().path(uri).request(MediaType.APPLICATION_JSON)
-        .header(HTTP_SESSIONKEY, getTokenKey()).delete(c);
+        .header(API_TOKEN_HTTP_HEADER, encodesAPITokenValue(getAPITokenValue())).delete(c);
   }
 
   @Test
@@ -107,7 +107,7 @@ public abstract class ResourceDeletionTest extends RESTWebServiceTest
     try {
       resource().path(aResourceURI()).
           request(MediaType.APPLICATION_JSON).
-          header(HTTP_SESSIONKEY, UUID.randomUUID().toString()).
+          header(API_TOKEN_HTTP_HEADER, encodesAPITokenValue(UUID.randomUUID().toString())).
           delete();
       fail("A user with a deprecated session shouldn't delete a resource");
     } catch (WebApplicationException ex) {

--- a/core-web-test/src/main/java/org/silverpeas/web/ResourceGettingTest.java
+++ b/core-web-test/src/main/java/org/silverpeas/web/ResourceGettingTest.java
@@ -44,8 +44,8 @@ import static org.junit.Assert.fail;
  */
 public abstract class ResourceGettingTest extends RESTWebServiceTest implements WebResourceTesting {
 
-  public static String withAsSessionKey(String sessionKey) {
-    return sessionKey;
+  public static String withAsApiToken(String apiTokenValue) {
+    return apiTokenValue;
   }
 
   public static MediaType asMediaType(MediaType mediaType) {
@@ -78,13 +78,13 @@ public abstract class ResourceGettingTest extends RESTWebServiceTest implements 
    * @return the web entity representing the resource at the specified URI.
    */
   public <C> C getAt(String uri, MediaType mediaType, Class<C> c) {
-    return getAt(uri, withAsSessionKey(getTokenKey()), asMediaType(mediaType), c);
+    return getAt(uri, withAsApiToken(getAPITokenValue()), asMediaType(mediaType), c);
   }
 
   @Test
   public void gettingAResourceByANonAuthenticatedUser() {
     try {
-      getAt(aResourceURI(), withAsSessionKey(null), asMediaType(MediaType.APPLICATION_JSON_TYPE),
+      getAt(aResourceURI(), withAsApiToken(null), asMediaType(MediaType.APPLICATION_JSON_TYPE),
           getWebEntityClass());
       fail("A non authenticated user shouldn't access the resource");
     } catch (WebApplicationException ex) {
@@ -97,7 +97,7 @@ public abstract class ResourceGettingTest extends RESTWebServiceTest implements 
   @Test
   public void gettingAResourceWithAnExpiredSession() {
     try {
-      getAt(aResourceURI(), withAsSessionKey(UUID.randomUUID().toString()),
+      getAt(aResourceURI(), withAsApiToken(UUID.randomUUID().toString()),
           asMediaType(MediaType.APPLICATION_JSON_TYPE), getWebEntityClass());
       fail("A non authenticated user shouldn't access the resource");
     } catch (WebApplicationException ex) {
@@ -132,7 +132,7 @@ public abstract class ResourceGettingTest extends RESTWebServiceTest implements 
     }
   }
 
-  private <C> C getAt(String uri, String sessionKey, MediaType mediaType, Class<C> c) {
+  private <C> C getAt(String uri, String apiToken, MediaType mediaType, Class<C> c) {
     String thePath = uri;
     String queryParams = "";
     WebTarget resource = resource();
@@ -144,8 +144,9 @@ public abstract class ResourceGettingTest extends RESTWebServiceTest implements 
 
     Invocation.Builder requestBuilder =
         applyQueryParameters(queryParams, resource.path(thePath)).request(mediaType);
-    if (StringUtil.isDefined(sessionKey)) {
-      requestBuilder = requestBuilder.header(HTTP_SESSIONKEY, sessionKey);
+    if (StringUtil.isDefined(apiToken)) {
+      requestBuilder =
+          requestBuilder.header(API_TOKEN_HTTP_HEADER, encodesAPITokenValue(apiToken));
     }
     return requestBuilder.get(c);
   }

--- a/core-web-test/src/main/java/org/silverpeas/web/ResourceUpdateTest.java
+++ b/core-web-test/src/main/java/org/silverpeas/web/ResourceUpdateTest.java
@@ -81,8 +81,8 @@ public abstract class ResourceUpdateTest extends RESTWebServiceTest implements W
     return uri;
   }
 
-  private static String withAsSessionKey(String sessionKey) {
-    return sessionKey;
+  private static String withAsApiToken(String apiTokenValue) {
+    return apiTokenValue;
   }
 
   /**
@@ -93,13 +93,13 @@ public abstract class ResourceUpdateTest extends RESTWebServiceTest implements W
    * @return
    */
   public <C> C putAt(String uri, C newResourceState) {
-    return put(newResourceState, at(uri), withAsSessionKey(getTokenKey()));
+    return put(newResourceState, at(uri), withAsApiToken(getAPITokenValue()));
   }
 
   @Test
   public void updateOfAResourceByANonAuthenticatedUser() {
     try {
-      put(aResource(), at(aResourceURI()), withAsSessionKey(null));
+      put(aResource(), at(aResourceURI()), withAsApiToken(null));
       fail("A non authenticated user shouldn't update the resource");
     } catch (WebApplicationException ex) {
       int receivedStatus = ex.getResponse().getStatus();
@@ -111,7 +111,7 @@ public abstract class ResourceUpdateTest extends RESTWebServiceTest implements W
   @Test
   public void updateOfAResourceWithinADeprecatedSession() {
     try {
-      put(aResource(), at(aResourceURI()), withAsSessionKey(UUID.randomUUID().toString()));
+      put(aResource(), at(aResourceURI()), withAsApiToken(UUID.randomUUID().toString()));
       fail("A user shouldn't update the resource through an expired session");
     } catch (WebApplicationException ex) {
       int receivedStatus = ex.getResponse().getStatus();
@@ -169,7 +169,7 @@ public abstract class ResourceUpdateTest extends RESTWebServiceTest implements W
   }
 
   @SuppressWarnings("unchecked")
-  private <E> E put(final E entity, String atURI, String withSessionKey) {
+  private <E> E put(final E entity, String atURI, String apiTokenValue) {
     String thePath = atURI;
     String queryParams = "";
     WebTarget resource = resource();
@@ -180,8 +180,9 @@ public abstract class ResourceUpdateTest extends RESTWebServiceTest implements W
     }
     Invocation.Builder resourcePutter = applyQueryParameters(queryParams, resource.path(thePath))
         .request(MediaType.APPLICATION_JSON);
-    if (isDefined(withSessionKey)) {
-      resourcePutter = resourcePutter.header(HTTP_SESSIONKEY, withSessionKey);
+    if (isDefined(apiTokenValue)) {
+      resourcePutter =
+          resourcePutter.header(API_TOKEN_HTTP_HEADER, encodesAPITokenValue(apiTokenValue));
     }
     Class<E> c = (Class<E>) entity.getClass();
     return resourcePutter.put(Entity.entity(entity, MediaType.APPLICATION_JSON), c);

--- a/core-web-test/src/main/java/org/silverpeas/web/WebResourceTesting.java
+++ b/core-web-test/src/main/java/org/silverpeas/web/WebResourceTesting.java
@@ -30,10 +30,12 @@ package org.silverpeas.web;
 public interface WebResourceTesting {
 
   /**
-   * The HTTP header paremeter in an incoming request that carries the user session key as it is
-   * defined in the Silverpeas REST web service API.
+   * The HTTP header parameter in an incoming request that carries the user API token value as it is
+   * defined in the Silverpeas REST web service API. The API token value must be first encoded
+   * before setting the HTTP parameter with it; for doing, please use the
+   * {@link WebResourceTesting#encodesAPITokenValue(String)} ()} method.
    */
-  String HTTP_SESSIONKEY = "X-Silverpeas-Session";
+  String API_TOKEN_HTTP_HEADER = "Authorization";
 
   /**
    * Gets the URI of a valid and existing web resource backed by a REST web service.
@@ -57,14 +59,27 @@ public interface WebResourceTesting {
   <T> T aResource();
 
   /**
-   * Gets the valid token key to use in tests.
-   * @return a valid token key.
+   * Gets the valid API token value to use in tests.
+   * To be authorize to consume the REST API in the tests, the user must pass its API token
+   * through a bearer authorization scheme.
+   * @return a valid API user token key.
    */
-  String getTokenKey();
+  String getAPITokenValue();
+
 
   /**
    * Gets the class of the web entities handled by the REST web service to test.
    * @return the class of the web entities.
    */
   Class<?> getWebEntityClass();
+
+  /**
+   * encodes the value of the specified API token so that it can be passed into the HTTP header
+   * that carries the API tokens in the HTTP requests.
+   * @param apiTokenValue the value of an API token.
+   * @return the encoded API token value.
+   */
+  default String encodesAPITokenValue(final String apiTokenValue)  {
+    return "Bearer " + apiTokenValue;
+  }
 }

--- a/core-web-test/src/main/java/org/silverpeas/web/environment/SilverpeasEnvironmentTest.java
+++ b/core-web-test/src/main/java/org/silverpeas/web/environment/SilverpeasEnvironmentTest.java
@@ -87,10 +87,10 @@ public class SilverpeasEnvironmentTest {
   }
 
   /**
-   * Gets the token of a user that must be passed into request header with parameter
-   * "X-Silverpeas-Size".
+   * Gets the token of a user that must be passed into the request header "Authorization" as a
+   * value of a bearer authorization scheme.
    * @param userDetail the user details for which the token is needed.
-   * @return the token of the given user.
+   * @return the API token of the given user.
    */
   public String getTokenOf(UserDetail userDetail) {
     try {

--- a/core-web/src/integration-test/java/org/silverpeas/core/webapi/password/PasswordPolicyCheckingIT.java
+++ b/core-web/src/integration-test/java/org/silverpeas/core/webapi/password/PasswordPolicyCheckingIT.java
@@ -118,7 +118,7 @@ public class PasswordPolicyCheckingIT extends ResourceCreationTest {
   }
 
   @Override
-  public String getTokenKey() {
+  public String getAPITokenValue() {
     return sessionKey;
   }
 

--- a/core-web/src/integration-test/java/org/silverpeas/core/webapi/password/PasswordPolicyGettingIT.java
+++ b/core-web/src/integration-test/java/org/silverpeas/core/webapi/password/PasswordPolicyGettingIT.java
@@ -121,7 +121,7 @@ public class PasswordPolicyGettingIT extends ResourceGettingTest {
   }
 
   @Override
-  public String getTokenKey() {
+  public String getAPITokenValue() {
     return sessionKey;
   }
 

--- a/core-web/src/integration-test/java/org/silverpeas/core/webapi/viewer/DocumentViewGettingIT.java
+++ b/core-web/src/integration-test/java/org/silverpeas/core/webapi/viewer/DocumentViewGettingIT.java
@@ -58,7 +58,7 @@ import static org.mockito.Mockito.when;
 @RunWith(Arquillian.class)
 public class DocumentViewGettingIT extends ResourceGettingTest {
 
-  private String sessionKey;
+  private String apiToken;
   private DocumentView expected;
   private ComponentInst component;
 
@@ -111,7 +111,7 @@ public class DocumentViewGettingIT extends ResourceGettingTest {
   @Before
   public void prepareTestResources() {
     component = getSilverpeasEnvironmentTest().getDummyPublicComponent();
-    sessionKey = getTokenKeyOf(getSilverpeasEnvironmentTest().createDefaultUser());
+    apiToken = getTokenKeyOf(getSilverpeasEnvironmentTest().createDefaultUser());
     expected = DocumentViewBuilder.getDocumentViewBuilder()
         .buildFileName("documentViewId", "originalFileName7");
   }
@@ -143,8 +143,8 @@ public class DocumentViewGettingIT extends ResourceGettingTest {
   }
 
   @Override
-  public String getTokenKey() {
-    return sessionKey;
+  public String getAPITokenValue() {
+    return apiToken;
   }
 
   @Override

--- a/core-web/src/integration-test/java/org/silverpeas/core/webapi/viewer/PreviewGettingIT.java
+++ b/core-web/src/integration-test/java/org/silverpeas/core/webapi/viewer/PreviewGettingIT.java
@@ -143,7 +143,7 @@ public class PreviewGettingIT extends ResourceGettingTest {
   }
 
   @Override
-  public String getTokenKey() {
+  public String getAPITokenValue() {
     return tokenKey;
   }
 

--- a/core-web/src/main/java/org/silverpeas/core/webapi/base/AuthenticationScheme.java
+++ b/core-web/src/main/java/org/silverpeas/core/webapi/base/AuthenticationScheme.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2000 - 2016 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "http://www.silverpeas.org/docs/core/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.silverpeas.core.webapi.base;
+
+import org.silverpeas.core.util.logging.SilverLogger;
+
+import java.util.Optional;
+
+/**
+ * The different HTTP authentication schemes supported by Silverpeas.
+ * @author mmoquillon
+ */
+public enum AuthenticationScheme {
+
+  /**
+   * The basic authentication expects the user credentials to be passed in a base 64 encoded string.
+   * This string must contain both the user identifier and its password separated by a single colon
+   * character. It is the default HTTP authentication scheme.
+   */
+  BASIC,
+
+  /**
+   * The Bearer authentication scheme was defined first for the OAuth authentication mechanism
+   * (IETF RFC 6750) and it is now used by any other token-based authentication or authorization
+   * mechanisms like the JSON Web Token (JWT, IETF RFC 7797).
+   * <p>
+   * In this scheme, the token must be a string that must satisfy the following grammar:
+   * ( ALPHA | DIGIT | "-" | "." | "_" | "~" | "+" | "/" )+ "="*
+   */
+  BEARER;
+
+  /**
+   * Gets an {@link AuthenticationScheme} from the specified keyword identifying a particular
+   * HTTP authentication scheme.
+   * @param scheme a string containing an HTTP Authentication scheme.
+   * @return an optional {@link AuthenticationScheme} instance matching the specified scheme. If
+   * the given scheme isn't supported by Silverpeas, then nothing is returned (the optional is
+   * empty).
+   */
+  public static Optional<AuthenticationScheme> from(final String scheme) {
+    try {
+      return Optional.of(AuthenticationScheme.valueOf(scheme.trim().toUpperCase()));
+    } catch (IllegalArgumentException ex) {
+      SilverLogger.getLogger(AuthenticationScheme.class)
+          .error("The authentication scheme " + scheme + " isn't supported", ex);
+      return Optional.empty();
+    }
+  }
+}

--- a/core-web/src/main/java/org/silverpeas/core/webapi/base/HTTPAuthentication.java
+++ b/core-web/src/main/java/org/silverpeas/core/webapi/base/HTTPAuthentication.java
@@ -1,0 +1,294 @@
+/*
+ * Copyright (C) 2000 - 2016 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "http://www.silverpeas.org/docs/core/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.silverpeas.core.webapi.base;
+
+import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.collections.map.HashedMap;
+import org.silverpeas.core.SilverpeasRuntimeException;
+import org.silverpeas.core.admin.service.AdminException;
+import org.silverpeas.core.admin.service.Administration;
+import org.silverpeas.core.admin.user.UserReference;
+import org.silverpeas.core.admin.user.model.UserDetail;
+import org.silverpeas.core.security.authentication.AuthenticationCredential;
+import org.silverpeas.core.security.authentication.AuthenticationService;
+import org.silverpeas.core.security.authentication.AuthenticationServiceProvider;
+import org.silverpeas.core.security.authentication.exception.AuthenticationException;
+import org.silverpeas.core.security.authentication.verifier.AuthenticationUserVerifierFactory;
+import org.silverpeas.core.security.session.SessionInfo;
+import org.silverpeas.core.security.session.SessionManagementProvider;
+import org.silverpeas.core.security.token.Token;
+import org.silverpeas.core.security.token.persistent.PersistentResourceToken;
+import org.silverpeas.core.util.Charsets;
+import org.silverpeas.core.util.Mutable;
+import org.silverpeas.core.util.StringUtil;
+import org.silverpeas.core.util.logging.SilverLogger;
+import org.silverpeas.core.web.token.SynchronizerTokenService;
+
+import javax.inject.Singleton;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.silverpeas.core.webapi.base.UserPrivilegeValidation.HTTP_ACCESS_TOKEN;
+import static org.silverpeas.core.webapi.base.UserPrivilegeValidation.HTTP_AUTHORIZATION;
+import static org.silverpeas.core.webapi.base.UserPrivilegeValidation.HTTP_SESSIONKEY;
+
+/**
+ * An HTTP authentication mechanism for Silverpeas. It implements the authentication mechanism
+ * in Silverpeas from an incoming HTTP request. This HTTP request can be as well an explicit
+ * authentication call as a Silverpeas API consume. The HTTP request is expected either to contain
+ * the HTTP header {@code Authorization} valued with the authentication scheme and the user
+ * credentials as expected by the IETF RFC 2617 or to target an URI with the query parameter
+ * {@code access_token} (see IETF RFC 6750).
+ * <p>
+ * Actually, Silverpeas supports two HTTP authentication schemes: the {@code Basic} one
+ * (covered by the IETF RFC 2617) and the Bearer one (covered by the IETF RFC 6750). The API token
+ * of the users must be passed with the {@code Bearer} scheme to access the REST API of
+ * Silverpeas.
+ * </p>
+ * <p>
+ * The authentication opens a new session when succeeded, otherwise a
+ * {@link WebApplicationException} exception is thrown with the status
+ * {@link Response.Status#UNAUTHORIZED}.
+ * </p>
+ * @author mmoquillon
+ */
+@Singleton
+public class HTTPAuthentication {
+
+  private static final Pattern AUTHORIZATION_PATTERN = Pattern.compile("(?i)^(Basic|Bearer) (.*)");
+
+  // the first ':' character is the separator according to the RFC 2617 in basic digest
+  private static final Pattern AUTHENTICATION_PATTERN =
+      Pattern.compile("(?i)^[\\s]*([^\\s]+)[\\s]*@domain([0-9]+):(.+)$");
+
+  private static final int SUPPORTED_AUTHENTICATION_SCHEME_COUNT = 2;
+  private static Map<AuthenticationScheme, Function<AuthenticationContext, SessionInfo>>
+      schemeHandlers = new HashedMap(SUPPORTED_AUTHENTICATION_SCHEME_COUNT);
+
+  static {
+    schemeHandlers.put(AuthenticationScheme.BASIC, HTTPAuthentication::performBasicAuthentication);
+    schemeHandlers.put(AuthenticationScheme.BEARER,
+        HTTPAuthentication::performTokenBasedAuthentication);
+  }
+
+  protected HTTPAuthentication() {
+  }
+
+  /**
+   * Authenticates the user behind the incoming HTTP request according to the specified
+   * authentication context.
+   * <p>
+   * The context is defined for the incoming HTTP request and for the HTTP response to send. The
+   * HTTP request contains the elements required to authenticate the user at the source of the
+   * request. The mandatory element is either the {@code Authorization} HTTP header that must be
+   * valued with an authentication scheme and with the credentials of the user or the
+   * {@code access_token} URI query parameter or the {@code access_token} form-encoded body
+   * parameter.
+   * </p>
+   * <p>
+   * A {@link WebApplicationException} is thrown with the status
+   * {@link Response.Status#UNAUTHORIZED} in the following case:
+   * </p>
+   * <ul>
+   *   <li>No {@code Authentication} header and no {@code access_token} parameter</li>
+   *   <li>The authentication scheme isn't supported</li>
+   *   <li>the credentials passed in the {@code Authentication} header are invalid</li>
+   *   <li>the user API token passed in the {@code access_token} parameter is invalid</li>
+   *   <li>the user account in Silverpeas isn't valid (blocked, deactivated, ...)</li>
+   * </ul>
+   * <p>
+   * If the authentication process succeeds, then a session is created and returned. For a basic
+   * authentication scheme, the session comes from a session opening in Silverpeas by the
+   * {@link org.silverpeas.core.security.session.SessionManagement} subsystem and its unique
+   * identifier is set in the {@link UserPrivilegeValidation#HTTP_SESSIONKEY} header of the
+   * HTTP response; the session life will span over several HTTP requests and it will be closed
+   * either explicitly or by the default session timeout. For a bearer authentication scheme and for
+   * an authentication from the {@code access_token} parameter, the
+   * session is just created for the specific incoming request and will expire at the end of it.
+   * </p>
+   * <p>
+   * At the end of the authentication, the context is alimented with the user credentials and with
+   * the authentication scheme that were fetched from the HTTP request. They can then be retrieved
+   * for further operation by the invoker of this method. In the case of an authentication from
+   * the {@code access_token} parameter, the authentication scheme is in the context is set as
+   * a bearer authentication scheme.
+   * </p>
+   * @param context the context of the authentication with the HTTP request and with the HTTP
+   * response.
+   * @return the created session for the request if the authentication succeeds or throws a
+   * {@link WebApplicationException} with as status {@link Response.Status#UNAUTHORIZED}.
+   */
+  public SessionInfo authenticate(final AuthenticationContext context) {
+    try {
+      final Mutable<SessionInfo> session = Mutable.empty();
+      String authorizationValue = context.getHttpServletRequest().getHeader(HTTP_AUTHORIZATION);
+      if (StringUtil.isDefined(authorizationValue)) {
+        Matcher authorizationMatcher = AUTHORIZATION_PATTERN.matcher(authorizationValue);
+        final int authorizationValuePartCount = 2;
+        final int schemePart = 1;
+        final int credentialsPart = 2;
+        if (!authorizationMatcher.matches() ||
+            authorizationMatcher.groupCount() != authorizationValuePartCount) {
+          throw new WebApplicationException(Response.Status.UNAUTHORIZED);
+        }
+        Optional<AuthenticationScheme> credentialType =
+            AuthenticationScheme.from(authorizationMatcher.group(schemePart));
+        String userCredentials = authorizationMatcher.group(credentialsPart);
+
+        credentialType.ifPresent(scheme -> {
+          context.setAuthenticationScheme(scheme);
+          context.setUserCredentials(userCredentials);
+          session.set(schemeHandlers.get(scheme).apply(context));
+        });
+      } else {
+        authorizationValue = context.getHttpServletRequest().getParameter(HTTP_ACCESS_TOKEN);
+        if (StringUtil.isDefined(authorizationValue)) {
+          context.setAuthenticationScheme(AuthenticationScheme.BEARER);
+          context.setUserCredentials(authorizationValue);
+          session.set(schemeHandlers.get(AuthenticationScheme.BEARER).apply(context));
+        }
+      }
+      return session.orElseThrow(() -> new WebApplicationException(Response.Status.UNAUTHORIZED));
+    } catch (final AuthenticationInternalException ex) {
+      throw new WebApplicationException(ex, Response.Status.SERVICE_UNAVAILABLE);
+    }
+  }
+
+  private static SessionInfo performBasicAuthentication(final AuthenticationContext context) {
+    final String decodedCredentials =
+        new String(Base64.decodeBase64(context.getUserCredentials()), Charsets.UTF_8).trim();
+
+    // Getting expected parts of credentials
+    Matcher matcher = AUTHENTICATION_PATTERN.matcher(decodedCredentials);
+    final int credentialPartCount = 3;
+    final int loginPart = 1;
+    final int passwordPart = 3;
+    final int domainIdPart = 2;
+    if (matcher.matches() && matcher.groupCount() == credentialPartCount) {
+
+      // All expected parts detected, so getting an authentication key
+      AuthenticationCredential credential =
+          AuthenticationCredential.newWithAsLogin(matcher.group(loginPart))
+              .withAsPassword(matcher.group(passwordPart))
+              .withAsDomainId(matcher.group(domainIdPart));
+      AuthenticationService authenticator = AuthenticationServiceProvider.getService();
+      String key = authenticator.authenticate(credential);
+      if (!authenticator.isInError(key)) {
+        try {
+          String userId = Administration.get().getUserIdByAuthenticationKey(key);
+          UserDetail user = UserDetail.getById(userId);
+          verifyUserCanLogin(user);
+          SessionInfo session = SessionManagementProvider.getSessionManagement()
+              .openSession(user, context.getHttpServletRequest());
+          context.getHttpServletResponse().setHeader(HTTP_SESSIONKEY, session.getSessionId());
+          context.getHttpServletResponse()
+              .addHeader("Access-Control-Expose-Headers", UserPrivilegeValidation.HTTP_SESSIONKEY);
+          SynchronizerTokenService tokenService = SynchronizerTokenService.getInstance();
+          tokenService.setUpSessionTokens(session);
+          Token token = tokenService.getSessionToken(session);
+          context.getHttpServletResponse()
+              .addHeader(SynchronizerTokenService.SESSION_TOKEN_KEY, token.getValue());
+          return session;
+        } catch (AdminException e) {
+          throw new AuthenticationInternalException(e.getMessage(), e);
+        }
+      }
+    }
+    return null;
+  }
+
+  private static SessionInfo performTokenBasedAuthentication(final AuthenticationContext context) {
+    final String token = context.getUserCredentials();
+    final PersistentResourceToken userToken = PersistentResourceToken.getToken(token);
+    UserReference userRef = userToken.getResource(UserReference.class);
+    if (userRef != null) {
+      UserDetail user = userRef.getEntity();
+      verifyUserCanLogin(user);
+      return new SessionInfo(token, user);
+    }
+    return null;
+  }
+
+  private static void verifyUserCanLogin(final UserDetail user) {
+    if (user != null) {
+      try {
+        AuthenticationUserVerifierFactory.getUserCanLoginVerifier(user).verify();
+      } catch (AuthenticationException e) {
+        SilverLogger.getLogger(HTTPAuthentication.class).error(e);
+        throw new WebApplicationException(Response.Status.UNAUTHORIZED);
+      }
+    }
+  }
+
+  public static class AuthenticationContext {
+    private String credentials;
+    private AuthenticationScheme scheme;
+    private HttpServletResponse response;
+    private HttpServletRequest request;
+
+    public AuthenticationContext(final HttpServletRequest request,
+        final HttpServletResponse response) {
+      this.request = request;
+      this.response = response;
+    }
+
+    public String getUserCredentials() {
+      return credentials;
+    }
+
+    public void setUserCredentials(final String credentials) {
+      this.credentials = credentials;
+    }
+
+    public AuthenticationScheme getAuthenticationScheme() {
+      return this.scheme;
+    }
+
+    public void setAuthenticationScheme(final AuthenticationScheme scheme) {
+      this.scheme = scheme;
+    }
+
+    public HttpServletResponse getHttpServletResponse() {
+      return this.response;
+    }
+
+    public HttpServletRequest getHttpServletRequest() {
+      return this.request;
+    }
+  }
+
+  private static class AuthenticationInternalException extends SilverpeasRuntimeException {
+
+    public AuthenticationInternalException(final String message, final Throwable cause) {
+      super(message, cause);
+    }
+  }
+}

--- a/core-web/src/main/java/org/silverpeas/core/webapi/base/UserPrivilegeValidation.java
+++ b/core-web/src/main/java/org/silverpeas/core/webapi/base/UserPrivilegeValidation.java
@@ -29,6 +29,7 @@ import org.silverpeas.core.contribution.attachment.model.SimpleDocument;
 import org.silverpeas.core.util.ServiceProvider;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.WebApplicationException;
 
 /**
@@ -51,13 +52,31 @@ public interface UserPrivilegeValidation {
   String HTTP_PARAMKEY = "sptkn";
 
   /**
+   * The name of the standard URI query parameter and of the standard form-encoded parameter
+   * in an HTTP request to use in a token based authentication mechanism like for example OAuth2.
+   */
+  String HTTP_ACCESS_TOKEN = "access_token";
+
+  /**
    * The standard HTTP header parameter in an incoming request that carries user credentials
    * information in order to open an authorized connexion with the web service that backs the
-   * refered resource. This parameter must be used when requests aren't sent through an opened HTTP
-   * session. It should be the prefered way for a REST client to access resources in Silverpeas as
+   * referred resource. This parameter must be used when requests aren't sent through an opened HTTP
+   * session. It should be the preferred way for a REST client to access resources in Silverpeas as
    * it offers better scalability.
    */
   String HTTP_AUTHORIZATION = "Authorization";
+
+  /**
+   * The standard keyword qualifying a basic HTTP authentication used in the value of an
+   * Authorization HTTP header.
+   */
+  String HTTP_BASIC_AUTHORIZATION = "Basic";
+
+  /**
+   * The standard keyword qualifying an HTTP authentication built upon a token based mechanism like
+   * for example OAuth2. The keyword is used in the value of an Authorization HTTP header.
+   */
+  String HTTP_TOKEN_AUTHORIZATION = "Bearer";
 
   static UserPrivilegeValidation get() {
     return ServiceProvider.getService(UserPrivilegeValidation.class);
@@ -69,17 +88,20 @@ public interface UserPrivilegeValidation {
    * The validation checks first the user is already authenticated and then it has a valid opened
    * session in Silverpeas. Otherwise it attempts to open a new session for the user by using its
    * credentials passed through the request (as an HTTP header). Once the authentication succeed,
-   * the identification of the user is done and detail about it can then be got. A runtime exception
+   * the identification of the user is done and detail about it can then be got, and the session
+   * information is set in the header(s) of the HTTP response. A runtime exception
    * is thrown with an HTTP status code UNAUTHORIZED (401) at validation failure. The validation
-   * fails when one of the belowed situation is occuring: <ul> <li>The user session key is
+   * fails when one of the bellowed situation is occurring: <ul> <li>The user session key is
    * invalid;</li> <li>The user isn't authenticated and no credentials are passed with the
    * request;</li> <li>The user authentication failed.</li> </ul>
    *
    * @param request the HTTP request from which the authentication of the caller can be done.
+   * @param response the HTTP response that will be sent with the session information set in the
+   * header(s).
    * @return the opened session of the user at the origin of the specified request.
    * @throws WebApplicationException exception if the validation failed.
    */
-  SessionInfo validateUserAuthentication(HttpServletRequest request) throws WebApplicationException;
+  SessionInfo validateUserAuthentication(HttpServletRequest request, HttpServletResponse response);
 
   /**
    * Sets into the request attributes the {@link
@@ -97,8 +119,7 @@ public interface UserPrivilegeValidation {
    * @param instanceId the unique identifier of the accessed component instance.
    * @throws WebApplicationException exception if the validation failed.
    */
-  void validateUserAuthorizationOnComponentInstance(User user, String instanceId)
-              throws WebApplicationException;
+  void validateUserAuthorizationOnComponentInstance(User user, String instanceId);
 
   /**
    * Validates the authorization of the specified user to access the specified attachment.
@@ -109,5 +130,5 @@ public interface UserPrivilegeValidation {
    * @throws WebApplicationException exception if the validation failed.
    */
   void validateUserAuthorizationOnAttachment(HttpServletRequest request, User user,
-      SimpleDocument doc) throws WebApplicationException;
+      SimpleDocument doc);
 }

--- a/core-web/src/main/java/org/silverpeas/core/webapi/base/UserPrivilegeValidator.java
+++ b/core-web/src/main/java/org/silverpeas/core/webapi/base/UserPrivilegeValidator.java
@@ -24,40 +24,27 @@
 package org.silverpeas.core.webapi.base;
 
 import org.silverpeas.core.admin.user.model.User;
+import org.silverpeas.core.admin.user.model.UserDetail;
+import org.silverpeas.core.contribution.attachment.model.SimpleDocument;
 import org.silverpeas.core.security.authorization.AccessControlContext;
 import org.silverpeas.core.security.authorization.AccessControlOperation;
+import org.silverpeas.core.security.authorization.ComponentAccessControl;
+import org.silverpeas.core.security.authorization.SimpleDocumentAccessControl;
 import org.silverpeas.core.security.session.SessionInfo;
 import org.silverpeas.core.security.session.SessionManagement;
 import org.silverpeas.core.security.session.SessionValidationContext;
-import org.silverpeas.core.admin.service.AdminException;
-import org.silverpeas.core.admin.service.Administration;
-import org.silverpeas.core.admin.user.model.UserDetail;
-import org.apache.commons.codec.binary.Base64;
-import org.silverpeas.core.security.authorization.ComponentAccessControl;
-import org.silverpeas.core.security.authorization.SimpleDocumentAccessControl;
-import org.silverpeas.core.contribution.attachment.model.SimpleDocument;
-import org.silverpeas.core.security.authentication.AuthenticationCredential;
-import org.silverpeas.core.security.authentication.AuthenticationService;
-import org.silverpeas.core.security.authentication.AuthenticationServiceProvider;
-import org.silverpeas.core.security.authentication.UserSessionReference;
-import org.silverpeas.core.security.authentication.exception.AuthenticationException;
-import org.silverpeas.core.security.authentication.verifier.AuthenticationUserVerifierFactory;
-import org.silverpeas.core.admin.service.OrganizationController;
-import org.silverpeas.core.admin.user.UserReference;
-import org.silverpeas.core.security.token.persistent.PersistentResourceToken;
-import org.silverpeas.core.util.Charsets;
 import org.silverpeas.core.util.StringUtil;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 import javax.ws.rs.HttpMethod;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 
 import static org.silverpeas.core.util.StringUtil.isDefined;
-import static org.silverpeas.core.util.StringUtil.isInteger;
 
 /**
  * It is a decorator of a REST-based web service that provides access to the validation of the
@@ -80,7 +67,7 @@ public class UserPrivilegeValidator implements UserPrivilegeValidation {
   private SimpleDocumentAccessControl documentAccessController;
 
   @Inject
-  private OrganizationController organisationController;
+  private HTTPAuthentication authentication;
 
   /**
    * This constant is used to specify into the request attributes if the registering of "the last
@@ -108,8 +95,8 @@ public class UserPrivilegeValidator implements UserPrivilegeValidation {
    * @throws WebApplicationException exception if the validation failed.
    */
   @Override
-  public SessionInfo validateUserAuthentication(final HttpServletRequest request) throws
-      WebApplicationException {
+  public SessionInfo validateUserAuthentication(final HttpServletRequest request,
+      final HttpServletResponse response) {
     SessionInfo userSession;
     String sessionKey = getUserSessionKey(request);
     if (isDefined(sessionKey)) {
@@ -120,11 +107,9 @@ public class UserPrivilegeValidator implements UserPrivilegeValidation {
       }
       userSession = validateUserSession(sessionValidationContext);
     } else {
-      userSession = authenticateUser(request);
+      userSession = authentication.authenticate(
+          new HTTPAuthentication.AuthenticationContext(request, response));
     }
-
-    // Verify that the user can login
-    verifyUserCanLogin(userSession);
 
     // Returning the user session
     return userSession;
@@ -155,22 +140,6 @@ public class UserPrivilegeValidator implements UserPrivilegeValidation {
   }
 
   /**
-   * Verify that the user can login
-   *
-   * @param userSession
-   */
-  private void verifyUserCanLogin(SessionInfo userSession) {
-    if (userSession != null && userSession.getUserDetail() != null) {
-      try {
-        AuthenticationUserVerifierFactory.getUserCanLoginVerifier(userSession.getUserDetail())
-            .verify();
-      } catch (AuthenticationException e) {
-        throw new WebApplicationException(Response.Status.UNAUTHORIZED);
-      }
-    }
-  }
-
-  /**
    * Validates the authorization of the specified user to access the component instance with the
    * specified unique identifier.
    *
@@ -179,8 +148,7 @@ public class UserPrivilegeValidator implements UserPrivilegeValidation {
    * @throws WebApplicationException exception if the validation failed.
    */
   @Override
-  public void validateUserAuthorizationOnComponentInstance(final User user, String instanceId)
-      throws WebApplicationException {
+  public void validateUserAuthorizationOnComponentInstance(final User user, String instanceId) {
     if (user == null || !componentAccessController.isUserAuthorized(user.getId(), instanceId)) {
       throw new WebApplicationException(Response.Status.FORBIDDEN);
     }
@@ -196,7 +164,7 @@ public class UserPrivilegeValidator implements UserPrivilegeValidation {
    */
   @Override
   public void validateUserAuthorizationOnAttachment(final HttpServletRequest request,
-      final User user, SimpleDocument doc) throws WebApplicationException {
+      final User user, SimpleDocument doc) {
     AccessControlContext context = AccessControlContext.init();
     if (HttpMethod.PUT.equals(request.getMethod())) {
       context.onOperationsOf(AccessControlOperation.creation);
@@ -237,77 +205,19 @@ public class UserPrivilegeValidator implements UserPrivilegeValidation {
   }
 
   /**
-   * Authenticates the user by using the credentials in the header Authorization of the specified
-   * HTTP request.
-   *
-   * According to the HTTP specification, authentication credentials must be carried by the HTTP
-   * header Authorization. Its value must follow the RFC 2617 basic digest and it must be Base 64
-   * encoded.
-   *
-   * In Silverpeas, the authentication process with web services asks for the unique identifier of
-   * the user as login instead of its true login text that can be not unique (it is unique only
-   * within a given Silverpeas domain).
-   *
-   * Once the user well authenticated, return details about him. If the authentication fails, then a
-   * WebApplicationException exception is thrown with an HTTP status code UNAUTHORIZED (401). The
-   * implementation of this method is for taking into account the Silverpeas security doesn't
-   * satisfy the JAAS way. Once JAAS supported in Silverpeas, the web services should use the
-   * SecurityContext instead of the credentials token passed in the header of HTTP requests.
-   *
-   * @return the detail about the authenticated user requested this web service.
-   */
-  private SessionInfo authenticateUser(final HttpServletRequest request) {
-    SessionInfo session = SessionInfo.NoneSession;
-    String userCredentials = request.getHeader(HTTP_AUTHORIZATION);
-    if (isDefined(userCredentials)) {
-      String[] auth = userCredentials.split(" ");
-      if (auth.length == 2 && auth[0].equalsIgnoreCase("Basic")) {
-        String decoded = new String(Base64.decodeBase64(auth[1]), Charsets.UTF_8);
-        // the first ':' character is the separator according to the RFC 2617 in basic digest
-        int loginPasswordSeparatorIndex = decoded.indexOf(':');
-        if (loginPasswordSeparatorIndex > 0) {
-          String[] login = decoded.substring(0, loginPasswordSeparatorIndex).split("@domain");
-          String password = decoded.substring(loginPasswordSeparatorIndex + 1);
-          if (login.length == 2 && isDefined(login[0]) && isInteger(login[1])) {
-            AuthenticationCredential credential =
-                AuthenticationCredential.newWithAsLogin(login[0])
-                    .withAsPassword(password)
-                    .withAsDomainId(login[1]);
-            AuthenticationService authenticator = AuthenticationServiceProvider.getService();
-            String key = authenticator.authenticate(credential);
-            if (!authenticator.isInError(key)) {
-              HttpSession httpSession = request.getSession(true);
-              try {
-                String userId = Administration.get().identify(key, httpSession.getId(), false);
-                session = sessionManagement.openSession(UserDetail.getById(userId), request);
-              } catch (AdminException e) {
-                throw new WebApplicationException(Response.Status.UNAUTHORIZED);
-              }
-            }
-          }
-        }
-      }
-    }
-    if (!session.isDefined()) {
-      throw new WebApplicationException(Response.Status.UNAUTHORIZED);
-    }
-    return session;
-  }
-
-  /**
    * Validates the current user session with the specified session key. The session key is either an
-   * identifier of an opened HTTP session or an identifier token associated to an existing user.
+   * identifier of an opened HTTP session or a token associated with a virtual existing user session.
    *
    * This method checks first that the specified key identifies uniquely an opened session in
    * Silverpeas. In this case it validates this session matches the one within which the current
    * HTTP request was sent. If the validation succeeds, the HTTP session is returned. If the key
-   * doesn't identify any opened session, the method validates it matchs the identifier token of a
-   * user in Silverpeas and in this case a session is then created only for the current request and
+   * doesn't identify any opened session, the method validates it matches the token of a virtual
+   * user session and in this case a session is then created only for the current request and it
    * is returned. If the validation fails, a WebApplicationException exception is thrown.
    *
-   * As the anonymous user has no opened session, when a request is recieved by this web service and
-   * that request does neither belong to an opened session nor carries autentication information, it
-   * is accepted only if the anonymous access is activated; in this case, an anonymous session is
+   * As the anonymous user has no opened session, when a request is received by this web service and
+   * that request does neither belong to an opened session nor carries authentication information,
+   * it is accepted only if the anonymous access is activated; in this case, an anonymous session is
    * created for the circumstance.
    *
    * @param context the context of the validation that contains at least the session key
@@ -315,34 +225,14 @@ public class UserPrivilegeValidator implements UserPrivilegeValidation {
    * session or a session spawned only for the current request.
    */
   private SessionInfo validateUserSession(SessionValidationContext context) {
-    String sessionKey = context.getSessionKey();
     SessionInfo sessionInfo = sessionManagement.validateSession(context);
     if (!sessionInfo.isDefined()) {
-      // the key isn't a session identifier; is it then a user auth token?
-      UserDetail user = null;
-      final PersistentResourceToken userToken = PersistentResourceToken.getToken(sessionKey);
-      UserSessionReference userSessionRef = userToken.getResource(UserSessionReference.class);
-      if (userSessionRef != null) {
-        user = userSessionRef.getEntity().getUser();
-        if (!user.isValidState()) {
-          user = null;
-        }
-      } else {
-        // the key isn't a user auth token; is it then a user token?
-        UserReference userRef = userToken.getResource(UserReference.class);
-        if (userRef != null) {
-          user = userRef.getEntity();
-        }
-      }
-      if (user != null) {
-        // the session key is a token and this token is bound to an existing user
-        sessionInfo = new SessionInfo(sessionKey, user);
-      } else {
-        // the session key isn't a token or it isn't bound to an existing user
-        if (!UserDetail.isAnonymousUserExist()) {
-          throw new WebApplicationException(Response.Status.UNAUTHORIZED);
-        }
+      // no existing session for the user behind the incoming HTTP request. So, is this an
+      // anonymous request?
+      if (UserDetail.isAnonymousUserExist()) {
         sessionInfo = new SessionInfo(null, UserDetail.getAnonymousUser());
+      } else {
+        throw new WebApplicationException(Response.Status.UNAUTHORIZED);
       }
     }
     return sessionInfo;


### PR DESCRIPTION
Each user in Silverpeas has an API token that can be use to consume the REST API of Silverpeas. Until now the token was passed through a custom HTTP header `X-Silverpeas-Session` to authenticate and identify the user behind the token. In order to be conformed to the standard token-based authorization mechanism in use for any Web authentication/identification system and that comes from the IETF RFC 6750 (OAuth), the token now is transmitted through either the standard Authorization HTTP header by following the Bearer authorization scheme or the `access_token` parameter in the URI.

Warning: once this PR merged, all the clients consuming the REST API of Silverpeas require to be updated by replacing the old authorization mechanism with the new one.