### PR TITLE
Bug #9674

### DIFF
--- a/core-api/src/main/java/org/silverpeas/core/contribution/content/renderer/AbstractContributionRenderer.java
+++ b/core-api/src/main/java/org/silverpeas/core/contribution/content/renderer/AbstractContributionRenderer.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2000 - 2018 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.contribution.content.renderer;
+
+import org.silverpeas.core.contribution.model.ContributionContent;
+
+/**
+ * All implementations MUST extend this abstraction in order to be provided automatically by
+ * {@link ContributionContentRendererProvider}.
+ * @author silveryocha
+ */
+public abstract class AbstractContributionRenderer<T extends ContributionContent>
+    implements ContributionContentRenderer {
+  private static final long serialVersionUID = -6884150454054720613L;
+
+  private T content;
+
+  @SuppressWarnings("unchecked")
+  void setContent(ContributionContent content) {
+    this.content = (T) content;
+  }
+
+  protected T getContent() {
+    return content;
+  }
+}

--- a/core-api/src/main/java/org/silverpeas/core/contribution/content/renderer/ContributionContentRenderer.java
+++ b/core-api/src/main/java/org/silverpeas/core/contribution/content/renderer/ContributionContentRenderer.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2000 - 2018 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.contribution.content.renderer;
+
+import org.silverpeas.core.contribution.model.ContributionContent;
+
+import java.io.Serializable;
+
+/**
+ * The renderer of a {@link ContributionContent}. Each implementation of
+ * {@link ContributionContent} MUST provide a renderer by the method
+ * {@link ContributionContent#getRenderer()}.
+ * <p>
+ * According to the context of content rendering, the content could be more or less transformed.
+ * </p>
+ * @author silveryocha
+ */
+public interface ContributionContentRenderer extends Serializable {
+
+  /**
+   * Rendering the HTML content in order to be displayed into a context of edition.
+   * @return HTML as {@link String}.
+   */
+  String renderView();
+
+  /**
+   * Rendering the HTML content in order to be displayed into a context of edition.
+   * @return HTML as {@link String}.
+   */
+  String renderEdition();
+}

--- a/core-api/src/main/java/org/silverpeas/core/contribution/content/renderer/ContributionContentRendererProvider.java
+++ b/core-api/src/main/java/org/silverpeas/core/contribution/content/renderer/ContributionContentRendererProvider.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2000 - 2018 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.contribution.content.renderer;
+
+import org.silverpeas.core.contribution.model.ContributionContent;
+import org.silverpeas.core.util.ServiceProvider;
+
+import javax.inject.Named;
+
+/**
+ * In charge of providing {@link ContributionContentRenderer} as implementations of renderer
+ * are existing at most of time into UI modules but not at the API level.
+ * @author silveryocha
+ */
+public interface ContributionContentRendererProvider {
+
+  /**
+   * Gets the instance of the implementation of the interface.
+   * @return an implementation of {@link ContributionContentRendererProvider}.
+   */
+  static ContributionContentRendererProvider get() {
+    return ServiceProvider.getService(ContributionContentRendererProvider.class);
+  }
+
+  /**
+   * Gets the {@link ContributionContentRenderer} instance according to given
+   * {@link ContributionContent}.
+   * <p>
+   * This method offers to provide an instance by observing following convention of
+   * renderer naming: <br/>
+   * <code>
+   * [simple class name of ContributionContent, with first letter turn into lower case]Renderer
+   * </code><br/>
+   * <code>wysiwygContentRenderer</code> for example, where
+   * <code>wysiwygContent</code> is computed from {@link ContributionContent} simple class name
+   * and 'Renderer' is the suffix.
+   * </p>
+   * <p>
+   * To be provided by this way, an implementation must use {@link Named}
+   * annotation and fill {@link Named#value()} in case where the implementation class name does not
+   * correspond to the above naming convention.
+   * </p>
+   * @param content the content to render.
+   * @return the {@link ContributionContentRenderer} instance.
+   */
+  AbstractContributionRenderer ofContent(ContributionContent content);
+}

--- a/core-api/src/main/java/org/silverpeas/core/contribution/model/ContributionContent.java
+++ b/core-api/src/main/java/org/silverpeas/core/contribution/model/ContributionContent.java
@@ -23,6 +23,9 @@
  */
 package org.silverpeas.core.contribution.model;
 
+import org.silverpeas.core.contribution.content.renderer.ContributionContentRenderer;
+import org.silverpeas.core.contribution.content.renderer.ContributionContentRendererProvider;
+
 import java.io.Serializable;
 
 /**
@@ -55,5 +58,13 @@ public interface ContributionContent<T> extends Serializable {
    */
   default boolean isEmpty() {
     return getData() != null;
+  }
+
+  /**
+   * Gets the renderer of the content.
+   * @return the {@link ContributionContentRenderer} instance.
+   */
+  default ContributionContentRenderer getRenderer() {
+    return ContributionContentRendererProvider.get().ofContent(this);
   }
 }

--- a/core-configuration/src/main/config/properties/org/silverpeas/lookSilverpeasV5/multilang/lookBundle.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/lookSilverpeasV5/multilang/lookBundle.properties
@@ -69,6 +69,6 @@ lookSilverpeasV5.homepage.space.events = Prochains \u00e9v\u00e9nements
 lookSilverpeasV5.homepage.space.publications = Derni\u00e8res publications
 
 lookSilverpeasV5.ticker.label = A la une
