### PR TITLE
Fix the bug 9650

### DIFF
--- a/core-api/src/main/java/org/silverpeas/core/util/ResourceLocator.java
+++ b/core-api/src/main/java/org/silverpeas/core/util/ResourceLocator.java
@@ -225,9 +225,9 @@ public class ResourceLocator {
   }
 
   private static void checkBundleName(String bundleName) {
-    if (!bundleName.startsWith("org.silverpeas.")) {
-      SilverLogger.getLogger(ResourceLocator.class)
-          .error("INVALID BUNDLE BASE NAME: " + bundleName);
+    if (!bundleName.startsWith("org.silverpeas.") &&
+        !bundleName.startsWith("com.silverpeas.customers")) {
+      SilverLogger.getLogger(ResourceLocator.class).warn("INVALID BUNDLE BASE NAME: " + bundleName);
     }
   }
 


### PR DESCRIPTION
Now the bundle base name in Silverpeas can be either "org.silverpeas" or "com.silverpeas.customers".
Increase the log level from ERROR to WARN when a bundle name doesn't start by
one of the above base name.