### PR TITLE
Feature #5778: displaying an attachment document as a contribution content

### DIFF
--- a/core-configuration/src/main/config/properties/org/silverpeas/util/attachment/multilang/attachment.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/util/attachment/multilang/attachment.properties
@@ -105,6 +105,8 @@ attachment.dialog.errorAtLeastOneFileSize = Au moins un des fichiers du zip est 
 
 attachment.download.forbidReaders=Interdire le t\u00e9l\u00e9chargement aux lecteurs
 attachment.download.allowReaders=Autoriser le t\u00e9l\u00e9chargement aux lecteurs
+attachment.displayAsContent.disable=Ne pas afficher en tant que contenu
+attachment.displayAsContent.enable=Afficher en tant que contenu
 attachment.dialog.checkin.webdav.multilang.language.help=la langue dans laquelle le contenu \u00e9tait affich\u00e9 lors de la r\u00e9servation du document
 attachment.warning.translations=Ce document existe dans plusieurs langues...
 attachment.warning.translations.label=Attention \!

--- a/core-configuration/src/main/config/properties/org/silverpeas/util/attachment/multilang/attachment_de.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/util/attachment/multilang/attachment_de.properties
@@ -105,6 +105,8 @@ attachment.dialog.errorAtLeastOneFileSize = mindestens eine der Zip-Datei ist zu
 
 attachment.download.forbidReaders=Forbid downloading for readers
 attachment.download.allowReaders=Allow downloading for readers
+attachment.displayAsContent.disable=Not display as content
+attachment.displayAsContent.enable=Display as content
 attachment.dialog.checkin.webdav.multilang.language.help=the language in which the content was displayed on the document reservation
 attachment.warning.translations=Dieses Dokument ist in mehreren Sprachen verf\u00fcgbar...
 attachment.warning.translations.label=Achtung\!

--- a/core-configuration/src/main/config/properties/org/silverpeas/util/attachment/multilang/attachment_en.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/util/attachment/multilang/attachment_en.properties
@@ -105,6 +105,8 @@ attachment.dialog.errorAtLeastOneFileSize = At least one of the files in the zip
 
 attachment.download.forbidReaders=Forbid downloading for readers
 attachment.download.allowReaders=Allow downloading for readers
+attachment.displayAsContent.disable=Not display as content
+attachment.displayAsContent.enable=Display as content
 attachment.dialog.checkin.webdav.multilang.language.help=the language in which the content was displayed on the document reservation
 attachment.warning.translations=This document is available in several languages...
 attachment.warning.translations.label=Warning\!

--- a/core-configuration/src/main/config/properties/org/silverpeas/util/attachment/multilang/attachment_fr.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/util/attachment/multilang/attachment_fr.properties
@@ -106,6 +106,8 @@ attachment.dialog.errorAtLeastOneFileSize = Au moins un des fichiers du zip est 
 
 attachment.download.forbidReaders=Interdire le t\u00e9l\u00e9chargement aux lecteurs
 attachment.download.allowReaders=Autoriser le t\u00e9l\u00e9chargement aux lecteurs
+attachment.displayAsContent.disable=Ne pas afficher en tant que contenu
+attachment.displayAsContent.enable=Afficher en tant que contenu
 attachment.dialog.checkin.webdav.multilang.language.help=la langue dans laquelle le contenu \u00e9tait affich\u00e9 lors de la r\u00e9servation du document
 attachment.warning.translations.label=Attention \!
 attachment.dialog.onlineEditing.customProtocol.button.edit=J'ai install\u00e9 le programme

--- a/core-configuration/src/main/config/properties/org/silverpeas/util/logging/viewerLogging.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/util/logging/viewerLogging.properties
@@ -1,0 +1,36 @@
+#
+# Copyright (C) 2000 - 2018 Silverpeas
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# As a special exception to the terms and conditions of version 3.0 of
+# the GPL, you may redistribute this Program in connection with Free/Libre
+# Open Source Software ("FLOSS") applications as described in Silverpeas's
+# FLOSS exception.  You should have received a copy of the text describing
+# the FLOSS exception, and it is also available here:
+# "https://www.silverpeas.org/legal/floss_exception.html"
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+#
+# Logger definition.
+# Each logger is defined by its unique namespace and by a logging level.
+#
+# - namespace: identifies uniquely a logger and represents the hierarchical category to which
+#              messages are logged with the logger. Each substring before a dot is the namespace
+#              of a parent logger.
+# - level: defines the minimum level at which will be accepted the logged messages. If not
+#          set, the first defined parent logger's level will be then taken into account. Possible
+#          value is: ERROR, WARNING, INFO, DEBUG
+#
+namespace=silverpeas.core.viewer

--- a/core-configuration/src/main/config/properties/org/silverpeas/viewer/viewer.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/viewer/viewer.properties
@@ -43,3 +43,6 @@ viewer.cache.timeToLive.enabled = true
 
 # Enable the conversion strategy that consists to convert a file into as many files as there are pages.
 viewer.conversion.strategy.split.enabled = true