-lookSilverpeasV5.ticker.date.yesterday = hier \ufffd
+lookSilverpeasV5.ticker.date.yesterday = hier \u00e0
 lookSilverpeasV5.ticker.date.daysAgo = il y a {0} jours
 lookSilverpeasV5.ticker.notifications.permission.request = Autoriser les notifications sur mon bureau ?

--- a/core-configuration/src/main/config/properties/org/silverpeas/lookSilverpeasV5/multilang/lookBundle_fr.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/lookSilverpeasV5/multilang/lookBundle_fr.properties
@@ -68,6 +68,6 @@ lookSilverpeasV5.homepage.space.events = Prochains \u00e9v\u00e9nements
 lookSilverpeasV5.homepage.space.publications = Derni\u00e8res publications
 
 lookSilverpeasV5.ticker.label = A la une
-lookSilverpeasV5.ticker.date.yesterday = hier \ufffd
+lookSilverpeasV5.ticker.date.yesterday = hier \u00e0
 lookSilverpeasV5.ticker.date.daysAgo = il y a {0} jours
 lookSilverpeasV5.ticker.notifications.permission.request = Autoriser les notifications sur mon bureau ?

--- a/core-library/src/integration-test/java/org/silverpeas/core/contribution/publication/service/PublicationDAOIT.java
+++ b/core-library/src/integration-test/java/org/silverpeas/core/contribution/publication/service/PublicationDAOIT.java
@@ -117,7 +117,7 @@ public class PublicationDAOIT {
       assertEquals(detail.getAuthor(), result.getAuthor());
       assertEquals(detail.getBeginDate(), result.getBeginDate());
       assertEquals(detail.getBeginHour(), result.getBeginHour());
-      assertEquals(detail.getContent(), result.getContent());
+      assertEquals(detail.getContentPagePath(), result.getContentPagePath());
       assertEquals(detail.getCreationDate(), result.getCreationDate());
       assertEquals(detail.getUpdateDate(), result.getCreationDate());
       assertEquals(detail.getCreatorId(), result.getCreatorId());
@@ -146,7 +146,7 @@ public class PublicationDAOIT {
       assertEquals("Homer Simpson", result.getAuthor());
       assertEquals("2009/10/18", DateUtil.formatDate(result.getBeginDate()));
       assertEquals("00:00", result.getBeginHour());
-      assertEquals("Contenu de la publication 1", result.getContent());
+      assertEquals("Contenu de la publication 1", result.getContentPagePath());
       assertEquals("2008/11/18", DateUtil.formatDate(result.getCreationDate()));
       assertEquals("100", result.getCreatorId());
       assertEquals("Première publication de test", result.getDescription());
@@ -177,7 +177,7 @@ public class PublicationDAOIT {
       assertEquals("Homer Simpson", result.getAuthor());
       assertEquals("2009/10/18", DateUtil.formatDate(result.getBeginDate()));
       assertEquals("00:00", result.getBeginHour());
-      assertEquals("Contenu de la publication 1", result.getContent());
+      assertEquals("Contenu de la publication 1", result.getContentPagePath());
       assertEquals("2008/11/18", DateUtil.formatDate(result.getCreationDate()));
       assertEquals("100", result.getCreatorId());
       assertEquals("Première publication de test", result.getDescription());
@@ -210,7 +210,7 @@ public class PublicationDAOIT {
       assertEquals("Homer Simpson", result.getAuthor());
       assertEquals("2009/10/18", DateUtil.formatDate(result.getBeginDate()));
       assertEquals("00:00", result.getBeginHour());
-      assertEquals("Contenu de la publication 1", result.getContent());
+      assertEquals("Contenu de la publication 1", result.getContentPagePath());
       assertEquals("2008/11/18", DateUtil.formatDate(result.getCreationDate()));
       assertEquals("100", result.getCreatorId());
       assertEquals("Première publication de test", result.getDescription());
@@ -244,7 +244,7 @@ public class PublicationDAOIT {
       assertEquals("Homer Simpson", detail.getAuthor());
       assertEquals("2009/10/18", DateUtil.formatDate(detail.getBeginDate()));
       assertEquals("00:00", detail.getBeginHour());
-      assertEquals("Contenu de la publication 1", detail.getContent());
+      assertEquals("Contenu de la publication 1", detail.getContentPagePath());
       assertEquals("2008/11/18", DateUtil.formatDate(detail.getCreationDate()));
       assertEquals("100", detail.getCreatorId());
       assertEquals("Première publication de test", detail.getDescription());
@@ -265,7 +265,7 @@ public class PublicationDAOIT {
       assertEquals("Bart Simpson", detail.getAuthor());
       assertEquals("2009/10/18", DateUtil.formatDate(detail.getBeginDate()));
       assertEquals("01:10", detail.getBeginHour());
-      assertEquals("Contenu de la publication 2", detail.getContent());
+      assertEquals("Contenu de la publication 2", detail.getContentPagePath());
       assertEquals("2008/11/18", DateUtil.formatDate(detail.getCreationDate()));
       assertEquals("101", detail.getCreatorId());
       assertEquals("2ème publication de test", detail.getDescription());
@@ -303,7 +303,7 @@ public class PublicationDAOIT {
       assertEquals("Homer Simpson", detail.getAuthor());
       assertEquals("2009/10/18", DateUtil.formatDate(detail.getBeginDate()));
       assertEquals("00:00", detail.getBeginHour());
-      assertEquals("Contenu de la publication 1", detail.getContent());
+      assertEquals("Contenu de la publication 1", detail.getContentPagePath());
       assertEquals("2008/11/18", DateUtil.formatDate(detail.getCreationDate()));
       assertEquals("100", detail.getCreatorId());
       assertEquals("Première publication de test", detail.getDescription());
@@ -330,7 +330,7 @@ public class PublicationDAOIT {
       assertEquals("Homer Simpson", detail.getAuthor());
       assertEquals("2009/10/18", DateUtil.formatDate(detail.getBeginDate()));
       assertEquals("00:00", detail.getBeginHour());
-      assertEquals("Contenu de la publication 1", detail.getContent());
+      assertEquals("Contenu de la publication 1", detail.getContentPagePath());
       assertEquals("2008/11/18", DateUtil.formatDate(detail.getCreationDate()));
       assertEquals("100", detail.getCreatorId());
       assertEquals("Première publication de test", detail.getDescription());
@@ -429,7 +429,7 @@ public class PublicationDAOIT {
       assertEquals("Homer Simpson", result.getAuthor());
       assertEquals("2009/10/18", DateUtil.formatDate(result.getBeginDate()));
       assertEquals("00:00", result.getBeginHour());
-      assertEquals("Contenu de la publication 1", result.getContent());
+      assertEquals("Contenu de la publication 1", result.getContentPagePath());
       assertEquals("2008/11/18", DateUtil.formatDate(result.getCreationDate()));
       assertEquals("100", result.getCreatorId());
       assertEquals("Première publication de test", result.getDescription());
@@ -458,7 +458,7 @@ public class PublicationDAOIT {
       assertEquals("Homer Simpson", result.getAuthor());
       assertEquals("2009/10/18", DateUtil.formatDate(result.getBeginDate()));
       assertEquals("00:00", result.getBeginHour());
-      assertEquals("Contenu de la publication 1", result.getContent());
+      assertEquals("Contenu de la publication 1", result.getContentPagePath());
       assertEquals("2008/11/18", DateUtil.formatDate(result.getCreationDate()));
       assertEquals("100", result.getCreatorId());
       assertEquals("Première publication de test", result.getDescription());
@@ -487,7 +487,7 @@ public class PublicationDAOIT {
       assertEquals("Homer Simpson", detail.getAuthor());
       assertEquals("2009/10/18", DateUtil.formatDate(detail.getBeginDate()));
       assertEquals("00:00", detail.getBeginHour());
-      assertEquals("Contenu de la publication 1", detail.getContent());
+      assertEquals("Contenu de la publication 1", detail.getContentPagePath());
       assertEquals("2008/11/18", DateUtil.formatDate(detail.getCreationDate()));
       assertEquals("100", detail.getCreatorId());
       assertEquals("Première publication de test", detail.getDescription());
@@ -509,7 +509,7 @@ public class PublicationDAOIT {
       assertEquals("Homer Simpson", detail.getAuthor());
       assertEquals("2009/10/18", DateUtil.formatDate(detail.getBeginDate()));
       assertEquals("00:00", detail.getBeginHour());
-      assertEquals("Contenu de la publication 1", detail.getContent());
+      assertEquals("Contenu de la publication 1", detail.getContentPagePath());
       assertEquals("2008/11/18", DateUtil.formatDate(detail.getCreationDate()));
       assertEquals("100", detail.getCreatorId());
       assertEquals("Première publication de test", detail.getDescription());
@@ -538,7 +538,7 @@ public class PublicationDAOIT {
       assertEquals("Homer Simpson", detail.getAuthor());
       assertEquals("2009/10/18", DateUtil.formatDate(detail.getBeginDate()));
       assertEquals("00:00", detail.getBeginHour());
-      assertEquals("Contenu de la publication 1", detail.getContent());
+      assertEquals("Contenu de la publication 1", detail.getContentPagePath());
       assertEquals("2008/11/18", DateUtil.formatDate(detail.getCreationDate()));
       assertEquals("100", detail.getCreatorId());
       assertEquals("Première publication de test", detail.getDescription());
@@ -583,7 +583,7 @@ public class PublicationDAOIT {
       detail.setImportance(importance);
       detail.setVersion(version);
       detail.setKeywords(keywords);
-      detail.setContent(contenu);
+      detail.setContentPagePath(contenu);
       detail.setBeginHour(DateUtil.formatTime(beginDate));
       detail.setEndHour(DateUtil.formatTime(endDate));
       PublicationDAO.storeRow(con, detail);
@@ -595,7 +595,7 @@ public class PublicationDAOIT {
       assertEquals(detail.getAuthor(), result.getAuthor());
       assertEquals(detail.getBeginDate(), result.getBeginDate());
       assertEquals(detail.getBeginHour(), result.getBeginHour());
-      assertEquals(detail.getContent(), result.getContent());
+      assertEquals(detail.getContentPagePath(), result.getContentPagePath());
       assertEquals(detail.getCreationDate(), result.getCreationDate());
       assertEquals(detail.getUpdateDate(), result.getCreationDate());
       assertEquals(detail.getCreatorId(), result.getCreatorId());
@@ -626,7 +626,7 @@ public class PublicationDAOIT {
       assertEquals("Homer Simpson", result.getAuthor());
       assertEquals("2009/10/18", DateUtil.formatDate(result.getBeginDate()));
       assertEquals("00:00", result.getBeginHour());
-      assertEquals("Contenu de la publication 1", result.getContent());
+      assertEquals("Contenu de la publication 1", result.getContentPagePath());
       assertEquals("2008/11/18", DateUtil.formatDate(result.getCreationDate()));
       assertEquals("100", result.getCreatorId());
       assertEquals("Première publication de test", result.getDescription());
@@ -657,7 +657,7 @@ public class PublicationDAOIT {
       assertEquals("Homer Simpson", result.getAuthor());
       assertEquals("2009/10/18", DateUtil.formatDate(result.getBeginDate()));
       assertEquals("00:00", result.getBeginHour());
-      assertEquals("Contenu de la publication 1", result.getContent());
+      assertEquals("Contenu de la publication 1", result.getContentPagePath());
       assertEquals("2008/11/18", DateUtil.formatDate(result.getCreationDate()));
       assertEquals("100", result.getCreatorId());
       assertEquals("Première publication de test", result.getDescription());

--- a/core-library/src/integration-test/java/org/silverpeas/core/test/WarBuilder4LibCore.java
+++ b/core-library/src/integration-test/java/org/silverpeas/core/test/WarBuilder4LibCore.java
@@ -457,6 +457,7 @@ public class WarBuilder4LibCore extends WarBuilder<WarBuilder4LibCore> {
     if (!contains(WysiwygManager.class)) {
       addClasses(ContributionIdentifier.class, ContributionContent.class);
       addPackages(true, "org.silverpeas.core.contribution.content.wysiwyg");
+      addPackages(true, "org.silverpeas.core.contribution.content.renderer");
       addMavenDependencies("net.htmlparser.jericho:jericho-html");
     }
     return this;

--- a/core-library/src/main/java/org/silverpeas/core/contribution/content/renderer/DefaultContributionContentRendererProvider.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/content/renderer/DefaultContributionContentRendererProvider.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2000 - 2018 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.contribution.content.renderer;
+
+import org.silverpeas.core.contribution.model.ContributionContent;
+import org.silverpeas.core.util.ServiceProvider;
+
+import javax.inject.Singleton;
+
+/**
+ * Default implementation of {@link ContributionContentRendererProvider}.
+ * @author silveryocha
+ */
+@Singleton
+public class DefaultContributionContentRendererProvider
+    implements ContributionContentRendererProvider {
+
+  private static final String NAME_SUFFIX = "Renderer";
+
+  @Override
+  public AbstractContributionRenderer ofContent(final ContributionContent content) {
+    final String contentClassName = content.getClass().getSimpleName();
+    final AbstractContributionRenderer renderer = ServiceProvider.getService(
+        contentClassName.substring(0, 1).toLowerCase() + contentClassName.substring(1) +
+            NAME_SUFFIX);
+    renderer.setContent(content);
+    return renderer;
+  }
+}

--- a/core-library/src/main/java/org/silverpeas/core/contribution/content/wysiwyg/service/WysiwygContentRenderer.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/content/wysiwyg/service/WysiwygContentRenderer.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2000 - 2018 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.contribution.content.wysiwyg.service;
+
+import org.silverpeas.core.contribution.content.renderer.AbstractContributionRenderer;
+import org.silverpeas.core.contribution.content.renderer.ContributionContentRendererProvider;
+import org.silverpeas.core.contribution.model.ContributionContent;
+import org.silverpeas.core.contribution.model.WysiwygContent;
+
+import javax.inject.Named;
+
+/**
+ * This renderer is instantiated as explained into
+ * {@link ContributionContentRendererProvider#ofContent(ContributionContent)}
+ * documentation.
+ * @author silveryocha
+ */
+@Named
+public class WysiwygContentRenderer extends AbstractContributionRenderer<WysiwygContent> {
+  private static final long serialVersionUID = -5283748624108237499L;
+
+  @Override
+  public String renderView() {
+    return WysiwygContentTransformer
+        .on(getContent().getData())
+        .modifyImageUrlAccordingToHtmlSizeDirective()
+        .transform();
+  }
+
+  @Override
+  public String renderEdition() {
+    return getContent().getData();
+  }
+}

--- a/core-library/src/main/java/org/silverpeas/core/contribution/content/wysiwyg/service/WysiwygContentTransformer.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/content/wysiwyg/service/WysiwygContentTransformer.java
@@ -80,12 +80,11 @@ public class WysiwygContentTransformer {
   /**
    * Applies all the transformation directives and finally processing the given treatment.
    * @param process the process to execute after all the directives.
-   * @param <TYPED_RESULT> the result type of the process.
+   * @param <R> the result type of the process.
    * @return the result of the process execution.
-   * @throws Exception
+   * @throws Exception on technical error.
    */
-  public <TYPED_RESULT> TYPED_RESULT transform(
-      WysiwygContentTransformerProcess<TYPED_RESULT> process) throws Exception {
+  public <R> R transform(WysiwygContentTransformerProcess<R> process) throws Exception {
     return process.execute(transform());
   }
 

--- a/core-library/src/main/java/org/silverpeas/core/contribution/content/wysiwyg/service/WysiwygController.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/content/wysiwyg/service/WysiwygController.java
@@ -254,27 +254,38 @@ public class WysiwygController {
   }
 
   /**
-   * Loads wysiwyg content.
-   * @param contribution the localized contribution for which the WYSIWYG content has to be loaded.
-   * @return text the contents of the file attached.
+   * Gets representation of a wysiwyg content.
+   * @param contribution the localized contribution for which the WYSIWYG content has to be get.
+   * @return {@link WysiwygContent} instance.
    */
-  public static String load(final LocalizedContribution contribution) {
-    return getManager().getByContribution(contribution).getData();
+  public static WysiwygContent get(final LocalizedContribution contribution) {
+    return getManager().getByContribution(contribution);
   }
 
   /**
-   * Loads wysiwyg content.
+   * Gets representation of a wysiwyg content.
+   * @param componentId String : the id of component.
+   * @param objectId String : for example the id of the publication.
+   * @param language the language of the content.
+   * @return {@link WysiwygContent} instance.
+   */
+  public static WysiwygContent get(String componentId, String objectId, String language) {
+    return get(contributionFrom(componentId, objectId, language));
+  }
+
+  /**
+   * Loads wysiwyg content rendered for edition context.
    * @param componentId String : the id of component.
    * @param objectId String : for example the id of the publication.
    * @param language the language of the content.
    * @return text : the contents of the file attached.
    */
   public static String load(String componentId, String objectId, String language) {
-    return load(contributionFrom(componentId, objectId, language));
+    return get(componentId, objectId, language).getData();
   }
 
   /**
-   * Loads wysiwyg content that will only be read and never updated.<br>
+   * Loads wysiwyg content that will only be read and never be updated.<br>
    * Indeed, this method will call standard WYSIWYG transformations that are necessary only in
    * readOnly mode. The resizing of image attachments for example.
    * @param componentId String : the id of component.
@@ -283,9 +294,7 @@ public class WysiwygController {
    * @return text : the contents of the file attached.
    */
   public static String loadForReadOnly(String componentId, String objectId, String language) {
-    String wysiwygContent = load(componentId, objectId, language);
-    return WysiwygContentTransformer.on(wysiwygContent).modifyImageUrlAccordingToHtmlSizeDirective()
-        .transform();
+    return get(componentId, objectId, language).getRenderer().renderView();
   }
 
   /**

--- a/core-library/src/main/java/org/silverpeas/core/contribution/publication/dao/PublicationDAO.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/publication/dao/PublicationDAO.java
@@ -465,7 +465,7 @@ public class PublicationDAO {
       prepStmt.setInt(9, detail.getImportance());
       prepStmt.setString(10, detail.getVersion());
       prepStmt.setString(11, detail.getKeywords());
-      prepStmt.setString(12, detail.getContent());
+      prepStmt.setString(12, detail.getContentPagePath());
       prepStmt.setString(13, detail.getStatus());
       if (detail.isUpdateDateMustBeSet() && detail.getUpdateDate() != null) {
         prepStmt.setString(14, DateUtil.formatDate(detail.getUpdateDate()));
@@ -1774,7 +1774,7 @@ public class PublicationDAO {
       prepStmt.setInt(8, detail.getImportance());
       prepStmt.setString(9, detail.getVersion());
       prepStmt.setString(10, detail.getKeywords());
-      prepStmt.setString(11, detail.getContent());
+      prepStmt.setString(11, detail.getContentPagePath());
       prepStmt.setString(12, detail.getStatus());
       if (detail.getUpdateDate() == null) {
         prepStmt.setString(13, DateUtil.formatDate(detail.getCreationDate()));

--- a/core-library/src/main/java/org/silverpeas/core/contribution/publication/model/PublicationDetail.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/publication/model/PublicationDetail.java
@@ -42,9 +42,12 @@ import org.silverpeas.core.contribution.contentcontainer.content.ContentManager;
 import org.silverpeas.core.contribution.contentcontainer.content.ContentManagerException;
 import org.silverpeas.core.contribution.contentcontainer.content.ContentManagerProvider;
 import org.silverpeas.core.contribution.contentcontainer.content.SilverContentInterface;
+import org.silverpeas.core.contribution.model.ContributionContent;
 import org.silverpeas.core.contribution.model.ContributionIdentifier;
 import org.silverpeas.core.contribution.model.I18nContribution;
+import org.silverpeas.core.contribution.model.LocalizedContribution;
 import org.silverpeas.core.contribution.model.WithAttachment;
+import org.silverpeas.core.contribution.model.WysiwygContent;
 import org.silverpeas.core.contribution.publication.service.PublicationService;
 import org.silverpeas.core.contribution.rating.model.ContributionRating;
 import org.silverpeas.core.contribution.rating.model.ContributionRatingPK;
@@ -559,7 +562,7 @@ public class PublicationDetail extends AbstractI18NBean<PublicationI18N>
     this.creatorId = creatorId;
   }
 
-  public void setContent(String content) {
+  public void setContentPagePath(String content) {
     this.content = content;
   }
 
@@ -627,7 +630,7 @@ public class PublicationDetail extends AbstractI18NBean<PublicationI18N>
     return getKeywords();
   }
 
-  public String getContent() {
+  public String getContentPagePath() {
     return content;
   }
 
@@ -700,7 +703,7 @@ public class PublicationDetail extends AbstractI18NBean<PublicationI18N>
     result.append(" getImportance() = ").append(getImportance()).append("\n");
     result.append(" getVersion() = ").append(getVersion()).append("\n");
     result.append(" getKeywords() = ").append(getKeywords()).append("\n");
-    result.append(" getContent() = ").append(getContent()).append("\n");
+    result.append(" getContent() = ").append(getContentPagePath()).append("\n");
     result.append(" getStatus() = ").append(getStatus()).append("\n");
     result.append(" getUpdateDate() = ").append(getUpdateDate()).append("\n");
     result.append(" getUpdaterId() = ").append(getUpdaterId()).append("\n");
@@ -961,18 +964,16 @@ public class PublicationDetail extends AbstractI18NBean<PublicationI18N>
     }
   }
 
-  public String getWysiwyg() {
-    String wysiwygContent;
+  public ContributionContent getContent() {
     try {
-      wysiwygContent =
-          WysiwygController.load(getPK().getComponentName(), getPK().getId(), getLanguage());
+      return WysiwygController.get(getPK().getComponentName(), getPK().getId(), getLanguage());
     } catch (Exception e) {
-      wysiwygContent = "Erreur lors du chargement du wysiwyg !";
       SilverLogger.getLogger(this)
           .warn("can not load wysiwyg of publication {0} into {1} language", getId(), getLanguage(),
               e);
     }
-    return wysiwygContent;
+    return new WysiwygContent(LocalizedContribution.from(this, getLanguage()),
+        "Erreur lors du chargement du wysiwyg !");
   }
 
   public void setImportance(int importance) {
@@ -1086,7 +1087,7 @@ public class PublicationDetail extends AbstractI18NBean<PublicationI18N>
     clone.setAuthor(author);
     clone.setBeginDate(beginDate);
     clone.setBeginHour(beginHour);
-    clone.setContent(content);
+    clone.setContentPagePath(content);
     clone.setCreationDate(creationDate);
     clone.setCreatorId(creatorId);
     clone.setDescription(getDescription());

--- a/core-library/src/main/java/org/silverpeas/core/contribution/publication/model/PublicationSelection.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/publication/model/PublicationSelection.java
@@ -95,7 +95,7 @@ public class PublicationSelection extends ClipboardSelection implements Serializ
     keyData.setAuthor(m_pub.getCreatorId());
     keyData.setCreationDate(m_pub.getCreationDate());
     keyData.setDesc(m_pub.getDescription());
-    keyData.setText(m_pub.getContent());
+    keyData.setText(m_pub.getContentPagePath());
     try {
       keyData.setProperty("BEGINDATE", m_pub.getBeginDate().toString());
       keyData.setProperty("ENDDATE", m_pub.getEndDate().toString());

--- a/core-library/src/main/java/org/silverpeas/core/contribution/publication/service/DefaultPublicationService.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/publication/service/DefaultPublicationService.java
@@ -415,8 +415,8 @@ public class DefaultPublicationService implements PublicationService, ComponentI
       if (pubDetail.getKeywords() != null) {
         publi.setKeywords(pubDetail.getKeywords());
       }
-      if (pubDetail.getContent() != null) {
-        publi.setContent(pubDetail.getContent());
+      if (pubDetail.getContentPagePath() != null) {
+        publi.setContentPagePath(pubDetail.getContentPagePath());
       }
       if (pubDetail.getStatus() != null) {
         publi.setStatus(pubDetail.getStatus());

--- a/core-services/importExport/src/main/java/org/silverpeas/core/importexport/control/PublicationImportExport.java
+++ b/core-services/importExport/src/main/java/org/silverpeas/core/importexport/control/PublicationImportExport.java
@@ -143,7 +143,7 @@ public class PublicationImportExport {
       nomPub = settings.getPublicationForAllFiles().getName();
       description = settings.getPublicationForAllFiles().getDescription();
       motsClefs = settings.getPublicationForAllFiles().getKeywords();
-      content = settings.getPublicationForAllFiles().getContent();
+      content = settings.getPublicationForAllFiles().getContentPagePath();
     }
     PublicationDetail publication =
         new PublicationDetail("unknown", nomPub, description, creationDate, new Date(), null,

--- a/core-war/src/main/webapp/util/javaScript/angularjs/controllers/calendar/silverpeas-calendar.js
+++ b/core-war/src/main/webapp/util/javaScript/angularjs/controllers/calendar/silverpeas-calendar.js
@@ -109,10 +109,10 @@
             });
           };
 
-          $scope.loadOccurrenceFromContext = function(creationMode) {
+          $scope.loadOccurrenceFromContext = function(editionMode) {
             $scope.loadCalendarsFromContext().then(function(calendars) {
               $scope.calendars = $scope.getVisibleCalendars(calendars);
-              return $scope.reloadEventOccurrence(context.occurrenceUri, creationMode).then(
+              return $scope.reloadEventOccurrence(context.occurrenceUri, editionMode).then(
                   function(reloadedOccurrence) {
                     if (!reloadedOccurrence.uri && context.occurrenceStartDate) {
                       reloadedOccurrence.startDate = context.occurrenceStartDate;
@@ -137,9 +137,10 @@
             });
           };
 
-          $scope.reloadEventOccurrence = function(occurrenceUri, creationMode) {
+          $scope.reloadEventOccurrence = function(occurrenceUri, editionMode) {
             if (occurrenceUri) {
-              return CalendarService.getEventOccurrenceByUri(occurrenceUri)
+              // Case or existing event occurrence
+              return CalendarService.getEventOccurrenceByUri(occurrenceUri, editionMode)
                   .then(function(reloadedOccurrence) {
                     return CalendarService.getByUri(reloadedOccurrence.calendarUri).then(
                         function(calendar) {
@@ -147,16 +148,16 @@
                           return reloadedOccurrence;
                         })
                   });
-            } else {
-              if (creationMode) {
-                return sp.volatileIdentifier.newOn(context.component).then(function(volatileId) {
-                  var newOccurrence = SilverpeasCalendarTools.newEventOccurrenceEntity();
-                  newOccurrence.eventId = volatileId;
-                  return newOccurrence;
-                });
-              }
-              return sp.promise.resolveDirectlyWith(SilverpeasCalendarTools.newEventOccurrenceEntity());
+            } else if (editionMode) {
+              // Case of creation
+              return sp.volatileIdentifier.newOn(context.component).then(function(volatileId) {
+                var newOccurrence = SilverpeasCalendarTools.newEventOccurrenceEntity();
+                newOccurrence.eventId = volatileId;
+                return newOccurrence;
+              });
             }
+            // Default case
+            return sp.promise.resolveDirectlyWith(SilverpeasCalendarTools.newEventOccurrenceEntity());
           };
         }]);
 })();

--- a/core-war/src/main/webapp/util/javaScript/angularjs/directives/calendar/silverpeas-calendar-event-view-main.jsp
+++ b/core-war/src/main/webapp/util/javaScript/angularjs/directives/calendar/silverpeas-calendar-event-view-main.jsp
@@ -78,5 +78,5 @@
   <p ng-bind-html="$ctrl.ceo.description | noHTML | newlines"></p>
 </div>
 <div class="occurrence-content" ng-if="$ctrl.ceo.content">
-  <p ng-bind-html="$ctrl.ceo.content"></p>
+  <p ng-bind-html="$ctrl.ceo.content | trustedHTML"></p>
 </div>

--- a/core-war/src/main/webapp/util/javaScript/angularjs/directives/contribution/silverpeas-contribution-reminder.js
+++ b/core-war/src/main/webapp/util/javaScript/angularjs/directives/contribution/silverpeas-contribution-reminder.js
@@ -172,7 +172,6 @@
                   } else {
                     this.reminder = undefined;
                   }
-                  console.log(values)
                   $timeout(function() {
                     if (this.mode === 'DATETIME'
                         || this.reminder

--- a/core-war/src/main/webapp/util/javaScript/angularjs/services/calendar/silverpeas-calendar.js
+++ b/core-war/src/main/webapp/util/javaScript/angularjs/services/calendar/silverpeas-calendar.js
@@ -96,13 +96,15 @@
           /**
            * Gets the occurrence by its uri.
            * @param occurrenceUri uri of occurrence to get.
+           * @param editionMode true if context is edition, false otherwise.
            * @returns {promise|a.fn.promise|*} a promise with the asked occurrence as callbck
            *     parameter.
            */
-          this.getEventOccurrenceByUri = function(occurrenceUri) {
+          this.getEventOccurrenceByUri = function(occurrenceUri, editionMode) {
             var adapter = RESTAdapter.get(occurrenceUri, CalendarEventOccurrence);
             var criteria = {
-              zoneid : context.zoneId
+              zoneid : context.zoneId,
+              editionMode : editionMode ? true : false
             }
             return adapter.find({
               url : adapter.url,
@@ -328,11 +330,12 @@
         /**
          * Gets the occurrence by its uri.
          * @param occurrenceUri uri of occurrence to get.
+         * @param editionMode true if context is edition, false otherwise.
          * @returns {promise|a.fn.promise|*} a promise with the asked occurrence as callback
          *     parameter.
          */
-        this.getEventOccurrenceByUri = function(occurrenceUri) {
-          return CalendarEventOccurrence.getEventOccurrenceByUri(occurrenceUri);
+        this.getEventOccurrenceByUri = function(occurrenceUri, editionMode) {
+          return CalendarEventOccurrence.getEventOccurrenceByUri(occurrenceUri, editionMode);
         };
 
         /**

--- a/core-war/src/main/webapp/util/javaScript/angularjs/silverpeas-angular.js
+++ b/core-war/src/main/webapp/util/javaScript/angularjs/silverpeas-angular.js
@@ -122,7 +122,7 @@ __silverpeasAngularModule.filter('newlines', function () {
   return function(text) {
     return text ? text.convertNewLineAsHtml() : text;
   }
-})
+});
 
 /**
  * This filter permits to transform javascript newlines into html newlines.
@@ -131,7 +131,7 @@ __silverpeasAngularModule.filter('noHTML', function () {
   return function(text) {
     return text ? text.noHTML() : text;
   }
-})
+});
 
 /**
  * This filter permits to transform ISO String date into a readable date.
@@ -140,7 +140,7 @@ __silverpeasAngularModule.filter('displayAsDate', function () {
   return function(dateAsText) {
     return dateAsText ? sp.moment.displayAsDate(dateAsText) : dateAsText;
   }
-})
+});
 
 /**
  * This filter permits to transform ISO String date time into a readable time.
@@ -149,7 +149,7 @@ __silverpeasAngularModule.filter('displayAsTime', function () {
   return function(dateAsText) {
     return dateAsText ? sp.moment.displayAsTime(dateAsText) : dateAsText;
   }
-})
+});
 
 /**
  * This filter permits to transform ISO String date time into a readable one.
@@ -158,7 +158,16 @@ __silverpeasAngularModule.filter('displayAsDateTime', function () {
   return function(dateAsText) {
     return dateAsText ? sp.moment.displayAsDateTime(dateAsText) : dateAsText;
   }
-})
+});
+
+/**
+ * This filter permits to trust an HTML content.
+ */
+__silverpeasAngularModule.filter('trustedHTML', ['$sce', function($sce) {
+  return function(html) {
+    return $sce.trustAsHtml(html);
+  }
+}]);
 
 /**
  * Common directive to provide solution to update HTML DOM with partial HTML

--- a/core-web/src/main/java/org/silverpeas/core/web/calendar/AbstractCalendarWebController.java
+++ b/core-web/src/main/java/org/silverpeas/core/web/calendar/AbstractCalendarWebController.java
@@ -208,7 +208,7 @@ public abstract class AbstractCalendarWebController<C extends AbstractCalendarWe
     if (occurrence != null) {
       CalendarEventOccurrenceEntity entity =
           CalendarEventOccurrenceEntity.fromOccurrence(occurrence, context.getComponentInstanceId(),
-              getCalendarTimeWindowContext().getZoneId()).withOccurrenceURI(
+              getCalendarTimeWindowContext().getZoneId(), false).withOccurrenceURI(
               context.uri().ofOccurrence(occurrence));
       context.getRequest().setAttribute("occurrence", entity);
 

--- a/core-web/src/main/java/org/silverpeas/core/webapi/calendar/AbstractCalendarResource.java
+++ b/core-web/src/main/java/org/silverpeas/core/webapi/calendar/AbstractCalendarResource.java
@@ -43,6 +43,9 @@ public abstract class AbstractCalendarResource extends RESTWebService {
   @QueryParam("zoneid")
   private String zoneId;
 
+  @QueryParam("editionMode")
+  private Boolean editionMode;
+
   @Inject
   private CalendarResourceURIs uri;
 
@@ -66,5 +69,9 @@ public abstract class AbstractCalendarResource extends RESTWebService {
 
   public CalendarResourceURIs uri() {
     return uri;
+  }
+
+  boolean isEditionMode() {
+    return editionMode != null ? editionMode : false;
   }
 }

--- a/core-web/src/main/java/org/silverpeas/core/webapi/calendar/CalendarEventOccurrenceEntity.java
+++ b/core-web/src/main/java/org/silverpeas/core/webapi/calendar/CalendarEventOccurrenceEntity.java
@@ -71,8 +71,9 @@ public class CalendarEventOccurrenceEntity extends CalendarEventEntity {
 
   public static CalendarEventOccurrenceEntity fromOccurrence(
       final CalendarEventOccurrence occurrence, final String componentInstanceId,
-      final ZoneId zoneId) {
-    return new CalendarEventOccurrenceEntity().decorate(occurrence, componentInstanceId, zoneId);
+      final ZoneId zoneId, final boolean isEditionMode) {
+    return new CalendarEventOccurrenceEntity()
+        .decorate(occurrence, componentInstanceId, zoneId, isEditionMode);
   }
 
   public static String decodeId(String occurrenceId) {
@@ -254,9 +255,9 @@ public class CalendarEventOccurrenceEntity extends CalendarEventEntity {
 
   protected CalendarEventOccurrenceEntity decorate(
       final CalendarEventOccurrence calendarEventOccurrence, final String componentInstanceId,
-      final ZoneId zoneId) {
+      final ZoneId zoneId, final boolean isEditionMode) {
     final CalendarEvent calEvent = calendarEventOccurrence.getCalendarEvent();
-    decorate(calEvent, calEvent.getCalendar().getComponentInstanceId(), zoneId);
+    decorate(calEvent, calEvent.getCalendar().getComponentInstanceId(), zoneId, isEditionMode);
     this.occurrenceId = StringUtil.asBase64(calendarEventOccurrence.getId().getBytes());
     this.originalStartDate = calendarEventOccurrence.getOriginalStartDate().toString();
     setFirstEventOccurrence(calendarEventOccurrence.getOriginalStartDate()

--- a/core-web/src/main/java/org/silverpeas/core/webapi/calendar/CalendarResource.java
+++ b/core-web/src/main/java/org/silverpeas/core/webapi/calendar/CalendarResource.java
@@ -674,7 +674,8 @@ public class CalendarResource extends AbstractCalendarResource {
     SimpleCache cache = CacheServiceProvider.getRequestCacheService().getCache();
     CalendarEventEntity entity = cache.get(event.getId(), CalendarEventEntity.class);
     if (entity == null) {
-      entity = CalendarEventEntity.fromEvent(event, getComponentId(), getZoneId())
+      entity = CalendarEventEntity
+          .fromEvent(event, getComponentId(), getZoneId(), isEditionMode())
           .withEventURI(uri().ofEvent(event))
           .withCalendarURI(uri().ofCalendar(event.getCalendar()));
       cache.put(event.getId(), entity);
@@ -703,13 +704,14 @@ public class CalendarResource extends AbstractCalendarResource {
   public CalendarEventOccurrenceEntity asOccurrenceWebEntity(
       CalendarEventOccurrence occurrence) {
     assertEntityIsDefined(occurrence.getCalendarEvent().asCalendarComponent());
-    List<CalendarEventAttendeeEntity> attendeeEntities = occurrence.getAttendees().stream()
+    final List<CalendarEventAttendeeEntity> attendeeEntities = occurrence.getAttendees().stream()
         .map(attendee -> asAttendeeWebEntity(occurrence, attendee))
         .collect(Collectors.toList());
-    List<CalendarEventAttributeEntity> attributeEntities = occurrence.getAttributes().stream()
+    final List<CalendarEventAttributeEntity> attributeEntities = occurrence.getAttributes().stream()
             .map(this::asAttributeWebEntity)
             .collect(Collectors.toList());
-    return CalendarEventOccurrenceEntity.fromOccurrence(occurrence, getComponentId(), getZoneId())
+    return CalendarEventOccurrenceEntity
+        .fromOccurrence(occurrence, getComponentId(), getZoneId(), isEditionMode())
         .withCalendarURI(uri().ofCalendar(occurrence.getCalendarEvent().getCalendar()))
         .withEventURI(uri().ofEvent(occurrence.getCalendarEvent()))
         .withOccurrenceURI(uri().ofOccurrence(occurrence))


### PR DESCRIPTION
- extending the ContributionContent API in order to introduce ContributionContentRenderer concept which permits to handle easily and rightly the rendering of a contribution content (like WYSIWYG) according of the context of use (simple view, edition, etc.)
- renaming PublicationDetail methods in order to get a right semantic for recent adds
- fixing the display of a wysiwyg content from 'ng-bind-html' AngularJS directive by adding a centralized filter to trust a HTML content
- fixing wrong character encoding on look bundle properties

Linked to PR: https://github.com/Silverpeas/Silverpeas-Components/pull/579