### PR TITLE
Bug #9601 & #9612

### DIFF
--- a/lib-core/src/main/java/org/silverpeas/attachment/repository/DocumentConverter.java
+++ b/lib-core/src/main/java/org/silverpeas/attachment/repository/DocumentConverter.java
@@ -51,6 +51,7 @@ import java.util.Iterator;
 import java.util.List;
 
 import static com.silverpeas.jcrutil.JcrConstants.*;
+import static com.silverpeas.util.StringUtil.defaultStringIfNotDefined;
 import static javax.jcr.Property.JCR_FROZEN_PRIMARY_TYPE;
 import static javax.jcr.Property.JCR_LAST_MODIFIED_BY;
 import static javax.jcr.nodetype.NodeType.MIX_SIMPLE_VERSIONABLE;
@@ -341,11 +342,13 @@ class DocumentConverter extends AbstractJcrConverter {
     if (!StringUtil.isDefined(language)) {
       language = I18NHelper.defaultLanguage;
     }
-    String attachmentNodeName = SimpleDocument.FILE_PREFIX + language;
+    final String attachmentNodeName = SimpleDocument.FILE_PREFIX + language;
     if (documentNode.hasNode(attachmentNodeName)) {
-      Node attachmentNode = getAttachmentNode(attachmentNodeName, documentNode);
-      addStringProperty(attachmentNode, JCR_LAST_MODIFIED_BY, getStringProperty(documentNode,
-          SLV_PROPERTY_OWNER));
+      final Node attachmentNode = getAttachmentNode(attachmentNodeName, documentNode);
+      final String currentLastModifiedBy = getStringProperty(attachmentNode, JCR_LAST_MODIFIED_BY);
+      final String ownerId = getStringProperty(documentNode, SLV_PROPERTY_OWNER);
+      final String lastModifiedBy = defaultStringIfNotDefined(ownerId, currentLastModifiedBy);
+      addStringProperty(attachmentNode, JCR_LAST_MODIFIED_BY, lastModifiedBy);
     }
     addDateProperty(documentNode, SLV_PROPERTY_EXPIRY_DATE, null);
     addDateProperty(documentNode, SLV_PROPERTY_ALERT_DATE, null);

--- a/war-core/src/main/java/org/silverpeas/attachment/web/VersioningRequestRouter.java
+++ b/war-core/src/main/java/org/silverpeas/attachment/web/VersioningRequestRouter.java
@@ -34,6 +34,8 @@ import javax.servlet.http.HttpServletRequest;
 import java.rmi.RemoteException;
 import java.util.List;
 
+import static com.silverpeas.util.StringUtil.defaultStringIfNotDefined;
+
 public class VersioningRequestRouter extends ComponentRequestRouter<VersioningSessionController> {
 
   private static final long serialVersionUID = 4808952397898736028L;

--- a/war-core/src/main/java/org/silverpeas/attachment/web/VersioningSessionController.java
+++ b/war-core/src/main/java/org/silverpeas/attachment/web/VersioningSessionController.java
@@ -46,6 +46,8 @@ import java.rmi.RemoteException;
 import java.util.Collections;
 import java.util.List;
 
+import static com.silverpeas.util.StringUtil.defaultStringIfNotDefined;
+
 /**
  * @author Michael Nikolaenko
  * @version 1.0
@@ -148,7 +150,7 @@ public class VersioningSessionController extends AbstractComponentSessionControl
   }
 
   public void setContentLanguage(final String contentLanguage) {
-    this.contentLanguage = contentLanguage;
+    this.contentLanguage = defaultStringIfNotDefined(contentLanguage, this.contentLanguage);
   }
 
   /**

--- a/war-core/src/main/webapp/attachment/jsp/publicVersions.jsp
+++ b/war-core/src/main/webapp/attachment/jsp/publicVersions.jsp
@@ -93,7 +93,7 @@
   <view:includePlugin name="qtip"/>
 </head>
 <body>
-<view:window>
+<view:window popup="true">
   <view:browseBar extraInformations="${requestScope.Document.title}" clickable="false"/>
 
   <%
@@ -103,7 +103,7 @@
 
 // header of the array
     ArrayColumn arrayColumn_version = arrayPane.addArrayColumn(messages.getString("version"));
-    arrayColumn_version.setSortable(false);
+    arrayColumn_version.setSortable(true);
     ArrayColumn arrayColumn_mimeType =
         arrayPane.addArrayColumn(messages.getString("GML.attachments"));
     arrayColumn_mimeType.setSortable(false);
@@ -161,6 +161,9 @@
         sb.append("</a>");
       }
       sb.append(permalink).append(spinFire);
+      final String sortMajorPart = StringUtil.leftPad(String.valueOf(publicVersion.getMajorVersion()), 5, "0");
+      final String sortMinorPart = StringUtil.leftPad(String.valueOf(publicVersion.getMinorVersion()), 5, "0");
+      sb.insert(0, "<!--" + sortMajorPart + "." + sortMinorPart + "-->");
       arrayLine.addArrayCellText(sb.toString());
       sb.setLength(0);
       sb.append("<img src=\"")


### PR DESCRIPTION
- fixing the attachment version history display which was loosing the content language set on parent page
- adding possibility to sort on version column
- applying popup display behavior
- fixing a problem around the copy of attachments of a publication

Linked to PR: https://github.com/Silverpeas/Silverpeas-Components/pull/570