+
+# Enable the conversion strategy that consists to convert a file into as many files as there are pages.
+viewer.conversion.nb.max = 3

--- a/core-library/src/integration-test/java/org/silverpeas/core/contribution/attachment/mock/AttachmentServiceMockWrapper.java
+++ b/core-library/src/integration-test/java/org/silverpeas/core/contribution/attachment/mock/AttachmentServiceMockWrapper.java
@@ -312,4 +312,8 @@ public class AttachmentServiceMockWrapper implements AttachmentService {
     mock.switchAllowingDownloadForReaders(pk, allowing);
   }
 
+  @Override
+  public void switchEnableDisplayAsContent(final SimpleDocumentPK pk, final boolean enable) {
+    mock.switchEnableDisplayAsContent(pk, enable);
+  }
 }

--- a/core-library/src/integration-test/java/org/silverpeas/core/contribution/attachment/repository/DocumentRepositoryIT.java
+++ b/core-library/src/integration-test/java/org/silverpeas/core/contribution/attachment/repository/DocumentRepositoryIT.java
@@ -313,7 +313,33 @@ public class DocumentRepositoryIT extends JcrIntegrationIT {
       session.save();
       SimpleDocument doc = documentRepository.findDocumentById(session, result, "fr");
       assertThat(doc.getForbiddenDownloadForRoles(), contains(SilverpeasRole.reader));
+    }
+  }
 
+  /**
+   * Test of saveDisplayableAsContent method, of class DocumentRepository.
+   */
+  @Test
+  public void testSaveDisplayableAsContent() throws Exception {
+    try (JcrSession session = openSystemSession()) {
+      SimpleDocumentPK emptyId = new SimpleDocumentPK("-1", instanceId);
+      ByteArrayInputStream content = new ByteArrayInputStream("This is a test".getBytes(
+          Charsets.UTF_8));
+      SimpleAttachment attachment = createEnglishSimpleAttachment();
+      String foreignId = "node18";
+      SimpleDocument document = new SimpleDocument(emptyId, foreignId, 10, false, attachment);
+      SimpleDocumentPK result = documentRepository.createDocument(session, document);
+      documentRepository.storeContent(document, content);
+      SimpleDocumentPK expResult = new SimpleDocumentPK(result.getId(), instanceId);
+      assertThat(result, is(expResult));
+      assertThat(document.isDisplayableAsContent(), is(true));
+      attachment = createFrenchSimpleAttachment();
+      document = new SimpleDocument(emptyId, foreignId, 15, false, attachment);
+      document.setDisplayableAsContent(false);
+      documentRepository.saveDisplayableAsContent(session, document);
+      session.save();
+      SimpleDocument doc = documentRepository.findDocumentById(session, result, "fr");
+      assertThat(doc.isDisplayableAsContent(), is(false));
     }
   }
 

--- a/core-library/src/integration-test/java/org/silverpeas/core/contribution/attachment/repository/HistorisedDocumentRepositoryIT.java
+++ b/core-library/src/integration-test/java/org/silverpeas/core/contribution/attachment/repository/HistorisedDocumentRepositoryIT.java
@@ -3445,7 +3445,147 @@ public class HistorisedDocumentRepositoryIT extends JcrIntegrationIT {
       for (SimpleDocumentVersion version : doc.getHistory()) {
         assertThat(version.getForbiddenDownloadForRoles(), nullValue());
       }
+    }
+  }
 
