### PR TITLE
[User profile] : Extending standard data with custom template

### DIFF
--- a/core-configuration/src/main/config/properties/org/silverpeas/jobDomainPeas/multilang/jobDomainPeasBundle.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/jobDomainPeas/multilang/jobDomainPeasBundle.properties
@@ -100,6 +100,9 @@ JDP.userState = Etat
 JDP.userSynchro = Synchroniser un utilisateur
 JDP.userUnsynchro = Supprimer la synchronisation d'un utilisateur
 JDP.userUpdate = Editer les informations de l'utilisateur
+JDP.user.state.BLOCKED=Le compte de cet utilisateur est actuellement bloqu\u00e9...
+JDP.user.state.DEACTIVATED = Le compte de cet utilisateur est actuellement d\u00e9sactiv\u00e9...
+JDP.user.avatar.delete.confirm = Etes-vous s\u00fbr(e) de vouloir supprimer d\u00e9finitivement cet avatar ?
 
 JDP.traceLevel = Niveau de trace
 

--- a/core-configuration/src/main/config/properties/org/silverpeas/jobDomainPeas/multilang/jobDomainPeasBundle_de.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/jobDomainPeas/multilang/jobDomainPeasBundle_de.properties
@@ -101,6 +101,9 @@ JDP.userState = Zustand
 JDP.userSynchro = Einen Benutzer synchronisieren
 JDP.userUnsynchro = Synchronisation eines Benutzers l\u00f6schen
 JDP.userUpdate = Informationen des Benutzers editieren
+JDP.user.state.BLOCKED=Der Account dieses Benutzers ist derzeit gesperrt...
+JDP.user.state.DEACTIVATED=Das Konto dieses Benutzers ist derzeit deaktiviert...
+JDP.user.avatar.delete.confirm = Bist du sicher, dass du diesen Avatar endg\u00fcltig l\u00f6schen m\u00f6chtest?
 
 JDP.traceLevel = Trace-Ebene
 

--- a/core-configuration/src/main/config/properties/org/silverpeas/jobDomainPeas/multilang/jobDomainPeasBundle_en.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/jobDomainPeas/multilang/jobDomainPeasBundle_en.properties
@@ -100,6 +100,9 @@ JDP.userState = State
 JDP.userSynchro = Synchronize a user
 JDP.userUnsynchro = Delete the user synchronization
 JDP.userUpdate = Edit the user data
+JDP.user.state.BLOCKED=The account of this user is currently blocked...
+JDP.user.state.DEACTIVATED=The account of this user is currently disabled...
+JDP.user.avatar.delete.confirm = Are you sure you want to permanently delete this avatar?
 
 JDP.traceLevel = Trace level
 

--- a/core-configuration/src/main/config/properties/org/silverpeas/jobDomainPeas/multilang/jobDomainPeasBundle_fr.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/jobDomainPeas/multilang/jobDomainPeasBundle_fr.properties
@@ -100,6 +100,9 @@ JDP.userState = Etat
 JDP.userSynchro = Synchroniser un utilisateur
 JDP.userUnsynchro = Supprimer la synchronisation d'un utilisateur
 JDP.userUpdate = Editer les informations de l'utilisateur
+JDP.user.state.BLOCKED=Le compte de cet utilisateur est actuellement bloqu\u00e9...
+JDP.user.state.DEACTIVATED = Le compte de cet utilisateur est actuellement d\u00e9sactiv\u00e9...
+JDP.user.avatar.delete.confirm = Etes-vous s\u00fbr(e) de vouloir supprimer d\u00e9finitivement cet avatar ?
 
 JDP.traceLevel = Niveau de trace
 

