### PR TITLE
Fix the bug #9552

### DIFF
--- a/core-api/src/main/java/org/silverpeas/core/util/logging/SilverLoggerProvider.java
+++ b/core-api/src/main/java/org/silverpeas/core/util/logging/SilverLoggerProvider.java
@@ -47,6 +47,7 @@ public class SilverLoggerProvider {
   public static final String ROOT_NAMESPACE = "silverpeas";
 
   private LoggerConfigurationManager configurationManager;
+  private SilverLoggerFactory loggerFactory = SilverLoggerFactory.get();
 
   @Inject
   protected SilverLoggerProvider(final LoggerConfigurationManager loggerConfigurationManager) {
@@ -80,7 +81,7 @@ public class SilverLoggerProvider {
   public SilverLogger getLogger(final String module) {
     LoggerConfigurationManager.LoggerConfiguration configuration =
         this.configurationManager.getLoggerConfiguration(module);
-    return SilverLoggerFactory.get().getLogger(configuration.getNamespace(), configuration);
+    return loggerFactory.getLogger(configuration.getNamespace(), configuration);
   }
 
   /**
@@ -109,6 +110,5 @@ public class SilverLoggerProvider {
     }
     return getLogger(namespace);
   }
-
 }
   

--- a/core-library/src/main/java/org/silverpeas/core/util/logging/sys/SysLogger.java
+++ b/core-library/src/main/java/org/silverpeas/core/util/logging/sys/SysLogger.java
@@ -23,9 +23,9 @@
  */
 package org.silverpeas.core.util.logging.sys;
 
+import org.silverpeas.core.util.ServiceProvider;
 import org.silverpeas.core.util.logging.Level;
 import org.silverpeas.core.util.logging.SilverLogger;
-import org.silverpeas.core.util.logging.SilverLoggerFactory;
 import org.silverpeas.core.util.logging.SilverLoggerProvider;
 
 import java.text.MessageFormat;
@@ -46,7 +46,7 @@ public class SysLogger implements SilverLogger {
                                         // with logging level and handlers
 
   private static SilverLogger getLoggerByNamespace(String namespace) {
-    return SilverLoggerFactory.get().getLogger(namespace);
+    return ServiceProvider.getService(SilverLoggerProvider.class).getLogger(namespace);
   }
 
   protected SysLogger(String namespace) {

--- a/core-library/src/test/java/org/silverpeas/core/util/logging/sys/SysLoggerTest.java
+++ b/core-library/src/test/java/org/silverpeas/core/util/logging/sys/SysLoggerTest.java
@@ -69,6 +69,15 @@ public class SysLoggerTest {
   }
 
   @Test
+  public void getADeepLogger() {
+    final String namespace = LOGGER_NAMESPACE + ".toto.titi.tutu.boo";
+    SilverLogger logger = new SysLogger(namespace);
+    assertThat(logger.getNamespace(), is(namespace));
+    assertThat(logger.getLevel(), notNullValue());
+    assertThat(logger.getLevel(), is(Level.INFO));
+  }
+
+  @Test
   public void changeLoggerLevel() {
     final String namespace = LOGGER_NAMESPACE;
     SilverLogger logger = new SysLogger(namespace);


### PR DESCRIPTION
The cache of the loggers is now replaced by a WeakHashMap that is more efficient in its management of the WeakReference that our own custom mechanism