+  /**
+   * Test of saveDisplayableAsContent method, of class DocumentRepository.
+   * Testing also history, functional history, repository path and version index.
+   */
+  @Test
+  public void testSaveDisplayableAsContent() throws Exception {
+    try (JcrSession session = openSystemSession()) {
+
+      /*
+      Context of this test
+       */
+
+      // Create a versioned work document
+      SimpleDocumentPK emptyId = new SimpleDocumentPK("-1", instanceId);
+      ByteArrayInputStream content =
+          new ByteArrayInputStream("This is a test".getBytes(Charsets.UTF_8));
+      SimpleAttachment attachment = createEnglishVersionnedAttachment();
+      String foreignId = "node78";
+      SimpleDocument document = new HistorisedDocument(emptyId, foreignId, 10, attachment);
+      document.setPublicDocument(false);
+      SimpleDocumentPK result = createVersionedDocument(session, document, content);
+      SimpleDocumentPK expResult = new SimpleDocumentPK(result.getId(), instanceId);
+      assertThat(result, is(expResult));
+      assertThat(document.isDisplayableAsContent(), is(true));
+      HistorisedDocument docCreated =
+          (HistorisedDocument) documentRepository.findDocumentById(session, result, "fr");
+      assertThat(docCreated, is(notNullValue()));
+      assertThat(docCreated.getOrder(), is(10));
+      assertThat(docCreated.getContentType(), is(MimeTypes.PDF_MIME_TYPE));
+      assertThat(docCreated.getSize(), is(14L));
+      assertThat(docCreated.getHistory(), is(notNullValue()));
+      assertThat(docCreated.getHistory(), hasSize(0));
+      assertThat(docCreated.getFunctionalHistory(), is(notNullValue()));
+      assertThat(docCreated.getFunctionalHistory(), hasSize(0));
+      assertThat(docCreated.getMajorVersion(), is(0));
+      assertThat(docCreated.getMinorVersion(), is(1));
+      assertThat(docCreated.getVersionIndex(), is(0));
+      assertThat(docCreated.getVersionIndex(), is(docCreated.getVersionMaster().getVersionIndex()));
+
+      // Verifying data are ok
+      String masterUuid = docCreated.getVersionMaster().getId();
+      String masterPath = docCreated.getVersionMaster().getRepositoryPath();
+      assertThat(masterUuid, is(docCreated.getId()));
+      assertThat(masterPath, is("/kmelia73/attachments/" + docCreated.getNodeName()));
+
+      // Update the versioned document to a public one
+      attachment = createFrenchVersionnedAttachment();
+      document = new HistorisedDocument(emptyId, foreignId, 15, attachment);
+      document.setPublicDocument(true);
+      documentRepository.lock(session, document, document.getEditedBy());
+      documentRepository.updateDocument(session, document, true);
+      session.save();
+      documentRepository.unlock(session, document, false);
+      HistorisedDocument doc =
+          (HistorisedDocument) documentRepository.findDocumentById(session, result, "fr");
+      assertThat(doc, is(notNullValue()));
+      assertThat(doc.getOrder(), is(15));
+      assertThat(doc.getContentType(), is(MimeTypes.MIME_TYPE_OO_PRESENTATION));
+      assertThat(doc.getSize(), is(28L));
+      assertThat(doc.getHistory(), is(notNullValue()));
+      assertThat(doc.getHistory(), hasSize(1));
+      assertThat(doc.getFunctionalHistory(), is(notNullValue()));
+      assertThat(doc.getFunctionalHistory(), hasSize(1));
+      assertThat(doc.getHistory().get(0).getOrder(), is(0));
+      assertThat(doc.getMajorVersion(), is(1));
+      assertThat(doc.getMinorVersion(), is(0));
+      assertThat(doc.getVersionIndex(), is(1));
+      assertThat(doc.getVersionIndex(), is(doc.getVersionMaster().getVersionIndex()));
+
+      // Update the versioned document to a working one
+      attachment = createFrenchVersionnedAttachment();
+      document = new HistorisedDocument(emptyId, foreignId, 15, attachment);
+      document.setPublicDocument(false);
+      documentRepository.lock(session, document, document.getEditedBy());
+      documentRepository.updateDocument(session, document, true);
+      session.save();
+      documentRepository.unlock(session, document, false);
+      doc = (HistorisedDocument) documentRepository.findDocumentById(session, result, "fr");
+      assertThat(doc, is(notNullValue()));
+      assertThat(doc.getOrder(), is(15));
+      assertThat(doc.getContentType(), is(MimeTypes.MIME_TYPE_OO_PRESENTATION));
+      assertThat(doc.getSize(), is(28L));
+      assertThat(doc.getHistory(), is(notNullValue()));
+      assertThat(doc.getHistory(), hasSize(2));
+      assertThat(doc.getFunctionalHistory(), is(notNullValue()));
+      assertThat(doc.getFunctionalHistory(), hasSize(2));
+      assertThat(doc.getHistory().get(0).getOrder(), is(0));
+      assertThat(doc.getMajorVersion(), is(1));
+      assertThat(doc.getMinorVersion(), is(1));
+      assertThat(doc.getVersionIndex(), is(2));
+      assertThat(doc.getVersionIndex(), is(doc.getVersionMaster().getVersionIndex()));
+
+      /*
+      Test starts here
+       */
+      document.setDisplayableAsContent(false);
+      documentRepository.saveDisplayableAsContent(session, document);
+
+      doc = (HistorisedDocument) documentRepository.findDocumentById(session, result, "fr");
+      assertThat(doc, is(notNullValue()));
+      assertThat(doc.getOrder(), is(15));
+      assertThat(doc.getContentType(), is(MimeTypes.MIME_TYPE_OO_PRESENTATION));
+      assertThat(doc.getSize(), is(28L));
+      assertThat(doc.getHistory(), is(notNullValue()));
+      assertThat(doc.getHistory(), hasSize(3));
+      assertThat(doc.getFunctionalHistory(), is(notNullValue()));
+      assertThat(doc.getFunctionalHistory(), hasSize(2));
+      assertThat(doc.getHistory().get(0).getOrder(), is(0));
+      assertThat(doc.getMajorVersion(), is(1));
+      assertThat(doc.getMinorVersion(), is(1));
+      assertThat(doc.getVersionIndex(), is(3));
+      assertThat(doc.getVersionIndex(), is(doc.getVersionMaster().getVersionIndex()));
+      assertThat(doc.isDisplayableAsContent(), is(false));
+      for (SimpleDocumentVersion version : doc.getHistory()) {
+        assertThat(version.isDisplayableAsContent(), is(false));
+      }
+
+      document.setDisplayableAsContent(true);
+      documentRepository.saveDisplayableAsContent(session, document);
+
+      doc = (HistorisedDocument) documentRepository.findDocumentById(session, result, "fr");
+      assertThat(doc, is(notNullValue()));
+      assertThat(doc.getOrder(), is(15));
+      assertThat(doc.getContentType(), is(MimeTypes.MIME_TYPE_OO_PRESENTATION));
+      assertThat(doc.getSize(), is(28L));
+      assertThat(doc.getHistory(), is(notNullValue()));
+      assertThat(doc.getHistory(), hasSize(4));
+      assertThat(doc.getFunctionalHistory(), is(notNullValue()));
+      assertThat(doc.getFunctionalHistory(), hasSize(2));
+      assertThat(doc.getHistory().get(0).getOrder(), is(0));
+      assertThat(doc.getMajorVersion(), is(1));
+      assertThat(doc.getMinorVersion(), is(1));
+      assertThat(doc.getVersionIndex(), is(4));
+      assertThat(doc.getVersionIndex(), is(doc.getVersionMaster().getVersionIndex()));
+      assertThat(doc.isDisplayableAsContent(), is(true));
+      for (SimpleDocumentVersion version : doc.getHistory()) {
+        assertThat(version.isDisplayableAsContent(), is(true));
+      }
     }
   }
 

