### PR TITLE
Making the thread in charge of indexation compliant with JEE managed thread mechanism by using the existing task engine (AbstractRequestTask) to process queued requests (by this way, request process exceptions are well logged).

### DIFF
--- a/core-api/src/main/java/org/silverpeas/core/thread/task/RequestTaskManager.java
+++ b/core-api/src/main/java/org/silverpeas/core/thread/task/RequestTaskManager.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright (C) 2000 - 2017 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception. You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "http://www.silverpeas.org/docs/core/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.thread.task;
+
+import org.silverpeas.core.SilverpeasRuntimeException;
+import org.silverpeas.core.thread.ManagedThreadPool;
+import org.silverpeas.core.thread.task.AbstractRequestTask.Request;
+import org.silverpeas.core.util.ServiceProvider;
+import org.silverpeas.core.util.logging.SilverLogger;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.Semaphore;
+
+/**
+ * This manager handles the threading side of {@link AbstractRequestTask} processing.
+ * <p>The aim is to avoid the developer to think about how to write rightly the consummation of a
+ * list of request to process.</p>
+ * <p>To process a request, an {@link AbstractRequestTask} must be implemented and this
+ * implementation must push request to process by using
+ * {@link RequestTaskManager#push(Class, Request)} method.</p>
+ * @author silveryocha
+ */
+public class RequestTaskManager {
+
+  static final ConcurrentMap<Class, RequestTaskMonitor> tasks = new ConcurrentHashMap<>();
+  private static final int RESTART_WAITING_BEFORE_GETTING_RESULT = 200;
+
+  /**
+   * Hidden constructor because the class is not instantiable.
+   */
+  private RequestTaskManager() {
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T extends AbstractRequestTask, C extends AbstractRequestTask.ProcessContext>
+  boolean startIfNecessary(final RequestTaskMonitor<T, C> monitor) {
+    if (!monitor.isTaskRunning()) {
+      AbstractRequestTask<C> task =
+          (AbstractRequestTask) ServiceProvider.getService(monitor.taskClass);
+      try {
+        debug(monitor.taskClass, "starting a thread in charge of request processing");
+        monitor.task = ManagedThreadPool.getPool().invoke(task);
+        task.monitor = monitor;
+        monitor.taskWatcher = ManagedThreadPool.getPool().invoke(new TaskWatcher(monitor));
+        return true;
+      } catch (InterruptedException e) {
+        error(monitor.taskClass, "the task {0} can not be invoked",
+            task.getClass().getSimpleName());
+        throw new SilverpeasRuntimeException(e);
+      }
+    }
+    return false;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T extends AbstractRequestTask, C extends AbstractRequestTask.ProcessContext>
+  boolean restartIfNecessary(final RequestTaskMonitor<T, C> monitor) {
+    if (!monitor.isTaskRunning() && !monitor.requestList.isEmpty()) {
+      warn(monitor.taskClass,
+          "the task is not running but there are yet some requests to process!!! ({0} " +
+              "requests queued) restarting it again", monitor.requestList.size());
+      return startIfNecessary(monitor);
+    }
+    return false;
+  }
+
+  private static void warn(Class taskClass, String message, Object... parameters) {
+    getLogger().warn(taskClass.getSimpleName() + " - " + message, parameters);
+  }
+
+  private static void error(Class taskClass, String message, Object... parameters) {
+    getLogger().error(taskClass.getSimpleName() + " - " + message, parameters);
+  }
+
+  private static void error(Class taskClass, Exception e) {
+    getLogger().error(taskClass.getSimpleName() + " - an error occurred", e);
+  }
+
+  private static void debug(Class taskClass, String message, Object... parameters) {
+    getLogger().debug(taskClass.getSimpleName() + " - " + message, parameters);
+  }
+
+  private static SilverLogger getLogger() {
+    return SilverLogger.getLogger("silverpeas.core.thread");
+  }
+
+  /**
+   * This method is the only entry point to add a request to process.
+   * <p>There is three synchronized steps performed into this method:
+   * <ul><li>first, starting the consummation task if exists at least one request into the queue and
+   * if the task is not running</li>
+   * <li>then, acquiring a semaphore access if the queue size is limited</li>
+   * <li>finally, adding the request into the queue and starting the task if it is not running</li>
+   * </ul></p>
+   * @param taskClass the class of the {@link AbstractRequestTask} implementation which provides
+   * the
+   * {@link AbstractRequestTask.Request}.
+   * @param request the request to process.
+   * @param <T> the type of the task.
+   * @param <C> the type of the task process context.
+   */
+  @SuppressWarnings("unchecked")
+  public static <T extends AbstractRequestTask, C extends AbstractRequestTask.ProcessContext>
+  void push(
+      Class<T> taskClass, Request<C> request) {
+    RequestTaskMonitor<T, C> monitor = tasks.computeIfAbsent(taskClass, c -> {
+      AbstractRequestTask<C> taskForInit = (AbstractRequestTask) ServiceProvider.getService(c);
+      return new RequestTaskMonitor<>(taskForInit);
+    });
+    synchronized (monitor.requestList) {
+      restartIfNecessary(monitor);
+    }
+    monitor.acquireAccess();
+    synchronized (monitor.requestList) {
+      debug(taskClass, "pushing new request {0} ({1} requests queued before push)",
+          request.getClass().getSimpleName(), monitor.requestList.size());
+      monitor.requestList.add(request);
+      startIfNecessary(monitor);
+    }
+  }
+
+  static class TaskWatcher implements Callable<Void> {
+    final RequestTaskMonitor monitor;
+
+    TaskWatcher(final RequestTaskMonitor monitor) {
+      this.monitor = monitor;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Void call() {
+      debug(this.monitor.taskClass, "task watcher - started");
+      try {
+        Thread.sleep(RESTART_WAITING_BEFORE_GETTING_RESULT);
+      } catch (InterruptedException e) {
+        error(TaskWatcher.class, e);
+      }
+      boolean endedOnError = false;
+      try {
+        this.monitor.task.get();
+      } catch (CancellationException | InterruptedException | ExecutionException e) {
+        endedOnError = true;
+        error(this.monitor.taskClass, e);
+      }
+      synchronized (monitor.requestList) {
+        debug(this.monitor.taskClass, "task watcher - watched " +
+            (endedOnError ? "task has been terminated on error" : "task ended without error"));
+        if (!restartIfNecessary(this.monitor) && !this.monitor.isTaskRunning()) {
+          debug(this.monitor.taskClass, "task watcher - unregistering instances from monitor");
+          this.monitor.task = null;
+          this.monitor.taskWatcher = null;
+        }
+      }
+      debug(this.monitor.taskClass, "task watcher - stopped");
+      return null;
+    }
+  }
+
+  static class RequestTaskMonitor<T extends AbstractRequestTask, C extends AbstractRequestTask
+      .ProcessContext> {
+    final Class taskClass;
+    final List<Request<C>> requestList;
+    private final Semaphore queueSemaphore;
+    Future<Void> task = null;
+    Future<Void> taskWatcher = null;
+
+    /**
+     * @param taskForInit a task instance for initialization, it will not be run.
+     */
+    RequestTaskMonitor(final T taskForInit) {
+      final int queueLimit = taskForInit.getRequestQueueLimit();
+      this.queueSemaphore = queueLimit > 0 ? new Semaphore(queueLimit, true) : null;
+      this.requestList = queueLimit > 0 ? new ArrayList<>(queueLimit) : new ArrayList<>();
+      this.taskClass = taskForInit.getClass();
+    }
+
+    boolean isTaskRunning() {
+      return task != null && !task.isCancelled() && !task.isDone();
+    }
+
+    void acquireAccess() {
+      if (queueSemaphore != null) {
+        try {
+          debug(taskClass, "acquiring queue semaphore ({0} available permits before acquire)",
+              queueSemaphore.availablePermits());
+          queueSemaphore.acquire();
+        } catch (InterruptedException e) {
+          error(taskClass, "not possible to acquire semaphore");
+          throw new SilverpeasRuntimeException(e);
+        }
+      }
+    }
+
+    void releaseAccess() {
+      if (queueSemaphore != null) {
+        debug(taskClass,
+            "consumer thread - releasing queue semaphore ({0} available permits before release)",
+            queueSemaphore.availablePermits());
+        queueSemaphore.release();
+      }
+    }
+  }
+}

--- a/core-configuration/src/main/config/properties/org/silverpeas/util/logging/threadLogging.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/util/logging/threadLogging.properties
@@ -1,0 +1,36 @@
+#
+# Copyright (C) 2000 - 2017 Silverpeas
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# As a special exception to the terms and conditions of version 3.0 of
+# the GPL, you may redistribute this Program in connection with Free/Libre
+# Open Source Software ("FLOSS") applications as described in Silverpeas's
+# FLOSS exception. You should have received a copy of the text describing
+# the FLOSS exception, and it is also available here:
+# "http://www.silverpeas.org/docs/core/legal/floss_exception.html"
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+#
+# Logger definition.
+# Each logger is defined by its unique namespace and by a logging level.
+#
+# - namespace: identifies uniquely a logger and represents the hierarchical category to which
+#              messages are logged with the logger. Each substring before a dot is the namespace
+#              of a parent logger.
+# - level: defines the minimum level at which will be accepted the logged messages. If not
+#          set, the first defined parent logger's level will be then taken into account. Possible
+#          value is: ERROR, WARNING, INFO, DEBUG
+#
+namespace=silverpeas.core.thread

--- a/core-library/src/main/java/org/silverpeas/core/index/indexing/model/IndexEngineProxy.java
+++ b/core-library/src/main/java/org/silverpeas/core/index/indexing/model/IndexEngineProxy.java
@@ -45,7 +45,7 @@ public final class IndexEngineProxy {
    * @param entry the index to add.
    */
   public void add(FullIndexEntry entry) {
-    IndexerThread.addIndexEntry(entry);
+    IndexerTask.addIndexEntry(entry);
   }
 
   /**
@@ -53,7 +53,7 @@ public final class IndexEngineProxy {
    * @param entryKey the key of the entry in the indexes.
    */
   public void delete(IndexEntryKey entryKey) {
-    IndexerThread.removeIndexEntry(entryKey);
+    IndexerTask.removeIndexEntry(entryKey);
   }
 
   public static IndexEngineProxy get() {

--- a/core-library/src/main/java/org/silverpeas/core/index/indexing/model/IndexEngineProxy.java
+++ b/core-library/src/main/java/org/silverpeas/core/index/indexing/model/IndexEngineProxy.java
@@ -25,7 +25,6 @@ package org.silverpeas.core.index.indexing.model;
 
 import org.silverpeas.core.util.ServiceProvider;
 
-import javax.annotation.PostConstruct;
 import javax.inject.Singleton;
 
 /**
@@ -74,13 +73,4 @@ public final class IndexEngineProxy {
   public static void removeIndexEntry(IndexEntryKey indexEntry) {
     get().delete(indexEntry);
   }
-
-  /**
-   * Initialize the engine proxy.
-   */
-  @PostConstruct
-  private void init() {
-    IndexerThread.start(IndexManager.get());
-  }
-
 }

--- a/core-library/src/main/java/org/silverpeas/core/index/indexing/model/IndexManager.java
+++ b/core-library/src/main/java/org/silverpeas/core/index/indexing/model/IndexManager.java
@@ -50,6 +50,7 @@ import org.silverpeas.core.util.StringUtil;
 import org.silverpeas.core.util.logging.SilverLogger;
 
 import javax.inject.Inject;
+import javax.inject.Singleton;
 import java.io.File;
 import java.io.IOException;
 import java.io.Reader;
@@ -70,6 +71,7 @@ import static org.silverpeas.core.i18n.I18NHelper.defaultLocale;
  * An IndexManager manage all the web'activ's index. An IndexManager is NOT thread safe : to share
  * an IndexManager between several threads use an IndexerThread.
  */
+@Singleton
 public class IndexManager {
 
   /**

--- a/core-library/src/main/java/org/silverpeas/core/index/indexing/model/IndexerTask.java
+++ b/core-library/src/main/java/org/silverpeas/core/index/indexing/model/IndexerTask.java
@@ -32,7 +32,7 @@ import javax.inject.Inject;
 /**
  * This task is in charge of processing indexation requests.
  */
-public class IndexerThread extends AbstractRequestTask<IndexerThread.IndexerProcessContext> {
+public class IndexerTask extends AbstractRequestTask<IndexerTask.IndexerProcessContext> {
 
   private static final int QUEUE_LIMIT = 200;
 
@@ -44,7 +44,7 @@ public class IndexerThread extends AbstractRequestTask<IndexerThread.IndexerProc
   private IndexManager indexManager;
 
   private static SilverLogger getLogger() {
-    return SilverLogger.getLogger(IndexerThread.class);
+    return SilverLogger.getLogger(IndexerTask.class);
   }
 
   /**
@@ -52,7 +52,7 @@ public class IndexerThread extends AbstractRequestTask<IndexerThread.IndexerProc
    * @param indexEntry the index entry ro process.
    */
   public static void addIndexEntry(FullIndexEntry indexEntry) {
-    RequestTaskManager.push(IndexerThread.class, new AddIndexEntryRequest(indexEntry));
+    RequestTaskManager.push(IndexerTask.class, new AddIndexEntryRequest(indexEntry));
   }
 
   /**
@@ -60,7 +60,7 @@ public class IndexerThread extends AbstractRequestTask<IndexerThread.IndexerProc
    * @param indexEntry the index entry ro process.
    */
   public static void removeIndexEntry(IndexEntryKey indexEntry) {
-    RequestTaskManager.push(IndexerThread.class, new RemoveIndexEntryRequest(indexEntry));
+    RequestTaskManager.push(IndexerTask.class, new RemoveIndexEntryRequest(indexEntry));
   }
 
   @Override

--- a/core-library/src/main/java/org/silverpeas/core/index/search/model/DidYouMeanSearcher.java
+++ b/core-library/src/main/java/org/silverpeas/core/index/search/model/DidYouMeanSearcher.java
@@ -37,6 +37,7 @@ import org.silverpeas.core.util.StringUtil;
 import org.silverpeas.core.util.logging.SilverLogger;
 
 import javax.inject.Inject;
+import javax.inject.Singleton;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -48,6 +49,7 @@ import java.util.StringTokenizer;
  * An interactive search to propose queries matching some results the user is expecting.
  *
  */
+@Singleton
 public class DidYouMeanSearcher {
   private List<SpellChecker> spellCheckers = null;
   private String query = null;

--- a/core-library/src/main/java/org/silverpeas/core/index/search/model/IndexSearcher.java
+++ b/core-library/src/main/java/org/silverpeas/core/index/search/model/IndexSearcher.java
@@ -58,6 +58,7 @@ import org.silverpeas.core.util.logging.SilverLogger;
 
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -74,6 +75,7 @@ import java.util.StringTokenizer;
  * The IndexSearcher class implements search over all the indexes. A IndexSearcher
  * manages a set of cached lucene IndexSearcher.
  */
+@Singleton
 public class IndexSearcher {
 
   public static QueryParser.Operator defaultOperand = QueryParser.AND_OPERATOR;
@@ -88,6 +90,7 @@ public class IndexSearcher {
    * abstract match the query.
    */
   private int secondaryFactor = 1;
+
   @Inject
   private IndexManager indexManager;
 

--- a/core-library/src/test/java/org/silverpeas/core/mail/TestSmtpMailSending.java
+++ b/core-library/src/test/java/org/silverpeas/core/mail/TestSmtpMailSending.java
@@ -32,10 +32,12 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.silverpeas.core.mail.engine.MailSender;
 import org.silverpeas.core.mail.engine.MailSenderProvider;
+import org.silverpeas.core.mail.engine.MailSenderTask;
 import org.silverpeas.core.mail.engine.SmtpMailSender;
 import org.silverpeas.core.test.rule.CommonAPI4Test;
 import org.silverpeas.core.util.MimeTypes;
 import org.silverpeas.core.util.StringUtil;
+import org.silverpeas.core.util.logging.Level;
 
 import javax.mail.Message;
 import javax.mail.Multipart;
@@ -69,6 +71,8 @@ public class TestSmtpMailSending {
     oldMailSender = MailSenderProvider.get();
     FieldUtils.writeDeclaredStaticField(MailSenderProvider.class, "mailSender",
         new StubbedSmtpMailSender(), true);
+    commonAPI4Test.injectIntoMockedBeanContainer(new MailSenderTask());
+    commonAPI4Test.setLoggerLevel(Level.DEBUG);
   }
 
   @After

--- a/core-library/src/test/java/org/silverpeas/core/mail/TestSmtpMailSendingMassive.java
+++ b/core-library/src/test/java/org/silverpeas/core/mail/TestSmtpMailSendingMassive.java
@@ -31,9 +31,11 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.silverpeas.core.mail.engine.MailSender;
 import org.silverpeas.core.mail.engine.MailSenderProvider;
+import org.silverpeas.core.mail.engine.MailSenderTask;
 import org.silverpeas.core.mail.engine.SmtpMailSender;
 import org.silverpeas.core.test.rule.CommonAPI4Test;
 import org.silverpeas.core.util.StringUtil;
+import org.silverpeas.core.util.logging.Level;
 
 import javax.mail.internet.MimeMessage;
 import java.util.ArrayList;
@@ -62,6 +64,8 @@ public class TestSmtpMailSendingMassive {
     oldMailSender = MailSenderProvider.get();
     FieldUtils.writeDeclaredStaticField(MailSenderProvider.class, "mailSender",
         new StubbedSmtpMailSender(), true);
+    commonAPI4Test.injectIntoMockedBeanContainer(new MailSenderTask());
+    commonAPI4Test.setLoggerLevel(Level.DEBUG);
   }
 
   @After

--- a/core-library/src/test/java/org/silverpeas/core/notification/sse/AbstractServerEventDispatcherTaskTest.java
+++ b/core-library/src/test/java/org/silverpeas/core/notification/sse/AbstractServerEventDispatcherTaskTest.java
@@ -31,6 +31,7 @@ import org.mockito.ArgumentCaptor;
 import org.silverpeas.core.admin.user.model.User;
 import org.silverpeas.core.notification.sse.ServerEventDispatcherTask.ServerEventStore;
 import org.silverpeas.core.test.rule.CommonAPI4Test;
+import org.silverpeas.core.util.logging.Level;
 
 import javax.servlet.AsyncContext;
 import javax.servlet.http.HttpServletRequest;
@@ -70,6 +71,8 @@ class AbstractServerEventDispatcherTaskTest {
     asyncContextMap.clear();
     serverEventStore.clear();
     FieldUtils.writeDeclaredStaticField(AbstractServerEvent.class, "idCounter", 0L, true);
+    commonAPI4Test.injectIntoMockedBeanContainer(new ServerEventDispatcherTask());
+    commonAPI4Test.setLoggerLevel(Level.DEBUG);
     new SseLogger().init();
   }
 

--- a/core-library/src/test/java/org/silverpeas/core/thread/task/RequestTaskManagerTest.java
+++ b/core-library/src/test/java/org/silverpeas/core/thread/task/RequestTaskManagerTest.java
@@ -29,7 +29,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TestName;
 import org.silverpeas.core.test.rule.CommonAPI4Test;
 import org.silverpeas.core.thread.task.RequestTaskManager.RequestTaskMonitor;
 import org.silverpeas.core.util.logging.Level;
@@ -40,9 +39,7 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeoutException;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.*;
 
 /**
  * @author silveryocha
@@ -51,9 +48,6 @@ public class RequestTaskManagerTest {
 
   private static int counter = 0;
   private static int afterNoMoreRequestCounter = 0;
-
-  @Rule
-  public TestName testName = new TestName();
 
   @Rule
   public CommonAPI4Test commonAPI4Test = new CommonAPI4Test();

--- a/core-library/src/test/java/org/silverpeas/core/thread/task/RequestTaskManagerTest.java
+++ b/core-library/src/test/java/org/silverpeas/core/thread/task/RequestTaskManagerTest.java
@@ -1,0 +1,379 @@
+/*
+ * Copyright (C) 2000 - 2017 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception. You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "http://www.silverpeas.org/docs/core/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.thread.task;
+
+import org.apache.commons.lang.reflect.FieldUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.silverpeas.core.test.rule.CommonAPI4Test;
+import org.silverpeas.core.thread.task.RequestTaskManager.RequestTaskMonitor;
+import org.silverpeas.core.util.logging.Level;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeoutException;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+/**
+ * @author silveryocha
+ */
+public class RequestTaskManagerTest {
+
+  private static int counter = 0;
+  private static int afterNoMoreRequestCounter = 0;
+
+  @Rule
+  public TestName testName = new TestName();
+
+  @Rule
+  public CommonAPI4Test commonAPI4Test = new CommonAPI4Test();
+
+  private static synchronized int getCounter() {
+    return counter;
+  }
+
+  private static synchronized int getAfterNoMoreRequestCounter() {
+    return afterNoMoreRequestCounter;
+  }
+
+  static synchronized void incrementCounter() {
+    counter++;
+  }
+
+  static synchronized void incrementAfterNoMoreRequestCounter() {
+    afterNoMoreRequestCounter++;
+  }
+
+  @Before
+  public void init() {
+    commonAPI4Test.injectIntoMockedBeanContainer(new TestRequestTask());
+    commonAPI4Test.injectIntoMockedBeanContainer(new TestRequestTaskWithLimit());
+    commonAPI4Test.injectIntoMockedBeanContainer(new TestRequestTaskWithAfterNoMoreRequestLongTreatment());
+    commonAPI4Test.setLoggerLevel(Level.DEBUG);
+  }
+
+  @Before
+  @After
+  public synchronized void clean() {
+    RequestTaskManager.tasks.clear();
+  }
+
+  @Before
+  public synchronized void resetCounter() {
+    counter = 0;
+  }
+
+  @Before
+  public synchronized void resetAfterNoMoreRequestCounter() {
+    afterNoMoreRequestCounter = 0;
+  }
+
+  @Test
+  public void usingNormallyShouldWork()
+      throws ExecutionException, InterruptedException, TimeoutException {
+    assertThat(counter, is(0));
+    final int nbRequests = 100;
+    for (int i = 0; i < nbRequests; i++) {
+      TestRequestTask.newRandomSleepRequest();
+      if (Math.random() > 0.7) {
+        Thread.sleep(50);
+      }
+    }
+    RequestTaskMonitor monitor = waitForTaskEndingAtEndOfTest(TestRequestTask.class);
+    assertThatThreadsAreStoppedAndMonitorsAreCleanedAndQueuesAreConsummed(monitor);
+    assertThat(counter, is(nbRequests));
+  }
+
+  @Test
+  public void usingLimitedQueueShouldWork()
+      throws ExecutionException, InterruptedException, TimeoutException {
+    assertThat(counter, is(0));
+    final int nbRequests = 100;
+    for (int i = 0; i < nbRequests; i++) {
+      TestRequestTaskWithLimit.newRandomSleepRequest();
+      if (Math.random() > 0.7) {
+        Thread.sleep(50);
+      }
+    }
+    RequestTaskMonitor monitor = waitForTaskEndingAtEndOfTest(TestRequestTaskWithLimit.class);
+    assertThatThreadsAreStoppedAndMonitorsAreCleanedAndQueuesAreConsummed(monitor);
+    assertThat(counter, is(nbRequests));
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void firstRequestKillsTaskButRestartedOnNewRequestPush()
+      throws ExecutionException, InterruptedException, TimeoutException {
+
+    // Firstly initializing the monitor by pushing a request
+    TestRequestTaskWithLimit.newEmptyRequest();
+    RequestTaskMonitor monitor = waitForTaskEndingAfterFirstInit(TestRequestTaskWithLimit.class);
+
+    // Setting manually the queue
+    monitor.requestList.add(new TestRequestTaskWithLimit.ThreadKillTestRequest());
+    monitor.requestList.add(new TestRequestTaskWithLimit.SleepTestRequest(0));
+    monitor.requestList.add(new TestRequestTaskWithLimit.SleepTestRequest(0));
+    monitor.requestList.add(new TestRequestTaskWithLimit.SleepTestRequest(0));
+    Thread.sleep(500);
+
+    assertThat(counter, is(0));
+    assertThat(monitor.isTaskRunning(), is(false));
+    assertThat(monitor.task, nullValue());
+    assertThat(monitor.taskWatcher, nullValue());
+    assertThat(monitor.requestList.size(), is(4));
+    assertThat(getCounter(), is(0));
+
+    // Starting the thread by adding a new request
+    TestRequestTaskWithLimit.newRandomSleepRequest();
+
+    waitForTaskEndingAtEndOfTest(TestRequestTaskWithLimit.class);
+    assertThatThreadsAreStoppedAndMonitorsAreCleanedAndQueuesAreConsummed(monitor);
+    assertThat(counter, is(4));
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void notFirstRequestKillsTaskButRestartedOnNewRequestPush()
+      throws ExecutionException, InterruptedException, TimeoutException {
+
+    // Firstly initializing the monitor by pushing a request
+    TestRequestTaskWithLimit.newEmptyRequest();
+    RequestTaskMonitor monitor = waitForTaskEndingAfterFirstInit(TestRequestTaskWithLimit.class);
+
+    // Setting manually the queue
+    monitor.requestList.add(new TestRequestTaskWithLimit.SleepTestRequest(0));
+    monitor.requestList.add(new TestRequestTaskWithLimit.SleepTestRequest(0));
+    monitor.requestList.add(new TestRequestTaskWithLimit.SleepTestRequest(0));
+    monitor.requestList.add(new TestRequestTaskWithLimit.SleepTestRequest(0));
+    monitor.requestList.add(new TestRequestTaskWithLimit.ThreadKillTestRequest());
+    monitor.requestList.add(new TestRequestTaskWithLimit.SleepTestRequest(0));
+    monitor.requestList.add(new TestRequestTaskWithLimit.SleepTestRequest(0));
+    monitor.requestList.add(new TestRequestTaskWithLimit.SleepTestRequest(0));
+    Thread.sleep(500);
+
+    assertThat(monitor.isTaskRunning(), is(false));
+    assertThat(monitor.requestList.size(), is(8));
+    assertThat(getCounter(), is(0));
+
+    // Starting the thread by adding a new request
+    TestRequestTaskWithLimit.newRandomSleepRequest();
+
+    waitForTaskEndingAtEndOfTest(TestRequestTaskWithLimit.class);
+    assertThatThreadsAreStoppedAndMonitorsAreCleanedAndQueuesAreConsummed(monitor);
+    assertThat(counter, is(8));
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void newRequestPushWakeUpTheTaskBeforeAcquiringAccessToAddTheRequestIntoQueue()
+      throws Exception {
+
+    // Firstly initializing the monitor by pushing a request
+    TestRequestTaskWithLimit.newEmptyRequest();
+    RequestTaskMonitor monitor = waitForTaskEndingAfterFirstInit(TestRequestTaskWithLimit.class);
+
+    // Setting manually the queue
+    monitor.requestList.add(new TestRequestTaskWithLimit.SleepTestRequest(0));
+
+    // Acquiring all access
+    monitor.acquireAccess();
+    monitor.acquireAccess();
+    Thread.sleep(500);
+
+    Semaphore semaphore = (Semaphore) FieldUtils.readDeclaredField(monitor, "queueSemaphore", true);
+    assertThat(semaphore.availablePermits(), is(0));
+    assertThat(monitor.isTaskRunning(), is(false));
+    assertThat(monitor.task, nullValue());
+    assertThat(monitor.taskWatcher, nullValue());
+    assertThat(monitor.requestList.size(), is(1));
+    assertThat(getCounter(), is(0));
+
+    // Starting the thread by adding a new request whereas the semaphore has no more available
+    // permits.
+    TestRequestTaskWithLimit.newRandomSleepRequest();
+
+    waitForTaskEndingAtEndOfTest(TestRequestTaskWithLimit.class);
+    assertThatThreadsAreStoppedAndMonitorsAreCleanedAndQueuesAreConsummed(monitor);
+    assertThat(counter, is(2));
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void requestPushedDuringAfterNoMoreRequestMustBeHandledBySameTask() throws Exception {
+
+    // Firstly initializing the monitor by pushing a request
+    TestRequestTaskWithAfterNoMoreRequestLongTreatment.newRandomSleepRequest();
+    Thread.sleep(200);
+
+    RequestTaskMonitor monitor =
+        RequestTaskManager.tasks.get(TestRequestTaskWithAfterNoMoreRequestLongTreatment.class);
+    Future taskInstanceOnAfterNoMoreRequest = monitor.task;
+    assertThat(monitor.isTaskRunning(), is(true));
+    assertThat(monitor.taskWatcher.isDone(), is(false));
+    assertThat(monitor.taskWatcher.isCancelled(), is(false));
+    assertThat(monitor.requestList.size(), is(0));
+    assertThat(getCounter(), is(1));
+    assertThat(getAfterNoMoreRequestCounter(), is(1));
+
+    // Adding a new request
+    TestRequestTaskWithAfterNoMoreRequestLongTreatment.newSleepRequest(20);
+    Future taskInstanceAfterEndOfTreatment = monitor.task;
+
+    waitForTaskEndingAtEndOfTest(TestRequestTaskWithAfterNoMoreRequestLongTreatment.class);
+    assertThat(taskInstanceOnAfterNoMoreRequest, is(taskInstanceAfterEndOfTreatment));
+    assertThatThreadsAreStoppedAndMonitorsAreCleanedAndQueuesAreConsummed(monitor);
+    assertThat(counter, is(2));
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void onlyRequestKillingTaskMustAlsoBeConsumed()
+      throws ExecutionException, InterruptedException, TimeoutException {
+    // Firstly initializing the monitor by pushing a request
+    TestRequestTask.newEmptyRequest();
+    RequestTaskMonitor monitor = waitForTaskEndingAfterFirstInit(TestRequestTask.class);
+
+    // Setting manually the queue
+    monitor.requestList.add(new TestRequestTask.ThreadKillTestRequest());
+    monitor.requestList.add(new TestRequestTask.ThreadKillTestRequest());
+    monitor.requestList.add(new TestRequestTask.ThreadKillTestRequest());
+    monitor.requestList.add(new TestRequestTask.ThreadKillTestRequest());
+
+    // Starting the thread by adding a new request
+    TestRequestTask.newThreadKillRequest();
+
+    waitForTaskEndingAtEndOfTest(TestRequestTask.class);
+    assertThatThreadsAreStoppedAndMonitorsAreCleanedAndQueuesAreConsummed(monitor);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void onlyRequestKillingTaskMusAlsoBeConsumedWithLimitedQueue()
+      throws ExecutionException, InterruptedException, TimeoutException {
+    // Firstly initializing the monitor by pushing a request
+    TestRequestTaskWithLimit.newEmptyRequest();
+    Thread.sleep(100);
+    RequestTaskMonitor monitor = RequestTaskManager.tasks.get(TestRequestTaskWithLimit.class);
+    assertThat(monitor.isTaskRunning(), is(false));
+    assertThat(monitor.requestList.size(), is(0));
+    assertThat(counter, is(1));
+
+    // Setting manually the queue
+    monitor.requestList.add(new TestRequestTaskWithLimit.ThreadKillTestRequest());
+    monitor.requestList.add(new TestRequestTaskWithLimit.ThreadKillTestRequest());
+    monitor.requestList.add(new TestRequestTaskWithLimit.ThreadKillTestRequest());
+    monitor.requestList.add(new TestRequestTaskWithLimit.ThreadKillTestRequest());
+
+    // Starting the thread by adding a new request
+    TestRequestTaskWithLimit.newThreadKillRequest();
+
+    waitForTaskEndingAtEndOfTest(TestRequestTaskWithLimit.class);
+    assertThatThreadsAreStoppedAndMonitorsAreCleanedAndQueuesAreConsummed(monitor);
+  }
+
+  @Test
+  public void bigMelting() throws ExecutionException, InterruptedException, TimeoutException {
+    assertThat(counter, is(0));
+    final int nbRequests = 100;
+    int nbSleepRequests = 0;
+    for (int i = 0; i < nbRequests; i++) {
+      if (Math.random() < 0.8) {
+        TestRequestTask.newRandomSleepRequest();
+        TestRequestTaskWithLimit.newRandomSleepRequest();
+        nbSleepRequests += 2;
+      } else {
+        TestRequestTaskWithLimit.newThreadKillRequest();
+        TestRequestTask.newThreadKillRequest();
+      }
+      if (Math.random() > 0.7) {
+        Thread.sleep(50);
+      }
+    }
+    RequestTaskMonitor monitor = waitForTaskEndingAtEndOfTest(TestRequestTask.class);
+    waitForTaskEndingAtEndOfTest(TestRequestTaskWithLimit.class);
+    assertThat(monitor, notNullValue());
+    assertThatThreadsAreStoppedAndMonitorsAreCleanedAndQueuesAreConsummed(monitor);
+    assertThat(counter, is(nbSleepRequests));
+  }
+
+  private RequestTaskMonitor waitForTaskEndingAfterFirstInit(final Class testClass)
+      throws InterruptedException, ExecutionException {
+    Thread.sleep(100);
+    RequestTaskMonitor monitor = RequestTaskManager.tasks.get(testClass);
+    // Waiting the end of the current task
+    monitor.task.get();
+    monitor.taskWatcher.get();
+    // Checking status
+    assertThatThreadsAreStoppedAndMonitorsAreCleanedAndQueuesAreConsummed(monitor);
+    assertThat(counter, is(1));
+
+    // Resetting counter
+    resetCounter();
+    return monitor;
+  }
+
+  private void assertThatThreadsAreStoppedAndMonitorsAreCleanedAndQueuesAreConsummed(
+      final RequestTaskMonitor monitor) {
+    assertThat(monitor.isTaskRunning(), is(false));
+    assertThat(monitor.task, nullValue());
+    assertThat(monitor.taskWatcher, nullValue());
+    assertThat(monitor.requestList.size(), is(0));
+  }
+
+  private RequestTaskMonitor waitForTaskEndingAtEndOfTest(final Class testClass)
+      throws InterruptedException {
+    Thread.sleep(100);
+    RequestTaskMonitor monitor = RequestTaskManager.tasks.get(testClass);
+    int nbTry = 0;
+    while (nbTry < 20) {
+      Thread.sleep(10);
+      if (monitor.isTaskRunning()) {
+        nbTry = 0;
+      }
+      // Waiting the end of the current task
+      try {
+        monitor.task.get();
+      } catch (Exception ignore) {
+      }
+      try {
+        monitor.taskWatcher.get();
+      } catch (Exception ignore) {
+      }
+      nbTry++;
+    }
+    // Checking status
+    assertThat(monitor.isTaskRunning(), is(false));
+    assertThat(monitor.requestList.size(), is(0));
+    return monitor;
+  }
+}

--- a/core-library/src/test/java/org/silverpeas/core/thread/task/TestRequestTask.java
+++ b/core-library/src/test/java/org/silverpeas/core/thread/task/TestRequestTask.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2000 - 2017 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception. You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "http://www.silverpeas.org/docs/core/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.thread.task;
+
+import org.silverpeas.core.util.logging.SilverLogger;
+
+/**
+ * @author silveryocha
+ */
+class TestRequestTask extends AbstractRequestTask<TestRequestTask.TestProcessContext> {
+
+  protected static SilverLogger getLogger() {
+    return SilverLogger.getLogger(TestRequestTask.class);
+  }
+
+  static void newEmptyRequest() {
+    RequestTaskManager.push(TestRequestTask.class, new SleepTestRequest(0));
+  }
+
+  static void newRandomSleepRequest() {
+    RequestTaskManager.push(TestRequestTask.class, new RandomSleepTestRequest());
+  }
+
+  static void newThreadKillRequest() {
+    RequestTaskManager.push(TestRequestTask.class, new ThreadKillTestRequest());
+  }
+
+  static class TestProcessContext implements AbstractRequestTask.ProcessContext {
+    TestProcessContext() {
+      getLogger().debug("initializing the process context ({0})", getClass().getSimpleName());
+    }
+  }
+
+  static class SleepTestRequest implements AbstractRequestTask.Request<TestProcessContext> {
+    private final int sleep;
+
+    SleepTestRequest(final int sleep) {
+      this.sleep = sleep;
+    }
+
+    public void process(TestProcessContext context) throws InterruptedException {
+      if (sleep > 0) {
+        getLogger().debug("sleeping for {0}ms ({1})", sleep, getClass().getSimpleName());
+        Thread.sleep(sleep);
+      }
+      RequestTaskManagerTest.incrementCounter();
+    }
+  }
+
+  static class RandomSleepTestRequest extends SleepTestRequest {
+    RandomSleepTestRequest() {
+      super((int) (Math.random() * 10));
+    }
+  }
+
+  static class ThreadKillTestRequest implements AbstractRequestTask.Request<TestProcessContext> {
+
+    @Override
+    public void process(TestProcessContext context) throws InterruptedException {
+      getLogger().debug("killing thread into 10ms");
+      Thread.sleep(10);
+      throw new Error();
+    }
+  }
+}

--- a/core-library/src/test/java/org/silverpeas/core/thread/task/TestRequestTaskWithAfterNoMoreRequestLongTreatment.java
+++ b/core-library/src/test/java/org/silverpeas/core/thread/task/TestRequestTaskWithAfterNoMoreRequestLongTreatment.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2000 - 2017 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception. You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "http://www.silverpeas.org/docs/core/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.thread.task;
+
+/**
+ * @author silveryocha
+ */
+public class TestRequestTaskWithAfterNoMoreRequestLongTreatment extends TestRequestTask {
+
+  static void newRandomSleepRequest() {
+    RequestTaskManager.push(TestRequestTaskWithAfterNoMoreRequestLongTreatment.class,
+        new RandomSleepTestRequest());
+  }
+
+  static void newSleepRequest(int sleep) {
+    RequestTaskManager.push(TestRequestTaskWithAfterNoMoreRequestLongTreatment.class,
+        new SleepTestRequest(sleep));
+  }
+
+  @Override
+  protected void afterNoMoreRequest() {
+    super.afterNoMoreRequest();
+    try {
+      getLogger().debug("starting sleeping for 2s from afterNoMoreRequest method invocation");
+      RequestTaskManagerTest.incrementAfterNoMoreRequestCounter();
+      Thread.sleep(2000);
+    } catch (InterruptedException ignore) {
+    }
+  }
+}

--- a/core-library/src/test/java/org/silverpeas/core/thread/task/TestRequestTaskWithLimit.java
+++ b/core-library/src/test/java/org/silverpeas/core/thread/task/TestRequestTaskWithLimit.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2000 - 2017 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception. You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "http://www.silverpeas.org/docs/core/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.thread.task;
+
+/**
+ * @author silveryocha
+ */
+public class TestRequestTaskWithLimit extends TestRequestTask {
+
+  static void newEmptyRequest() {
+    RequestTaskManager.push(TestRequestTaskWithLimit.class, new SleepTestRequest(0));
+  }
+
+  static void newRandomSleepRequest() {
+    RequestTaskManager.push(TestRequestTaskWithLimit.class, new RandomSleepTestRequest());
+  }
+
+  static void newThreadKillRequest() {
+    RequestTaskManager.push(TestRequestTaskWithLimit.class, new ThreadKillTestRequest());
+  }
+
+  @Override
+  protected int getRequestQueueLimit() {
+    return 2;
+  }
+}

--- a/core-test/src/main/java/org/silverpeas/core/test/rule/CommonAPI4Test.java
+++ b/core-test/src/main/java/org/silverpeas/core/test/rule/CommonAPI4Test.java
@@ -29,6 +29,7 @@ import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 import org.mockito.internal.util.MockUtil;
+import org.silverpeas.core.SilverpeasRuntimeException;
 import org.silverpeas.core.admin.user.model.User;
 import org.silverpeas.core.admin.user.service.GroupProvider;
 import org.silverpeas.core.admin.user.service.UserProvider;
@@ -38,6 +39,7 @@ import org.silverpeas.core.test.util.lang.TestSystemWrapper;
 import org.silverpeas.core.test.util.log.TestSilverpeasTrace;
 import org.silverpeas.core.thread.ManagedThreadPool;
 import org.silverpeas.core.util.lang.SystemWrapper;
+import org.silverpeas.core.util.logging.Level;
 import org.silverpeas.core.util.logging.LoggerConfigurationManager;
 import org.silverpeas.core.util.logging.SilverLoggerProvider;
 
@@ -45,8 +47,14 @@ import javax.enterprise.concurrent.ManagedThreadFactory;
 import java.io.File;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
+import java.util.logging.ConsoleHandler;
+import java.util.logging.Handler;
+import java.util.logging.Logger;
+import java.util.logging.SimpleFormatter;
 
 import static org.mockito.Mockito.*;
+import static org.silverpeas.core.util.logging.SilverLoggerProvider.ROOT_NAMESPACE;
 
 /**
  * @author Yohann Chastagnier
@@ -96,6 +104,38 @@ public class CommonAPI4Test implements TestRule {
 
   public TestContext getTestContext() {
     return testContext;
+  }
+
+  public void setLoggerLevel(Level level) {
+    final ConsoleHandler handler = new ConsoleHandler();
+    setLoggerHandler(handler);
+    handler.setFormatter(new SimpleFormatter());
+    switch (level) {
+      case INFO:
+        Logger.getLogger(ROOT_NAMESPACE).setLevel(java.util.logging.Level.INFO);
+        handler.setLevel(java.util.logging.Level.INFO);
+        break;
+      case DEBUG:
+        Logger.getLogger(ROOT_NAMESPACE).setLevel(java.util.logging.Level.FINE);
+        handler.setLevel(java.util.logging.Level.FINE);
+        break;
+      case WARNING:
+        Logger.getLogger(ROOT_NAMESPACE).setLevel(java.util.logging.Level.WARNING);
+        handler.setLevel(java.util.logging.Level.WARNING);
+        break;
+      case ERROR:
+        Logger.getLogger(ROOT_NAMESPACE).setLevel(java.util.logging.Level.SEVERE);
+        handler.setLevel(java.util.logging.Level.SEVERE);
+        break;
+    }
+  }
+
+  public void setLoggerHandler(final Handler handler) {
+    Logger.getLogger(ROOT_NAMESPACE).setUseParentHandlers(false);
+    if (Arrays.stream(Logger.getLogger(ROOT_NAMESPACE).getHandlers())
+        .filter(h -> handler.getClass().isInstance(h)).count() == 0) {
+      Logger.getLogger(ROOT_NAMESPACE).addHandler(handler);
+    }
   }
 
   @SuppressWarnings("unchecked")
@@ -170,7 +210,7 @@ public class CommonAPI4Test implements TestRule {
           .getBeanByType(ManagedThreadPool.class)).thenReturn(managedThreadPool);
     } catch (IllegalAccessException | NoSuchMethodException | InstantiationException |
         InvocationTargetException e) {
-      throw new RuntimeException(e);
+      throw new SilverpeasRuntimeException(e);
     }
   }
 


### PR DESCRIPTION
Making some service instances as singletons!!!
Adding some debug routines in order to get more readable and comprehensive data to analyze when getting errors into context of production:
- "silverpeas.core.thread" logger category permits to follow Thread engine execution
- "silverpeas.core.index.indexing" logger category permits to follow indexation pushing request