### PR TITLE
Handling a new way of SSO user authentication.

### DIFF
--- a/core-configuration/src/main/config/properties/org/silverpeas/util/logging/silverpeasSsoLogging.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/util/logging/silverpeasSsoLogging.properties
@@ -1,0 +1,36 @@
+#
+# Copyright (C) 2000 - 2018 Silverpeas
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# As a special exception to the terms and conditions of version 3.0 of
+# the GPL, you may redistribute this Program in connection with Free/Libre
+# Open Source Software ("FLOSS") applications as described in Silverpeas's
+# FLOSS exception.  You should have received a copy of the text describing
+# the FLOSS exception, and it is also available here:
+# "https://www.silverpeas.org/legal/floss_exception.html"
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+#
+# Logger definition.
+# Each logger is defined by its unique namespace and by a logging level.
+#
+# - namespace: identifies uniquely a logger and represents the hierarchical category to which
+#              messages are logged with the logger. Each substring before a dot is the namespace
+#              of a parent logger.
+# - level: defines the minimum level at which will be accepted the logged messages. If not
+#          set, the first defined parent logger's level will be then taken into account. Possible
+#          value is: ERROR, WARNING, INFO, DEBUG
+#
+namespace=silverpeas.sso

--- a/core-war/src/main/webapp/WEB-INF/web.xml
+++ b/core-war/src/main/webapp/WEB-INF/web.xml
@@ -722,7 +722,7 @@
   </servlet-mapping>
   <servlet-mapping>
     <servlet-name>LogoutServlet</servlet-name>
-    <url-pattern>/LogoutServlet</url-pattern>
+    <url-pattern>/Logout</url-pattern>
   </servlet-mapping>
   <servlet-mapping>
     <servlet-name>POPUPRequestRouter</servlet-name>

--- a/core-war/src/main/webapp/jobManagerPeas/jsp/topBarManager.jsp
+++ b/core-war/src/main/webapp/jobManagerPeas/jsp/topBarManager.jsp
@@ -61,7 +61,7 @@ function routPage() {
 }
 
 function exit(){
-  window.parent.location.href="<%=m_context%>/LogoutServlet";
+  window.parent.location.href="<%=m_context%>/Logout";
 }
 
 // User Notification Popup

--- a/core-war/src/main/webapp/util/javaScript/silverpeas-lang.js
+++ b/core-war/src/main/webapp/util/javaScript/silverpeas-lang.js
@@ -48,7 +48,7 @@
               timeout: false,
               closeWith: ['button']
             };
-          notySuccess($('<a></a>').attr("href", webContext + "/LogoutServlet").attr("target", "_top").html(__getFromBundleKey('GML.reconnect')), changeLanguageOptions);
+          notySuccess($('<a></a>').attr("href", webContext + "/Logout").attr("target", "_top").html(__getFromBundleKey('GML.reconnect')), changeLanguageOptions);
         }
       });
     },