--- a/core-library/src/main/java/org/silverpeas/core/contribution/attachment/AttachmentService.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/attachment/AttachmentService.java
@@ -488,4 +488,11 @@ public interface AttachmentService extends DocumentIndexing {
    * versioned attachments become simple attachments.
    */
   void switchAllowingDownloadForReaders(SimpleDocumentPK pk, boolean allowing);
+
+  /**
+   * Enables or not the display of the content of an attachment.
+   * @param pk the id of the document.
+   * @param enable enable the display if true
+   */
+  void switchEnableDisplayAsContent(SimpleDocumentPK pk, boolean enable);
 }

--- a/core-library/src/main/java/org/silverpeas/core/contribution/attachment/SimpleDocumentService.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/attachment/SimpleDocumentService.java
@@ -1042,6 +1042,23 @@ public class SimpleDocumentService
     }
   }
 
+  @Override
+  public void switchEnableDisplayAsContent(final SimpleDocumentPK pk, final boolean enable) {
+    SimpleDocument document = searchDocumentById(pk, null);
+    final boolean documentUpdateRequired = enable != document.isDisplayableAsContent();
+
+    // Updating JCR if required
+    if (documentUpdateRequired) {
+      document.setDisplayableAsContent(enable);
+      try (JcrSession session = openSystemSession()) {
+        repository.saveDisplayableAsContent(session, document);
+        session.save();
+      } catch (RepositoryException ex) {
+        throw new AttachmentException(this.getClass().getName(), SilverpeasException.ERROR, "", ex);
+      }
+    }
+  }
+
   /**
    * Check if notification must be really performed
    */

