### PR TITLE
Update of the code with the update of some of the dependencies

### DIFF
--- a/core-api/pom.xml
+++ b/core-api/pom.xml
@@ -60,8 +60,8 @@
       <artifactId>commons-io</artifactId>
     </dependency>
     <dependency>
-      <groupId>net.sf.ehcache</groupId>
-      <artifactId>ehcache-core</artifactId>
+      <groupId>org.ehcache</groupId>
+      <artifactId>ehcache</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -76,8 +76,8 @@
       <artifactId>slf4j-log4j12</artifactId>
     </dependency>
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
     </dependency>
 
     <!-- Tests-->

--- a/core-api/src/main/java/org/silverpeas/core/cache/model/AbstractCache.java
+++ b/core-api/src/main/java/org/silverpeas/core/cache/model/AbstractCache.java
@@ -33,8 +33,8 @@ import java.util.UUID;
 public abstract class AbstractCache extends AbstractSimpleCache
     implements Cache {
 
-  // In seconds, 12 hours (60seconds x 60minutes x 12hours)
-  private final static int DEFAULT_TIME_TO_IDLE = 60 * 60 * 12;
+  // In seconds, 12 hours (60 seconds x 60 minutes x 12 hours)
+  private static final int DEFAULT_TIME_TO_IDLE = 60 * 60 * 12;
 
   @Override
   public String add(final Object value, final int timeToLive) {

--- a/core-api/src/main/java/org/silverpeas/core/cache/model/Cache.java
+++ b/core-api/src/main/java/org/silverpeas/core/cache/model/Cache.java
@@ -30,42 +30,56 @@ package org.silverpeas.core.cache.model;
 public interface Cache extends SimpleCache {
 
   /**
-   * Adds a value and generate a unique key to retrieve later the value.
-   * After the given time, the value is trashed.
+   * Adds a value and generates a unique mapping key to be used to retrieve later the value.
    * @param value an object to add into the cache
-   * @param timeToLive 0 = unlimited
-   * @return the key to which the added object is mapped in the cache
+   * @param timeToLive the time to live in seconds of the value in the cache. After this time,
+   * the value expires and consequently it is removed from the cache. 0 = unlimited.
+   * @return the key to which the added value is mapped in the cache
    */
   String add(Object value, int timeToLive);
 
   /**
-   * Adds a value and generate a unique key to retrieve later the value.
-   * After the given live time, the value is trashed.
-   * After the given idle time, the value is trashed.
+   * Adds a value and generate a unique mapping key to be used to retrieve later the value.
+   * When both the time to live and the time to idle are set, the lifetime of the value in the
+   * cache is initially bounded by the time to live except if the lifetime computed from the time
+   * to live at the last access of the value (access time plus the
+   * time to idle) exceeds this initial lifetime.
    * @param value the object to add in the cache.
-   * @param timeToLive 0 = unlimited
-   * @param timeToIdle 0 = unlimited
+   * @param timeToLive the time to live in seconds of the object in the cache. The time to live
+   * can be exceeded if the time to idle is set and the value is accessed after the time to live
+   * minus the time to idle. 0 = unlimited.
+   * @param timeToIdle the time to idle in seconds of the object in the cache between two accesses.
+   * With the time to live set, the time to idle is taken into account only once the time starting
+   * at the access time exceed the initial lifetime of the value computed from the time to live.
+   * After this time, the value expires and consequently it is remove from the cache. 0 = unlimited.
    * @return the key to which the added object is mapped in the cache
    */
   String add(Object value, int timeToLive, int timeToIdle);
 
   /**
-   * Puts a value for a given key.
-   * After the given time, the value is trashed.
-   * @param key the key with which the object to add has to be mapped.
-   * @param value the object to add in the cache.
-   * @param timeToLive 0 = unlimited
+   * Puts a new value for the given key and updates its time to live.
+   * @param key the key with which the object to put has to be mapped.
+   * @param value the object to put in the cache.
+   * @param timeToLive the time to live in seconds of the value in the cache. After this time,
+   * the value expires and consequently it is removed from the cache. 0 = unlimited.
    */
   void put(Object key, Object value, int timeToLive);
 
   /**
-   * Puts a value for a given key.
-   * After the given time, the value is trashed.
-   * After the given idle time, the value is trashed.
-   * @param key the key with which the object to add has to be mapped.
-   * @param value the object to add in the cache.
-   * @param timeToLive 0 = unlimited
-   * @param timeToIdle 0 = unlimited
+   * Puts a new value for the given key and updates both its time to live and its time to idle.
+   * When both the time to live and the time to idle are set, the lifetime of the value in the
+   * cache is initially bounded by the time to live except if the lifetime computed from the time
+   * to live at the last access of the value (access time plus the
+   * time to idle) exceeds this initial lifetime.
+   * @param key the key with which the object to put has to be mapped.
+   * @param value the object to put in the cache.
+   * @param timeToLive the time to live in seconds of the object in the cache. The time to live
+   * can be exceeded if the time to idle is set and the value is accessed after the time to live
+   * minus the time to idle. 0 = unlimited.
+   * @param timeToIdle the time to idle in seconds of the object in the cache between two accesses.
+   * With the time to live set, the time to idle is taken into account only once the time starting
+   * at the access time exceed the initial lifetime of the value computed from the time to live.
+   * After this time, the value expires and consequently it is remove from the cache. 0 = unlimited.
    */
   void put(Object key, Object value, int timeToLive, int timeToIdle);
 }

--- a/core-api/src/main/java/org/silverpeas/core/cache/model/SimpleCache.java
+++ b/core-api/src/main/java/org/silverpeas/core/cache/model/SimpleCache.java
@@ -46,13 +46,13 @@ public interface SimpleCache {
 
   /**
    * Gets a typed element from the cache.
-   * Null is returned if an element exists for the given key but the object type doesn't
-   * correspond.
+   * Null is returned if an element exists for the given key but the object doesn't satisfy the
+   * expected type.
    * @param <T> the concrete type of the object to get.
    * @param key the key with which the object to get is mapped in the cache.
-   * @param classType the class of the instance to get.
-   * @return the object mapped with the key or null if no there is no object mapped with the
-   * specified key.
+   * @param classType the class type the instance to get as to satisfy.
+   * @return the object mapped with the key or null if either there is no object mapped with the
+   * specified key or the object doesn't satisfy the expected class type.
    */
   <T> T get(Object key, Class<T> classType);
 

--- a/core-api/src/main/java/org/silverpeas/core/notification/message/MessageManager.java
+++ b/core-api/src/main/java/org/silverpeas/core/notification/message/MessageManager.java
@@ -116,7 +116,12 @@ public class MessageManager {
   }
 
   public static void clear(String registredKey) {
-    applicationCache.remove(registredKey);
+    try {
+      applicationCache.remove(registredKey);
+    } catch (NullPointerException e) {
+      // the MessageManager was already cleared!
+      SilverLogger.getLogger(MessageManager.class).silent(e);
+    }
   }
 
   public static String getRegistredKey() {
@@ -158,7 +163,14 @@ public class MessageManager {
 
 
   public static MessageContainer getMessageContainer(String registredKey) {
-    return applicationCache.get(registredKey, MessageContainer.class);
+    try {
+      return applicationCache.get(registredKey, MessageContainer.class);
+    } catch (NullPointerException e) {
+      SilverLogger.getLogger(MessageManager.class)
+          .silent(e)
+          .error("No Message Container registered!");
+      return null;
+    }
   }
 
   /**

--- a/core-api/src/main/java/org/silverpeas/core/util/JSONCodec.java
+++ b/core-api/src/main/java/org/silverpeas/core/util/JSONCodec.java
@@ -23,6 +23,7 @@
  */
 package org.silverpeas.core.util;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.AnnotationIntrospector;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -46,7 +47,7 @@ import java.util.function.Function;
  * corresponding Java bean.
  * <p>
  * In order to perform the marshalling and the unmarchalling, the fields of the bean must be
- * annotated with the JAXB annotations.
+ * annotated with the JAXB annotations. All null fields are by default ignored.
  * @author mmoquillon
  */
 public class JSONCodec {
@@ -160,6 +161,7 @@ public class JSONCodec {
     AnnotationIntrospector introspector = new JaxbAnnotationIntrospector(
         TypeFactory.defaultInstance());
     mapper.setAnnotationIntrospector(introspector);
+    mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
     mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     return mapper;
   }

--- a/core-api/src/test/java/org/silverpeas/core/date/period/PeriodTest.java
+++ b/core-api/src/test/java/org/silverpeas/core/date/period/PeriodTest.java
@@ -23,12 +23,12 @@
  */
 package org.silverpeas.core.date.period;
 
-import org.silverpeas.core.date.DateTime;
-import org.silverpeas.core.util.DateUtil;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.silverpeas.core.date.DateTime;
 import org.silverpeas.core.notification.message.MessageManager;
+import org.silverpeas.core.util.DateUtil;
 import org.silverpeas.core.util.time.TimeUnit;
 
 import java.sql.Timestamp;
@@ -46,12 +46,13 @@ public class PeriodTest {
 
   Date periodReferenceBeginDate = Timestamp.valueOf("2013-11-28 12:00:00.000");
   Date periodReferenceEndDate = Timestamp.valueOf("2013-12-25 18:30:40.006");
-  Period periodReferenceTest = Period.from(periodReferenceBeginDate, periodReferenceEndDate);
+  Period periodReferenceTest;
 
   @Before
   public void setup() {
     MessageManager.initialize();
     MessageManager.setLanguage("fr");
+    periodReferenceTest = Period.from(periodReferenceBeginDate, periodReferenceEndDate);
     periodReferenceTest.inTimeZone(TimeZone.getTimeZone("Europe/Paris"));
   }
 

--- a/core-api/src/test/java/org/silverpeas/core/util/TestMemoryData.java
+++ b/core-api/src/test/java/org/silverpeas/core/util/TestMemoryData.java
@@ -24,7 +24,9 @@
 package org.silverpeas.core.util;
 
 import org.apache.commons.lang3.StringUtils;
+import org.junit.Before;
 import org.junit.Test;
+import org.silverpeas.core.notification.message.MessageManager;
 import org.silverpeas.core.util.memory.MemoryData;
 import org.silverpeas.core.util.memory.MemoryUnit;
 
@@ -40,6 +42,12 @@ import static org.hamcrest.Matchers.is;
  * Date: 14/11/13
  */
 public class TestMemoryData extends AbstractUnitTest {
+
+  @Before
+  public void setUpMessageManager() {
+    MessageManager.initialize();
+    MessageManager.setLanguage("fr");
+  }
 
   @Test
   public void getSize() {

--- a/core-api/src/test/java/org/silverpeas/core/util/TestUnitUtil.java
+++ b/core-api/src/test/java/org/silverpeas/core/util/TestUnitUtil.java
@@ -23,7 +23,9 @@
  */
 package org.silverpeas.core.util;
 
+import org.junit.Before;
 import org.junit.Test;
+import org.silverpeas.core.notification.message.MessageManager;
 import org.silverpeas.core.util.memory.MemoryUnit;
 
 import java.math.BigDecimal;
@@ -33,6 +35,12 @@ import static org.hamcrest.Matchers.is;
 import static org.silverpeas.core.util.UnitUtil.*;
 
 public class TestUnitUtil extends AbstractUnitTest {
+
+  @Before
+  public void setUpMessageManager() {
+    MessageManager.initialize();
+    MessageManager.setLanguage("fr");
+  }
 
   @Test
   public void testConvertToFromBigDecimal() {

--- a/core-api/src/test/resources/org/silverpeas/util/logging/silverpeasLogging.properties
+++ b/core-api/src/test/resources/org/silverpeas/util/logging/silverpeasLogging.properties
@@ -1,0 +1,58 @@
+#
+# Copyright (C) 2000 - 2017 Silverpeas
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# As a special exception to the terms and conditions of version 3.0 of
+# the GPL, you may redistribute this Program in connection with Free/Libre
+# Open Source Software ("FLOSS") applications as described in Silverpeas's
+# FLOSS exception.  You should have received a copy of the text describing
+# the FLOSS exception, and it is also available here:
+# "http://www.silverpeas.org/legal/licensing"
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+#
+# Copyright (C) 2000 - 2017 Silverpeas
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# As a special exception to the terms and conditions of version 3.0 of
+# the GPL, you may redistribute this Program in connection with Free/Libre
+# Open Source Software ("FLOSS") applications as described in Silverpeas's
+# FLOSS exception.  You should have recieved a copy of the text describing
+# the FLOSS exception, and it is also available here:
+# "http://www.silverpeas.org/docs/core/legal/floss_exception.html"
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+
+#
+# Logger definition.
+# Each logger is defined by its unique namespace and by a logging level.
+#
+# - namespace: identifies uniquely a logger and represents the hierarchical category to which
+#              messages are logged with the logger. Each substring before a dot is the namespace
+#              of a parent logger.
+# - level: defines the minimum level at which will be accepted the logged messages. If not
+#          set, the first defined parent logger's level will be then taken into account. Possible
+#          value is: ERROR, WARNING, INFO, DEBUG
+#
+namespace=silverpeas
+level=ERROR

--- a/core-library/pom.xml
+++ b/core-library/pom.xml
@@ -46,6 +46,10 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
+      <groupId>javax.cache</groupId>
+      <artifactId>cache-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.module</groupId>
       <artifactId>jackson-module-jaxb-annotations</artifactId>
     </dependency>
@@ -67,11 +71,6 @@
       <version>${project.version}</version>
       <scope>test</scope>
       <type>jar</type>
-    </dependency>
-    <dependency>
-      <groupId>informa</groupId>
-      <artifactId>informa</artifactId>
-      <classifier>silverpeas</classifier>
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
@@ -136,10 +135,6 @@
     <dependency>
       <groupId>org.apache.lucene</groupId>
       <artifactId>lucene-spellchecker</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.jdom</groupId>
-      <artifactId>jdom</artifactId>
     </dependency>
     <dependency>
       <groupId>net.htmlparser.jericho</groupId>

--- a/core-library/src/integration-test/java/org/silverpeas/core/mail/MsgMailExtractorIntegrationTest.java
+++ b/core-library/src/integration-test/java/org/silverpeas/core/mail/MsgMailExtractorIntegrationTest.java
@@ -77,6 +77,7 @@ public class MsgMailExtractorIntegrationTest {
         .addAsResource("org/silverpeas/converter")
         .testFocusedOn(warBuilder -> {
           warBuilder
+              .addMavenDependencies("org.apache.poi:poi-scratchpad")
               .addMavenDependencies("com.icegreen:greenmail")
               .addPackages(true, "org.silverpeas.core.mail")
               .addAsResource("org/silverpeas/core/mail/mailWithAttachments.msg");
@@ -108,7 +109,7 @@ public class MsgMailExtractorIntegrationTest {
     if (attachments != null && attachments.length > 0) {
       System.out.print("\n");
       for (AttachmentChunks attachmentChunks : attachments) {
-        System.out.println(attachmentChunks.attachFileName.getValue());
+        System.out.println(attachmentChunks.getAttachFileName().getValue());
       }
     } else {
       System.out.println("None.");
@@ -178,8 +179,8 @@ public class MsgMailExtractorIntegrationTest {
    * @throws Exception
    */
   protected static Date extractDateOfReception(MAPIMessage msg) throws Exception {
-    if (msg.getMainChunks().messageHeaders != null) {
-      String chunkContent = msg.getMainChunks().messageHeaders.getValue();
+    if (msg.getMainChunks().getMessageHeaders() != null) {
+      String chunkContent = msg.getMainChunks().getMessageHeaders().getValue();
       int dateIdx = chunkContent.indexOf("Date: ");
       if (dateIdx >= 0) {
         chunkContent = chunkContent.substring(dateIdx + 6, chunkContent.indexOf("\n", dateIdx))

--- a/core-library/src/integration-test/java/org/silverpeas/core/test/CalendarWarBuilder.java
+++ b/core-library/src/integration-test/java/org/silverpeas/core/test/CalendarWarBuilder.java
@@ -24,6 +24,7 @@
 package org.silverpeas.core.test;
 
 import org.silverpeas.core.calendar.CalendarEventOccurrenceBuilder;
+import org.silverpeas.core.calendar.ical4j.HtmlProperty;
 import org.silverpeas.core.test.stub.StubbedWysiwygContentRepository;
 
 /**
@@ -44,7 +45,8 @@ public class CalendarWarBuilder extends WarBuilder4LibCore {
     addJpaPersistenceFeatures();
     addNotificationFeatures();
     addPackages(true, "org.silverpeas.core.notification.user.delayed.model");
-    addClasses(CalendarEventOccurrenceBuilder.class, StubbedWysiwygContentRepository.class);
+    addClasses(CalendarEventOccurrenceBuilder.class, StubbedWysiwygContentRepository.class,
+        HtmlProperty.class);
   }
 
   /**

--- a/core-library/src/main/java/org/silverpeas/core/admin/persistence/Table.java
+++ b/core-library/src/main/java/org/silverpeas/core/admin/persistence/Table.java
@@ -215,7 +215,7 @@ public abstract class Table<T> extends AbstractTable<T> {
   }
 
   /**
-   * Returns the nb of rows in the given table agregated on the given column
+   * Returns the nb of rows in the given table aggregated on the given column
    * @param tableName
    * @param whereClause
    * @param param
@@ -238,7 +238,7 @@ public abstract class Table<T> extends AbstractTable<T> {
   }
 
   /**
-   * Returns the nb of rows in the given table agregated on the given column
+   * Returns the nb of rows in the given table aggregated on the given column
    * @param tableName
    * @param whereClause
    * @param id

--- a/core-library/src/main/java/org/silverpeas/core/calendar/ical4j/HtmlProperty.java
+++ b/core-library/src/main/java/org/silverpeas/core/calendar/ical4j/HtmlProperty.java
@@ -26,29 +26,33 @@ package org.silverpeas.core.calendar.ical4j;
 import net.fortuna.ical4j.model.Escapable;
 import net.fortuna.ical4j.model.ParameterList;
 import net.fortuna.ical4j.model.Property;
-import net.fortuna.ical4j.model.PropertyFactoryImpl;
+import net.fortuna.ical4j.model.PropertyFactory;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.text.ParseException;
 
 public class HtmlProperty extends Property implements Escapable {
 
   public static final String X_ALT_DESC = "X-ALT-DESC";
+  public static final String PROPERTY_NAME = X_ALT_DESC + ";FMTTYPE=text/html";
+  public static final HtmlPropertyFactory FACTORY = new HtmlPropertyFactory();
 
   private static final long serialVersionUID = 7287564228220558361L;
-  private static final String HTML = X_ALT_DESC + ";FMTTYPE=text/html";
-
   private String value;
 
   /**
    * Default constructor.
    */
   public HtmlProperty() {
-    super(HTML, PropertyFactoryImpl.getInstance());
+    super(PROPERTY_NAME, FACTORY);
   }
 
   /**
    * @param aValue a value string for this component
    */
   public HtmlProperty(final String aValue) {
-    super(HTML, PropertyFactoryImpl.getInstance());
+    super(PROPERTY_NAME, FACTORY);
     setValue(aValue);
   }
 
@@ -57,7 +61,7 @@ public class HtmlProperty extends Property implements Escapable {
    * @param aValue a value string for this component
    */
   public HtmlProperty(final ParameterList aList, final String aValue) {
-    super(HTML, aList, PropertyFactoryImpl.getInstance());
+    super(PROPERTY_NAME, aList, FACTORY);
     setValue(aValue);
   }
 
@@ -83,5 +87,28 @@ public class HtmlProperty extends Property implements Escapable {
   @Override
   public final void setValue(final String aValue) {
     this.value = aValue;
+  }
+
+  public static class HtmlPropertyFactory implements PropertyFactory<Property> {
+
+    public HtmlPropertyFactory() {
+      super();
+    }
+
+    @Override
+    public Property createProperty() {
+      return new HtmlProperty();
+    }
+
+    @Override
+    public Property createProperty(final ParameterList parameters, final String value)
+        throws IOException, URISyntaxException, ParseException {
+      return new HtmlProperty(parameters, value);
+    }
+
+    @Override
+    public boolean supports(final String name) {
+      return PROPERTY_NAME.equals(name);
+    }
   }
 }

--- a/core-library/src/main/java/org/silverpeas/core/calendar/ical4j/ICal4JImporter.java
+++ b/core-library/src/main/java/org/silverpeas/core/calendar/ical4j/ICal4JImporter.java
@@ -24,11 +24,15 @@
 package org.silverpeas.core.calendar.ical4j;
 
 import net.fortuna.ical4j.data.CalendarBuilder;
+import net.fortuna.ical4j.data.CalendarParserFactory;
 import net.fortuna.ical4j.data.ParserException;
 import net.fortuna.ical4j.model.Calendar;
 import net.fortuna.ical4j.model.Date;
 import net.fortuna.ical4j.model.DateTime;
+import net.fortuna.ical4j.model.ParameterFactoryRegistry;
 import net.fortuna.ical4j.model.Property;
+import net.fortuna.ical4j.model.PropertyFactoryRegistry;
+import net.fortuna.ical4j.model.TimeZoneRegistryFactory;
 import net.fortuna.ical4j.model.component.VEvent;
 import net.fortuna.ical4j.model.component.VTimeZone;
 import net.fortuna.ical4j.model.property.Categories;
@@ -101,7 +105,12 @@ public class ICal4JImporter implements ICalendarImporter {
       final Consumer<Stream<Pair<CalendarEvent, List<CalendarEventOccurrence>>>> consumer)
       throws ImportException {
     try {
-      CalendarBuilder builder = new CalendarBuilder();
+      PropertyFactoryRegistry propertyFactoryRegistry = new PropertyFactoryRegistry();
+      propertyFactoryRegistry.register(HtmlProperty.PROPERTY_NAME, HtmlProperty.FACTORY);
+      CalendarBuilder builder =
+          new CalendarBuilder(CalendarParserFactory.getInstance().createParser(),
+              propertyFactoryRegistry, new ParameterFactoryRegistry(),
+              TimeZoneRegistryFactory.getInstance().createRegistry());
       Calendar calendar = builder.build(getCalendarInputStream(descriptor));
       if (calendar.getComponents().isEmpty()) {
         consumer.accept(Stream.empty());

--- a/core-library/src/main/java/org/silverpeas/core/socialnetwork/service/SocialNetworkAuthorizationException.java
+++ b/core-library/src/main/java/org/silverpeas/core/socialnetwork/service/SocialNetworkAuthorizationException.java
@@ -23,34 +23,22 @@
  */
 package org.silverpeas.core.socialnetwork.service;
 
-import org.silverpeas.core.exception.SilverpeasException;
+import org.silverpeas.core.SilverpeasException;
 
 public class SocialNetworkAuthorizationException extends SilverpeasException {
 
   private static final long serialVersionUID = -7964169729516682237L;
 
-  @Override
-  public String getModule() {
-    return "socialNetwork";
+
+  public SocialNetworkAuthorizationException(final String message, final String... parameters) {
+    super(message, parameters);
   }
 
-  public SocialNetworkAuthorizationException(String callingClass,
-      int errorLevel, String message, Exception nested) {
-    super(callingClass, errorLevel, message, nested);
+  public SocialNetworkAuthorizationException(final String message, final Throwable cause) {
+    super(message, cause);
   }
 
-  public SocialNetworkAuthorizationException(String callingClass,
-      int errorLevel, String message, String extraParams, Exception nested) {
-    super(callingClass, errorLevel, message, extraParams, nested);
-  }
-
-  public SocialNetworkAuthorizationException(String callingClass,
-      int errorLevel, String message, String extraParams) {
-    super(callingClass, errorLevel, message, extraParams);
-  }
-
-  public SocialNetworkAuthorizationException(String callingClass,
-      int errorLevel, String message) {
-    super(callingClass, errorLevel, message);
+  public SocialNetworkAuthorizationException(final Throwable cause) {
+    super(cause);
   }
 }

--- a/core-library/src/test/java/org/silverpeas/core/chart/period/AbstractPeriodChartTest.java
+++ b/core-library/src/test/java/org/silverpeas/core/chart/period/AbstractPeriodChartTest.java
@@ -23,6 +23,8 @@
  */
 package org.silverpeas.core.chart.period;
 
+import org.junit.Before;
+import org.silverpeas.core.notification.message.MessageManager;
 import org.silverpeas.core.util.JSONCodec;
 
 import java.util.function.Function;
@@ -31,6 +33,12 @@ import java.util.function.Function;
  * @author Yohann Chastagnier
  */
 public class AbstractPeriodChartTest {
+
+  @Before
+  public void setUpMessageManager() {
+    MessageManager.initialize();
+    MessageManager.setLanguage("fr");
+  }
 
   @SuppressWarnings("unchecked")
   protected String expJsChart(String title, String defaultPeriodType, String xLabel, String yLabel,

--- a/core-war/pom.xml
+++ b/core-war/pom.xml
@@ -188,8 +188,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>com.rometools</groupId>
       <artifactId>rome</artifactId>
-      <groupId>rome</groupId>
     </dependency>
   </dependencies>
 

--- a/core-war/src/main/webapp/util/javaScript/silverpeas-fileUpload.js
+++ b/core-war/src/main/webapp/util/javaScript/silverpeas-fileUpload.js
@@ -983,7 +983,7 @@
    * @private
    */
   function __buildOptions(options) {
-    var agregatedOptions = {
+    var aggregatedOptions = {
       multiple: true,
       dragAndDropDisplay: true,
       dragAndDropDisplayIcon: true,
@@ -1008,7 +1008,7 @@
         deleteFile: ''
       }
     };
-    var _options = $.extend(agregatedOptions, options);
+    var _options = $.extend(aggregatedOptions, options);
     if (!isFileAPI) {
       _options.multiple = false;
       _options.dragAndDropDisplay = false;

--- a/core-web/pom.xml
+++ b/core-web/pom.xml
@@ -168,7 +168,7 @@
       <artifactId>cas-client-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>rome</groupId>
+      <groupId>com.rometools</groupId>
       <artifactId>rome</artifactId>
     </dependency>
     <dependency>

--- a/core-web/src/integration-test/java/org/silverpeas/core/web/test/WarBuilder4WebCore.java
+++ b/core-web/src/integration-test/java/org/silverpeas/core/web/test/WarBuilder4WebCore.java
@@ -89,6 +89,7 @@ public class WarBuilder4WebCore extends BasicCoreWarBuilder {
    * @return the instance of the war archive builder.
    */
   public WarBuilder4WebCore addRESTWebServiceEnvironment() {
+    addMavenDependencies("org.apache.httpcomponents:httpclient");
     addPackages(true, "org.silverpeas.core.web.token");
     addPackages(true, "org.silverpeas.core.webapi.base");
     return this;

--- a/core-web/src/main/java/org/silverpeas/core/web/calendar/ical/ImportIcalManager.java
+++ b/core-web/src/main/java/org/silverpeas/core/web/calendar/ical/ImportIcalManager.java
@@ -23,7 +23,7 @@
  */
 package org.silverpeas.core.web.calendar.ical;
 
-import com.sun.syndication.io.XmlReader;
+import com.rometools.rome.io.XmlReader;
 import net.fortuna.ical4j.data.CalendarBuilder;
 import net.fortuna.ical4j.model.Calendar;
 import net.fortuna.ical4j.model.Component;

--- a/core-web/src/main/java/org/silverpeas/core/web/filter/MessageFilter.java
+++ b/core-web/src/main/java/org/silverpeas/core/web/filter/MessageFilter.java
@@ -76,7 +76,7 @@ public class MessageFilter implements Filter {
 
       } finally {
 
-        // Remove message container if no message registred
+        // Remove message container if no message registered
         if (MessageManager.getMessageContainer(registredKey).getMessages().isEmpty()) {
           MessageManager.clear(registredKey);
           httpResponse.setHeader(HTTP_MESSAGEKEY, null);


### PR DESCRIPTION
Don't forget to merge before:
- Silverpeas/Silverpeas-JCR-AccessControl#1
- Silverpeas/Silverpeas-Jackrabbit-JCA#1
- Silverpeas/silverpeas-dependencies-bom#4

Don't forget to merge after:
- Silverpeas/Silverpeas-Components#558
- Silverpeas/Silverpeas-Assembly#15

With the update of some of the dependencies and the removal of some of very old
dependencies, some codes have been refactored:
- The application cache in the Caching Engine is now based upon the new version
  of ehcache. In its new version the element expiry mechanism has now to be
  explicitly defined. If ehcache 3 provides a default mechanism for TTL-based
  expiry or TTI-based expiry, nothing is provided to define a mechanism based
  upon both TTL and TTI as it was in ehcache 2. So a custom expiry mechanism
  is defined to implement the way the TTL-and-TTI-based expiry was
  managed in ehcache 2.
  With the new version of ehcache, any null key throws immediately
  NullPointerException. This cause problems with MessageManager that uses the
  application cache and particularely in tests. So, the tests were updated to
  initialize MessageManager and a check is performed in MessageManager when
  accessing the application cache to catch the NullPointerException exception.

- In the last version of Apache POI, the attributes are now encapsultated by
  getter. So replace all the direct attribute accesses by their counterpart
  getter.

- The iCal4J API as some subtle changes. The HTMLProperty is modified
  consequently to those changes. Timezone registry in iCal4J requires a JCache
  implementation to cache timezones. EhCache 3 provides an implementation of
  JCache but it is necessary to declare the cache-api (JCache API) dependency to
  load this implementation for the iCal4J Timezone (use of the ServiceLoader 
  mechanism)

- In the new Jackson version, the null fields are now also serialized.
  Set a configuration parameter to the ObjectMapper in JSONCodec so that
  Jackson behaves like its previous versions, that is to say by omitting any null fields.

- The very old informa library to produce or to consume RSS feeds is now
  replaced by the last version of Rome. All the codes that used informa are now
  refactored to use Rome instead of informa.

 - Spring social connectors are updated to their last stable version. For doing,
   as LinkedIn has migrated their OAuth mechanism to OAuth2 and discourages
   strongly the use of OAuth1, the Linked connector in Silverpeas is updated to
   use OAuth2 instead of OAuth1.