--- a/core-war/src/main/webapp/util/javaScript/silverpeas-user-session.js
+++ b/core-war/src/main/webapp/util/javaScript/silverpeas-user-session.js
@@ -76,7 +76,7 @@ Silverpeas plugin which handles the behaviour about the connected users informat
      */
     this.logout = function(options) {
       var params = extendsObject({
-        logoutDestination : webContext + '/LogoutServlet'
+        logoutDestination : webContext + '/Logout'
       }, options);
       spServerEventSource.close();
       __doLogout(function() {

--- a/core-web/src/main/java/org/silverpeas/core/web/authentication/LoginServlet.java
+++ b/core-web/src/main/java/org/silverpeas/core/web/authentication/LoginServlet.java
@@ -119,7 +119,7 @@ public class LoginServlet extends SilverpeasHttpServlet {
     String loginPage;
     String errorCode = getErrorCode(request);
     if (isSsoEnabled() && isNotDefined(errorCode)) {
-      loginPage = request.getContextPath() + "/sso";
+      loginPage = request.getContextPath() + "/sso/kerberos";
     } else {
       loginPage = general.getString("loginPage");
 

--- a/core-web/src/main/java/org/silverpeas/core/web/authentication/LogoutServlet.java
+++ b/core-web/src/main/java/org/silverpeas/core/web/authentication/LogoutServlet.java
@@ -23,9 +23,9 @@
  */
 package org.silverpeas.core.web.authentication;
 
-import org.silverpeas.core.security.session.SessionManagementProvider;
 import org.silverpeas.core.util.ResourceLocator;
 import org.silverpeas.core.util.SettingBundle;
+import org.silverpeas.core.util.logging.SilverLogger;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
@@ -33,6 +33,8 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 import java.io.IOException;
+
+import static org.silverpeas.core.security.session.SessionManagementProvider.getSessionManagement;
 
 public class LogoutServlet extends HttpServlet {
 
@@ -43,7 +45,12 @@ public class LogoutServlet extends HttpServlet {
     // Get the session
     HttpSession session = request.getSession(false);
     if (session != null) {
-      SessionManagementProvider.getSessionManagement().closeSession(session.getId());
+      getSessionManagement().closeSession(session.getId());
+      try {
+        session.invalidate();
+      } catch (IllegalStateException e) {
+        SilverLogger.getLogger(this).silent(e);
+      }
     }
     StringBuilder buffer = new StringBuilder(512);
     buffer.append(request.getScheme()).append("://").append(request.getServerName()).append(':');

--- a/core-web/src/main/java/org/silverpeas/core/web/sso/SilverpeasSsoHttpRequest.java
+++ b/core-web/src/main/java/org/silverpeas/core/web/sso/SilverpeasSsoHttpRequest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2000 - 2018 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.web.sso;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+import java.security.Principal;
+
+/**
+ * @author silveryocha
+ */
+public class SilverpeasSsoHttpRequest extends HttpServletRequestWrapper {
+
+  private final SilverpeasSsoPrincipal ssoPrincipal;
+
+  /**
+   * Constructs a request object wrapping the given request.
+   * @param request the current request
+   * @param ssoPrincipal the silverpeas sso principal.
+   * @throws IllegalArgumentException if the request is null
+   */
+  public SilverpeasSsoHttpRequest(final HttpServletRequest request,
+      final SilverpeasSsoPrincipal ssoPrincipal) {
+    super(request);
+    this.ssoPrincipal = ssoPrincipal;
+  }
+
+  @Override
+  public String getRemoteUser() {
+    if (null == this.ssoPrincipal) {
+      return super.getRemoteUser();
+    } else {
+      return ssoPrincipal.getName();
+    }
+  }
+
+  @Override
+  public Principal getUserPrincipal() {
+    return ssoPrincipal;
+  }
+}

--- a/core-web/src/main/java/org/silverpeas/core/web/sso/SilverpeasSsoHttpServlet.java
+++ b/core-web/src/main/java/org/silverpeas/core/web/sso/SilverpeasSsoHttpServlet.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2000 - 2017 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.silverpeas.core.web.sso;
+
+import javax.servlet.RequestDispatcher;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * This servlet is the parent one of Silverpeas SSO modules.
+ * @author Yohann Chastagnier
+ */
+public abstract class SilverpeasSsoHttpServlet extends HttpServlet {
+
+  private static final long serialVersionUID = -2013173095753706593L;
+
+  /**
+   * Computes the {@link SilverpeasSsoPrincipal} if possible.
+   * @return a valid {@link SilverpeasSsoPrincipal} on successful SSO authentication, null
+   * otherwise.
+   */
+  protected abstract SilverpeasSsoPrincipal computeSsoPrincipal(final HttpServletRequest request,
+      final HttpServletResponse response);
+
+  @Override
+  public void doPost(final HttpServletRequest request, final HttpServletResponse response)
+      throws ServletException, IOException {
+    final SilverpeasSsoPrincipal ssoPrincipal = computeSsoPrincipal(request, response);
+    final RequestDispatcher requestDispatcher = getServletConfig().getServletContext()
+        .getRequestDispatcher("/sso");
+    if (ssoPrincipal != null) {
+      // SSO authentication detected
+      requestDispatcher.forward(new SilverpeasSsoHttpRequest(request, ssoPrincipal), response);
+    } else {
+      requestDispatcher.forward(request, response);
+    }
+  }
+
+  @Override
+  public void doGet(HttpServletRequest request, HttpServletResponse response)
+      throws ServletException, IOException {
+    doPost(request, response);
+  }
+}

--- a/core-web/src/main/java/org/silverpeas/core/web/sso/SilverpeasSsoPrincipal.java
+++ b/core-web/src/main/java/org/silverpeas/core/web/sso/SilverpeasSsoPrincipal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2000 - 2017 Silverpeas
+ * Copyright (C) 2000 - 2018 Silverpeas
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -9,9 +9,9 @@
  * As a special exception to the terms and conditions of version 3.0 of
  * the GPL, you may redistribute this Program in connection with Free/Libre
  * Open Source Software ("FLOSS") applications as described in Silverpeas's
- * FLOSS exception.  You should have recieved a copy of the text describing
+ * FLOSS exception.  You should have received a copy of the text describing
  * the FLOSS exception, and it is also available here:
- * "http://www.silverpeas.org/docs/core/legal/floss_exception.html"
+ * "https://www.silverpeas.org/legal/floss_exception.html"
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -21,22 +21,27 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-function login() {
-  var loginField = document.authForm.Login.value;
-  if (loginField.length != 0) {
-    document.authForm.action = getContext() + "/AuthenticationServlet";
-    document.authForm.submit();
-  }
-}
 
-function logout() {
-  document.authForm.action = getContext() + "/Logout";
-  document.authForm.submit();
-}
+package org.silverpeas.core.web.sso;
 
-function checkSubmitToLogin(ev) {
-  var touche = ev.keyCode;
-  if (touche == 13) {
-    login();
+import java.security.Principal;
+
+/**
+ * @author silveryocha
+ */
+public interface SilverpeasSsoPrincipal extends Principal {
+
+  /**
+   * The login of the user behind the principal. By default it corresponds to {@link #getName()}.
+   * @return login as string.
+   */
+  default String getLogin() {
+    return getName();
   }
+
+  /**
+   * The domain identifier of Silverpeas domain from which the SSO is performed.
+   * @return an identifier as string.
+   */
+  String getDomainId();
 }


### PR DESCRIPTION
On "/sso" uri, Silverpeas is checking the user principal of the current request. If it is a SilverpeasSsoPrincipal one, then the authentication is peformed automatically with the data provided by the principal.
By this way, additional Silverpeas module (like silverpeas-sso-azure) in charge of performing user authentications by delegating it to authorities servers (like the one of Azure AD) can easily supply the PRINCIPAL to Silverpeas authentication.