--- a/core-library/src/main/java/org/silverpeas/core/contribution/attachment/model/SimpleDocument.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/attachment/model/SimpleDocument.java
@@ -98,6 +98,7 @@ public class SimpleDocument implements Serializable {
   private DocumentType documentType = DocumentType.attachment;
   private Set<SilverpeasRole> forbiddenDownloadForRoles = null;
   private SimpleAttachment attachment;
+  private boolean displayableAsContent = true;
 
   public SimpleDocument(SimpleDocumentPK pk, String foreignId, int order, boolean versioned,
       SimpleAttachment attachment) {
@@ -176,6 +177,7 @@ public class SimpleDocument implements Serializable {
     this.documentType = simpleDocument.getDocumentType();
     this.forbiddenDownloadForRoles = simpleDocument.forbiddenDownloadForRoles;
     this.attachment = simpleDocument.getAttachment();
+    this.displayableAsContent = simpleDocument.displayableAsContent;
   }
 
   public void setDocumentType(DocumentType documentType) {
@@ -1000,5 +1002,17 @@ public class SimpleDocument implements Serializable {
    */
   public boolean isContentPdf() {
     return FileUtil.isPdf(getAttachmentPath());
+  }
+
+  /**
+   * Indicates if the attachment content can be displayed as a contribution content.
+   * @return true to display as content, false otherwise.
+   */
+  public boolean isDisplayableAsContent() {
+    return getVersionMaster().displayableAsContent;
+  }
+
+  public void setDisplayableAsContent(final boolean displayableAsContent) {
+    this.displayableAsContent = displayableAsContent;
   }
 }

--- a/core-library/src/main/java/org/silverpeas/core/contribution/attachment/repository/DocumentRepository.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/attachment/repository/DocumentRepository.java
@@ -349,6 +349,32 @@ public class DocumentRepository {
   }
 
   /**
+   * Save the optional slv:displayableAsContent simple document property (MIXIN).
+   * This saving works with versionable documents without changing the major and minor version.
+   * This property is transverse between all versions.
+   *
+   * @param session
+   * @param document
+   * @throws RepositoryException
+   */
+  public void saveDisplayableAsContent(Session session, SimpleDocument document)
+      throws RepositoryException {
+    Node documentNode = session.getNodeByIdentifier(document.getVersionMaster().getPk().getId());
+    boolean checkedin = !documentNode.isCheckedOut();
+    if (checkedin) {
+      session.getWorkspace().getVersionManager().checkout(documentNode.getPath());
+    }
+
+    // Optional viewable mixin
+    converter.setDisplayableAsContentOptionalNodeProperty(document, documentNode);
+
+    if (checkedin) {
+      session.save();
+      session.getWorkspace().getVersionManager().checkin(documentNode.getPath());
+    }
+  }
+
+  /**
    * Add the document's clone id to the document even if it is locked.
    *
    * @param session the JCR session.

--- a/core-library/src/main/java/org/silverpeas/core/persistence/jcr/AbstractJcrConverter.java
+++ b/core-library/src/main/java/org/silverpeas/core/persistence/jcr/AbstractJcrConverter.java
@@ -238,16 +238,18 @@ public abstract class AbstractJcrConverter {
    *
    * @param node the node whose property is required.
    * @param propertyName the name of the property required.
+   * @param defaultValueIfNull the default value of the value does not exist
    * @return the boolean value of the property - false if the property doesn't exist.
    * @throws RepositoryException on error
    * @throws ValueFormatException on error
    */
-  protected boolean getBooleanProperty(Node node, String propertyName) throws ValueFormatException,
-      RepositoryException {
+  protected boolean getBooleanProperty(Node node, String propertyName,
+      final boolean defaultValueIfNull) throws ValueFormatException,
+                                               RepositoryException {
     if (node.hasProperty(propertyName)) {
       return node.getProperty(propertyName).getBoolean();
     }
-    return false;
+    return defaultValueIfNull;
   }
 
   /**

--- a/core-library/src/main/java/org/silverpeas/core/persistence/jcr/util/JcrConstants.java
+++ b/core-library/src/main/java/org/silverpeas/core/persistence/jcr/util/JcrConstants.java
@@ -199,6 +199,11 @@ public interface JcrConstants extends Property {
   String SLV_DOWNLOADABLE_MIXIN = "slv:downloadable";
 
   /**
+   * Silverpeas Mixin to add viewable data to the node.
+   */
+  String SLV_VIEWABLE_MIXIN = "slv:viewable";
+
+  /**
    * Translation node 's name prefix. A translation's name should be TRANSLATION_NAME_PREFIX+ lang.
    */
   String TRANSLATION_NAME_PREFIX = "traduction_";
@@ -256,4 +261,5 @@ public interface JcrConstants extends Property {
   String SLV_PROPERTY_XMLFORM_ID = "slv:xmlFormId";
   String SLV_PROPERTY_COMMENT = "slv:comment";
   String SLV_PROPERTY_FORBIDDEN_DOWNLOAD_FOR_ROLES = "slv:forbiddenDownloadForRoles";
+  String SLV_PROPERTY_DISPLAYABLE_AS_CONTENT = "slv:displayableAsContent";
 }

--- a/core-library/src/main/resources/silverpeas-jcr.cnd
+++ b/core-library/src/main/resources/silverpeas-jcr.cnd
@@ -19,6 +19,11 @@
   mixin
   - slv:forbiddenDownloadForRoles (STRING) IGNORE
 
+/* Mixin viewable */
+[slv:viewable]
+  mixin
+  - slv:displayableAsContent (BOOLEAN) IGNORE
+
 [slv:simpleDocument] >  nt:folder, mix:referenceable, slv:ownable, slv:commentable
   - slv:foreignKey (STRING)
   - slv:instanceId (STRING) MANDATORY

--- a/core-services/viewer/src/main/java/org/silverpeas/core/viewer/model/ViewerSettings.java
+++ b/core-services/viewer/src/main/java/org/silverpeas/core/viewer/model/ViewerSettings.java
@@ -113,4 +113,12 @@ public class ViewerSettings {
         TemporaryDataManagementSetting.getTimeAfterThatFilesMustBeDeleted() >= 0 &&
         settings.getBoolean("viewer.cache.timeToLive.enabled", true);
   }
+
+  /**
+   * Maximum number of conversions at a same instant.
+   * @return a primitive integer.
+   */
+  public static int nbMaxConversionsAtSameInstant() {
+    return settings.getInteger("viewer.conversion.nb.max", 3);
+  }
 }

--- a/core-services/viewer/src/main/java/org/silverpeas/core/viewer/service/DefaultPreviewService.java
+++ b/core-services/viewer/src/main/java/org/silverpeas/core/viewer/service/DefaultPreviewService.java
@@ -139,7 +139,7 @@ public class DefaultPreviewService extends AbstractViewerService implements Prev
           ManagedThreadPool.getPool().invoke(() -> {
             ViewService.get().getDocumentView(viewerContext.clone());
           });
-        return super.performAfterSuccess(result);
+        return ViewerTreatment.super.performAfterSuccess(result);
       }
     }).execute(viewerContext);
   }