--- a/core-configuration/src/main/config/properties/org/silverpeas/multilang/generalMultilang.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/multilang/generalMultilang.properties
@@ -443,6 +443,9 @@ GML.search.error.and.or.not = Recherche non valide ! Les requ\u00eates contenant
 GML.search.error.quotes.closed = Recherche non valide ! Merci de fermer le caract\u00e8re (").
 GML.search.error.quotes.content = Recherche non valide ! Il doit y avoir au moins un caract\u00e8re entre deux caract\u00e8res ("). Veuillez modifier votre recherche.
 GML.search.error.colon = Recherche non valide ! Le champ d\u00e9claration (:) doit \u00eatre pr\u00e9c\u00e9d\u00e9 par au moins un caract\u00e8re alphanum\u00e9rique et suivi par au moins un caract\u00e8re alphanum\u00e9rique. Veuillez modifier votre recherche.
+GML.search.advanced = Avanc\u00e9e
+GML.search.simple = Simple
+GML.search.clear = RAZ
 
 GML.list.changed.message = La liste a \u00e9t\u00e9 modifi\u00e9e, merci de valider pour l'enregistrer
 

--- a/core-configuration/src/main/config/properties/org/silverpeas/multilang/generalMultilang_de.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/multilang/generalMultilang_de.properties
@@ -443,6 +443,9 @@ GML.search.error.and.or.not = Invalid search query! Queries containing AND/OR/NO
 GML.search.error.quotes.closed = Invalid search query! Please close all quote (\\") marks.
 GML.search.error.quotes.content = Invalid search query! Quotes must contain at least one character. Please try again.
 GML.search.error.colon = Invalid search query! Field declarations (:) must be preceded by at least one alphabet or number and followed by at least one alphabet or number. Please try again.
+GML.search.advanced=Fortschritte
+GML.search.simple = Einfach
+GML.search.clear = Klare
 
 GML.list.changed.message = The list has been changed, please validate to save it
 

--- a/core-configuration/src/main/config/properties/org/silverpeas/multilang/generalMultilang_en.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/multilang/generalMultilang_en.properties
@@ -443,6 +443,9 @@ GML.search.error.and.or.not = Invalid search query! Queries containing AND/OR/NO
 GML.search.error.quotes.closed = Invalid search query! Please close all quote (\\") marks.
 GML.search.error.quotes.content = Invalid search query! Quotes must contain at least one character. Please try again.
 GML.search.error.colon = Invalid search query! Field declarations (:) must be preceded by at least one alphabet or number and followed by at least one alphabet or number. Please try again.
+GML.search.advanced =Advanced
+GML.search.simple =Simple
+GML.search.clear = Clear
 
 GML.list.changed.message = The list has been changed, please validate to save it
 

--- a/core-configuration/src/main/config/properties/org/silverpeas/multilang/generalMultilang_fr.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/multilang/generalMultilang_fr.properties
@@ -444,6 +444,9 @@ GML.search.error.and.or.not = Recherche non valide ! Les requ\u00eates contenant
 GML.search.error.quotes.closed = Recherche non valide ! Merci de fermer le caract\u00e8re (").
 GML.search.error.quotes.content = Recherche non valide ! Il doit y avoir au moins un caract\u00e8re entre deux caract\u00e8res ("). Veuillez modifier votre recherche.
 GML.search.error.colon = Recherche non valide ! Le champ d\u00e9claration (:) doit \u00eatre pr\u00e9c\u00e9d\u00e9 par au moins un caract\u00e8re alphanum\u00e9rique et suivi par au moins un caract\u00e8re alphanum\u00e9rique. Veuillez modifier votre recherche.
+GML.search.advanced =Avanc\u00e9e
+GML.search.simple = Simple
+GML.search.clear = RAZ
 
 GML.list.changed.message = La liste a \u00e9t\u00e9 modifi\u00e9e, merci de valider pour l'enregistrer
 

--- a/core-configuration/src/main/config/properties/org/silverpeas/templatedesigner/multilang/templateDesignerBundle_de.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/templatedesigner/multilang/templateDesignerBundle_de.properties
@@ -39,7 +39,7 @@ templateDesigner.header.visible.spaces = Concerned space(s)
 templateDesigner.header.visible.applications = Concerned application(s)
 templateDesigner.header.visible.instances = Concerned instance(s)
 templateDesigner.header.encrypted = Encrypted data
-
+templateDesigner.header.directory = Verzeichnis
 templateDesigner.header.fieldset.customization = Customization
 templateDesigner.header.customization.view = Presentation overlay
 templateDesigner.header.customization.update = Edition overlay
@@ -106,7 +106,7 @@ templateDesigner.newFieldMap = Ein 'Adresse/Karte'-Feld hinzuf\u00fcgen
 templateDesigner.newFieldEmail = Ein 'E-mail'-Feld hinzuf\u00fcgen
 
 templateDesigner.js.incorrectName = darf sich nicht 'name' nennen. Verwenden Sie einen aussagekr\u00e4ftigen Namen.
-templateDesigner.js.nameAlreadyExist = Es gibt bereits ein Feld mit diesem Namen. Bitte benutzen Sie einen anderen Namen f\u00FCr diesen neuen Bereich.
+templateDesigner.js.nameAlreadyExist = Es gibt bereits ein Feld mit diesem Namen. Bitte benutzen Sie einen anderen Namen f\u00fcr diesen neuen Bereich.
 
 templateDesigner.field.multivalued = wiederholbar
 templateDesigner.field.multivalued.max = mal Max
@@ -144,7 +144,7 @@ templateDesigner.displayer.sequence.global = Die Nummerierung ist die globale Pl
 
 templateDesigner.displayer.explorer.scope = Identifizierung(en)
 
-templateDesigner.displayer.jdbc.autocompletion = Auto-Vervollst\u00E4ndigung
+templateDesigner.displayer.jdbc.autocompletion = Auto-Vervollst\u00e4ndigung
 templateDesigner.displayer.jdbc.listbox = Dropdown-Liste
 
 templateDesigner.displayer.map.map = LandKarte
@@ -154,7 +154,7 @@ templateDesigner.displayer.map.kind.satellite = Satellit
 templateDesigner.displayer.map.kind.hybrid = hybride
 templateDesigner.displayer.map.kind.relief = Relief
 templateDesigner.displayer.map.width = Breite
-templateDesigner.displayer.map.height = H\u00F6he
+templateDesigner.displayer.map.height = H\u00f6he
 templateDesigner.displayer.map.zoom = Zoom
 templateDesigner.displayer.map.zoom.help = (1-23)
 templateDesigner.displayer.map.link = Link "Address"

--- a/core-configuration/src/main/config/properties/org/silverpeas/templatedesigner/multilang/templateDesignerBundle_en.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/templatedesigner/multilang/templateDesignerBundle_en.properties
@@ -39,7 +39,7 @@ templateDesigner.header.visible.spaces = Concerned space(s)
 templateDesigner.header.visible.applications = Concerned application(s)
 templateDesigner.header.visible.instances = Concerned instance(s)
 templateDesigner.header.encrypted = Encrypted data
-
+templateDesigner.header.directory = Directory
 templateDesigner.header.fieldset.customization = Customization
 templateDesigner.header.customization.view = Presentation overlay
 templateDesigner.header.customization.update = Edition overlay

--- a/core-configuration/src/main/config/properties/org/silverpeas/templatedesigner/multilang/templateDesignerBundle_fr.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/templatedesigner/multilang/templateDesignerBundle_fr.properties
@@ -39,7 +39,7 @@ templateDesigner.header.visible.spaces = Espace(s) concern\u00e9(s)
 templateDesigner.header.visible.applications = Application(s) concern\u00e9e(s)
 templateDesigner.header.visible.instances = Instance(s) concern\u00e9e(s)
 templateDesigner.header.encrypted = Donn\u00e9es crypt\u00e9es
-
+templateDesigner.header.directory = Annuaire
 templateDesigner.header.fieldset.customization = Personnalisation
 templateDesigner.header.customization.view = Surcouche consultation
 templateDesigner.header.customization.update = Surcouche \u00e9dition

--- a/core-library/src/integration-test/java/org/silverpeas/core/admin/UsersAndGroupsTest.java
+++ b/core-library/src/integration-test/java/org/silverpeas/core/admin/UsersAndGroupsTest.java
@@ -83,6 +83,7 @@ public class UsersAndGroupsTest {
         .addIndexEngineFeatures()
         .addSilverpeasUrlFeatures()
         .addProcessFeatures()
+        .addPublicationTemplateFeatures()
         .addAsResource("org/silverpeas/jobStartPagePeas/settings")
         .addAsResource("org/silverpeas/core/admin/domain/driver")
         .addAsResource("org/silverpeas/index/search")

--- a/core-library/src/integration-test/java/org/silverpeas/core/contribution/attachment/AttachmentServiceIntegrationTest.java
+++ b/core-library/src/integration-test/java/org/silverpeas/core/contribution/attachment/AttachmentServiceIntegrationTest.java
@@ -94,6 +94,7 @@ public class AttachmentServiceIntegrationTest extends JcrIntegrationTest {
   public static Archive<?> createTestArchive() {
     return WarBuilder4LibCore.onWarForTestClass(DocumentRepositoryIntegrationTest.class)
         .addJcrFeatures()
+        .addPublicationTemplateFeatures()
         .testFocusedOn(war -> war.addAsResource("LibreOffice.odt"))
         .build();
   }

--- a/core-library/src/integration-test/java/org/silverpeas/core/contribution/attachment/HistorisedAttachmentServiceIntegrationTest.java
+++ b/core-library/src/integration-test/java/org/silverpeas/core/contribution/attachment/HistorisedAttachmentServiceIntegrationTest.java
@@ -92,6 +92,7 @@ public class HistorisedAttachmentServiceIntegrationTest extends JcrIntegrationTe
   public static Archive<?> createTestArchive() {
     return WarBuilder4LibCore.onWarForTestClass(DocumentRepositoryIntegrationTest.class)
         .addJcrFeatures()
+        .addPublicationTemplateFeatures()
         .testFocusedOn(war -> war.addAsResource("LibreOffice.odt"))
         .build();
   }

--- a/core-library/src/integration-test/java/org/silverpeas/core/test/WarBuilder4LibCore.java
+++ b/core-library/src/integration-test/java/org/silverpeas/core/test/WarBuilder4LibCore.java
@@ -90,6 +90,7 @@ import org.silverpeas.core.contribution.model.ContributionIdentifier;
 import org.silverpeas.core.contribution.model.SilverpeasContent;
 import org.silverpeas.core.contribution.publication.social.SocialInformationPublication;
 import org.silverpeas.core.contribution.template.publication.PublicationTemplateException;
+import org.silverpeas.core.contribution.template.publication.PublicationTemplateUserEventListener;
 import org.silverpeas.core.exception.DecodingException;
 import org.silverpeas.core.exception.EncodingException;
 import org.silverpeas.core.exception.FromModule;
@@ -469,11 +470,14 @@ public class WarBuilder4LibCore extends WarBuilder<WarBuilder4LibCore> {
    */
   public WarBuilder4LibCore addPublicationTemplateFeatures() {
     addSecurityFeatures();
+    addIndexEngineFeatures();
+    addApacheFileUploadFeatures();
     addPackages(true, "org.silverpeas.core.contribution.template.publication");
     addPackages(false, "org.silverpeas.core.contribution.content.form");
     addPackages(false, "org.silverpeas.core.contribution.content.form.record");
     addPackages(false, "org.silverpeas.core.contribution.content.form.form");
     addAsResource("org/silverpeas/publicationTemplate/settings");
+    applyManually(war -> war.deleteClass(PublicationTemplateUserEventListener.class));
     return this;
   }
 

--- a/core-library/src/main/java/org/silverpeas/core/admin/component/model/Parameter.java
+++ b/core-library/src/main/java/org/silverpeas/core/admin/component/model/Parameter.java
@@ -39,6 +39,7 @@ import org.silverpeas.core.contribution.template.publication.PublicationTemplate
 import org.silverpeas.core.contribution.template.publication.PublicationTemplateManager;
 import org.silverpeas.core.ui.DisplayI18NHelper;
 import org.silverpeas.core.silvertrace.SilverTrace;
+import org.silverpeas.core.util.CollectionUtil;
 
 /**
  * <p>
@@ -227,7 +228,7 @@ public class Parameter implements Cloneable {
    * Objects of the following type(s) are allowed in the list {@link Parameter.Options }
    */
   public List<Option> getOptions() {
-    if (isXmlTemplate()) {
+    if (isXmlTemplate() && CollectionUtil.isEmpty(options)) {
       loadXmlTemplates();
     } else if (options == null) {
       options = new ArrayList<Option>();

--- a/core-library/src/main/java/org/silverpeas/core/admin/user/model/UserDetail.java
+++ b/core-library/src/main/java/org/silverpeas/core/admin/user/model/UserDetail.java
@@ -644,7 +644,7 @@ public class UserDetail implements User {
   @Override
   public String getAvatar() {
     String avatar = getAvatarFileName();
-    if (isAvatarPersonnalized()) {
+    if (isAvatarDefined()) {
       return AVATAR_BASEURI + avatar;
     }
     return User.DEFAULT_AVATAR_PATH;
@@ -659,7 +659,7 @@ public class UserDetail implements User {
     return avatar;
   }
 
-  private boolean isAvatarPersonnalized() {
+  public boolean isAvatarDefined() {
     return new File(FileRepositoryManager.getAvatarPath(), getAvatarFileName()).exists();
   }
 

--- a/core-library/src/main/java/org/silverpeas/core/contribution/content/form/AbstractForm.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/content/form/AbstractForm.java
@@ -92,7 +92,7 @@ public abstract class AbstractForm implements Form {
    */
   @Override
   public String getTitle() {
-    return (title == null ? "" : title);
+    return title == null ? "" : title;
   }
 
   /**
@@ -135,13 +135,7 @@ public abstract class AbstractForm implements Form {
       }
 
       if (!jsAdded) {
-        if (!fieldTemplates.isEmpty()) {
-          FieldTemplate fieldTemplate = fieldTemplates.get(0);
-          if (StringUtil.isDefined(fieldTemplate.getTemplateName())) {
-            out.append("<script type=\"text/javascript\" src=\"/weblib/xmlForms/")
-                .append(fieldTemplate.getTemplateName()).append(".js\"></script>\n");
-          }
-        }
+        out.append(getJavascriptSnippet());
       }
 
       PagesContext pc = new PagesContext(pagesContext);
@@ -306,7 +300,7 @@ public abstract class AbstractForm implements Form {
           if (fieldDisplayerName == null || fieldDisplayerName.isEmpty()) {
             fieldDisplayerName = getTypeManager().getDisplayerName(fieldType);
           }
-          if ((!"wysiwyg".equals(fieldDisplayerName) || updateWysiwyg)) {
+          if (!"wysiwyg".equals(fieldDisplayerName) || updateWysiwyg) {
             FieldDisplayer fieldDisplayer = getTypeManager().getDisplayer(fieldType, fieldDisplayerName);
             if (fieldDisplayer != null) {
               for (int occ=0; occ<fieldTemplate.getMaximumNumberOfOccurrences(); occ++) {
@@ -495,6 +489,22 @@ public abstract class AbstractForm implements Form {
       SilverLogger.getLogger(this).error("getting a field displayer instance", fe);
     }
     return null;
+  }
+
+  protected String getJavascriptSnippet() {
+    if (!fieldTemplates.isEmpty()) {
+      FieldTemplate fieldTemplate = fieldTemplates.get(0);
+      if (StringUtil.isDefined(fieldTemplate.getTemplateName())) {
+        return "<script type=\"text/javascript\" src=\"/weblib/xmlForms/" +
+            fieldTemplate.getTemplateName() + ".js\"></script>\n";
+      }
+    }
+    return "";
+  }
+
+  @Override
+  public String toString(PagesContext pageContext) {
+    return toString(pageContext, getData());
   }
 
 }

--- a/core-library/src/main/java/org/silverpeas/core/contribution/content/form/Form.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/content/form/Form.java
@@ -108,6 +108,8 @@ public interface Form {
 
   public String toString(PagesContext pagesContext, DataRecord record);
 
+  public String toString(PagesContext pagesContext);
+
   public boolean isEmpty(List<FileItem> items, DataRecord record, PagesContext pagesContext);
 
   public void setFormName(String name);

--- a/core-library/src/main/java/org/silverpeas/core/contribution/content/form/PagesContext.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/content/form/PagesContext.java
@@ -107,20 +107,6 @@ public class PagesContext {
     setUserId(userId);
   }
 
-  public PagesContext(String formIndex, String language, boolean printTitle) {
-    setFormIndex(formIndex);
-    setLanguage(language);
-    setPrintTitle(printTitle);
-  }
-
-  public PagesContext(String formName, String formIndex, String language,
-      boolean printTitle) {
-    setFormIndex(formIndex);
-    setFormName(formName);
-    setLanguage(language);
-    setPrintTitle(printTitle);
-  }
-
   public PagesContext(String formName, String formIndex, String language,
       boolean printTitle, String componentId, String userId) {
     setFormIndex(formIndex);
@@ -350,6 +336,16 @@ public class PagesContext {
 
   public boolean isSharingContext() {
     return sharingContext != null;
+  }
+
+  public static PagesContext getDirectoryContext(String userId, String contributorId,
+      String userLanguage) {
+    PagesContext context = new PagesContext();
+    context.setComponentId("directory");
+    context.setObjectId(userId);
+    context.setUserId(contributorId);
+    context.setLanguage(userLanguage);
+    return context;
   }
 
 }

--- a/core-library/src/main/java/org/silverpeas/core/contribution/content/form/form/XmlSearchForm.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/content/form/form/XmlSearchForm.java
@@ -63,7 +63,9 @@ public class XmlSearchForm extends AbstractForm {
    */
   @Override
   public void displayScripts(JspWriter jw, PagesContext pagesContext) {
-      // No scripts displayed on search form
+    PrintWriter out = new PrintWriter(jw, true);
+    out.append(getJavascriptSnippet());
+    out.flush();
   }
 
   /**
@@ -121,6 +123,8 @@ public class XmlSearchForm extends AbstractForm {
 
       out.flush();
       PagesContext pc = new PagesContext(pagesContext);
+      pc.setUseMandatory(false);
+      pc.setIgnoreDefaultValues(true);
 
       for (FieldTemplate fieldTemplate : listFields) {
         String fieldName = fieldTemplate.getFieldName();

--- a/core-library/src/main/java/org/silverpeas/core/contribution/template/publication/PublicationTemplate.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/template/publication/PublicationTemplate.java
@@ -134,4 +134,6 @@ public interface PublicationTemplate {
 
   public boolean isUpdateLayerExist();
 
+  public boolean isDirectoryUsage();
+
 }

--- a/core-library/src/main/java/org/silverpeas/core/contribution/template/publication/PublicationTemplateImpl.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/template/publication/PublicationTemplateImpl.java
@@ -24,6 +24,7 @@
 package org.silverpeas.core.contribution.template.publication;
 
 import org.apache.commons.io.FilenameUtils;
+import org.silverpeas.core.contribution.content.form.AbstractForm;
 import org.silverpeas.core.contribution.content.form.FieldTemplate;
 import org.silverpeas.core.contribution.content.form.Form;
 import org.silverpeas.core.contribution.content.form.FormException;
@@ -79,6 +80,8 @@ public class PublicationTemplateImpl implements PublicationTemplate {
   private String description = "";
   @XmlElement(name = "image")
   private String thumbnail = "";
+  @XmlElement(required = true, defaultValue = "false")
+  private boolean directoryUsage = false;
   @XmlElement(required = true, defaultValue = "false")
   private boolean visible = false;
   @XmlElement(required = true, defaultValue = "false")
@@ -280,7 +283,7 @@ public class PublicationTemplateImpl implements PublicationTemplate {
 
   private Form getForm(String fileName, String fileType, boolean viewForm)
       throws PublicationTemplateException {
-    Form form;
+    AbstractForm form;
     RecordTemplate templateForm;
     String currentFileName = fileName;
 
@@ -314,6 +317,7 @@ public class PublicationTemplateImpl implements PublicationTemplate {
       }
     }
     form.setFormName(FilenameUtils.getBaseName(this.fileName));
+    form.setTitle(getName());
     return form;
   }
 
@@ -561,6 +565,15 @@ public class PublicationTemplateImpl implements PublicationTemplate {
     return visible;
   }
 
+  @Override
+  public boolean isDirectoryUsage() {
+    return directoryUsage;
+  }
+
+  public void setDirectoryUsage(final boolean directoryUsage) {
+    this.directoryUsage = directoryUsage;
+  }
+
   public String getSearchFileName() {
     return searchFileName;
   }
@@ -640,6 +653,7 @@ public class PublicationTemplateImpl implements PublicationTemplate {
     cloneTemplate.setSpaces(getSpaces());
     cloneTemplate.setApplications(getApplications());
     cloneTemplate.setInstances(getInstances());
+    cloneTemplate.setDirectoryUsage(isDirectoryUsage());
     return cloneTemplate;
   }
 

--- a/core-library/src/main/java/org/silverpeas/core/contribution/template/publication/PublicationTemplateUserEventListener.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/template/publication/PublicationTemplateUserEventListener.java
@@ -1,0 +1,18 @@
+package org.silverpeas.core.contribution.template.publication;
+
+import org.silverpeas.core.admin.user.model.UserDetail;
+import org.silverpeas.core.admin.user.notification.UserEvent;
+import org.silverpeas.core.notification.system.CDIResourceEventListener;
+
+/**
+ * Created by Nicolas on 14/09/2017.
+ */
+public class PublicationTemplateUserEventListener extends CDIResourceEventListener<UserEvent> {
+
+  @Override
+  public void onDeletion(final UserEvent event) throws Exception {
+    UserDetail detail = event.getTransition().getBefore();
+    PublicationTemplateManager templateManager = PublicationTemplateManager.getInstance();
+    templateManager.deleteDirectoryData(detail.getId());
+  }
+}

--- a/core-library/src/main/java/org/silverpeas/core/index/search/model/IndexSearcher.java
+++ b/core-library/src/main/java/org/silverpeas/core/index/search/model/IndexSearcher.java
@@ -195,45 +195,40 @@ public class IndexSearcher {
       rangeClauses.add(getVisibilityStartQuery(), BooleanClause.Occur.MUST);
       rangeClauses.add(getVisibilityEndQuery(), BooleanClause.Occur.MUST);
 
-      if (query.getXmlQuery() != null) {
-        booleanQuery.add(getXMLQuery(query), BooleanClause.Occur.MUST);
+      if (query.getMultiFieldQuery() != null) {
+        booleanQuery.add(getMultiFieldQuery(query), BooleanClause.Occur.MUST);
       } else {
-        if (query.getMultiFieldQuery() != null) {
-          booleanQuery.add(getMultiFieldQuery(query), BooleanClause.Occur.MUST);
-        } else {
-          TermRangeQuery rangeQuery = getRangeQueryOnCreationDate(query);
-          if (!StringUtil.isDefined(query.getQuery()) && (query.isSearchBySpace() || query.
-              isSearchByComponentType()) && !query.isPeriodDefined()) {
-            rangeQuery = new TermRangeQuery(IndexManager.CREATIONDATE, "1900/01/01", "2200/01/01",
-                true, true);
-          }
-          if (rangeQuery != null) {
-            rangeClauses.add(rangeQuery, BooleanClause.Occur.MUST);
-          }
-          TermRangeQuery rangeQueryOnLastUpdateDate = getRangeQueryOnLastUpdateDate(query);
-          if (rangeQueryOnLastUpdateDate != null) {
-            rangeClauses.add(rangeQueryOnLastUpdateDate, BooleanClause.Occur.MUST);
-          }
-          TermQuery termQueryOnAuthor = getTermQueryOnAuthor(query);
-          if (termQueryOnAuthor != null) {
-            booleanQuery.add(termQueryOnAuthor, BooleanClause.Occur.MUST);
-          }
-          PrefixQuery termQueryOnFolder = getTermQueryOnFolder(query);
-          if (termQueryOnFolder != null) {
-            booleanQuery.add(termQueryOnFolder, BooleanClause.Occur.MUST);
-          }
+        TermRangeQuery rangeQuery = getRangeQueryOnCreationDate(query);
+        if (!StringUtil.isDefined(query.getQuery()) && (query.isSearchBySpace() || query.
+            isSearchByComponentType()) && !query.isPeriodDefined()) {
+          rangeQuery = new TermRangeQuery(IndexManager.CREATIONDATE, "1900/01/01", "2200/01/01",
+              true, true);
+        }
+        if (rangeQuery != null) {
+          rangeClauses.add(rangeQuery, BooleanClause.Occur.MUST);
+        }
+        TermRangeQuery rangeQueryOnLastUpdateDate = getRangeQueryOnLastUpdateDate(query);
+        if (rangeQueryOnLastUpdateDate != null) {
+          rangeClauses.add(rangeQueryOnLastUpdateDate, BooleanClause.Occur.MUST);
+        }
+        TermQuery termQueryOnAuthor = getTermQueryOnAuthor(query);
+        if (termQueryOnAuthor != null) {
+          booleanQuery.add(termQueryOnAuthor, BooleanClause.Occur.MUST);
+        }
+        PrefixQuery termQueryOnFolder = getTermQueryOnFolder(query);
+        if (termQueryOnFolder != null) {
+          booleanQuery.add(termQueryOnFolder, BooleanClause.Occur.MUST);
+        }
 
-          try {
-            Query plainTextQuery = getPlainTextQuery(query, IndexManager.CONTENT);
-            if (plainTextQuery != null) {
-              booleanQuery.add(plainTextQuery, BooleanClause.Occur.MUST);
-            }
-          } catch (ParseException e) {
-            throw new org.silverpeas.core.index.search.model.ParseException("IndexSearcher", e);
+        try {
+          Query plainTextQuery = getPlainTextQuery(query, IndexManager.CONTENT);
+          if (plainTextQuery != null) {
+            booleanQuery.add(plainTextQuery, BooleanClause.Occur.MUST);
           }
+        } catch (ParseException e) {
+          throw new org.silverpeas.core.index.search.model.ParseException("IndexSearcher", e);
         }
       }
-
 
       // date range clauses are passed in the filter to optimize search performances
       // but the query cannot be empty : if so, then pass date range in the query
@@ -297,33 +292,6 @@ public class IndexSearcher {
     }
 
     return parsedQuery;
-  }
-
-  private Query getXMLQuery(QueryDescription query)
-      throws org.silverpeas.core.index.search.model.ParseException {
-    try {
-      Set<String> languages = I18NHelper.getAllSupportedLanguages();
-      Analyzer analyzer = indexManager.getAnalyzer(query.getRequestedLanguage());
-      BooleanQuery booleanQuery = new BooleanQuery();
-
-      String xmlTitle = query.getXmlTitle();
-      if (StringUtil.isDefined(xmlTitle)) {
-        Query headerQuery = getQuery(IndexManager.HEADER, xmlTitle, languages, analyzer);
-        booleanQuery.add(headerQuery, BooleanClause.Occur.MUST);
-      }
-
-      Map<String, String> xmlQuery = query.getXmlQuery();
-      for (String fieldName : xmlQuery.keySet()) {
-        Query fieldI18NQuery =
-            getQuery(fieldName, xmlQuery.get(fieldName), languages, analyzer);
-        booleanQuery.add(fieldI18NQuery, BooleanClause.Occur.MUST);
-      }
-
-
-      return booleanQuery;
-    } catch (org.apache.lucene.queryParser.ParseException e) {
-      throw new org.silverpeas.core.index.search.model.ParseException("IndexSearcher", e);
-    }
   }
 
   private Query getMultiFieldQuery(QueryDescription query)

--- a/core-library/src/main/java/org/silverpeas/core/index/search/model/QueryDescription.java
+++ b/core-library/src/main/java/org/silverpeas/core/index/search/model/QueryDescription.java
@@ -23,18 +23,16 @@
  */
 package org.silverpeas.core.index.search.model;
 
+import org.silverpeas.core.index.indexing.model.ExternalComponent;
+import org.silverpeas.core.index.indexing.model.FieldDescription;
+import org.silverpeas.core.util.StringUtil;
+
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import java.util.Set;
-
-import org.silverpeas.core.index.indexing.model.ExternalComponent;
-import org.silverpeas.core.index.indexing.model.FieldDescription;
-
-import org.silverpeas.core.util.StringUtil;
 
 /**
  * A QueryDescription packs a query with the different spaces and components to be searched.
@@ -68,8 +66,6 @@ public final class QueryDescription implements Serializable {
   private String requestedCreatedAfter = null;
   private String requestedUpdatedBefore = null;
   private String requestedUpdatedAfter = null;
-  private Map<String, String> xmlQuery = null;
-  private String xmlTitle = null;
   private List<FieldDescription> multiFieldQuery = null;
   private boolean searchBySpace = false;
   private boolean searchByComponentType = false;
@@ -104,14 +100,6 @@ public final class QueryDescription implements Serializable {
    */
   public void setQuery(String query) {
     this.query = (query == null) ? "" : query.toLowerCase();
-    // string already in lower case, means "and" "And" "AND" will works.
-    this.query = findAndReplace(this.query, " and ", " AND ");
-    this.query = findAndReplace(this.query, " or ", " OR ");
-    this.query = findAndReplace(this.query, " not ", " NOT ");
-    if (this.query.indexOf("not ") == 0) {
-      this.query = "NOT " + this.query.substring(4, this.query.length());
-    }
-
   }
 
   /**
@@ -215,22 +203,6 @@ public final class QueryDescription implements Serializable {
     return requestedCreatedAfter;
   }
 
-  public void setXmlQuery(Map<String, String> xmlQuery) {
-    this.xmlQuery = xmlQuery;
-  }
-
-  public Map<String, String> getXmlQuery() {
-    return xmlQuery;
-  }
-
-  public String getXmlTitle() {
-    return xmlTitle;
-  }
-
-  public void setXmlTitle(String xmlTitle) {
-    this.xmlTitle = xmlTitle;
-  }
-
   public List<FieldDescription> getMultiFieldQuery() {
     return multiFieldQuery;
   }
@@ -268,27 +240,10 @@ public final class QueryDescription implements Serializable {
 
   public boolean isEmpty() {
     boolean queryDefined = StringUtil.isDefined(query) || getMultiFieldQuery() != null;
-    boolean xmlQueryDefined = getXmlQuery() != null;
     boolean filtersDefined = isSearchBySpace() || isSearchByComponentType() ||
         StringUtil.isDefined(getRequestedAuthor());
     filtersDefined = filtersDefined || isPeriodDefined();
-    return !queryDefined && !xmlQueryDefined && !filtersDefined;
-  }
-
-  /**
-   * Find and replace used for the AND OR NOT lucene's keyword in the search engine query.
-   * 26/01/2004
-   */
-  private String findAndReplace(String source, String find, String replace) {
-    int index = source.indexOf(find);
-
-    while (index > -1) {
-      source = source.substring(0, index) + replace +
-          source.substring(index + find.length(), source.length());
-      index = source.indexOf(find);
-    }
-
-    return source;
+    return !queryDefined && !filtersDefined;
   }
 
   public boolean isPeriodDefined() {

--- a/core-war/src/main/java/org/silverpeas/web/jobdomain/servlets/JobDomainPeasRequestRouter.java
+++ b/core-war/src/main/java/org/silverpeas/web/jobdomain/servlets/JobDomainPeasRequestRouter.java
@@ -144,14 +144,13 @@ public class JobDomainPeasRequestRouter extends
         jobDomainSC.returnIntoGroup(null);
         jobDomainSC.setDefaultTargetDomain();
         destination = "jobDomain.jsp";
-      } // USER Actions --------------------------------------------
-      else if (function.startsWith("user")) {
+      } else if (function.startsWith("user")) {
+        // USER Actions --------------------------------------------
         if (function.startsWith("userContent")) {
-          if ((request.getParameter("Iduser") != null)
-              && (request.getParameter("Iduser").length() > 0)) {
+          if (StringUtil.isDefined(request.getParameter("Iduser"))) {
             jobDomainSC.setTargetUser(request.getParameter("Iduser"));
           }
-        } else if (function.equals("userGetP12")) {
+        } else if ("userGetP12".equals(function)) {
           String userId = request.getParameter("Iduser");
           jobDomainSC.getP12(userId);
         } else if (function.startsWith("userCreate")) {
@@ -193,6 +192,8 @@ public class JobDomainPeasRequestRouter extends
           jobDomainSC.activateUser(request.getParameter("Iduser"));
         } else if (function.startsWith("userDelete")) {
           jobDomainSC.deleteUser(request.getParameter("Iduser"));
+        } else if (function.startsWith("userAvatarDelete")) {
+          jobDomainSC.deleteUserAvatar(request.getParameter("Iduser"));
         } else if (function.startsWith("userMS")) {
           UserRequestData userRequestData =
               RequestParameterDecoder.decode(request, UserRequestData.class);
@@ -239,7 +240,7 @@ public class JobDomainPeasRequestRouter extends
 
           destination = getDestination("displayUserImport", jobDomainSC,
               request);
-        } else if (function.equals("userImport")) {
+        } else if ("userImport".equals(function)) {
           String[] specificIds = request.getParameterValues("specificIds");
           // Massive users import
           if (specificIds != null) {
@@ -247,15 +248,14 @@ public class JobDomainPeasRequestRouter extends
             specificIds = new String[jobDomainSC.getListSelectedUsers().size()];
             jobDomainSC.getListSelectedUsers().toArray(specificIds);
             jobDomainSC.importUsers(specificIds);
-          } // Unitary user Import
-          else {
+          } else {
+            // Unitary user Import
             String specificId = request.getParameter("specificIds");
-
             if (StringUtil.isDefined(specificId)) {
               jobDomainSC.importUser(specificId);
             }
           }
-        } else if (function.equals("userImportAll")) {
+        } else if ("userImportAll".equals(function)) {
           Iterator<UserDetail> usersIt = jobDomainSC.getUsersToImport().iterator();
           ArrayList<String> listSelectedUsersIds = new ArrayList<>();
           while (usersIt.hasNext()) {
@@ -265,7 +265,7 @@ public class JobDomainPeasRequestRouter extends
           String[] specificIds = new String[jobDomainSC.getListSelectedUsers().size()];
           jobDomainSC.getListSelectedUsers().toArray(specificIds);
           jobDomainSC.importUsers(specificIds);
-        } else if (function.equals("userView")) {
+        } else if ("userView".equals(function)) {
           String specificId = request.getParameter("specificId");
 
           UserFull user = jobDomainSC.getUser(specificId);
@@ -277,7 +277,7 @@ public class JobDomainPeasRequestRouter extends
           jobDomainSC.synchroUser(request.getParameter("Iduser"));
         } else if (function.startsWith("userUnSynchro")) {
           jobDomainSC.unsynchroUser(request.getParameter("Iduser"));
-        } else if (function.equals("userOpen")) {
+        } else if ("userOpen".equals(function)) {
           String userId = request.getParameter("userId");
 
           OrganizationController orgaController = jobDomainSC.getOrganisationController();
@@ -320,8 +320,8 @@ public class JobDomainPeasRequestRouter extends
             destination = getDestination("groupContent", jobDomainSC, request);
           }
         }
-      } // GROUP Actions --------------------------------------------
-      else if (function.startsWith("group")) {
+      } else if (function.startsWith("group")) {
+        // GROUP Actions --------------------------------------------
         boolean bHaveToRefreshDomain = false;
 
         jobDomainSC.setTargetUser(null);
@@ -602,6 +602,7 @@ public class JobDomainPeasRequestRouter extends
               "myComponentURL"), jobDomainSC.getString("JDP.userUpdate") + "..."));
           request.setAttribute("minLengthLogin", jobDomainSC.getMinLengthLogin());
           request.setAttribute("CurrentUser", jobDomainSC.getUserDetail());
+
           destination = "userCreate.jsp";
         } else if (function.startsWith("displayUserMS")) {
           request.setAttribute("userObject", jobDomainSC.getTargetUserFull());
@@ -828,4 +829,5 @@ public class JobDomainPeasRequestRouter extends
     }
     return properties;
   }
+
 }

--- a/core-war/src/main/java/org/silverpeas/web/pdc/QueryParameters.java
+++ b/core-war/src/main/java/org/silverpeas/web/pdc/QueryParameters.java
@@ -23,6 +23,7 @@
  */
 package org.silverpeas.web.pdc;
 
+import org.silverpeas.core.index.indexing.model.FieldDescription;
 import org.silverpeas.core.util.StringUtil;
 import org.silverpeas.core.admin.user.model.UserDetail;
 import org.silverpeas.core.util.DateUtil;
@@ -161,10 +162,6 @@ public class QueryParameters implements java.io.Serializable {
     xmlQuery.put(field, query);
   }
 
-  public Map<String, String> getXmlQuery() {
-    return xmlQuery;
-  }
-
   public void clearXmlQuery() {
     xmlQuery = null;
   }
@@ -205,11 +202,13 @@ public class QueryParameters implements java.io.Serializable {
     }
 
     if (xmlQuery != null) {
-      query.setXmlQuery(xmlQuery);
+      for (String key : xmlQuery.keySet()) {
+        query.addFieldQuery(new FieldDescription(key, xmlQuery.get(key), searchingLanguage));
+      }
     }
 
     if (xmlTitle != null) {
-      query.setXmlTitle(xmlTitle);
+      query.setQuery(xmlTitle);
     }
 
     return query;

--- a/core-war/src/main/java/org/silverpeas/web/socialnetwork/myprofil/servlets/MyProfilRequestRouter.java
+++ b/core-war/src/main/java/org/silverpeas/web/socialnetwork/myprofil/servlets/MyProfilRequestRouter.java
@@ -40,7 +40,6 @@ import org.apache.commons.fileupload.FileItem;
 import org.silverpeas.core.security.authentication.exception.AuthenticationBadCredentialException;
 import org.silverpeas.core.util.file.FileUploadUtil;
 import org.silverpeas.core.web.http.HttpRequest;
-import org.silverpeas.core.util.WebEncodeHelper;
 import org.silverpeas.core.util.file.FileRepositoryManager;
 import org.silverpeas.core.util.ResourceLocator;
 import org.silverpeas.core.util.ServiceProvider;
@@ -56,10 +55,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.time.ZoneId;
 import java.util.ArrayList;
-import java.util.Enumeration;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Random;
 
 import static org.silverpeas.web.socialnetwork.myprofil.servlets.MyProfileRoutes.*;
@@ -258,7 +254,7 @@ public class MyProfilRequestRouter extends ComponentRequestRouter<MyProfilSessio
     return contacts;
   }
 
-  private void updateUserFull(HttpServletRequest request, MyProfilSessionController sc) {
+  private void updateUserFull(HttpRequest request, MyProfilSessionController sc) {
     SettingBundle rl = ResourceLocator.getSettingBundle(
         "org.silverpeas.personalization.settings.personalizationPeasSettings");
     SettingBundle authenticationSettings = ResourceLocator.getSettingBundle(
@@ -293,26 +289,12 @@ public class MyProfilRequestRouter extends ComponentRequestRouter<MyProfilSessio
         userLoginAnswer = currentUser.getLoginAnswer();
       }
 
-      // process extra properties
-      Map<String, String> properties = new HashMap<>();
-      Enumeration<String> parameters = request.getParameterNames();
-      String parameterName;
-      String property;
-      while (parameters.hasMoreElements()) {
-        parameterName = parameters.nextElement();
-        if (parameterName.startsWith("prop_")) {
-          property = parameterName.substring(5, parameterName.length()); // remove s"prop_"
-          properties.put(property, request.getParameter(parameterName));
-        }
-      }
-
       sc.modifyUser(currentUser.getId(), WebEncodeHelper.htmlStringToJavaString(userLastName),
           WebEncodeHelper.htmlStringToJavaString(userFirstName),
           WebEncodeHelper.htmlStringToJavaString(userEmail),
-          WebEncodeHelper.htmlStringToJavaString(request.getParameter("userAccessLevel")),
           WebEncodeHelper.htmlStringToJavaString(request.getParameter("OldPassword")),
           WebEncodeHelper.htmlStringToJavaString(request.getParameter("NewPassword")),
-          userLoginQuestion, userLoginAnswer, properties);
+          userLoginQuestion, userLoginAnswer, request);
       request.setAttribute("MessageOK", sc.getString("myProfile.MessageOK"));
     } catch (AuthenticationBadCredentialException e) {
       request.setAttribute("MessageNOK", sc.getString("myProfile.Error_bad_credential"));

--- a/core-war/src/main/java/org/silverpeas/web/socialnetwork/profil/control/ProfilSessionController.java
+++ b/core-war/src/main/java/org/silverpeas/web/socialnetwork/profil/control/ProfilSessionController.java
@@ -23,13 +23,12 @@
  */
 package org.silverpeas.web.socialnetwork.profil.control;
 
+import org.silverpeas.core.exception.SilverpeasException;
 import org.silverpeas.core.socialnetwork.SocialNetworkException;
 import org.silverpeas.core.socialnetwork.relationship.RelationShipService;
 import org.silverpeas.core.web.mvc.controller.AbstractComponentSessionController;
 import org.silverpeas.core.web.mvc.controller.ComponentContext;
 import org.silverpeas.core.web.mvc.controller.MainSessionController;
-import org.silverpeas.core.admin.user.model.UserFull;
-import org.silverpeas.core.exception.SilverpeasException;
 
 import java.sql.SQLException;
 
@@ -45,15 +44,6 @@ public class ProfilSessionController extends AbstractComponentSessionController 
         "org.silverpeas.social.multilang.socialNetworkBundle",
         "org.silverpeas.social.settings.socialNetworkIcons",
         "org.silverpeas.social.settings.socialNetworkSettings");
-  }
-
-  /**
-   * get this user with full information
-   * @param userId
-   * @return UserFull
-   */
-  public UserFull getUserFul(String userId) {
-    return this.getOrganisationController().getUserFull(userId);
   }
 
   /*
@@ -72,4 +62,5 @@ public class ProfilSessionController extends AbstractComponentSessionController 
           SilverpeasException.ERROR, "root.EX_NO_MESSAGE", ex);
     }
   }
+
 }

--- a/core-war/src/main/java/org/silverpeas/web/socialnetwork/profil/servlets/ProfilRequestRouter.java
+++ b/core-war/src/main/java/org/silverpeas/web/socialnetwork/profil/servlets/ProfilRequestRouter.java
@@ -23,6 +23,7 @@
  */
 package org.silverpeas.web.socialnetwork.profil.servlets;
 
+import org.silverpeas.core.admin.user.model.UserFull;
 import org.silverpeas.core.socialnetwork.SocialNetworkException;
 import org.silverpeas.core.util.logging.SilverLogger;
 import org.silverpeas.core.web.http.HttpRequest;
@@ -67,9 +68,7 @@ public class ProfilRequestRouter extends ComponentRequestRouter<ProfilSessionCon
         destination = context + "/RContactProfile/jsp/Main?userId=" + userId;
       } else {
         // this is not one of my contacts
-        request.setAttribute("userFull", profileSC.getUserFul(userId));
-        request.setAttribute("UserDetail", profileSC.getUserDetail(userId));
-        request.setAttribute("Settings", profileSC.getSettings());
+        request.setAttribute("userFull", UserFull.getById(userId));
         destination = "/socialNetwork/jsp/profil/profilPublic.jsp";
       }
     }

--- a/core-war/src/main/java/org/silverpeas/web/templatedesigner/control/TemplateDesignerSessionController.java
+++ b/core-war/src/main/java/org/silverpeas/web/templatedesigner/control/TemplateDesignerSessionController.java
@@ -214,6 +214,7 @@ public class TemplateDesignerSessionController extends AbstractComponentSessionC
     this.template.setDescription(updatedTemplate.getDescription());
     this.template.setThumbnail(updatedTemplate.getThumbnail());
     this.template.setVisible(updatedTemplate.isVisible());
+    this.template.setDirectoryUsage(updatedTemplate.isDirectoryUsage());
     this.template.setDataEncrypted(updatedTemplate.isDataEncrypted());
     this.template.setViewLayerFileName(updatedTemplate.getViewLayerFileName());
     this.template.setViewLayerAction(updatedTemplate.getViewLayerAction());

--- a/core-war/src/main/java/org/silverpeas/web/templatedesigner/servlets/TemplateDesignerRequestRouter.java
+++ b/core-war/src/main/java/org/silverpeas/web/templatedesigner/servlets/TemplateDesignerRequestRouter.java
@@ -297,6 +297,7 @@ public class TemplateDesignerRequestRouter extends
     String thumbnail = FileUploadUtil.getParameter(parameters, "Thumbnail");
     boolean searchable = StringUtil.getBooleanValue(FileUploadUtil.getParameter(parameters, "Searchable"));
     boolean encrypted = StringUtil.getBooleanValue(FileUploadUtil.getParameter(parameters, "Encrypted"));
+    boolean directoryUsage = request.getParameterAsBoolean("DirectoryUsage");
 
     PublicationTemplateImpl template = new PublicationTemplateImpl();
     template.setName(name);
@@ -304,6 +305,7 @@ public class TemplateDesignerRequestRouter extends
     template.setThumbnail(thumbnail);
     template.setVisible(visible);
     template.setDataEncrypted(encrypted);
+    template.setDirectoryUsage(directoryUsage);
 
     if (searchable) {
       template.setSearchFileName("dummy");

--- a/core-war/src/main/webapp/directory/jsp/css/print.css
+++ b/core-war/src/main/webapp/directory/jsp/css/print.css
@@ -1,0 +1,5 @@
+.cellOperation, #indexAndSearch, .ArrayNavigation,
+#users .infoConnection, #users .userType, #users .status,
+#pagination, .sp_goToTop {
+  display: none;
+}

--- a/core-war/src/main/webapp/jobDomainPeas/jsp/userContent.jsp
+++ b/core-war/src/main/webapp/jobDomainPeas/jsp/userContent.jsp
@@ -26,6 +26,7 @@
 <%@page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
 
 <%@ page import="org.silverpeas.core.notification.user.client.NotificationManagerSettings" %>
+<%@ page import="org.silverpeas.core.admin.user.constant.UserState" %>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 <%@ taglib uri="http://www.silverpeas.com/tld/viewGenerator" prefix="view" %>
@@ -34,14 +35,19 @@
 <%-- Set resource bundle --%>
 <fmt:setLocale value="${requestScope.resources.language}"/>
 <view:setBundle bundle="${requestScope.resources.multilangBundle}"/>
+<view:setBundle bundle="${requestScope.resources.iconsBundle}" var="icons"/>
 <view:setBundle basename="org.silverpeas.social.multilang.socialNetworkBundle" var="profile"/>
 
 <c:set var="USER_MANUAL_NOTIFICATION_MAX_RECIPIENT_LIMITATION_ENABLED" value="<%= NotificationManagerSettings.isUserManualNotificationRecipientLimitEnabled()%>"/>
 <c:set var="USER_MANUAL_NOTIFICATION_MAX_RECIPIENT_LIMITATION_DEFAULT_VALUE" value="<%= NotificationManagerSettings.getUserManualNotificationRecipientLimit()%>"/>
+<c:set var="USER_STATE_BLOCKED"><%= UserState.BLOCKED %></c:set>
+<c:set var="USER_STATE_DEACTIVATED"><%= UserState.DEACTIVATED %></c:set>
 
 <fmt:message key="GML.yes" var="yesLabel"/>
 <fmt:message key="GML.no" var="noLabel"/>
+<fmt:message key="GML.delete" var="labelDelete"/>
 <fmt:message key="JDP.userManualNotifReceiverLimitValue" var="userManualNotifReceiverLimitValueLabel"><fmt:param value="${USER_MANUAL_NOTIFICATION_MAX_RECIPIENT_LIMITATION_DEFAULT_VALUE}"/></fmt:message>
+<fmt:message key="JDP.user.avatar.delete.confirm" var="labelDeleteAvatar"/>
 
 <c:set var="userInfos" value="${requestScope.userObject}" />
 <jsp:useBean id="userInfos" type="org.silverpeas.core.admin.user.model.UserFull"/>
@@ -56,6 +62,8 @@
 <c:set var="displayedEmail"><view:encodeHtml string="${email}" /></c:set>
 <c:set var="login" value="${userInfos.login}" />
 <c:set var="displayedLogin"><view:encodeHtml string="${login}" /></c:set>
+<fmt:message key="GML.user.account.state.${userInfos.state.name}" var="stateLabel"/>
+<fmt:message key="JDP.user.state.${userInfos.state.name}" var="stateIcon" bundle="${icons}"/>
 
 <%@ include file="check.jsp" %>
 <%
@@ -71,6 +79,8 @@
       (Boolean) request.getAttribute("userManageableByGroupManager");
 
   String thisUserId = userObject.getId();
+  boolean updatableUser = false;
+  boolean avatarDefined = userObject.isAvatarDefined();
 
   if (domObject != null) {
     browseBar.setComponentName(getDomainLabel(domObject, resource),
@@ -85,6 +95,7 @@
     operationPane
         .addOperation(resource.getIcon("JDP.userUpdate"), resource.getString("GML.modify"),
             "displayUserModify?Iduser=" + thisUserId);
+    updatableUser = true;
     if (userObject.isBlockedState()) {
       operationPane
           .addOperation(resource.getIcon("JDP.userUnblock"), resource.getString("JDP.userUnblock"),
@@ -104,13 +115,13 @@
               "userDeactivate?Iduser=" + thisUserId);
     }
     operationPane.addOperation(resource.getIcon("JDP.userDel"), resource.getString("GML.delete"),
-        "javascript:ConfirmAndSend('" + resource.getString("JDP.userDelConfirm") +
-            "','" + thisUserId+ "')");
+        "javascript:deleteUser()");
   }
   if (isDomainSync && !isGroupManager) {
     operationPane
         .addOperation(resource.getIcon("JDP.userUpdate"), resource.getString("GML.modify"),
             "displayUserMS?Iduser=" + thisUserId);
+    updatableUser = true;
     if (userObject.isBlockedState()) {
       operationPane
           .addOperation(resource.getIcon("JDP.userUnblock"), resource.getString("JDP.userUnblock"),
@@ -148,111 +159,85 @@
   <view:looknfeel withFieldsetStyle="true"/>
   <view:includePlugin name="popup"/>
   <script type="text/javascript">
-    function ConfirmAndSend(textToDisplay, userId) {
-      jQuery.popup.confirm(textToDisplay, function() {
-        jQuery('#Iduser').val(userId);
+    function deleteUser() {
+      jQuery.popup.confirm("<%=resource.getString("JDP.userDelConfirm")%>", function() {
+        jQuery('#deletionForm').submit();
+      });
+    }
+
+    function deleteAvatar() {
+      jQuery.popup.confirm("${labelDeleteAvatar}", function() {
+        jQuery('#deletionForm').attr("action", "userAvatarDelete");
         jQuery('#deletionForm').submit();
       });
     }
   </script>
 </head>
-<body>
+<body class="admin-users">
 <%
 out.println(window.printBefore());
 %>
 <view:frame>
-<fieldset id="identity-main" class="skinFieldset">
-  <legend><fmt:message key="myProfile.identity.fieldset.main" bundle="${profile}" /></legend>
-  <ul class="fields">
-	<!--Last name-->
-	<li id="form-row-lastname" class="field">
-	<label class="txtlibform"><fmt:message key="GML.lastName"/></label>
-	<div class="champs">${displayedLastName}</div>
-	</li>
-	<!--Surname-->
-	<li id="form-row-surname" class="field">
-		<label class="txtlibform"><fmt:message key="GML.surname"/></label>
-		<div class="champs">${displayedFirstName}</div>
-	</li>
-	<!---Email-->
-	<li id="form-row-email" class="field">
-		<label class="txtlibform"><fmt:message key="GML.eMail"/></label>
-		<div class="champs"><a href="mailto:${displayedEmail}">${displayedEmail}</a></div>
-	</li>
-	<!---Rights-->
-	<li id="form-row-rights" class="field">
-		<label class="txtlibform"><fmt:message key="JDP.userRights"/></label>
-		<div class="champs">
-			<c:choose>
-				<c:when test="${userInfos.accessLevel.code == 'A'}">
-					<fmt:message key="GML.administrateur"/>
-				</c:when>
-				<c:when test="${userInfos.accessLevel.code == 'G'}">
-					<fmt:message key="GML.guest"/>
-				</c:when>
-				<c:when test="${userInfos.accessLevel.code == 'K'}">
-					<fmt:message key="GML.kmmanager"/>
-				</c:when>
-				<c:when test="${userInfos.accessLevel.code == 'D'}">
-					<fmt:message key="GML.domainManager"/>
-				</c:when>
-				<c:when test="${userInfos.accessLevel.code == 'U'}">
-					<fmt:message key="GML.user"/>
-				</c:when>
-				<c:otherwise>
-					<fmt:message key="GML.no"/>
-				</c:otherwise>
-			</c:choose>
-		</div>
-		</li>
-		<!---State-->
-		<li id="form-row-state" class="field">
-		<label class="txtlibform"><fmt:message key="JDP.userState"/></label>
-		<div class="champs"><fmt:message key="GML.user.account.state.${userInfos.state.name}"/></div>
-		</li>
-		<!--Login-->
-		<li id="form-row-login" class="field">
-		<label class="txtlibform"><fmt:message key="GML.login"/></label>
-		<div class="champs">${displayedLogin}</div>
-		</li>
-		<!--Password Silverpeas ?-->
-		<li id="form-row-passwordsp" class="field">
-			<label class="txtlibform"><fmt:message key="JDP.silverPassword"/></label>
-		<div class="champs">
-			<c:choose>
-				<c:when test="${userInfos.passwordAvailable && userInfos.passwordValid}">
-					<fmt:message key="GML.yes"/>
-				</c:when>
-				<c:otherwise>
-					<fmt:message key="GML.no"/>
-				</c:otherwise>
-			</c:choose>
-		</div>
-		</li>
-    <!--User Language-->
-    <li class="field" id="form-row-user-language">
-      <label class="txtlibform"><fmt:message key="JDP.userPreferredLanguage"/></label>
-
-      <div class="champs">
-        <viewTags:userPreferredLanguageSelector user="${userInfos}" readOnly="true"/>
-      </div>
-    </li>
-    <li class="field" id="form-row-user-lastConnection">
-      <label class="txtlibform"><fmt:message key="GML.user.lastConnection"/></label>
-      <div class="champs">
-        <view:formatDateTime value="${userInfos.lastLoginDate}"/>
-      </div>
-    </li>
-    <!--User ZoneId-->
-    <li class="field" id="form-row-user-zone-id">
-      <label class="txtlibform"><fmt:message key="JDP.userPreferredZoneId"/></label>
-
-      <div class="champs">
-        <viewTags:userPreferredZoneIdSelector user="${userInfos}" readOnly="true"/>
-      </div>
-    </li>
-	</ul>
-</fieldset>
+  <c:if test="${userInfos.state == USER_STATE_BLOCKED || userInfos.state == USER_STATE_DEACTIVATED}">
+    <div class="inlineMessage">
+      <fmt:message key="JDP.user.state.${userInfos.state.name}" />
+    </div>
+  </c:if>
+  <div class="table profile">
+    <div class="cell showActionsOnMouseOver">
+      <fieldset class="skinFieldset" id="identity-profil">
+        <legend class="without-img">
+          <div class="personna">
+            <span class="surname">${displayedFirstName}</span> <span class="lastname">${displayedLastName}</span>
+            <span class="access ${userInfos.state.name}"><img src="../..${stateIcon}" alt="${stateLabel}" title="${stateLabel}" /></span>
+          </div>
+        </legend>
+        <div class="avatar"> <view:image src="${userInfos.avatar}" size="120x" alt="viewUser" css="avatar"/>
+          <% if (updatableUser && avatarDefined) { %>
+          <div class="operation actionShownOnMouseOver">
+            <a title="${labelDelete}" href="#" onclick="deleteAvatar()"><img title="${labelDelete}" alt="${labelDelete}" src="../../util/icons/delete.gif" border="0"></a>
+          </div>
+          <% } %>
+        </div>
+        <div class="fields">
+          <div class="rights">
+            <c:choose>
+              <c:when test="${userInfos.accessLevel.code == 'A'}">
+                <fmt:message key="GML.administrateur"/>
+              </c:when>
+              <c:when test="${userInfos.accessLevel.code == 'G'}">
+                <fmt:message key="GML.guest"/>
+              </c:when>
+              <c:when test="${userInfos.accessLevel.code == 'K'}">
+                <fmt:message key="GML.kmmanager"/>
+              </c:when>
+              <c:when test="${userInfos.accessLevel.code == 'D'}">
+                <fmt:message key="GML.domainManager"/>
+              </c:when>
+              <c:when test="${userInfos.accessLevel.code == 'U'}">
+                <fmt:message key="GML.user"/>
+              </c:when>
+              <c:otherwise>
+                <fmt:message key="GML.no"/>
+              </c:otherwise>
+            </c:choose>
+          </div>
+          <div class="lastConnection"><fmt:message key="GML.user.lastConnection"/> <view:formatDateTime value="${userInfos.lastLoginDate}"/></div>
+          <div class="domain"><img class="img-label" src="../../util/icons/component/domainSmall.gif" alt="Domaine" title="Domaine"  />${userInfos.domain.name}</div>
+          <div class="access"> <span class="login"><img class="img-label" src="../../util/icons/Login.gif" alt="<fmt:message key="GML.login"/>" title="<fmt:message key="GML.login"/>" />${displayedLogin}</span></div>
+          <div class="email"><img  class="img-label" src="../../admin/jsp/icons/icoOutilsMail.gif" alt="Login" title="Login" /> <a href="mailto:${displayedEmail}">${displayedEmail}</a></div>
+          <div class="language"><img  class="img-label" src="../../util/icons/talk2user.gif" alt="<fmt:message key="JDP.userPreferredLanguage"/>" title="<fmt:message key="JDP.userPreferredLanguage"/>" /><viewTags:userPreferredLanguageSelector user="${userInfos}" readOnly="true"/></div>
+          <div class="user-zone-id"><img  class="img-label" src="../../util/icons/time-zone.png" alt="<fmt:message key="JDP.userPreferredZoneId"/>" title="<fmt:message key="JDP.userPreferredZoneId"/>" /><viewTags:userPreferredZoneIdSelector user="${userInfos}" readOnly="true"/></div>
+        </div>
+      </fieldset>
+    </div>
+    <div class="cell">
+      <fieldset id="identity-extra" class="skinFieldset">
+        <legend><fmt:message key="myProfile.identity.fieldset.extra" bundle="${profile}"/></legend>
+        <viewTags:displayUserExtraProperties user="<%=userObject%>" readOnly="true" includeEmail="false"/>
+      </fieldset>
+    </div>
+  </div>
 
   <%--User Manual Notification User Receiver Limit--%>
   <c:if test="${USER_MANUAL_NOTIFICATION_MAX_RECIPIENT_LIMITATION_ENABLED
@@ -262,7 +247,6 @@ out.println(window.printBefore());
       <div class="fields">
         <div class="field" id="form-row-user-manual-notification-limitation-activation">
           <label class="txtlibform"><fmt:message key="JDP.userManualNotifReceiverLimitActivation"/></label>
-
           <div class="champs">
               ${(userInfos.userManualNotificationUserReceiverLimit)? yesLabel : noLabel}
           </div>
@@ -270,7 +254,6 @@ out.println(window.printBefore());
         <c:if test="${userInfos.userManualNotificationUserReceiverLimit}">
           <div class="field" id="form-row-user-manual-notification-limitation-value">
             <label class="txtlibform">${userManualNotifReceiverLimitValueLabel}</label>
-
             <div class="champs">
                 ${userInfos.notifManualReceiverLimit}
             </div>
@@ -280,12 +263,10 @@ out.println(window.printBefore());
     </fieldset>
   </c:if>
 
-<fieldset id="identity-extra" class="skinFieldset">
-	<legend class="without-img"><fmt:message key="myProfile.identity.fieldset.extra" bundle="${profile}"/></legend>
-  <viewTags:displayUserExtraProperties user="<%=userObject%>" readOnly="true" includeEmail="false"/>
-</fieldset>
-  <form id="deletionForm" action="userDelete" method="POST">
-    <input id="Iduser" type="hidden" name="Iduser"/>
+  <view:directoryExtraForm userId="<%=thisUserId%>" />
+
+  <form id="deletionForm" action="userDelete" method="post">
+    <input id="Iduser" type="hidden" name="Iduser" value="${userInfos.id}"/>
   </form>
 </view:frame>
 <%

--- a/core-war/src/main/webapp/pdcPeas/jsp/globalSearchXML.jsp
+++ b/core-war/src/main/webapp/pdcPeas/jsp/globalSearchXML.jsp
@@ -42,12 +42,10 @@ List<PublicationTemplate> 	xmlForms 	= (List) request.getAttribute("XMLForms");
 PublicationTemplate template 	= (PublicationTemplate) request.getAttribute("Template");
 DataRecord			emptyData	= (DataRecord) request.getAttribute("Data");
 PagesContext		context		= (PagesContext) request.getAttribute("context");
-context.setUseMandatory(false);
 
 Form form = null;
 String selectedTemplate = null;
-if (template != null)
-{
+if (template != null) {
 	selectedTemplate 	= template.getFileName();
 	form 				= template.getSearchForm();
 }
@@ -58,13 +56,13 @@ QueryParameters query	= (QueryParameters) request.getAttribute("QueryParameters"
 String			spaceSelected		= null;
 String			componentSelected	= null;
 String			title				= "";
-if (query != null)
-{
+if (query != null) {
 	spaceSelected		= query.getSpaceId();
 	componentSelected	= query.getInstanceId();
 	title				= query.getXmlTitle();
-	if (title == null || "null".equals(title))
-		title = "";
+	if (title == null || "null".equals(title)) {
+    title = "";
+  }
 }
 
 String pageId = (String) request.getAttribute("PageId");

--- a/core-war/src/main/webapp/socialNetwork/jsp/myContactProfil/myContactProfileTabIdentity.jsp
+++ b/core-war/src/main/webapp/socialNetwork/jsp/myContactProfil/myContactProfileTabIdentity.jsp
@@ -35,3 +35,5 @@
 <div class="tab-content">
 <viewTags:displayUserExtraProperties user="<%=userFull%>" readOnly="true" includeEmail="true"/>
 </div>
+
+<view:directoryExtraForm userId="<%=userFull.getId()%>"/>

--- a/core-war/src/main/webapp/socialNetwork/jsp/myProfil/myProfileTabIdentity.jsp
+++ b/core-war/src/main/webapp/socialNetwork/jsp/myProfil/myProfileTabIdentity.jsp
@@ -80,7 +80,7 @@
 </c:if>
 
 <div id="identity">
-<form name="UserForm" action="<%=MyProfileRoutes.UpdateMyInfos %>" method="post">
+<form name="UserForm" action="<%=MyProfileRoutes.UpdateMyInfos %>" method="post" enctype="multipart/form-data">
 <fieldset id="identity-main" class="skinFieldset">
 <legend><fmt:message key="myProfile.identity.fieldset.main" /></legend>
 <table border="0" cellspacing="0" cellpadding="5" width="100%">
@@ -177,16 +177,19 @@
       <viewTags:displayUserExtraProperties user="<%=userFull%>" readOnly="false" includeEmail="false"/>
     </fieldset>
   </c:if>
+
+  <view:directoryExtraForm userId="<%=userFull.getId()%>" edition="true"/>
+
  </form>
  </div>
  <br clear="all"/>
  <%
 		ButtonPane buttonPane = gef.getButtonPane();
 		if (updateIsAllowed) {
-			Button validateButton = gef.getFormButton(resource.getString("GML.validate"), "javascript:onClick=submitForm();", false);
+			Button validateButton = gef.getFormButton(resource.getString("GML.validate"), "javascript:onclick=saveUser();", false);
 			buttonPane.addButton(validateButton);
 		}
-		Button cancelButton = gef.getFormButton(resource.getString("GML.cancel"), "javascript:onClick=history.back();", false);
+		Button cancelButton = gef.getFormButton(resource.getString("GML.cancel"), "javascript:onclick=history.back();", false);
 		buttonPane.addButton(cancelButton);
 		out.println(buttonPane.print());
 %>
@@ -198,7 +201,7 @@
     $('#newPassword').password();
   });
 
-	function submitForm() {
+	function ifCorrectBasicFormExecute(callback) {
 		var errorMsg = "";
 		<% if (updateLastNameIsAllowed) { %>
 			var namefld = document.UserForm.userLastName.value;
@@ -221,9 +224,23 @@
 		}
 		%>
 		if (errorMsg == "") {
-			document.UserForm.submit();
+      callback.call(this);
 		} else {
       jQuery.popup.error(errorMsg);
 		}
 	}
+
+  function saveUser() {
+    if ($("#identity-template").length) {
+      ifCorrectBasicFormExecute(function() {
+        ifCorrectFormExecute(function() {
+          document.UserForm.submit();
+        });
+      });
+    } else {
+      ifCorrectBasicFormExecute(function() {
+        document.UserForm.submit();
+      });
+    }
+  }
 </script>

--- a/core-war/src/main/webapp/socialNetwork/jsp/profil/profilPublic.jsp
+++ b/core-war/src/main/webapp/socialNetwork/jsp/profil/profilPublic.jsp
@@ -34,18 +34,14 @@
 <%@page import="org.silverpeas.core.web.util.viewgenerator.html.GraphicElementFactory"%>
 <%@page import="org.silverpeas.core.util.MultiSilverpeasBundle"%>
 <%@page import="org.silverpeas.core.util.URLUtil"%>
-<%@ page import="org.silverpeas.core.admin.user.model.UserDetail" %>
 <fmt:setLocale value="${sessionScope[sessionController].language}" />
 <view:setBundle bundle="${requestScope.resources.multilangBundle}" />
 
 <%
 	GraphicElementFactory gef = (GraphicElementFactory) session.getAttribute("SessionGraphicElementFactory");
 	MultiSilverpeasBundle resource = (MultiSilverpeasBundle) request.getAttribute("resources");
-
-    UserFull userFull = (UserFull) request.getAttribute("userFull");
-    UserDetail userDetail = (UserDetail) request.getAttribute("UserDetail");
-
-    String m_context = URLUtil.getApplicationURL();
+  UserFull userFull = (UserFull) request.getAttribute("userFull");
+  String m_context = URLUtil.getApplicationURL();
 %>
 
 <html>
@@ -61,10 +57,10 @@
 
 	<!-- info  -->
 	<div class="info tableBoard">
-	<h2 class="userName"><%=userDetail.getFirstName() %> <br /><%=userDetail.getLastName() %></h2>
+	<h2 class="userName"><%=userFull.getFirstName() %> <br /><%=userFull.getLastName() %></h2>
         <p class="infoConnection">
-		<% if (userDetail.isConnected()) { %>
-				<img src="<%=m_context%>/util/icons/online.gif" alt="connected"/> <fmt:message key="GML.user.online.for" /> <%=userDetail
+		<% if (userFull.isConnected()) { %>
+				<img src="<%=m_context%>/util/icons/online.gif" alt="connected"/> <fmt:message key="GML.user.online.for" /> <%=userFull
 						.getDurationOfCurrentSession()%>
 			<% } else { %>
 		<img src="<%=m_context%>/util/icons/offline.gif" alt="deconnected"/> <fmt:message key="GML.user.offline" />
@@ -73,14 +69,14 @@
 
 	    <!-- action  -->
     <div class="action">
-		  <a href="#" class="link invitation" rel="<%=userDetail.getId() %>,<%=userDetail.getDisplayedName() %>"><fmt:message key="invitation.send" /></a>
+		  <a href="#" class="link invitation" rel="<%=userFull.getId() %>,<%=userFull.getDisplayedName() %>"><fmt:message key="invitation.send" /></a>
       <br />
-      <a href="#" class="link notification" rel="<%=userDetail.getId() %>,'<%=userDetail.getDisplayedName()%>"><fmt:message key="GML.notification.send" /></a>
+      <a href="#" class="link notification" rel="<%=userFull.getId() %>,'<%=userFull.getDisplayedName()%>"><fmt:message key="GML.notification.send" /></a>
     </div> <!-- /action  -->
 
         <!-- profilPhoto  -->
 		<div class="profilPhoto">
-			<view:image src="<%=userDetail.getAvatar()%>" type="avatar.profil" alt="viewUser" css="avatar"/>
+			<view:image src="<%=userFull.getAvatar()%>" type="avatar.profil" alt="viewUser" css="avatar"/>
         </div>
 
         <p class="statut">
@@ -103,6 +99,9 @@
 	<div class="tab-content">
     <viewTags:displayUserExtraProperties user="<%=userFull%>" readOnly="true" includeEmail="true"/>
   </div>
+
+  <view:directoryExtraForm userId="<%=userFull.getId()%>"/>
+
 	<%
 		  ButtonPane buttonPane = gef.getButtonPane();
 		  Button button = gef.getFormButton(resource.getString("GML.back"), "javascript:history.back()", false);

--- a/core-war/src/main/webapp/templateDesigner/jsp/templateHeader.jsp
+++ b/core-war/src/main/webapp/templateDesigner/jsp/templateHeader.jsp
@@ -45,6 +45,7 @@ String visible = "";
 String encrypted = "";
 String searchable = "";
 String action = "AddTemplate";
+String directoryUsage = "";
 List<String> visibilitySpaces = null;
 List<String> visibilityApplications = null;
 List<String> visibilityInstances = null;
@@ -63,6 +64,9 @@ if (template != null) {
 	if (template.isSearchable()) {
 		searchable = "checked=\"checked\"";
 	}
+	if (template.isDirectoryUsage()) {
+    directoryUsage = "checked=\"checked\"";
+  }
 	visibilitySpaces = template.getSpaces();
 	visibilityApplications = template.getApplications();
 	visibilityInstances = template.getInstances();
@@ -151,6 +155,13 @@ $(function () {
 	$('#template-spaces-visibility').tagit({triggerKeys:tagTriggerKeys});
 	$('#template-instances-visibility').tagit({triggerKeys:tagTriggerKeys});
 
+	<%if (template != null && template.isDirectoryUsage()) { %>
+    $(".notApplicableToDirectory").hide();
+  <% } %>
+  $("#DirectoryUsage").click(function() {
+    $(".notApplicableToDirectory").toggle();
+  });
+
 });
 </script>
 </head>
@@ -213,7 +224,11 @@ out.println(tabbedPane.print());
 <tr>
 <td class="txtlibform"><%=resource.getString("templateDesigner.visible")%> :</td><td><input type="checkbox" name="Visible" value="true" <%=visible%>/></td>
 </tr>
-<tr id="spaces-visibility">
+<tr>
+  <td class="txtlibform"><%=resource.getString("templateDesigner.header.directory")%></td>
+  <td><input type="checkbox" name="DirectoryUsage" id="DirectoryUsage" value="true" <%=directoryUsage%>/></td>
+</tr>
+<tr id="spaces-visibility" class="notApplicableToDirectory">
 	<td class="txtlibform"><%=resource.getString("templateDesigner.header.visible.spaces")%> :</td>
 	<td>
 		<ul id="template-spaces-visibility">
@@ -226,7 +241,7 @@ out.println(tabbedPane.print());
 		<input type="hidden" id="Visibility_Spaces" name="Visibility_Spaces"/>
 	</td>
 </tr>
-<tr id="applications-visibility">
+<tr id="applications-visibility" class="notApplicableToDirectory">
 	<td class="txtlibform"><%=resource.getString("templateDesigner.header.visible.applications")%> :</td>
 	<td><ul id="template-apps-visibility">
 		<% for (LocalizedComponent component : components) {
@@ -240,7 +255,7 @@ out.println(tabbedPane.print());
 		</ul>
 	</td>
 </tr>
-<tr id="instances-visibility">
+<tr id="instances-visibility" class="notApplicableToDirectory">
 	<td class="txtlibform"><%=resource.getString("templateDesigner.header.visible.instances")%> :</td>
 	<td>
 		<ul id="template-instances-visibility">

--- a/core-war/src/main/webapp/util/styleSheets/globalSP_SilverpeasV5.css
+++ b/core-war/src/main/webapp/util/styleSheets/globalSP_SilverpeasV5.css
@@ -2329,7 +2329,8 @@ caption {
   margin-right: 5px;
 }
 
-#directory #indexAndSearch #search #help {
+#directory #indexAndSearch #search #help,
+#directory #indexAndSearch #search #clear {
   line-height: 20px;
   margin-left: 5px;
 }
@@ -6433,4 +6434,84 @@ silverpeas-attendee .not-answered {
 
 #pdcFrame .pdcFrameGroup #razButton img {
   vertical-align: middle;
+}
+
+.admin-users .profile {
+  line-height:2em
+}
+
+.admin-users .profile .avatar {
+  position: absolute;
+  display: inline-block;
+  float: right;
+  padding: 4px;
+  border: 1px solid #CCC;
+  background-color: #FFF;
+  top: -0.3em;
+  right: -1em;
+}
+
+.admin-users .profile .avatar .operation {
+  position:absolute;
+  bottom:-1.5em;
+  right:-0.5em;
+  background-color:#FFF;
+  border-radius:4px;
+  opacity:0.8;
+  padding:2px;
+}
+
+.admin-users .profile .personna{
+  font-size:2em;
+}
+
+.admin-users .profile .lastConnection ,
+.admin-users .profile .access,
+.admin-users .profile .email{
+  margin-bottom:1em;
+}
+.admin-users .profile .lastConnection {
+  font-style:italic;
+  color:#666;
+  line-height: 1em;
+}
+
+.admin-users .profile .img-label {
+  margin-right:1em;
+}
+
+.admin-users .profile .user-zone-id,
+.admin-users .profile .language {
+  float:left;
+  width:65%;
+}
+
+.admin-users .profile .user-zone-id {
+  float:left;
+  width:35%;
+}
+
+.admin-users .profile #profiles-link {
+  text-align:left;
+  margin-top: 2em;
+}
+
+.admin-users .profile #profiles-link > span {
+  background-image: url("../../util/icons/characteristic.png");
+  background-repeat:no-repeat;
+  background-position:7px 7px;
+  text-align:left;
+  padding-left:34px;
+  display:block
+}
+.admin-users .profile #profiles-link > span > span{
+  display:block
+}
+
+.admin-users .profile .user-zone-id .img-label{
+  width:14px;
+}
+
+.admin-users .profile #identity-extra legend {
+  background:transparent url("/silverpeas/util/icons/addFiche.png") 9px 0 no-repeat;
 }

--- a/core-web/src/integration-test/java/org/silverpeas/core/web/test/WarBuilder4WebCore.java
+++ b/core-web/src/integration-test/java/org/silverpeas/core/web/test/WarBuilder4WebCore.java
@@ -67,6 +67,7 @@ public class WarBuilder4WebCore extends BasicCoreWarBuilder {
     addAsResource("org/silverpeas/util/attachment/Attachment.properties");
     addAsResource("org/silverpeas/util/security.properties");
     addAsResource("org/silverpeas/social/settings/socialNetworkSettings.properties");
+    addAsResource("org/silverpeas/publicationTemplate/settings/template.properties");
   }
 
   /**

--- a/core-web/src/integration-test/resources/org/silverpeas/publicationTemplate/settings/mapping.properties
+++ b/core-web/src/integration-test/resources/org/silverpeas/publicationTemplate/settings/mapping.properties
@@ -1,0 +1,24 @@
+#
+# Copyright (C) 2000 - 2017 Silverpeas
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# As a special exception to the terms and conditions of version 3.0 of
+# the GPL, you may redistribute this Program in connection with Free/Libre
+# Open Source Software ("FLOSS") applications as described in Silverpeas's
+# FLOSS exception.  You should have recieved a copy of the text describing
+# the FLOSS exception, and it is also available here:
+# "http://www.silverpeas.org/docs/core/legal/floss_exception.html"
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+mappingDir  = file://${basedir}/target/test-classes/templateRepository

--- a/core-web/src/integration-test/resources/org/silverpeas/publicationTemplate/settings/template.properties
+++ b/core-web/src/integration-test/resources/org/silverpeas/publicationTemplate/settings/template.properties
@@ -1,0 +1,24 @@
+#
+# Copyright (C) 2000 - 2017 Silverpeas
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# As a special exception to the terms and conditions of version 3.0 of
+# the GPL, you may redistribute this Program in connection with Free/Libre
+# Open Source Software ("FLOSS") applications as described in Silverpeas's
+# FLOSS exception.  You should have recieved a copy of the text describing
+# the FLOSS exception, and it is also available here:
+# "http://www.silverpeas.org/docs/core/legal/floss_exception.html"
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+templateDir=${basedir}/target/test-classes

--- a/core-web/src/main/java/org/silverpeas/core/web/util/viewgenerator/html/DirectoryExtraFormTag.java
+++ b/core-web/src/main/java/org/silverpeas/core/web/util/viewgenerator/html/DirectoryExtraFormTag.java
@@ -1,0 +1,84 @@
+package org.silverpeas.core.web.util.viewgenerator.html;
+
+import org.apache.ecs.ElementContainer;
+import org.apache.ecs.html.FieldSet;
+import org.apache.ecs.html.Legend;
+import org.silverpeas.core.contribution.content.form.Form;
+import org.silverpeas.core.contribution.content.form.PagesContext;
+import org.silverpeas.core.contribution.template.publication.PublicationTemplateManager;
+import org.silverpeas.core.web.mvc.controller.MainSessionController;
+
+import javax.servlet.jsp.JspException;
+import javax.servlet.jsp.JspWriter;
+import javax.servlet.jsp.PageContext;
+import javax.servlet.jsp.tagext.SimpleTagSupport;
+import java.io.IOException;
+
+import static org.silverpeas.core.web.mvc.controller.MainSessionController
+    .MAIN_SESSION_CONTROLLER_ATT;
+
+/**
+ * Created by Nicolas on 14/09/2017.
+ */
+public class DirectoryExtraFormTag extends SimpleTagSupport {
+
+  private String userId;
+  private boolean edition = false;
+
+  public void setUserId(final String userId) {
+    this.userId = userId;
+  }
+
+  public void setEdition(final boolean edition) {
+    this.edition = edition;
+  }
+
+  @Override
+  public void doTag() throws JspException, IOException {
+    Form form = getForm();
+    if (form != null) {
+
+      PagesContext formContext = getFormContext();
+      if (edition) {
+        form.displayScripts(getOut(), formContext);
+      }
+
+      ElementContainer container = new ElementContainer();
+
+      FieldSet fieldSet = new FieldSet();
+      fieldSet.setID("identity-template");
+      fieldSet.setClass("skinFieldset");
+
+      Legend legend = new Legend(form.getTitle());
+      legend.setClass("without-img");
+      fieldSet.addElement(legend);
+
+      String strForm = form.toString(formContext);
+      fieldSet.addElement(strForm);
+
+      container.addElement(fieldSet);
+
+      container.output(getOut());
+    }
+  }
+
+  protected JspWriter getOut() {
+    return getJspContext().getOut();
+  }
+
+  private Form getForm() {
+    PublicationTemplateManager templateManager = PublicationTemplateManager.getInstance();
+    return templateManager.getDirectoryForm(getFormContext(), !edition);
+  }
+
+  private PagesContext getFormContext() {
+    MainSessionController session = (MainSessionController) getJspContext().getAttribute(
+        MAIN_SESSION_CONTROLLER_ATT, PageContext.SESSION_SCOPE);
+    if (session != null) {
+      return PagesContext.getDirectoryContext(userId, session.getUserId(),
+          session.getFavoriteLanguage());
+    }
+    return null;
+  }
+
+}

--- a/core-web/src/main/resources/META-INF/viewGenerator.tld
+++ b/core-web/src/main/resources/META-INF/viewGenerator.tld
@@ -2462,6 +2462,28 @@
       <type>java.lang.String</type>
     </attribute>
   </tag>
+  <tag>
+    <description>Tag that display the extra form associated to directory</description>
+    <name>directoryExtraForm</name>
+    <tag-class>
+      org.silverpeas.core.web.util.viewgenerator.html.DirectoryExtraFormTag
+    </tag-class>
+    <body-content>empty</body-content>
+    <attribute>
+      <description>Id of user</description>
+      <name>userId</name>
+      <required>true</required>
+      <rtexprvalue>true</rtexprvalue>
+      <type>java.lang.String</type>
+    </attribute>
+    <attribute>
+      <description>Form displayed in edition mode</description>
+      <name>edition</name>
+      <required>false</required>
+      <rtexprvalue>true</rtexprvalue>
+      <type>java.lang.Boolean</type>
+    </attribute>
+  </tag>
   <function>
     <description>Function that returns the value of a class constant.</description>
     <name>constantValue</name>


### PR DESCRIPTION
A custom template can be associated to directory and users profile. Only once template for the moment.
This template is displayed in front office (to user himself in edition and other users) and back office too.
This template is available in directory behind the advanced search. Do not forget to make this template "searchable" and some of its fields...

At this occasion, several improvements :
-  user page in back-office has been redesigned,
- admin is able to delete user's avatar.

Do not forget to check out PR on Silverpeas-Components...
 