### PR TITLE
Bug #9601 & #9612:

### DIFF
--- a/core-library/src/integration-test/java/org/silverpeas/core/contribution/attachment/repository/HistorisedDocumentRepositoryIT.java
+++ b/core-library/src/integration-test/java/org/silverpeas/core/contribution/attachment/repository/HistorisedDocumentRepositoryIT.java
@@ -2099,7 +2099,6 @@ public class HistorisedDocumentRepositoryIT extends JcrIntegrationIT {
       document.setForeignId(targetForeignId);
       document.setPK(result);
       document.setNodeName(doc.getNodeName());
-      document.setUpdatedBy(null);
       assertThat(doc, SimpleDocumentAttributesMatcher.matches(document));
       checkEnglishSimpleDocument(doc);
       assertThat(doc.getMajorVersion(), is(0));
@@ -3239,7 +3238,6 @@ public class HistorisedDocumentRepositoryIT extends JcrIntegrationIT {
       assertThat(doc, SimpleDocumentMatcher.matches(document));
       doc = documentRepository.findDocumentByOldSilverpeasId(session, instanceId, oldSilverpeasId,
           true, language);
-      document.setUpdatedBy(null);
       assertThat(doc, is(notNullValue()));
       assertThat(doc.getOldSilverpeasId(), is(2048L));
       assertThat(doc.getCreated(), is(creationDate));

--- a/core-library/src/main/java/org/silverpeas/core/contribution/attachment/repository/DocumentConverter.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/attachment/repository/DocumentConverter.java
@@ -23,20 +23,20 @@
  */
 package org.silverpeas.core.contribution.attachment.repository;
 
-import org.silverpeas.core.util.CollectionUtil;
-import org.silverpeas.core.util.StringUtil;
-import org.silverpeas.core.i18n.I18NHelper;
-import org.silverpeas.core.admin.user.model.SilverpeasRole;
 import org.apache.jackrabbit.core.state.NoSuchItemStateException;
+import org.silverpeas.core.admin.user.model.SilverpeasRole;
 import org.silverpeas.core.contribution.attachment.model.DocumentType;
 import org.silverpeas.core.contribution.attachment.model.HistorisedDocument;
 import org.silverpeas.core.contribution.attachment.model.HistorisedDocumentVersion;
 import org.silverpeas.core.contribution.attachment.model.SimpleAttachment;
 import org.silverpeas.core.contribution.attachment.model.SimpleDocument;
 import org.silverpeas.core.contribution.attachment.model.SimpleDocumentPK;
-import org.silverpeas.core.contribution.attachment.util.SimpleDocumentList;
 import org.silverpeas.core.contribution.attachment.model.SimpleDocumentVersion;
+import org.silverpeas.core.contribution.attachment.util.SimpleDocumentList;
+import org.silverpeas.core.i18n.I18NHelper;
 import org.silverpeas.core.persistence.jcr.AbstractJcrConverter;
+import org.silverpeas.core.util.CollectionUtil;
+import org.silverpeas.core.util.StringUtil;
 
 import javax.jcr.Node;
 import javax.jcr.NodeIterator;
@@ -50,10 +50,11 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
-import static org.silverpeas.core.persistence.jcr.util.JcrConstants.*;
 import static javax.jcr.Property.JCR_FROZEN_PRIMARY_TYPE;
 import static javax.jcr.Property.JCR_LAST_MODIFIED_BY;
 import static javax.jcr.nodetype.NodeType.MIX_SIMPLE_VERSIONABLE;
+import static org.silverpeas.core.persistence.jcr.util.JcrConstants.*;
+import static org.silverpeas.core.util.StringUtil.defaultStringIfNotDefined;
 
 /**
  *
@@ -341,11 +342,13 @@ class DocumentConverter extends AbstractJcrConverter {
     if (!StringUtil.isDefined(language)) {
       language = I18NHelper.defaultLanguage;
     }
-    String attachmentNodeName = SimpleDocument.FILE_PREFIX + language;
+    final String attachmentNodeName = SimpleDocument.FILE_PREFIX + language;
     if (documentNode.hasNode(attachmentNodeName)) {
-      Node attachmentNode = getAttachmentNode(attachmentNodeName, documentNode);
-      addStringProperty(attachmentNode, JCR_LAST_MODIFIED_BY, getStringProperty(documentNode,
-          SLV_PROPERTY_OWNER));
+      final Node attachmentNode = getAttachmentNode(attachmentNodeName, documentNode);
+      final String currentLastModifiedBy = getStringProperty(attachmentNode, JCR_LAST_MODIFIED_BY);
+      final String ownerId = getStringProperty(documentNode, SLV_PROPERTY_OWNER);
+      final String lastModifiedBy = defaultStringIfNotDefined(ownerId, currentLastModifiedBy);
+      addStringProperty(attachmentNode, JCR_LAST_MODIFIED_BY, lastModifiedBy);
     }
     addDateProperty(documentNode, SLV_PROPERTY_EXPIRY_DATE, null);
     addDateProperty(documentNode, SLV_PROPERTY_ALERT_DATE, null);

--- a/core-war/src/main/java/org/silverpeas/web/attachment/VersioningSessionController.java
+++ b/core-war/src/main/java/org/silverpeas/web/attachment/VersioningSessionController.java
@@ -23,29 +23,31 @@
  */
 package org.silverpeas.web.attachment;
 
-import org.silverpeas.core.web.mvc.controller.AbstractComponentSessionController;
-import org.silverpeas.core.web.mvc.controller.ComponentContext;
-import org.silverpeas.core.web.mvc.controller.MainSessionController;
-import org.silverpeas.core.util.URLUtil;
-import org.silverpeas.core.admin.user.model.SilverpeasRole;
-import org.silverpeas.core.admin.service.AdminController;
-import org.silverpeas.core.admin.component.model.ComponentInst;
 import org.silverpeas.core.admin.ObjectType;
+import org.silverpeas.core.admin.component.model.ComponentInst;
+import org.silverpeas.core.admin.service.AdminController;
 import org.silverpeas.core.admin.user.model.ProfileInst;
+import org.silverpeas.core.admin.user.model.SilverpeasRole;
 import org.silverpeas.core.admin.user.model.UserDetail;
-import org.silverpeas.core.node.service.NodeService;
-import org.silverpeas.core.node.model.NodeDetail;
-import org.silverpeas.core.node.model.NodePK;
 import org.silverpeas.core.contribution.attachment.AttachmentServiceProvider;
 import org.silverpeas.core.contribution.attachment.model.HistorisedDocument;
 import org.silverpeas.core.contribution.attachment.model.SimpleDocument;
 import org.silverpeas.core.contribution.attachment.model.SimpleDocumentPK;
+import org.silverpeas.core.node.model.NodeDetail;
+import org.silverpeas.core.node.model.NodePK;
+import org.silverpeas.core.node.service.NodeService;
 import org.silverpeas.core.util.ServiceProvider;
 import org.silverpeas.core.util.StringUtil;
+import org.silverpeas.core.util.URLUtil;
+import org.silverpeas.core.web.mvc.controller.AbstractComponentSessionController;
+import org.silverpeas.core.web.mvc.controller.ComponentContext;
+import org.silverpeas.core.web.mvc.controller.MainSessionController;
 
 import java.rmi.RemoteException;
 import java.util.Collections;
 import java.util.List;
+
+import static org.silverpeas.core.util.StringUtil.defaultStringIfNotDefined;
 
 /**
  * @author Michael Nikolaenko
@@ -149,7 +151,7 @@ public class VersioningSessionController extends AbstractComponentSessionControl
   }
 
   public void setContentLanguage(final String contentLanguage) {
-    this.contentLanguage = contentLanguage;
+    this.contentLanguage = defaultStringIfNotDefined(contentLanguage, this.contentLanguage);
   }
 
   /**

--- a/core-war/src/main/webapp/attachment/jsp/publicVersions.jsp
+++ b/core-war/src/main/webapp/attachment/jsp/publicVersions.jsp
@@ -94,7 +94,7 @@
   <view:includePlugin name="qtip"/>
 </head>
 <body>
-<view:window>
+<view:window popup="true">
   <view:browseBar extraInformations="${requestScope.Document.title}" clickable="false"/>
 
   <%
@@ -104,7 +104,7 @@
 
 // header of the array
     ArrayColumn arrayColumn_version = arrayPane.addArrayColumn(messages.getString("version"));
-    arrayColumn_version.setSortable(false);
+    arrayColumn_version.setSortable(true);
     ArrayColumn arrayColumn_mimeType =
         arrayPane.addArrayColumn(messages.getString("GML.attachments"));
     arrayColumn_mimeType.setSortable(false);
@@ -162,6 +162,9 @@
         sb.append("</a>");
       }
       sb.append(permalink).append(spinFire);
+      final String sortMajorPart = StringUtil.leftPad(String.valueOf(publicVersion.getMajorVersion()), 5, "0");
+      final String sortMinorPart = StringUtil.leftPad(String.valueOf(publicVersion.getMinorVersion()), 5, "0");
+      sb.insert(0, "<!--" + sortMajorPart + "." + sortMinorPart + "-->");
       arrayLine.addArrayCellText(sb.toString());
       sb.setLength(0);
       sb.append("<img src=\"")


### PR DESCRIPTION
- fixing the attachment version history display which was loosing the content language set on parent page
- adding possibility to sort on version column
- applying popup display behavior
- fixing a problem around the copy of attachments of a publication

Linked to PR: https://github.com/Silverpeas/Silverpeas-Components/pull/572