--- a/core-services/viewer/src/main/java/org/silverpeas/core/viewer/service/DefaultViewService.java
+++ b/core-services/viewer/src/main/java/org/silverpeas/core/viewer/service/DefaultViewService.java
@@ -126,7 +126,7 @@ public class DefaultViewService extends AbstractViewerService implements ViewSer
             PreviewService.get().getPreview(viewerContext.clone());
           });
         }
-        return super.performAfterSuccess(result);
+        return ViewerTreatment.super.performAfterSuccess(result);
       }
     }).execute(viewerContext);
   }

--- a/core-test/src/main/resources/silverpeas-jcr.txt
+++ b/core-test/src/main/resources/silverpeas-jcr.txt
@@ -19,6 +19,11 @@
   mixin
   - slv:forbiddenDownloadForRoles (STRING) IGNORE
 
+/* Mixin viewable */
+[slv:viewable]
+  mixin
+  - slv:displayableAsContent (BOOLEAN) IGNORE
+
 [slv:simpleDocument] >  nt:folder, mix:referenceable, slv:ownable, slv:commentable
   - slv:foreignKey (STRING)
   - slv:instanceId (STRING) MANDATORY

--- a/core-war/src/main/webapp/WEB-INF/tags/silverpeas/util/viewAttachmentsAsContent.tag
+++ b/core-war/src/main/webapp/WEB-INF/tags/silverpeas/util/viewAttachmentsAsContent.tag
@@ -1,0 +1,66 @@
+<%--
+  ~ Copyright (C) 2000 - 2018 Silverpeas
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as
+  ~ published by the Free Software Foundation, either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ As a special exception to the terms and conditions of version 3.0 of
+  ~ the GPL, you may redistribute this Program in connection with Free/Libre
+  ~ Open Source Software ("FLOSS") applications as described in Silverpeas's
+  ~ FLOSS exception.  You should have received a copy of the text describing
+  ~ the FLOSS exception, and it is also available here:
+  ~ "https://www.silverpeas.org/legal/floss_exception.html"
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  --%>
+
+<%@ tag language="java" pageEncoding="UTF-8" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn" %>
+<%@ taglib uri="http://www.silverpeas.com/tld/silverFunctions" prefix="silfn" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
+<%@ taglib uri="http://www.silverpeas.com/tld/viewGenerator" prefix="view" %>
+
+<c:set var="userLanguage" value="${sessionScope['SilverSessionController'].favoriteLanguage}"/>
+<fmt:setLocale value="${userLanguage}"/>
+<view:setBundle basename="org.silverpeas.multilang.generalMultilang"/>
+
+<%@ attribute name="componentInstanceId" required="true"
+              type="java.lang.String"
+              description="The component instance id associated to the drag and drop" %>
+<%@ attribute name="resourceId" required="true"
+              type="java.lang.String"
+              description="The identifier of the resource the uploaded document must be attached to" %>
+<%@ attribute name="resourceType" required="true"
+              type="java.lang.String"
+              description="The type of the resource the uploaded document must be attached to" %>
+<%@ attribute name="documentType" required="false"
+              type="java.lang.String"
+              description="The type of the document attachment" %>
+<%@ attribute name="contentLanguage" required="false"
+              type="java.lang.String"
+              description="The content language to retrieve as a first priority" %>
+
+<c:set var="domIdSuffix" value="${fn:replace(fn:replace(resourceId, '=', '_'), '-', '_')}"/>
+
+<div class="attachments-as-content" id="attachments-as-content-${domIdSuffix}"></div>
+<view:includePlugin name="preview" />
+<script type="text/JavaScript">
+  (function() {
+    new AttachmentAsContentViewer({
+      domSelector : '#attachments-as-content-${domIdSuffix}',
+      componentInstanceId : '${componentInstanceId}',
+      resourceId : '${resourceId}',
+      resourceType : '${resourceType}',
+      documentType : ${not empty documentType ? '\''.concat(documentType).concat('\''): 'undefined'}
+    });
+  })();
+</script>

--- a/core-war/src/main/webapp/attachment/jsp/displayAttachedFiles.jsp
+++ b/core-war/src/main/webapp/attachment/jsp/displayAttachedFiles.jsp
@@ -656,6 +656,21 @@
       });
     }
 
+    function switchDisplayAsContentEnabled(attachmentId, enabled) {
+      $.progressMessage();
+      $.ajax({
+        url : '<c:url value="/services/documents/${sessionScope.Silverpeas_Attachment_ComponentId}/document/"/>' +
+            attachmentId + '/switchDisplayAsContentEnabled',
+        type : "POST",
+        cache : false,
+        dataType : "json",
+        data : {"enabled" : (enabled) ? enabled : false},
+        success : function(data) {
+          reloadIncludingPage();
+        }
+      });
+    }
+
     <c:if test="${useXMLForm}">
       function EditXmlForm(id, lang) {
         var url = '<c:url value="/RformTemplate/jsp/Edit"><c:param name="IndexIt" value="${indexIt}" /><c:param name="ComponentId" value="${param.ComponentId}" /><c:param name="type" value="Attachment" /><c:param name="ObjectType" value="Attachment" /><c:param name="XMLFormName" value="${xmlForm}" /></c:url>&ReloadOpener=true&ObjectLanguage=' + lang + '&ObjectId=' + id;

--- a/core-war/src/main/webapp/attachment/jsp/editAttachedFiles.jsp
+++ b/core-war/src/main/webapp/attachment/jsp/editAttachedFiles.jsp
@@ -189,6 +189,21 @@
     });
   }
 
+  function switchDisplayAsContentEnabled(attachmentId, enabled) {
+    $.progressMessage();
+    $.ajax({
+      url : '<c:url value="/services/documents/${sessionScope.Silverpeas_Attachment_ComponentId}/document/"/>' +
+          attachmentId + '/switchDisplayAsContentEnabled',
+      type : "POST",
+      cache : false,
+      dataType : "json",
+      data : {"enabled" : (enabled) ? enabled : false},
+      success : function(data) {
+        reloadPage();
+      }
+    });
+  }
+
   function loadAttachment(id, lang) {
     translationsUrl = '<c:url value="/services/documents/${sessionScope.Silverpeas_Attachment_ComponentId}/document/"/>' + id + '/translations';
     $.ajax({

--- a/core-war/src/main/webapp/util/javaScript/silverpeas-embed-player.js
+++ b/core-war/src/main/webapp/util/javaScript/silverpeas-embed-player.js
@@ -92,8 +92,6 @@
    */
   function __configurePlayerContainer($container, config) {
     $container.empty();
-    $container.css('width', config.width);
-    $container.css('height', config.height);
     var $embed = $('<iframe>');
     $embed.attr('class', 'embed');
     $embed.attr('frameborder', '0');

--- a/core-war/src/main/webapp/util/styleSheets/silverpeas-main.css
+++ b/core-war/src/main/webapp/util/styleSheets/silverpeas-main.css
@@ -6574,6 +6574,26 @@ THESE TWO NEXT CLASSES ARE USED BY RESIZE WINDOW MECHANISM
   height: auto;
 }
 
+.attachments-as-content .attachment-container {
+  margin-bottom: 2em;
+}
+
+.attachments-as-content .content {
+  text-align: center;
+}
+
+.attachments-as-content .simple-text .content {
+  text-align: inherit;
+  white-space: pre-wrap;
+  padding: 10px;
+  margin: 0 20px 0 20px;
+  border: 2px solid #717171;
+}
+
+.attachments-as-content .content img {
+  max-width: 100%;
+}
+
 /**
  * JSP fragments : confirmation of wysiwyg backup manager
  */

--- a/core-web/src/main/java/org/silverpeas/core/web/attachment/tag/SimpleDocumentContextualMenu.java
+++ b/core-web/src/main/java/org/silverpeas/core/web/attachment/tag/SimpleDocumentContextualMenu.java
@@ -168,6 +168,13 @@ public class SimpleDocumentContextualMenu extends TagSupport {
     }
     prepareMenuItem(builder, "switchDownloadAllowedForReaders('" + attachment.getId() + "', " +
         !isDownloadAllowedForReaders + ");", message);
+    message = resources.getString("attachment.displayAsContent.enable");
+    boolean isDisplayAsContentEnabled = attachment.isDisplayableAsContent();
+    if (isDisplayAsContentEnabled) {
+      message = resources.getString("attachment.displayAsContent.disable");
+    }
+    prepareMenuItem(builder, "switchDisplayAsContentEnabled('" + attachment.getId() + "', " +
+        !isDisplayAsContentEnabled + ");", message);
     builder.append("</ul>").append(newline);
     builder.append("<ul>").append(newline);
     prepareMenuItem(builder, "ShareAttachment('" + attachmentId + "');", resources.getString(

--- a/core-web/src/main/java/org/silverpeas/core/web/util/viewgenerator/html/IncludeJSPluginTag.java
+++ b/core-web/src/main/java/org/silverpeas/core/web/util/viewgenerator/html/IncludeJSPluginTag.java
@@ -73,7 +73,7 @@ public class IncludeJSPluginTag extends SimpleTagSupport {
   }
 
   protected LookHelper getLookHelper() {
-    return (LookHelper) getSessionAttribute(LookHelper.SESSION_ATT);
+    return getSessionAttribute(LookHelper.SESSION_ATT);
   }
 
   protected String getLanguage() {

--- a/core-web/src/main/java/org/silverpeas/core/webapi/attachment/SimpleDocumentEntity.java
+++ b/core-web/src/main/java/org/silverpeas/core/webapi/attachment/SimpleDocumentEntity.java
@@ -77,6 +77,12 @@ public class SimpleDocumentEntity implements WebEntity {
   private String comment;
   @XmlElement(defaultValue = "false")
   private String versioned;
+  @XmlElement
+  private Boolean prewiewable;
+  @XmlElement
+  private Boolean viewable;
+  @XmlElement
+  private Boolean displayAsContent;
 
   public static SimpleDocumentEntity fromAttachment(SimpleDocument document) {
     SimpleDocumentEntity entity = new SimpleDocumentEntity();
@@ -192,4 +198,30 @@ public class SimpleDocumentEntity implements WebEntity {
     return versioned;
   }
 
+  public Boolean getPrewiewable() {
+    return prewiewable;
+  }
+
+  public SimpleDocumentEntity prewiewable(final boolean prewiewable) {
+    this.prewiewable = prewiewable;
+    return this;
+  }
+
+  public Boolean getViewable() {
+    return viewable;
+  }
+
+  public SimpleDocumentEntity viewable(final boolean viewable) {
+    this.viewable = viewable;
+    return this;
+  }
+
+  public Boolean getDisplayAsContent() {
+    return displayAsContent;
+  }
+
+  public SimpleDocumentEntity displayAsContent(final boolean displayAsContent) {
+    this.displayAsContent = displayAsContent;
+    return this;
+  }
 }

--- a/core-web/src/main/java/org/silverpeas/core/webapi/attachment/SimpleDocumentListResource.java
+++ b/core-web/src/main/java/org/silverpeas/core/webapi/attachment/SimpleDocumentListResource.java
@@ -29,13 +29,17 @@ import org.silverpeas.core.annotation.Service;
 import org.silverpeas.core.contribution.attachment.AttachmentServiceProvider;
 import org.silverpeas.core.contribution.attachment.model.DocumentType;
 import org.silverpeas.core.contribution.attachment.model.SimpleDocument;
+import org.silverpeas.core.viewer.service.PreviewService;
+import org.silverpeas.core.viewer.service.ViewService;
 import org.silverpeas.core.webapi.base.annotation.Authorized;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -48,6 +52,9 @@ public class SimpleDocumentListResource extends AbstractSimpleDocumentResource {
 
   @PathParam("id")
   private String resourceId;
+
+  @QueryParam("viewIndicators")
+  private boolean viewIndicators = false;
 
   public String getResourceId() {
     return resourceId;
@@ -96,9 +103,15 @@ public class SimpleDocumentListResource extends AbstractSimpleDocumentResource {
 
   private List<SimpleDocumentEntity> asWebEntities(List<SimpleDocument> docs) {
     List<SimpleDocumentEntity> entities = new ArrayList<>();
-    for (SimpleDocument doc : docs) {
-      entities.add(SimpleDocumentEntity.fromAttachment(doc));
-    }
+    docs.forEach(d -> {
+      final SimpleDocumentEntity entity = SimpleDocumentEntity.fromAttachment(d);
+      entities.add(entity);
+      if (viewIndicators) {
+        entity.prewiewable(PreviewService.get().isPreviewable(new File(d.getAttachmentPath())))
+              .viewable(ViewService.get().isViewable(new File(d.getAttachmentPath())))
+              .displayAsContent(d.isDisplayableAsContent());
+      }
+    });
     return entities;
   }
 

--- a/core-web/src/main/java/org/silverpeas/core/webapi/attachment/SimpleDocumentResource.java
+++ b/core-web/src/main/java/org/silverpeas/core/webapi/attachment/SimpleDocumentResource.java
@@ -502,6 +502,26 @@ public class SimpleDocumentResource extends AbstractSimpleDocumentResource {
   }
 
   /**
+   * Enable or not the display as content of an attachment.
+   * @return JSON display as content state. displayableAsContent = true or false.
+   */
+  @POST
+  @Path("switchDisplayAsContentEnabled")
+  @Produces(MediaType.APPLICATION_JSON)
+  public String switchDisplayAsContentEnabled(@FormParam("enabled") final boolean enabled) {
+
+    // Performing the request
+    SimpleDocument document = getSimpleDocument(null);
+    AttachmentServiceProvider.getAttachmentService()
+        .switchEnableDisplayAsContent(document.getPk(), enabled);
+
+    // JSON Response.
+    return MessageFormat.format(
+        "'{'\"displayableAsContent\":{0}, \"id\":{1,number,#}, \"attachmentId\":\"{2}\"}",
+        enabled, document.getOldSilverpeasId(), document.getId());
+  }
+
+  /**
    * Return the current document
    * @param lang
    * @return SimpleDocument


### PR DESCRIPTION
- adding new viewable JCR mixin with property displayableAsContent for a SimpleDocument
- implementing a Vanilla Javascript Plugin in order to view directly the attachment contents linked to a contribution
- modifying document list resource in order to get optionally the indicators about the viewing capacities
- improving viewer services in order to handle more precisely performances