### PR TITLE
Feature #5778: displaying attachment documents as contribution content.

### DIFF
--- a/core-api/src/main/java/org/silverpeas/core/util/Charsets.java
+++ b/core-api/src/main/java/org/silverpeas/core/util/Charsets.java
@@ -23,9 +23,8 @@
  */
 package org.silverpeas.core.util;
 
-import org.apache.commons.lang3.CharEncoding;
-
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.charset.UnsupportedCharsetException;
 
 /**
@@ -37,40 +36,40 @@ public class Charsets {
   /**
    * US-ASCII: seven-bit ASCII.
    */
-  public static final Charset US_ASCII = Charset.forName(CharEncoding.US_ASCII);
+  public static final Charset US_ASCII = StandardCharsets.US_ASCII;
   /**
    * ISO-8859-1 : ISO-LATIN-1.
    */
-  public static final Charset ISO_8859_1 = Charset.forName(CharEncoding.ISO_8859_1);
+  public static final Charset ISO_8859_1 = StandardCharsets.ISO_8859_1;
   /**
    * UTF-8.
    */
-  public static final Charset UTF_8 = Charset.forName(CharEncoding.UTF_8);
+  public static final Charset UTF_8 = StandardCharsets.UTF_8;
+
   /**
    * UTF-16BE: UTF-16 big-endian byte order.
    */
-  public static final Charset UTF_16BE = Charset.forName(CharEncoding.UTF_16BE);
+  public static final Charset UTF_16BE = StandardCharsets.UTF_16BE;
   /**
    * UTF-16LE: UTF-16 little-endian byte order.
    */
-  public static final Charset UTF_16LE = Charset.forName(CharEncoding.UTF_16LE);
+  public static final Charset UTF_16LE = StandardCharsets.UTF_16LE;
   /**
    * UTF-16: UTF-16 byte order identified by an optional byte-order mark.
    */
-  public static final Charset UTF_16 = Charset.forName(CharEncoding.UTF_16);
+  public static final Charset UTF_16 = StandardCharsets.UTF_16;
 
   private Charsets() {
   }
 
-
   /**
    * Returns a Charset for the named charset. If the name is null, return the default Charset.
-   *
+   * The {@link UnsupportedCharsetException} runtime exception is thrown if the specified charset
+   * doesn't exist or is not supported by Java.
    * @param charset The name of the requested charset, may be null.
    * @return a Charset for the named charset
-   * @throws java.nio.charset.UnsupportedCharsetException If the named charset is unavailable
    */
-  public static Charset toCharset(String charset) throws UnsupportedCharsetException {
+  public static Charset toCharset(String charset) {
     if (charset != null) {
       return Charset.forName(charset);
     }

--- a/core-configuration/src/main/config/properties/org/silverpeas/util/attachment/Attachment.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/util/attachment/Attachment.properties
@@ -90,3 +90,6 @@ attachment.onlineEditing.customProtocol.alert = true
 # Turn on this parameter if metadata of a file must be used to fill data (title & description) of
 # an attachment. By default metadata are not used.
 attachment.data.fromMetadata = false
+
+# List of component name, separated by comma, for which the displaying of attachment as content is enabled.
+attachmentsAsContent.component.names = kmelia

--- a/core-configuration/src/main/config/properties/org/silverpeas/util/attachment/multilang/attachment.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/util/attachment/multilang/attachment.properties
@@ -105,6 +105,8 @@ attachment.dialog.errorAtLeastOneFileSize = Au moins un des fichiers du zip est 
 
 attachment.download.forbidReaders=Interdire le t\u00e9l\u00e9chargement aux lecteurs
 attachment.download.allowReaders=Autoriser le t\u00e9l\u00e9chargement aux lecteurs
+attachment.displayAsContent.disable=Ne pas afficher en tant que contenu
+attachment.displayAsContent.enable=Afficher en tant que contenu
 attachment.dialog.checkin.webdav.multilang.language.help=la langue dans laquelle le contenu \u00e9tait affich\u00e9 lors de la r\u00e9servation du document
 attachment.warning.translations=Ce document existe dans plusieurs langues...
 attachment.warning.translations.label=Attention \!

--- a/core-configuration/src/main/config/properties/org/silverpeas/util/attachment/multilang/attachment_de.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/util/attachment/multilang/attachment_de.properties
@@ -105,6 +105,8 @@ attachment.dialog.errorAtLeastOneFileSize = mindestens eine der Zip-Datei ist zu
 
 attachment.download.forbidReaders=Forbid downloading for readers
 attachment.download.allowReaders=Allow downloading for readers
+attachment.displayAsContent.disable=Not display as content
+attachment.displayAsContent.enable=Display as content
 attachment.dialog.checkin.webdav.multilang.language.help=the language in which the content was displayed on the document reservation
 attachment.warning.translations=Dieses Dokument ist in mehreren Sprachen verf\u00fcgbar...
 attachment.warning.translations.label=Achtung\!

--- a/core-configuration/src/main/config/properties/org/silverpeas/util/attachment/multilang/attachment_en.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/util/attachment/multilang/attachment_en.properties
@@ -105,6 +105,8 @@ attachment.dialog.errorAtLeastOneFileSize = At least one of the files in the zip
 
 attachment.download.forbidReaders=Forbid downloading for readers
 attachment.download.allowReaders=Allow downloading for readers
+attachment.displayAsContent.disable=Not display as content
+attachment.displayAsContent.enable=Display as content
 attachment.dialog.checkin.webdav.multilang.language.help=the language in which the content was displayed on the document reservation
 attachment.warning.translations=This document is available in several languages...
 attachment.warning.translations.label=Warning\!

--- a/core-configuration/src/main/config/properties/org/silverpeas/util/attachment/multilang/attachment_fr.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/util/attachment/multilang/attachment_fr.properties
@@ -106,6 +106,8 @@ attachment.dialog.errorAtLeastOneFileSize = Au moins un des fichiers du zip est 
 
 attachment.download.forbidReaders=Interdire le t\u00e9l\u00e9chargement aux lecteurs
 attachment.download.allowReaders=Autoriser le t\u00e9l\u00e9chargement aux lecteurs
+attachment.displayAsContent.disable=Ne pas afficher en tant que contenu
+attachment.displayAsContent.enable=Afficher en tant que contenu
 attachment.dialog.checkin.webdav.multilang.language.help=la langue dans laquelle le contenu \u00e9tait affich\u00e9 lors de la r\u00e9servation du document
 attachment.warning.translations.label=Attention \!
 attachment.dialog.onlineEditing.customProtocol.button.edit=J'ai install\u00e9 le programme

--- a/core-configuration/src/main/config/properties/org/silverpeas/util/logging/viewerLogging.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/util/logging/viewerLogging.properties
@@ -1,0 +1,36 @@
+#
+# Copyright (C) 2000 - 2018 Silverpeas
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# As a special exception to the terms and conditions of version 3.0 of
+# the GPL, you may redistribute this Program in connection with Free/Libre
+# Open Source Software ("FLOSS") applications as described in Silverpeas's
+# FLOSS exception.  You should have received a copy of the text describing
+# the FLOSS exception, and it is also available here:
+# "https://www.silverpeas.org/legal/floss_exception.html"
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+#
+# Logger definition.
+# Each logger is defined by its unique namespace and by a logging level.
+#
+# - namespace: identifies uniquely a logger and represents the hierarchical category to which
+#              messages are logged with the logger. Each substring before a dot is the namespace
+#              of a parent logger.
+# - level: defines the minimum level at which will be accepted the logged messages. If not
+#          set, the first defined parent logger's level will be then taken into account. Possible
+#          value is: ERROR, WARNING, INFO, DEBUG
+#
+namespace=silverpeas.core.viewer

--- a/core-configuration/src/main/config/properties/org/silverpeas/viewer/viewer.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/viewer/viewer.properties
@@ -43,3 +43,6 @@ viewer.cache.timeToLive.enabled = true
 
 # Enable the conversion strategy that consists to convert a file into as many files as there are pages.
 viewer.conversion.strategy.split.enabled = true
+
+# Maximum number of document conversions at a same instant.
+viewer.conversion.nb.max = 3

--- a/core-library/src/integration-test/java/org/silverpeas/core/contribution/attachment/ActifyDocumentProcessSchedulerIT.java
+++ b/core-library/src/integration-test/java/org/silverpeas/core/contribution/attachment/ActifyDocumentProcessSchedulerIT.java
@@ -355,7 +355,7 @@ public class ActifyDocumentProcessSchedulerIT {
      */
     private void prepareMock() {
       when(attachmentService.listDocumentsByForeignKey(any(ResourceReference.class), eq((String) null)))
-          .thenReturn(new SimpleDocumentList<SimpleDocument>());
+          .thenReturn(new SimpleDocumentList<>());
       if (isVersioned()) {
         String lastFilename = ACTIFY_DOCUMENT_PREFIX + (actifyDocuments - 1) + ".3d";
         SimpleAttachment existingAttachment = new SimpleAttachment(lastFilename, null,

--- a/core-library/src/integration-test/java/org/silverpeas/core/contribution/attachment/AttachmentServiceIT.java
+++ b/core-library/src/integration-test/java/org/silverpeas/core/contribution/attachment/AttachmentServiceIT.java
@@ -34,7 +34,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.silverpeas.core.ResourceReference;
-import org.silverpeas.core.WAPrimaryKey;
 import org.silverpeas.core.admin.user.model.SilverpeasRole;
 import org.silverpeas.core.contribution.attachment.model.DocumentType;
 import org.silverpeas.core.contribution.attachment.model.SimpleAttachment;
@@ -816,7 +815,7 @@ public class AttachmentServiceIT extends JcrIntegrationIT {
    */
   @Test
   public void testReorderAttachments() throws RepositoryException, IOException {
-    WAPrimaryKey foreignKey = new ResourceReference("node36", instanceId);
+    ResourceReference foreignKey = new ResourceReference("node36", instanceId);
     try (JcrSession session = openSystemSession()) {
       DocumentRepository documentRepository = new DocumentRepository();
       Date creationDate = RandomGenerator.getRandomCalendar().getTime();
@@ -862,7 +861,8 @@ public class AttachmentServiceIT extends JcrIntegrationIT {
       document4.setPK(id);
       documentRepository.storeContent(document4, content);
       session.save();
-      List<SimpleDocument> result = instance.listDocumentsByForeignKey(foreignKey, "fr");
+      List<SimpleDocument> result =
+          instance.listDocumentsByForeignKey(foreignKey, "fr");
       assertThat(result, is(notNullValue()));
       assertThat(result, hasSize(3));
       assertThat(result.get(0), SimpleDocumentMatcher.matches(document2));
@@ -908,7 +908,7 @@ public class AttachmentServiceIT extends JcrIntegrationIT {
    */
   @Test
   public void testSearchAttachmentsByExternalObject() throws RepositoryException, IOException {
-    WAPrimaryKey foreignKey = new ResourceReference("node36", instanceId);
+    ResourceReference foreignKey = new ResourceReference("node36", instanceId);
     try (JcrSession session = openSystemSession()) {
       DocumentRepository documentRepository = new DocumentRepository();
       Date creationDate = RandomGenerator.getRandomCalendar().getTime();
@@ -955,7 +955,8 @@ public class AttachmentServiceIT extends JcrIntegrationIT {
       documentRepository.storeContent(document4, content);
 
       session.save();
-      List<SimpleDocument> result = instance.listDocumentsByForeignKey(foreignKey, "fr");
+      List<SimpleDocument> result =
+          instance.listDocumentsByForeignKey(foreignKey, "fr");
       assertThat(result, is(notNullValue()));
       assertThat(result, hasSize(3));
       assertThat(result.get(0), SimpleDocumentMatcher.matches(document2));

--- a/core-library/src/integration-test/java/org/silverpeas/core/contribution/attachment/HistorisedAttachmentServiceIT.java
+++ b/core-library/src/integration-test/java/org/silverpeas/core/contribution/attachment/HistorisedAttachmentServiceIT.java
@@ -34,7 +34,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.silverpeas.core.ResourceReference;
-import org.silverpeas.core.WAPrimaryKey;
 import org.silverpeas.core.admin.user.model.SilverpeasRole;
 import org.silverpeas.core.contribution.attachment.model.HistorisedDocument;
 import org.silverpeas.core.contribution.attachment.model.SimpleAttachment;
@@ -475,7 +474,7 @@ public class HistorisedAttachmentServiceIT extends JcrIntegrationIT {
   @Test
   public void testReorderAttachments() throws RepositoryException,
       IOException {
-    WAPrimaryKey foreignKey = new ResourceReference("node36", instanceId);
+    ResourceReference foreignKey = new ResourceReference("node36", instanceId);
     try (JcrSession session = openSystemSession()) {
       Date creationDate = RandomGenerator.getRandomCalendar().getTime();
       SimpleDocumentPK emptyId = new SimpleDocumentPK("-1", instanceId);
@@ -517,7 +516,8 @@ public class HistorisedAttachmentServiceIT extends JcrIntegrationIT {
       document4 = instance.searchDocumentById(id, "en");
 
       session.save();
-      List<SimpleDocument> result = instance.listDocumentsByForeignKey(foreignKey, "fr");
+      List<SimpleDocument> result =
+          instance.listDocumentsByForeignKey(foreignKey, "fr");
       assertThat(result, is(notNullValue()));
       assertThat(result, hasSize(3));
       assertThat(result.get(0), SimpleDocumentMatcher.matches(document2));
@@ -549,7 +549,7 @@ public class HistorisedAttachmentServiceIT extends JcrIntegrationIT {
    */
   @Test
   public void testSwitchAllowingDownloadForReaders() throws RepositoryException, IOException {
-    WAPrimaryKey foreignKey = new ResourceReference("node36", instanceId);
+    ResourceReference foreignKey = new ResourceReference("node36", instanceId);
     SimpleDocumentPK documentPK;
     try (JcrSession session = openSystemSession()) {
       Date creationDate = RandomGenerator.getRandomCalendar().getTime();
@@ -568,7 +568,8 @@ public class HistorisedAttachmentServiceIT extends JcrIntegrationIT {
     try (JcrSession session = openSystemSession()) {
 
       // Verifying document is created.
-      List<SimpleDocument> result = instance.listDocumentsByForeignKey(foreignKey, "fr");
+      List<SimpleDocument> result =
+          instance.listDocumentsByForeignKey(foreignKey, "fr");
       assertThat(result, notNullValue());
       assertThat(result, hasSize(1));
       SimpleDocument documentOfResult = result.get(0);
@@ -612,7 +613,7 @@ public class HistorisedAttachmentServiceIT extends JcrIntegrationIT {
    */
   @Test
   public void testSwitchDisplayableAsContent() throws RepositoryException, IOException {
-    WAPrimaryKey foreignKey = new ResourceReference("node36", instanceId);
+    ResourceReference foreignKey = new ResourceReference("node36", instanceId);
     SimpleDocumentPK documentPK;
     try (JcrSession session = openSystemSession()) {
       Date creationDate = RandomGenerator.getRandomCalendar().getTime();
@@ -688,7 +689,7 @@ public class HistorisedAttachmentServiceIT extends JcrIntegrationIT {
   @Test
   public void testSearchAttachmentsByExternalObject() throws RepositoryException,
       IOException {
-    WAPrimaryKey foreignKey = new ResourceReference("node36", instanceId);
+    ResourceReference foreignKey = new ResourceReference("node36", instanceId);
     try (JcrSession session = openSystemSession()) {
       Date creationDate = RandomGenerator.getRandomCalendar().getTime();
       SimpleDocumentPK emptyId = new SimpleDocumentPK("-1", instanceId);

--- a/core-library/src/integration-test/java/org/silverpeas/core/contribution/attachment/mock/AttachmentServiceMockWrapper.java
+++ b/core-library/src/integration-test/java/org/silverpeas/core/contribution/attachment/mock/AttachmentServiceMockWrapper.java
@@ -23,9 +23,8 @@
  */
 package org.silverpeas.core.contribution.attachment.mock;
 
-import org.silverpeas.core.ResourceReference;
-import org.silverpeas.core.WAPrimaryKey;
 import org.mockito.Mockito;
+import org.silverpeas.core.ResourceReference;
 import org.silverpeas.core.contribution.attachment.AttachmentException;
 import org.silverpeas.core.contribution.attachment.AttachmentService;
 import org.silverpeas.core.contribution.attachment.model.DocumentType;
@@ -108,8 +107,8 @@ public class AttachmentServiceMockWrapper implements AttachmentService {
   }
 
   @Override
-  public List<SimpleDocumentPK> copyAllDocuments(final WAPrimaryKey resourceSourcePk,
-      final WAPrimaryKey targetDestinationPk) {
+  public List<SimpleDocumentPK> copyAllDocuments(final ResourceReference resourceSourcePk,
+      final ResourceReference targetDestinationPk) {
     return mock.copyAllDocuments(resourceSourcePk, targetDestinationPk);
   }
 
@@ -119,8 +118,8 @@ public class AttachmentServiceMockWrapper implements AttachmentService {
   }
 
   @Override
-  public List<SimpleDocumentPK> moveAllDocuments(final WAPrimaryKey resourceSourcePk,
-      final WAPrimaryKey targetDestinationPk) {
+  public List<SimpleDocumentPK> moveAllDocuments(final ResourceReference resourceSourcePk,
+      final ResourceReference targetDestinationPk) {
     return mock.moveAllDocuments(resourceSourcePk, targetDestinationPk);
   }
 
@@ -211,25 +210,25 @@ public class AttachmentServiceMockWrapper implements AttachmentService {
   }
 
   @Override
-  public SimpleDocumentList<SimpleDocument> listDocumentsByForeignKey(WAPrimaryKey foreignKey,
+  public SimpleDocumentList<SimpleDocument> listDocumentsByForeignKey(ResourceReference foreignKey,
       String lang) {
     return mock.listDocumentsByForeignKey(foreignKey, lang);
   }
 
   @Override
-  public SimpleDocumentList<SimpleDocument> listAllDocumentsByForeignKey(WAPrimaryKey foreignKey,
+  public SimpleDocumentList<SimpleDocument> listAllDocumentsByForeignKey(ResourceReference foreignKey,
       String lang) {
     return mock.listAllDocumentsByForeignKey(foreignKey, lang);
   }
 
   @Override
   public SimpleDocumentList<SimpleDocument> listDocumentsByForeignKeyAndType(
-      WAPrimaryKey foreignKey, DocumentType type, String lang) {
+      ResourceReference foreignKey, DocumentType type, String lang) {
     return mock.listDocumentsByForeignKeyAndType(foreignKey, type, lang);
   }
 
   @Override
-  public void unindexAttachmentsOfExternalObject(WAPrimaryKey foreignKey) {
+  public void unindexAttachmentsOfExternalObject(ResourceReference foreignKey) {
     mock.unindexAttachmentsOfExternalObject(foreignKey);
   }
 
@@ -297,7 +296,7 @@ public class AttachmentServiceMockWrapper implements AttachmentService {
   }
 
   @Override
-  public void indexAllDocuments(WAPrimaryKey fk, Date startOfVisibilityPeriod,
+  public void indexAllDocuments(ResourceReference fk, Date startOfVisibilityPeriod,
       Date endOfVisibilityPeriod) {
     mock.indexAllDocuments(fk, startOfVisibilityPeriod, endOfVisibilityPeriod);
   }

--- a/core-library/src/integration-test/java/org/silverpeas/core/contribution/attachment/mock/AttachmentServiceMockWrapper.java
+++ b/core-library/src/integration-test/java/org/silverpeas/core/contribution/attachment/mock/AttachmentServiceMockWrapper.java
@@ -312,4 +312,8 @@ public class AttachmentServiceMockWrapper implements AttachmentService {
     mock.switchAllowingDownloadForReaders(pk, allowing);
   }
 
+  @Override
+  public void switchEnableDisplayAsContent(final SimpleDocumentPK pk, final boolean enable) {
+    mock.switchEnableDisplayAsContent(pk, enable);
+  }
 }

--- a/core-library/src/integration-test/java/org/silverpeas/core/contribution/attachment/repository/DocumentRepositoryIT.java
+++ b/core-library/src/integration-test/java/org/silverpeas/core/contribution/attachment/repository/DocumentRepositoryIT.java
@@ -313,7 +313,33 @@ public class DocumentRepositoryIT extends JcrIntegrationIT {
       session.save();
       SimpleDocument doc = documentRepository.findDocumentById(session, result, "fr");
       assertThat(doc.getForbiddenDownloadForRoles(), contains(SilverpeasRole.reader));
+    }
+  }
 
+  /**
+   * Test of saveDisplayableAsContent method, of class DocumentRepository.
+   */
+  @Test
+  public void testSaveDisplayableAsContent() throws Exception {
+    try (JcrSession session = openSystemSession()) {
+      SimpleDocumentPK emptyId = new SimpleDocumentPK("-1", instanceId);
+      ByteArrayInputStream content = new ByteArrayInputStream("This is a test".getBytes(
+          Charsets.UTF_8));
+      SimpleAttachment attachment = createEnglishSimpleAttachment();
+      String foreignId = "node18";
+      SimpleDocument document = new SimpleDocument(emptyId, foreignId, 10, false, attachment);
+      SimpleDocumentPK result = documentRepository.createDocument(session, document);
+      documentRepository.storeContent(document, content);
+      SimpleDocumentPK expResult = new SimpleDocumentPK(result.getId(), instanceId);
+      assertThat(result, is(expResult));
+      assertThat(document.isDisplayableAsContent(), is(true));
+      attachment = createFrenchSimpleAttachment();
+      document = new SimpleDocument(emptyId, foreignId, 15, false, attachment);
+      document.setDisplayableAsContent(false);
+      documentRepository.saveDisplayableAsContent(session, document);
+      session.save();
+      SimpleDocument doc = documentRepository.findDocumentById(session, result, "fr");
+      assertThat(doc.isDisplayableAsContent(), is(false));
     }
   }
 

--- a/core-library/src/integration-test/java/org/silverpeas/core/contribution/attachment/repository/HistorisedDocumentRepositoryIT.java
+++ b/core-library/src/integration-test/java/org/silverpeas/core/contribution/attachment/repository/HistorisedDocumentRepositoryIT.java
@@ -3445,7 +3445,147 @@ public class HistorisedDocumentRepositoryIT extends JcrIntegrationIT {
       for (SimpleDocumentVersion version : doc.getHistory()) {
         assertThat(version.getForbiddenDownloadForRoles(), nullValue());
       }
+    }
+  }
 
+  /**
+   * Test of saveDisplayableAsContent method, of class DocumentRepository.
+   * Testing also history, functional history, repository path and version index.
+   */
+  @Test
+  public void testSaveDisplayableAsContent() throws Exception {
+    try (JcrSession session = openSystemSession()) {
+
+      /*
+      Context of this test
+       */
+
+      // Create a versioned work document
+      SimpleDocumentPK emptyId = new SimpleDocumentPK("-1", instanceId);
+      ByteArrayInputStream content =
+          new ByteArrayInputStream("This is a test".getBytes(Charsets.UTF_8));
+      SimpleAttachment attachment = createEnglishVersionnedAttachment();
+      String foreignId = "node78";
+      SimpleDocument document = new HistorisedDocument(emptyId, foreignId, 10, attachment);
+      document.setPublicDocument(false);
+      SimpleDocumentPK result = createVersionedDocument(session, document, content);
+      SimpleDocumentPK expResult = new SimpleDocumentPK(result.getId(), instanceId);
+      assertThat(result, is(expResult));
+      assertThat(document.isDisplayableAsContent(), is(true));
+      HistorisedDocument docCreated =
+          (HistorisedDocument) documentRepository.findDocumentById(session, result, "fr");
+      assertThat(docCreated, is(notNullValue()));
+      assertThat(docCreated.getOrder(), is(10));
+      assertThat(docCreated.getContentType(), is(MimeTypes.PDF_MIME_TYPE));
+      assertThat(docCreated.getSize(), is(14L));
+      assertThat(docCreated.getHistory(), is(notNullValue()));
+      assertThat(docCreated.getHistory(), hasSize(0));
+      assertThat(docCreated.getFunctionalHistory(), is(notNullValue()));
+      assertThat(docCreated.getFunctionalHistory(), hasSize(0));
+      assertThat(docCreated.getMajorVersion(), is(0));
+      assertThat(docCreated.getMinorVersion(), is(1));
+      assertThat(docCreated.getVersionIndex(), is(0));
+      assertThat(docCreated.getVersionIndex(), is(docCreated.getVersionMaster().getVersionIndex()));
+
+      // Verifying data are ok
+      String masterUuid = docCreated.getVersionMaster().getId();
+      String masterPath = docCreated.getVersionMaster().getRepositoryPath();
+      assertThat(masterUuid, is(docCreated.getId()));
+      assertThat(masterPath, is("/kmelia73/attachments/" + docCreated.getNodeName()));
+
+      // Update the versioned document to a public one
+      attachment = createFrenchVersionnedAttachment();
+      document = new HistorisedDocument(emptyId, foreignId, 15, attachment);
+      document.setPublicDocument(true);
+      documentRepository.lock(session, document, document.getEditedBy());
+      documentRepository.updateDocument(session, document, true);
+      session.save();
+      documentRepository.unlock(session, document, false);
+      HistorisedDocument doc =
+          (HistorisedDocument) documentRepository.findDocumentById(session, result, "fr");
+      assertThat(doc, is(notNullValue()));
+      assertThat(doc.getOrder(), is(15));
+      assertThat(doc.getContentType(), is(MimeTypes.MIME_TYPE_OO_PRESENTATION));
+      assertThat(doc.getSize(), is(28L));
+      assertThat(doc.getHistory(), is(notNullValue()));
+      assertThat(doc.getHistory(), hasSize(1));
+      assertThat(doc.getFunctionalHistory(), is(notNullValue()));
+      assertThat(doc.getFunctionalHistory(), hasSize(1));
+      assertThat(doc.getHistory().get(0).getOrder(), is(0));
+      assertThat(doc.getMajorVersion(), is(1));
+      assertThat(doc.getMinorVersion(), is(0));
+      assertThat(doc.getVersionIndex(), is(1));
+      assertThat(doc.getVersionIndex(), is(doc.getVersionMaster().getVersionIndex()));
+
+      // Update the versioned document to a working one
+      attachment = createFrenchVersionnedAttachment();
+      document = new HistorisedDocument(emptyId, foreignId, 15, attachment);
+      document.setPublicDocument(false);
+      documentRepository.lock(session, document, document.getEditedBy());
+      documentRepository.updateDocument(session, document, true);
+      session.save();
+      documentRepository.unlock(session, document, false);
+      doc = (HistorisedDocument) documentRepository.findDocumentById(session, result, "fr");
+      assertThat(doc, is(notNullValue()));
+      assertThat(doc.getOrder(), is(15));
+      assertThat(doc.getContentType(), is(MimeTypes.MIME_TYPE_OO_PRESENTATION));
+      assertThat(doc.getSize(), is(28L));
+      assertThat(doc.getHistory(), is(notNullValue()));
+      assertThat(doc.getHistory(), hasSize(2));
+      assertThat(doc.getFunctionalHistory(), is(notNullValue()));
+      assertThat(doc.getFunctionalHistory(), hasSize(2));
+      assertThat(doc.getHistory().get(0).getOrder(), is(0));
+      assertThat(doc.getMajorVersion(), is(1));
+      assertThat(doc.getMinorVersion(), is(1));
+      assertThat(doc.getVersionIndex(), is(2));
+      assertThat(doc.getVersionIndex(), is(doc.getVersionMaster().getVersionIndex()));
+
+      /*
+      Test starts here
+       */
+      document.setDisplayableAsContent(false);
+      documentRepository.saveDisplayableAsContent(session, document);
+
+      doc = (HistorisedDocument) documentRepository.findDocumentById(session, result, "fr");
+      assertThat(doc, is(notNullValue()));
+      assertThat(doc.getOrder(), is(15));
+      assertThat(doc.getContentType(), is(MimeTypes.MIME_TYPE_OO_PRESENTATION));
+      assertThat(doc.getSize(), is(28L));
+      assertThat(doc.getHistory(), is(notNullValue()));
+      assertThat(doc.getHistory(), hasSize(3));
+      assertThat(doc.getFunctionalHistory(), is(notNullValue()));
+      assertThat(doc.getFunctionalHistory(), hasSize(2));
+      assertThat(doc.getHistory().get(0).getOrder(), is(0));
+      assertThat(doc.getMajorVersion(), is(1));
+      assertThat(doc.getMinorVersion(), is(1));
+      assertThat(doc.getVersionIndex(), is(3));
+      assertThat(doc.getVersionIndex(), is(doc.getVersionMaster().getVersionIndex()));
+      assertThat(doc.isDisplayableAsContent(), is(false));
+      for (SimpleDocumentVersion version : doc.getHistory()) {
+        assertThat(version.isDisplayableAsContent(), is(false));
+      }
+
+      document.setDisplayableAsContent(true);
+      documentRepository.saveDisplayableAsContent(session, document);
+
+      doc = (HistorisedDocument) documentRepository.findDocumentById(session, result, "fr");
+      assertThat(doc, is(notNullValue()));
+      assertThat(doc.getOrder(), is(15));
+      assertThat(doc.getContentType(), is(MimeTypes.MIME_TYPE_OO_PRESENTATION));
+      assertThat(doc.getSize(), is(28L));
+      assertThat(doc.getHistory(), is(notNullValue()));
+      assertThat(doc.getHistory(), hasSize(4));
+      assertThat(doc.getFunctionalHistory(), is(notNullValue()));
+      assertThat(doc.getFunctionalHistory(), hasSize(2));
+      assertThat(doc.getHistory().get(0).getOrder(), is(0));
+      assertThat(doc.getMajorVersion(), is(1));
+      assertThat(doc.getMinorVersion(), is(1));
+      assertThat(doc.getVersionIndex(), is(4));
+      assertThat(doc.getVersionIndex(), is(doc.getVersionMaster().getVersionIndex()));
+      assertThat(doc.isDisplayableAsContent(), is(true));
+      for (SimpleDocumentVersion version : doc.getHistory()) {
+        assertThat(version.isDisplayableAsContent(), is(true));
+      }
     }
   }
 

--- a/core-library/src/main/java/org/silverpeas/core/contribution/attachment/AttachmentException.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/attachment/AttachmentException.java
@@ -23,68 +23,22 @@
  */
 package org.silverpeas.core.contribution.attachment;
 
-import org.silverpeas.core.exception.SilverpeasRuntimeException;
+import org.silverpeas.core.SilverpeasRuntimeException;
 
 /**
- * Class declaration
- *
- * @author
+ * Exception thrown when an error occurs with attachments of a resource.
  */
 public class AttachmentException extends SilverpeasRuntimeException {
 
-  /**
-   * Creates new AttachmentException
-   */
-  public AttachmentException(String callingClass, int errorLevel, String message) {
-    super(callingClass, errorLevel, message);
+  public AttachmentException(final String message) {
+    super(message);
   }
 
-  /**
-   * Constructor declaration
-   *
-   * @param callingClass
-   * @param errorLevel
-   * @param message
-   * @param extraParams
-   *
-   */
-  public AttachmentException(String callingClass, int errorLevel, String message, String extraParams) {
-    super(callingClass, errorLevel, message, extraParams);
+  public AttachmentException(final String message, final Throwable cause) {
+    super(message, cause);
   }
 
-  /**
-   * Constructor declaration
-   *
-   * @param callingClass
-   * @param errorLevel
-   * @param message
-   * @param nested
-   *
-   */
-  public AttachmentException(String callingClass, int errorLevel, String message, Exception nested) {
-    super(callingClass, errorLevel, message, nested);
-  }
-
-  /**
-   * Constructor declaration
-   *
-   * @param callingClass
-   * @param errorLevel
-   * @param message
-   * @param extraParams
-   * @param nested
-   *
-   */
-  public AttachmentException(String callingClass, int errorLevel, String message, String extraParams,
-      Exception nested) {
-    super(callingClass, errorLevel, message, extraParams, nested);
-  }
-
-  /**
-   * method of interface FromModule
-   */
-  @Override
-  public String getModule() {
-    return "attachment";
+  public AttachmentException(final Throwable cause) {
+    super(cause);
   }
 }

--- a/core-library/src/main/java/org/silverpeas/core/contribution/attachment/AttachmentService.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/attachment/AttachmentService.java
@@ -24,15 +24,14 @@
 package org.silverpeas.core.contribution.attachment;
 
 import org.silverpeas.core.ResourceReference;
-import org.silverpeas.core.index.indexing.model.DocumentIndexing;
-import org.silverpeas.core.util.ServiceProvider;
-import org.silverpeas.core.WAPrimaryKey;
 import org.silverpeas.core.contribution.attachment.model.DocumentType;
 import org.silverpeas.core.contribution.attachment.model.SimpleDocument;
 import org.silverpeas.core.contribution.attachment.model.SimpleDocumentPK;
 import org.silverpeas.core.contribution.attachment.model.UnlockContext;
 import org.silverpeas.core.contribution.attachment.util.SimpleDocumentList;
+import org.silverpeas.core.index.indexing.model.DocumentIndexing;
 import org.silverpeas.core.index.indexing.model.FullIndexEntry;
+import org.silverpeas.core.util.ServiceProvider;
 
 import java.io.File;
 import java.io.InputStream;
@@ -42,7 +41,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- *
+ * Service to manage the attachments of resources in Silverpeas.
  * @author ehugonnet
  */
 public interface AttachmentService extends DocumentIndexing {
@@ -130,8 +129,8 @@ public interface AttachmentService extends DocumentIndexing {
    * that will get the copied attachments.
    * @return le list of copied attachments, empty if nothing is copied.
    */
-  List<SimpleDocumentPK> copyAllDocuments(WAPrimaryKey resourceSourcePk,
-      WAPrimaryKey targetDestinationPk);
+  List<SimpleDocumentPK> copyAllDocuments(ResourceReference resourceSourcePk,
+      ResourceReference targetDestinationPk);
 
   /**
    * Moves the attachment.
@@ -149,8 +148,8 @@ public interface AttachmentService extends DocumentIndexing {
    * that will get the moved attachments.
    * @return le list of moved attachments, empty if nothing is moved.
    */
-  List<SimpleDocumentPK> moveAllDocuments(WAPrimaryKey resourceSourcePk,
-      WAPrimaryKey targetDestinationPk);
+  List<SimpleDocumentPK> moveAllDocuments(ResourceReference resourceSourcePk,
+      ResourceReference targetDestinationPk);
 
 
   /**
@@ -310,7 +309,7 @@ public interface AttachmentService extends DocumentIndexing {
    * @return the list of attached documents.
    * @throws AttachmentException when is impossible to search
    */
-  SimpleDocumentList<SimpleDocument> listDocumentsByForeignKey(WAPrimaryKey foreignKey,
+  SimpleDocumentList<SimpleDocument> listDocumentsByForeignKey(ResourceReference foreignKey,
       String lang);
 
   /**
@@ -321,7 +320,7 @@ public interface AttachmentService extends DocumentIndexing {
    * @return the list of attached documents.
    * @throws AttachmentException when is impossible to search
    */
-  SimpleDocumentList<SimpleDocument> listAllDocumentsByForeignKey(WAPrimaryKey foreignKey,
+  SimpleDocumentList<SimpleDocument> listAllDocumentsByForeignKey(ResourceReference foreignKey,
       String lang);
 
   /**
@@ -333,10 +332,10 @@ public interface AttachmentService extends DocumentIndexing {
    * @return the list of attached documents.
    * @throws AttachmentException when is impossible to search
    */
-  SimpleDocumentList<SimpleDocument> listDocumentsByForeignKeyAndType(WAPrimaryKey foreignKey,
+  SimpleDocumentList<SimpleDocument> listDocumentsByForeignKeyAndType(ResourceReference foreignKey,
       DocumentType type, String lang);
 
-  void unindexAttachmentsOfExternalObject(WAPrimaryKey foreignKey);
+  void unindexAttachmentsOfExternalObject(ResourceReference foreignKey);
 
   /**
    * To update the document : status, metadata but not its content.
@@ -465,7 +464,7 @@ public interface AttachmentService extends DocumentIndexing {
    * @param startOfVisibilityPeriod can be null.
    * @param endOfVisibilityPeriod can be null.
    */
-  void indexAllDocuments(WAPrimaryKey fk, Date startOfVisibilityPeriod, Date endOfVisibilityPeriod);
+  void indexAllDocuments(ResourceReference fk, Date startOfVisibilityPeriod, Date endOfVisibilityPeriod);
 
   /**
    * Change the management of versions of the documents of a whole component (only attachments are

--- a/core-library/src/main/java/org/silverpeas/core/contribution/attachment/AttachmentService.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/attachment/AttachmentService.java
@@ -488,4 +488,11 @@ public interface AttachmentService extends DocumentIndexing {
    * versioned attachments become simple attachments.
    */
   void switchAllowingDownloadForReaders(SimpleDocumentPK pk, boolean allowing);
+
+  /**
+   * Enables or not the display of the content of an attachment.
+   * @param pk the id of the document.
+   * @param enable enable the display if true
+   */
+  void switchEnableDisplayAsContent(SimpleDocumentPK pk, boolean enable);
 }

--- a/core-library/src/main/java/org/silverpeas/core/contribution/attachment/ScheduledReservedFile.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/attachment/ScheduledReservedFile.java
@@ -23,26 +23,25 @@
  */
 package org.silverpeas.core.contribution.attachment;
 
+import org.silverpeas.core.contribution.attachment.model.SimpleDocument;
+import org.silverpeas.core.initialization.Initialization;
+import org.silverpeas.core.notification.user.client.NotificationManagerException;
+import org.silverpeas.core.notification.user.client.NotificationMetaData;
+import org.silverpeas.core.notification.user.client.NotificationParameters;
+import org.silverpeas.core.notification.user.client.NotificationSender;
+import org.silverpeas.core.notification.user.client.UserRecipient;
 import org.silverpeas.core.scheduler.Scheduler;
 import org.silverpeas.core.scheduler.SchedulerEvent;
 import org.silverpeas.core.scheduler.SchedulerEventListener;
 import org.silverpeas.core.scheduler.SchedulerProvider;
 import org.silverpeas.core.scheduler.trigger.JobTrigger;
 import org.silverpeas.core.ui.DisplayI18NHelper;
-import org.silverpeas.core.notification.user.client.NotificationManagerException;
-import org.silverpeas.core.notification.user.client.NotificationMetaData;
-import org.silverpeas.core.notification.user.client.NotificationParameters;
-import org.silverpeas.core.notification.user.client.NotificationSender;
-import org.silverpeas.core.notification.user.client.UserRecipient;
-import org.silverpeas.core.util.URLUtil;
-import org.silverpeas.core.contribution.attachment.model.SimpleDocument;
-import org.silverpeas.core.initialization.Initialization;
 import org.silverpeas.core.util.Link;
 import org.silverpeas.core.util.LocalizationBundle;
 import org.silverpeas.core.util.ResourceLocator;
 import org.silverpeas.core.util.SettingBundle;
 import org.silverpeas.core.util.StringUtil;
-import org.silverpeas.core.exception.SilverpeasRuntimeException;
+import org.silverpeas.core.util.URLUtil;
 import org.silverpeas.core.util.logging.SilverLogger;
 
 import java.util.Calendar;
@@ -152,8 +151,7 @@ public class ScheduledReservedFile implements Initialization {
         AttachmentServiceProvider.getAttachmentService().updateAttachment(document, false, false);
       }
     } catch (Exception e) {
-      throw new AttachmentException("ScheduledReservedFile.doScheduledReservedFile()",
-          SilverpeasRuntimeException.ERROR, "root.EX_CANT_GET_REMOTE_OBJECT", e);
+      throw new AttachmentException(e);
     }
 
   }
@@ -163,9 +161,8 @@ public class ScheduledReservedFile implements Initialization {
     atDate.setTime(document.getExpiry());
     String day = "GML.jour" + atDate.get(Calendar.DAY_OF_WEEK);
     String month = "GML.mois" + atDate.get(Calendar.MONTH);
-    String date = generalMessage.getString(day) + " " + atDate.get(Calendar.DATE) + " " +
+    return generalMessage.getString(day) + " " + atDate.get(Calendar.DATE) + " " +
         generalMessage.getString(month) + " " + atDate.get(Calendar.YEAR);
-    return date;
   }
 
   private void createMessageByLanguage(String date, String url, SimpleDocument document,
@@ -230,8 +227,7 @@ public class ScheduledReservedFile implements Initialization {
       NotificationSender notifSender = new NotificationSender(componentId);
       notifSender.notifyUser(notifMetaData);
     } catch (NotificationManagerException e) {
-      throw new AttachmentException("AttachmentBmImpl.notifyUser()",
-          SilverpeasRuntimeException.ERROR, "attachment.MSG_ATTACHMENT_NOT_EXIST", e);
+      throw new AttachmentException(e);
     }
   }
 

--- a/core-library/src/main/java/org/silverpeas/core/contribution/attachment/SimpleDocumentService.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/attachment/SimpleDocumentService.java
@@ -1042,6 +1042,23 @@ public class SimpleDocumentService
     }
   }
 
+  @Override
+  public void switchEnableDisplayAsContent(final SimpleDocumentPK pk, final boolean enable) {
+    SimpleDocument document = searchDocumentById(pk, null);
+    final boolean documentUpdateRequired = enable != document.isDisplayableAsContent();
+
+    // Updating JCR if required
+    if (documentUpdateRequired) {
+      document.setDisplayableAsContent(enable);
+      try (JcrSession session = openSystemSession()) {
+        repository.saveDisplayableAsContent(session, document);
+        session.save();
+      } catch (RepositoryException ex) {
+        throw new AttachmentException(this.getClass().getName(), SilverpeasException.ERROR, "", ex);
+      }
+    }
+  }
+
   /**
    * Check if notification must be really performed
    */

--- a/core-library/src/main/java/org/silverpeas/core/contribution/attachment/model/SimpleDocument.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/attachment/model/SimpleDocument.java
@@ -98,6 +98,7 @@ public class SimpleDocument implements Serializable {
   private DocumentType documentType = DocumentType.attachment;
   private Set<SilverpeasRole> forbiddenDownloadForRoles = null;
   private SimpleAttachment attachment;
+  private boolean displayableAsContent = true;
 
   public SimpleDocument(SimpleDocumentPK pk, String foreignId, int order, boolean versioned,
       SimpleAttachment attachment) {
@@ -176,6 +177,7 @@ public class SimpleDocument implements Serializable {
     this.documentType = simpleDocument.getDocumentType();
     this.forbiddenDownloadForRoles = simpleDocument.forbiddenDownloadForRoles;
     this.attachment = simpleDocument.getAttachment();
+    this.displayableAsContent = simpleDocument.displayableAsContent;
   }
 
   public void setDocumentType(DocumentType documentType) {
@@ -1000,5 +1002,17 @@ public class SimpleDocument implements Serializable {
    */
   public boolean isContentPdf() {
     return FileUtil.isPdf(getAttachmentPath());
+  }
+
+  /**
+   * Indicates if the attachment content can be displayed as a contribution content.
+   * @return true to display as content, false otherwise.
+   */
+  public boolean isDisplayableAsContent() {
+    return getVersionMaster().displayableAsContent;
+  }
+
+  public void setDisplayableAsContent(final boolean displayableAsContent) {
+    this.displayableAsContent = displayableAsContent;
   }
 }

--- a/core-library/src/main/java/org/silverpeas/core/contribution/attachment/process/AttachmentSimulationElementLister.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/attachment/process/AttachmentSimulationElementLister.java
@@ -23,11 +23,11 @@
  */
 package org.silverpeas.core.contribution.attachment.process;
 
+import org.silverpeas.core.NotSupportedException;
 import org.silverpeas.core.WAPrimaryKey;
 import org.silverpeas.core.contribution.attachment.AttachmentServiceProvider;
 import org.silverpeas.core.contribution.attachment.model.SimpleDocument;
 import org.silverpeas.core.process.annotation.SimulationElementLister;
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
 /**
  * User: Yohann Chastagnier
@@ -46,7 +46,7 @@ public class AttachmentSimulationElementLister extends SimulationElementLister {
   @Override
   public void listElements(final WAPrimaryKey sourcePK, final String language) {
     for (SimpleDocument document : AttachmentServiceProvider.getAttachmentService()
-        .listAllDocumentsByForeignKey(sourcePK, language)) {
+        .listAllDocumentsByForeignKey(sourcePK.toResourceReference(), language)) {
       addElement(new SimpleDocumentSimulationElement(document));
     }
   }
@@ -66,7 +66,7 @@ public class AttachmentSimulationElementLister extends SimulationElementLister {
       }
       addElement(new SimpleDocumentSimulationElement(document));
     } else {
-      throw new NotImplementedException();
+      throw new NotSupportedException("This class expects a SimpleDocument as source");
     }
   }
 }

--- a/core-library/src/main/java/org/silverpeas/core/contribution/attachment/process/SimpleDocumentDummyHandledFileConverter.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/attachment/process/SimpleDocumentDummyHandledFileConverter.java
@@ -23,11 +23,11 @@
  */
 package org.silverpeas.core.contribution.attachment.process;
 
+import org.silverpeas.core.ActionType;
+import org.silverpeas.core.NotSupportedException;
+import org.silverpeas.core.WAPrimaryKey;
 import org.silverpeas.core.process.annotation.AbstractDummyHandledFileConverter;
 import org.silverpeas.core.process.io.file.DummyHandledFile;
-import org.silverpeas.core.ActionType;
-import org.silverpeas.core.WAPrimaryKey;
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -44,7 +44,7 @@ public class SimpleDocumentDummyHandledFileConverter
       final WAPrimaryKey targetPK, final ActionType actionType) {
 
     // Initializing the result
-    List<DummyHandledFile> dummyHandledFiles = new LinkedList<DummyHandledFile>();
+    List<DummyHandledFile> dummyHandledFiles = new LinkedList<>();
 
     // For now, only move and copy actions are handled
     if (actionType.isCreate() || actionType.isUpdate() || actionType.isCopy() ||
@@ -69,7 +69,7 @@ public class SimpleDocumentDummyHandledFileConverter
         }
       }
     } else {
-      throw new NotImplementedException();
+      throw new NotSupportedException("The action type isn't supported by this class");
     }
 
     // Result

--- a/core-library/src/main/java/org/silverpeas/core/contribution/attachment/repository/DocumentRepository.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/attachment/repository/DocumentRepository.java
@@ -349,6 +349,32 @@ public class DocumentRepository {
   }
 
   /**
+   * Save the optional slv:displayableAsContent simple document property (MIXIN).
+   * This saving works with versionable documents without changing the major and minor version.
+   * This property is transverse between all versions.
+   *
+   * @param session
+   * @param document
+   * @throws RepositoryException
+   */
+  public void saveDisplayableAsContent(Session session, SimpleDocument document)
+      throws RepositoryException {
+    Node documentNode = session.getNodeByIdentifier(document.getVersionMaster().getPk().getId());
+    boolean checkedin = !documentNode.isCheckedOut();
+    if (checkedin) {
+      session.getWorkspace().getVersionManager().checkout(documentNode.getPath());
+    }
+
+    // Optional viewable mixin
+    converter.setDisplayableAsContentOptionalNodeProperty(document, documentNode);
+
+    if (checkedin) {
+      session.save();
+      session.getWorkspace().getVersionManager().checkin(documentNode.getPath());
+    }
+  }
+
+  /**
    * Add the document's clone id to the document even if it is locked.
    *
    * @param session the JCR session.

--- a/core-library/src/main/java/org/silverpeas/core/contribution/attachment/util/AttachmentSettings.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/attachment/util/AttachmentSettings.java
@@ -23,8 +23,13 @@
  */
 package org.silverpeas.core.contribution.attachment.util;
 
+import org.silverpeas.core.admin.component.model.SilverpeasComponent;
 import org.silverpeas.core.util.ResourceLocator;
 import org.silverpeas.core.util.SettingBundle;
+import org.silverpeas.core.util.StringUtil;
+
+import java.util.Optional;
+import java.util.stream.Stream;
 
 /**
  * Handled the settings around the attachments.
@@ -35,6 +40,10 @@ public class AttachmentSettings {
   private static SettingBundle settings =
       ResourceLocator.getSettingBundle("org.silverpeas.util.attachment.Attachment");
 
+  private AttachmentSettings() {
+    throw new IllegalStateException("Utility class");
+  }
+
   /**
    * Indicates if metadata of a file, if any, can be used to fill data (title & description) of an
    * attachment. (defined in properties by attachment.data.fromMetadata)
@@ -42,5 +51,24 @@ public class AttachmentSettings {
    */
   public static boolean isUseFileMetadataForAttachmentDataEnabled() {
     return settings.getBoolean("attachment.data.fromMetadata", false);
+  }
+
+  /**
+   * Indicates if the displaying as content is enabled for a component instance represented by
+   * the given identifier.
+   * @param componentInstanceId identifier of a component instance.
+   * @return true if activated, false otherwise.
+   */
+  public static boolean isDisplayableAsContentForComponentInstanceId(
+      final String componentInstanceId) {
+    return Stream
+        .of(settings.getString("attachmentsAsContent.component.names", StringUtil.EMPTY).split("[ ,;]"))
+        .map(c -> {
+          final Optional<SilverpeasComponent> component = SilverpeasComponent.getByInstanceId(componentInstanceId);
+          return component.isPresent() && component.get().getName().equalsIgnoreCase(c.trim());
+        })
+        .filter(b -> b)
+        .findFirst()
+        .orElse(false);
   }
 }

--- a/core-library/src/main/java/org/silverpeas/core/contribution/attachment/webdav/impl/WebDavDocumentService.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/attachment/webdav/impl/WebDavDocumentService.java
@@ -23,13 +23,11 @@
  */
 package org.silverpeas.core.contribution.attachment.webdav.impl;
 
-import org.silverpeas.core.silvertrace.SilverTrace;
 import org.silverpeas.core.contribution.attachment.AttachmentException;
 import org.silverpeas.core.contribution.attachment.model.SimpleDocument;
 import org.silverpeas.core.contribution.attachment.webdav.WebdavRepository;
 import org.silverpeas.core.contribution.attachment.webdav.WebdavService;
 import org.silverpeas.core.persistence.jcr.JcrSession;
-import org.silverpeas.core.exception.SilverpeasRuntimeException;
 
 import javax.inject.Inject;
 import javax.jcr.RepositoryException;
@@ -48,10 +46,7 @@ public class WebDavDocumentService implements WebdavService {
       webdavRepository.updateAttachmentBinaryContent(session, document);
       session.save();
     } catch (RepositoryException | IOException ex) {
-      SilverTrace
-          .error("attachment", "WebDavDocumentService", "attachment.jcr.create.exception", ex);
-      throw new AttachmentException("WebDavDocumentService", SilverpeasRuntimeException.ERROR,
-          "attachment.jcr.create.exception", ex);
+      throw new AttachmentException("Fail to update the document content", ex);
     }
   }
 
@@ -60,11 +55,7 @@ public class WebDavDocumentService implements WebdavService {
     try(JcrSession session = openSystemSession()) {
       return webdavRepository.getContentEditionLanguage(session, document);
     } catch (RepositoryException ex) {
-      SilverTrace
-          .error("attachment", "WebDavDocumentService", "attachment.jcr.node.notFound.exception",
-              ex);
-      throw new AttachmentException("WebDavDocumentService", SilverpeasRuntimeException.ERROR,
-          "attachment.jcr.node.notFound.exception", ex);
+      throw new AttachmentException("Document not found", ex);
     }
   }
 
@@ -73,11 +64,7 @@ public class WebDavDocumentService implements WebdavService {
     try(JcrSession session = openSystemSession()) {
       return webdavRepository.getContentEditionSize(session, document);
     } catch (RepositoryException ex) {
-      SilverTrace
-          .error("attachment", "WebDavDocumentService", "attachment.jcr.node.notFound.exception",
-              ex);
-      throw new AttachmentException("WebDavDocumentService", SilverpeasRuntimeException.ERROR,
-          "attachment.jcr.node.notFound.exception", ex);
+      throw new AttachmentException("Document not found", ex);
     }
   }
 }

--- a/core-library/src/main/java/org/silverpeas/core/contribution/content/wysiwyg/service/WysiwygManager.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/content/wysiwyg/service/WysiwygManager.java
@@ -46,7 +46,6 @@ import org.silverpeas.core.contribution.model.LocalizedContribution;
 import org.silverpeas.core.contribution.model.WysiwygContent;
 import org.silverpeas.core.contribution.service.WysiwygContentRepository;
 import org.silverpeas.core.exception.SilverpeasException;
-import org.silverpeas.core.exception.SilverpeasRuntimeException;
 import org.silverpeas.core.i18n.I18NHelper;
 import org.silverpeas.core.index.indexing.model.FullIndexEntry;
 import org.silverpeas.core.notification.system.ResourceEvent;
@@ -989,7 +988,7 @@ public class WysiwygManager implements WysiwygContentRepository {
   }
 
   /**
-   * To create path. Warning: the token separing the repertories is ",".
+   * To create path. Warning: the token separating the repertories is ",".
    * @param componentId : the name of component
    * @param context : string made up of the repertories separated by token ","
    * @return the path.
@@ -1003,8 +1002,7 @@ public class WysiwygManager implements WysiwygContentRepository {
       }
       return path;
     } catch (org.silverpeas.core.util.UtilException e) {
-      throw new AttachmentException("Wysiwyg.createPath(spaceId, componentId, context)",
-          SilverpeasRuntimeException.ERROR, "root.EX_CANT_CREATE_FILE", e);
+      throw new AttachmentException("Cannot create path", e);
     }
   }
 

--- a/core-library/src/main/java/org/silverpeas/core/persistence/jcr/AbstractJcrConverter.java
+++ b/core-library/src/main/java/org/silverpeas/core/persistence/jcr/AbstractJcrConverter.java
@@ -24,35 +24,27 @@
 package org.silverpeas.core.persistence.jcr;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.CharEncoding;
 import org.apache.jackrabbit.JcrConstants;
-import org.silverpeas.core.exception.UtilException;
 import org.silverpeas.core.persistence.jdbc.DBUtil;
 import org.silverpeas.core.util.ArrayUtil;
+import org.silverpeas.core.util.Charsets;
 import org.silverpeas.core.util.CollectionUtil;
 import org.silverpeas.core.util.file.FileUtil;
+import org.silverpeas.core.util.logging.SilverLogger;
 
-import javax.jcr.AccessDeniedException;
 import javax.jcr.Binary;
-import javax.jcr.ItemNotFoundException;
 import javax.jcr.Node;
 import javax.jcr.PathNotFoundException;
 import javax.jcr.RepositoryException;
 import javax.jcr.Value;
-import javax.jcr.ValueFormatException;
-import javax.jcr.lock.LockException;
-import javax.jcr.nodetype.ConstraintViolationException;
 import javax.jcr.nodetype.NodeType;
-import javax.jcr.version.VersionException;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.sql.SQLException;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Iterator;
@@ -75,10 +67,9 @@ public abstract class AbstractJcrConverter {
    * @param propertyName the name of the property required.
    * @return the String value of the property - null if the property doesn't exist.
    * @throws RepositoryException on error
-   * @throws ValueFormatException on error
    */
   protected String getStringProperty(Node node, String propertyName)
-      throws ValueFormatException, RepositoryException {
+      throws RepositoryException {
     if (node.hasProperty(propertyName)) {
       return node.getProperty(propertyName).getString();
     }
@@ -91,12 +82,9 @@ public abstract class AbstractJcrConverter {
    *
    * @param node the node whose componentId is required.
    * @return the componentId of the specified node.
-   * @throws ItemNotFoundException on error
-   * @throws AccessDeniedException on error
    * @throws RepositoryException on error
    */
-  protected String getComponentId(Node node) throws ItemNotFoundException,
-      AccessDeniedException, RepositoryException {
+  protected String getComponentId(Node node) throws RepositoryException {
     return JcrDataConverter.convertFromJcrPath(node.getAncestor(1).getName());
   }
 
@@ -107,18 +95,15 @@ public abstract class AbstractJcrConverter {
    * @param node the node whose property is being set.
    * @param propertyName the name of the property being set.
    * @param value the value being set. If it is null then the property is removed.
-   * @throws VersionException on error
-   * @throws LockException on error
-   * @throws ConstraintViolationException on error
    * @throws RepositoryException on error
    */
   public void addStringProperty(Node node, String propertyName,
-      String value) throws VersionException, LockException,
-      ConstraintViolationException, RepositoryException {
+      String value) throws RepositoryException {
     if (value == null) {
       try {
         node.getProperty(propertyName).remove();
-      } catch (PathNotFoundException pnfex) {
+      } catch (PathNotFoundException e) {
+        SilverLogger.getLogger(this).silent(e);
       }
     } else {
       node.setProperty(propertyName, value);
@@ -132,18 +117,15 @@ public abstract class AbstractJcrConverter {
    * @param node the node whose property is being set.
    * @param propertyName the name of the property being set.
    * @param value the value being set. If it is null then the property is removed.
-   * @throws VersionException on error
-   * @throws LockException on error
-   * @throws ConstraintViolationException on error
    * @throws RepositoryException on error
    */
   public void addDateProperty(Node node, String propertyName, Date value)
-      throws VersionException, LockException, ConstraintViolationException,
-      RepositoryException {
+      throws RepositoryException {
     if (value == null) {
       try {
         node.getProperty(propertyName).remove();
-      } catch (PathNotFoundException pnfex) {
+      } catch (PathNotFoundException e) {
+        SilverLogger.getLogger(this).silent(e);
       }
     } else {
       Calendar calend = Calendar.getInstance();
@@ -160,18 +142,15 @@ public abstract class AbstractJcrConverter {
    * @param node the node whose property is being set.
    * @param propertyName the name of the property being set.
    * @param value the value being set. If it is null then the property is removed.
-   * @throws VersionException on error
-   * @throws LockException on error
-   * @throws ConstraintViolationException on error
    * @throws RepositoryException on error
    */
   public void addCalendarProperty(Node node, String propertyName,
-      Calendar value) throws VersionException, LockException,
-      ConstraintViolationException, RepositoryException {
+      Calendar value) throws RepositoryException {
     if (value == null) {
       try {
         node.getProperty(propertyName).remove();
-      } catch (PathNotFoundException pnfex) {
+      } catch (PathNotFoundException e) {
+        SilverLogger.getLogger(this).silent(e);
       }
     } else {
       Value propertyValue = node.getSession().getValueFactory().createValue(value);
@@ -187,10 +166,9 @@ public abstract class AbstractJcrConverter {
    * @param propertyName the name of the property required.
    * @return the Calendar value of the property - null if the property doesn't exist.
    * @throws RepositoryException on error
-   * @throws ValueFormatException on error
    */
   protected Calendar getCalendarProperty(Node node, String propertyName)
-      throws ValueFormatException, RepositoryException {
+      throws RepositoryException {
     if (node.hasProperty(propertyName)) {
       return node.getProperty(propertyName).getDate();
     }
@@ -205,10 +183,8 @@ public abstract class AbstractJcrConverter {
    * @param propertyName the name of the property required.
    * @return the java.util.Date value of the property - null if the property doesn't exist.
    * @throws RepositoryException on error
-   * @throws ValueFormatException on error
    */
-  protected Date getDateProperty(Node node, String propertyName)
-      throws ValueFormatException, RepositoryException {
+  protected Date getDateProperty(Node node, String propertyName) throws RepositoryException {
     if (node.hasProperty(propertyName)) {
       return node.getProperty(propertyName).getDate().getTime();
     }
@@ -222,12 +198,10 @@ public abstract class AbstractJcrConverter {
    * @param propertyName the name of the property required.
    * @return the int value of the property - 0 if the property doesn't exist.
    * @throws RepositoryException on error
-   * @throws ValueFormatException on error
    */
-  protected int getIntProperty(Node node, String propertyName) throws ValueFormatException,
-      RepositoryException {
+  protected int getIntProperty(Node node, String propertyName) throws RepositoryException {
     if (node.hasProperty(propertyName)) {
-      return Long.valueOf(node.getProperty(propertyName).getLong()).intValue();
+      return ((Long)(node.getProperty(propertyName).getLong())).intValue();
     }
     return 0;
   }
@@ -241,11 +215,9 @@ public abstract class AbstractJcrConverter {
    * @param defaultValueIfNull the default value of the value does not exist
    * @return the boolean value of the property - false if the property doesn't exist.
    * @throws RepositoryException on error
-   * @throws ValueFormatException on error
    */
   protected boolean getBooleanProperty(Node node, String propertyName,
-      final boolean defaultValueIfNull) throws ValueFormatException,
-                                               RepositoryException {
+      final boolean defaultValueIfNull) throws RepositoryException {
     if (node.hasProperty(propertyName)) {
       return node.getProperty(propertyName).getBoolean();
     }
@@ -259,10 +231,8 @@ public abstract class AbstractJcrConverter {
    * @param propertyName the name of the property required.
    * @return the long value of the property - 0 if the property doesn't exist.
    * @throws RepositoryException on error
-   * @throws ValueFormatException on error
    */
-  protected long getLongProperty(Node node, String propertyName)
-      throws ValueFormatException, RepositoryException {
+  protected long getLongProperty(Node node, String propertyName) throws RepositoryException {
     if (node.hasProperty(propertyName)) {
       return node.getProperty(propertyName).getLong();
     }
@@ -276,12 +246,9 @@ public abstract class AbstractJcrConverter {
    * @param values the array of references
    * @param uuid the reference to be removed
    * @return the updated arry of references.
-   * @throws ValueFormatException on error
-   * @throws IllegalStateException on error
    * @throws RepositoryException on error
    */
-  protected Value[] removeReference(Value[] values, String uuid) throws ValueFormatException,
-      IllegalStateException, RepositoryException {
+  protected Value[] removeReference(Value[] values, String uuid) throws RepositoryException {
     List<Value> references = CollectionUtil.asList(values);
     Iterator<Value> iter = references.iterator();
     while (iter.hasNext()) {
@@ -301,9 +268,8 @@ public abstract class AbstractJcrConverter {
    * @param prefix a prefix to add to the node name
    * @param tableName the name of the column used to stored the id.
    * @return the name of the node.
-   * @throws UtilException on error
    */
-  protected String computeUniqueName(String prefix, String tableName) throws SQLException {
+  protected String computeUniqueName(String prefix, String tableName) {
     return prefix + DBUtil.getNextId(tableName, null);
   }
 
@@ -322,7 +288,7 @@ public abstract class AbstractJcrConverter {
     if (fileMimeType == null) {
       fileMimeType = FileUtil.getMimeType(fileNode.getProperty(SLV_PROPERTY_NAME).getString());
     }
-    contentNode.setProperty(JCR_ENCODING, CharEncoding.UTF_8);
+    contentNode.setProperty(JCR_ENCODING, Charsets.UTF_8.name());
     contentNode.setProperty(JCR_MIMETYPE, fileMimeType);
     Calendar lastModified = Calendar.getInstance();
     contentNode.setProperty(JCR_LAST_MODIFIED, lastModified);
@@ -360,14 +326,10 @@ public abstract class AbstractJcrConverter {
   }
 
   public void setContent(Node fileNode, File file, String mimeType) throws RepositoryException {
-    InputStream in = null;
-    try {
-      in = new FileInputStream(file);
+    try(InputStream in = new FileInputStream(file)) {
       setContent(fileNode, in, mimeType);
-    } catch (FileNotFoundException ex) {
+    } catch (IOException ex) {
       throw new RepositoryException(ex);
-    } finally {
-      IOUtils.closeQuietly(in);
     }
   }
 
@@ -433,8 +395,7 @@ public abstract class AbstractJcrConverter {
 
   }
 
-  private long getSize(Node contentNode) throws ValueFormatException, PathNotFoundException,
-      RepositoryException {
+  private long getSize(Node contentNode) throws RepositoryException {
     if (contentNode.hasProperty(JCR_DATA)) {
       return contentNode.getProperty(JCR_DATA).getBinary().getSize();
     }

--- a/core-library/src/main/java/org/silverpeas/core/persistence/jcr/AbstractJcrConverter.java
+++ b/core-library/src/main/java/org/silverpeas/core/persistence/jcr/AbstractJcrConverter.java
@@ -238,16 +238,18 @@ public abstract class AbstractJcrConverter {
    *
    * @param node the node whose property is required.
    * @param propertyName the name of the property required.
+   * @param defaultValueIfNull the default value of the value does not exist
    * @return the boolean value of the property - false if the property doesn't exist.
    * @throws RepositoryException on error
    * @throws ValueFormatException on error
    */
-  protected boolean getBooleanProperty(Node node, String propertyName) throws ValueFormatException,
-      RepositoryException {
+  protected boolean getBooleanProperty(Node node, String propertyName,
+      final boolean defaultValueIfNull) throws ValueFormatException,
+                                               RepositoryException {
     if (node.hasProperty(propertyName)) {
       return node.getProperty(propertyName).getBoolean();
     }
-    return false;
+    return defaultValueIfNull;
   }
 
   /**

--- a/core-library/src/main/java/org/silverpeas/core/persistence/jcr/util/JcrConstants.java
+++ b/core-library/src/main/java/org/silverpeas/core/persistence/jcr/util/JcrConstants.java
@@ -199,6 +199,11 @@ public interface JcrConstants extends Property {
   String SLV_DOWNLOADABLE_MIXIN = "slv:downloadable";
 
   /**
+   * Silverpeas Mixin to add viewable data to the node.
+   */
+  String SLV_VIEWABLE_MIXIN = "slv:viewable";
+
+  /**
    * Translation node 's name prefix. A translation's name should be TRANSLATION_NAME_PREFIX+ lang.
    */
   String TRANSLATION_NAME_PREFIX = "traduction_";
@@ -256,4 +261,5 @@ public interface JcrConstants extends Property {
   String SLV_PROPERTY_XMLFORM_ID = "slv:xmlFormId";
   String SLV_PROPERTY_COMMENT = "slv:comment";
   String SLV_PROPERTY_FORBIDDEN_DOWNLOAD_FOR_ROLES = "slv:forbiddenDownloadForRoles";
+  String SLV_PROPERTY_DISPLAYABLE_AS_CONTENT = "slv:displayableAsContent";
 }

--- a/core-library/src/main/resources/silverpeas-jcr.cnd
+++ b/core-library/src/main/resources/silverpeas-jcr.cnd
@@ -19,6 +19,11 @@
   mixin
   - slv:forbiddenDownloadForRoles (STRING) IGNORE
 
+/* Mixin viewable */
+[slv:viewable]
+  mixin
+  - slv:displayableAsContent (BOOLEAN) IGNORE
+
 [slv:simpleDocument] >  nt:folder, mix:referenceable, slv:ownable, slv:commentable
   - slv:foreignKey (STRING)
   - slv:instanceId (STRING) MANDATORY

--- a/core-services/importExport/src/main/java/org/silverpeas/core/importexport/attachment/AttachmentImportExport.java
+++ b/core-services/importExport/src/main/java/org/silverpeas/core/importexport/attachment/AttachmentImportExport.java
@@ -23,26 +23,25 @@
  */
 package org.silverpeas.core.importexport.attachment;
 
-import org.silverpeas.core.ResourceReference;
-import org.silverpeas.core.importexport.form.FormTemplateImportExport;
-import org.silverpeas.core.importexport.form.XMLModelContentType;
-import org.silverpeas.core.silvertrace.SilverTrace;
-import org.silverpeas.core.admin.user.model.UserDetail;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
+import org.silverpeas.core.ResourceReference;
+import org.silverpeas.core.admin.user.model.UserDetail;
 import org.silverpeas.core.contribution.attachment.AttachmentServiceProvider;
 import org.silverpeas.core.contribution.attachment.model.DocumentType;
 import org.silverpeas.core.contribution.attachment.model.SimpleAttachment;
 import org.silverpeas.core.contribution.attachment.model.SimpleDocument;
 import org.silverpeas.core.contribution.attachment.model.SimpleDocumentPK;
-import org.silverpeas.core.util.file.FileRepositoryManager;
-import org.silverpeas.core.util.file.FileServerUtils;
-import org.silverpeas.core.util.file.FileUtil;
+import org.silverpeas.core.importexport.form.FormTemplateImportExport;
+import org.silverpeas.core.importexport.form.XMLModelContentType;
+import org.silverpeas.core.silvertrace.SilverTrace;
 import org.silverpeas.core.util.ResourceLocator;
 import org.silverpeas.core.util.SettingBundle;
 import org.silverpeas.core.util.StringUtil;
-import org.silverpeas.core.WAPrimaryKey;
 import org.silverpeas.core.util.error.SilverpeasTransverseErrorUtil;
+import org.silverpeas.core.util.file.FileRepositoryManager;
+import org.silverpeas.core.util.file.FileServerUtils;
+import org.silverpeas.core.util.file.FileUtil;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -211,13 +210,13 @@ public class AttachmentImportExport {
    * @param extensionFilter
    * @return une liste des attachmentDetail trouves
    */
-  public List<AttachmentDetail> getAttachments(WAPrimaryKey pk, String exportPath,
+  public List<AttachmentDetail> getAttachments(ResourceReference pk, String exportPath,
       String relativeExportPath, String extensionFilter) {
 
     // Recuperation des attachments
     Collection<SimpleDocument> listAttachment = AttachmentServiceProvider.getAttachmentService()
         .listDocumentsByForeignKey(pk, null);
-    List<AttachmentDetail> listToReturn = new ArrayList<AttachmentDetail>(listAttachment.size());
+    List<AttachmentDetail> listToReturn = new ArrayList<>(listAttachment.size());
     if (!listAttachment.isEmpty()) {
       // Pour chaque attachment trouve, on copie le fichier dans le dossier
       // d'exportation

--- a/core-services/importExport/src/main/java/org/silverpeas/core/importexport/control/PublicationsTypeManager.java
+++ b/core-services/importExport/src/main/java/org/silverpeas/core/importexport/control/PublicationsTypeManager.java
@@ -269,7 +269,8 @@ public class PublicationsTypeManager {
       throws ImportExportException {
     // Récupération des attachments et copie des fichiers
     List<AttachmentDetail> attachments =
-        attachmentIE.getAttachments(publicationPK, exportPath, exportRelativePath, null);
+        attachmentIE.getAttachments(publicationPK.toResourceReference(), exportPath,
+            exportRelativePath, null);
     if (attachments != null && !attachments.isEmpty() && publicationType != null) {
       publicationType.setAttachmentsType(attachments);
     }
@@ -494,8 +495,8 @@ public class PublicationsTypeManager {
       PublicationDetail publicationDetail = publicationType.getPublicationDetail();
       fillPublicationType(gedIE, publicationType, rootPK);
 
-      List<AttachmentDetail> attachments = attachmentIE
-          .getAttachments(publicationDetail.getPK(), exportPath, null, "pdf");
+      List<AttachmentDetail> attachments = attachmentIE.getAttachments(
+          publicationDetail.getPK().toResourceReference(), exportPath, null, "pdf");
 
       if (attachments != null && !attachments.isEmpty()) {
         result.addAll(attachments);

--- a/core-services/viewer/src/main/java/org/silverpeas/core/viewer/model/ViewerSettings.java
+++ b/core-services/viewer/src/main/java/org/silverpeas/core/viewer/model/ViewerSettings.java
@@ -113,4 +113,12 @@ public class ViewerSettings {
         TemporaryDataManagementSetting.getTimeAfterThatFilesMustBeDeleted() >= 0 &&
         settings.getBoolean("viewer.cache.timeToLive.enabled", true);
   }
+
+  /**
+   * Maximum number of conversions at a same instant.
+   * @return a primitive integer.
+   */
+  public static int nbMaxConversionsAtSameInstant() {
+    return settings.getInteger("viewer.conversion.nb.max", 3);
+  }
 }

--- a/core-services/viewer/src/main/java/org/silverpeas/core/viewer/service/DefaultPreviewService.java
+++ b/core-services/viewer/src/main/java/org/silverpeas/core/viewer/service/DefaultPreviewService.java
@@ -139,7 +139,7 @@ public class DefaultPreviewService extends AbstractViewerService implements Prev
           ManagedThreadPool.getPool().invoke(() -> {
             ViewService.get().getDocumentView(viewerContext.clone());
           });
-        return super.performAfterSuccess(result);
+        return ViewerTreatment.super.performAfterSuccess(result);
       }
     }).execute(viewerContext);
   }

--- a/core-services/viewer/src/main/java/org/silverpeas/core/viewer/service/DefaultViewService.java
+++ b/core-services/viewer/src/main/java/org/silverpeas/core/viewer/service/DefaultViewService.java
@@ -126,7 +126,7 @@ public class DefaultViewService extends AbstractViewerService implements ViewSer
             PreviewService.get().getPreview(viewerContext.clone());
           });
         }
-        return super.performAfterSuccess(result);
+        return ViewerTreatment.super.performAfterSuccess(result);
       }
     }).execute(viewerContext);
   }

--- a/core-test/src/main/resources/silverpeas-jcr.txt
+++ b/core-test/src/main/resources/silverpeas-jcr.txt
@@ -19,6 +19,11 @@
   mixin
   - slv:forbiddenDownloadForRoles (STRING) IGNORE
 
+/* Mixin viewable */
+[slv:viewable]
+  mixin
+  - slv:displayableAsContent (BOOLEAN) IGNORE
+
 [slv:simpleDocument] >  nt:folder, mix:referenceable, slv:ownable, slv:commentable
   - slv:foreignKey (STRING)
   - slv:instanceId (STRING) MANDATORY

--- a/core-war/src/main/webapp/WEB-INF/tags/silverpeas/util/viewAttachmentsAsContent.tag
+++ b/core-war/src/main/webapp/WEB-INF/tags/silverpeas/util/viewAttachmentsAsContent.tag
@@ -1,0 +1,73 @@
+<%--
+  ~ Copyright (C) 2000 - 2018 Silverpeas
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as
+  ~ published by the Free Software Foundation, either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ As a special exception to the terms and conditions of version 3.0 of
+  ~ the GPL, you may redistribute this Program in connection with Free/Libre
+  ~ Open Source Software ("FLOSS") applications as described in Silverpeas's
+  ~ FLOSS exception.  You should have received a copy of the text describing
+  ~ the FLOSS exception, and it is also available here:
+  ~ "https://www.silverpeas.org/legal/floss_exception.html"
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  --%>
+
+<%@ tag import="org.silverpeas.core.contribution.attachment.util.AttachmentSettings" %>
+<%@ tag language="java" pageEncoding="UTF-8" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn" %>
+<%@ taglib uri="http://www.silverpeas.com/tld/silverFunctions" prefix="silfn" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
+<%@ taglib uri="http://www.silverpeas.com/tld/viewGenerator" prefix="view" %>
+
+<c:set var="userLanguage" value="${sessionScope['SilverSessionController'].favoriteLanguage}"/>
+<fmt:setLocale value="${userLanguage}"/>
+<view:setBundle basename="org.silverpeas.multilang.generalMultilang"/>
+
+<%@ attribute name="componentInstanceId" required="true"
+              type="java.lang.String"
+              description="The component instance id associated to the drag and drop" %>
+<%@ attribute name="resourceId" required="true"
+              type="java.lang.String"
+              description="The identifier of the resource the uploaded document must be attached to" %>
+<%@ attribute name="resourceType" required="true"
+              type="java.lang.String"
+              description="The type of the resource the uploaded document must be attached to" %>
+<%@ attribute name="documentType" required="false"
+              type="java.lang.String"
+              description="The type of the document attachment" %>
+<%@ attribute name="contentLanguage" required="false"
+              type="java.lang.String"
+              description="The content language to retrieve as a first priority" %>
+<%@ attribute name="highestUserRole" required="false"
+              type="org.silverpeas.core.admin.user.model.SilverpeasRole"
+              description="The highest role the user has" %>
+
+<c:set var="__viewAsContentActivated" value="<%=AttachmentSettings.isDisplayableAsContentForComponentInstanceId(componentInstanceId)%>"/>
+<c:if test="${__viewAsContentActivated}">
+  <c:set var="domIdSuffix" value="${fn:replace(fn:replace(resourceId, '=', '_'), '-', '_')}"/>
+  <div class="attachments-as-content" id="attachments-as-content-${domIdSuffix}"></div>
+  <view:includePlugin name="preview" />
+  <script type="text/JavaScript">
+    (function() {
+      new AttachmentsAsContentViewer({
+        domSelector : '#attachments-as-content-${domIdSuffix}',
+        highestUserRole : ${highestUserRole != null ? '\''.concat(highestUserRole.name).concat('\''): 'undefined'},
+        componentInstanceId : '${componentInstanceId}',
+        resourceId : '${resourceId}',
+        resourceType : '${resourceType}',
+        documentType : ${not empty documentType ? '\''.concat(documentType).concat('\''): 'undefined'}
+      });
+    })();
+  </script>
+</c:if>

--- a/core-war/src/main/webapp/attachment/jsp/displayAttachedFiles.jsp
+++ b/core-war/src/main/webapp/attachment/jsp/displayAttachedFiles.jsp
@@ -656,6 +656,21 @@
       });
     }
 
+    function switchDisplayAsContentEnabled(attachmentId, enabled) {
+      $.progressMessage();
+      $.ajax({
+        url : '<c:url value="/services/documents/${sessionScope.Silverpeas_Attachment_ComponentId}/document/"/>' +
+            attachmentId + '/switchDisplayAsContentEnabled',
+        type : "POST",
+        cache : false,
+        dataType : "json",
+        data : {"enabled" : (enabled) ? enabled : false},
+        success : function(data) {
+          reloadIncludingPage();
+        }
+      });
+    }
+
     <c:if test="${useXMLForm}">
       function EditXmlForm(id, lang) {
         var url = '<c:url value="/RformTemplate/jsp/Edit"><c:param name="IndexIt" value="${indexIt}" /><c:param name="ComponentId" value="${param.ComponentId}" /><c:param name="type" value="Attachment" /><c:param name="ObjectType" value="Attachment" /><c:param name="XMLFormName" value="${xmlForm}" /></c:url>&ReloadOpener=true&ObjectLanguage=' + lang + '&ObjectId=' + id;

--- a/core-war/src/main/webapp/attachment/jsp/editAttachedFiles.jsp
+++ b/core-war/src/main/webapp/attachment/jsp/editAttachedFiles.jsp
@@ -189,6 +189,21 @@
     });
   }
 
+  function switchDisplayAsContentEnabled(attachmentId, enabled) {
+    $.progressMessage();
+    $.ajax({
+      url : '<c:url value="/services/documents/${sessionScope.Silverpeas_Attachment_ComponentId}/document/"/>' +
+          attachmentId + '/switchDisplayAsContentEnabled',
+      type : "POST",
+      cache : false,
+      dataType : "json",
+      data : {"enabled" : (enabled) ? enabled : false},
+      success : function(data) {
+        reloadPage();
+      }
+    });
+  }
+
   function loadAttachment(id, lang) {
     translationsUrl = '<c:url value="/services/documents/${sessionScope.Silverpeas_Attachment_ComponentId}/document/"/>' + id + '/translations';
     $.ajax({

--- a/core-war/src/main/webapp/util/javaScript/silverpeas-embed-player.js
+++ b/core-war/src/main/webapp/util/javaScript/silverpeas-embed-player.js
@@ -92,8 +92,6 @@
    */
   function __configurePlayerContainer($container, config) {
     $container.empty();
-    $container.css('width', config.width);
-    $container.css('height', config.height);
     var $embed = $('<iframe>');
     $embed.attr('class', 'embed');
     $embed.attr('frameborder', '0');

--- a/core-war/src/main/webapp/util/javaScript/silverpeas-view.js
+++ b/core-war/src/main/webapp/util/javaScript/silverpeas-view.js
@@ -99,7 +99,12 @@
       var $_this = $(this);
 
       // Waiting animation
-      $.popup.showWaiting();
+      if (!options.insertMode) {
+        $.popup.showWaiting();
+      } else {
+        var imageUrl = popupViewGeneratorIconPath + '/inProgress.gif';
+        $_this.html($('<img>').attr('src', imageUrl).attr('width', '32').attr('height', '32'));
+      }
 
       // Getting view
       var url = $.view.webServiceContext;
@@ -114,15 +119,49 @@
         dataType : 'json',
         cache : false,
         success : function(data, status, jqXHR) {
-          __openDialogView($_this, data);
+          if (options.insertMode) {
+            __insertView($_this, data);
+          } else {
+            __openDialogView($_this, data);
+          }
           $.popup.hideWaiting();
         },
         error : function(jqXHR, textStatus, errorThrown) {
           $.popup.hideWaiting();
-          alert(errorThrown);
+          sp.log.error("view", "technical error for", JSON.stringify(options), errorThrown);
         }
       });
     })
+  }
+
+  /**
+   * Private function that centralizes the dialog view construction.
+   */
+  function __insertView($this, view) {
+    __adjustViewSize(view);
+
+    // Initializing the resulting html container
+    var $baseContainer = $("<div>")
+                      .css('display', 'block')
+                      .css('border', '0px')
+                      .css('padding', '0px')
+                      .css('margin', '0px auto')
+                      .css('text-align', 'center')
+                      .css('background-color', 'white');
+    $this.html($baseContainer);
+
+    // Popup
+    var $documentViewer = __setView($baseContainer, view, true);
+
+    // Player
+    $documentViewer.embedPlayer({
+      url : sp.ajaxRequest(view.viewerUri)
+              .withParam('documentId', view.documentId)
+              .withParam('language', view.language)
+              .getUrl(),
+      width : view.width,
+      height : view.height
+    });
   }
 
   /**
@@ -159,10 +198,10 @@
     };
 
     // Popup
-    __setView($baseContainer, view);
+    var $documentViewer = __setView($baseContainer, view);
 
     // Player
-    $('#documentViewer').embedPlayer({
+    $documentViewer.embedPlayer({
       url : sp.ajaxRequest(view.viewerUri)
               .withParam('documentId', view.documentId)
               .withParam('language', view.language)
@@ -212,22 +251,149 @@
   /**
    * Private function that sets the view container.
    */
-  function __setView($baseContainer, view) {
-    $baseContainer.html($('<div>')
+  function __setView($baseContainer, view, insertMode) {
+    var documentViewer = $('<div>')
+        .css('display', 'block')
+        .css('margin', '0px')
+        .css('padding', '0px');
+    var $viewerContainer = $('<div>')
         .attr('id','viewercontainer')
         .css('display', 'block')
         .css('margin', '0px')
         .css('padding', '0px')
-        .css('width', view.width + 'px')
-        .css('height', view.height + 'px')
         .css('text-align', 'center')
-        .append($('<div>')
-            .attr('id','documentViewer')
-            .css('display', 'block')
-            .css('margin', '0px')
-            .css('padding', '0px')
-            .css('width', view.width + 'px')
-            .css('height', view.height + 'px')
-            .css('background-color', '#222222')));
+        .append(documentViewer);
+    $baseContainer.html($viewerContainer);
+    if (!insertMode) {
+      $viewerContainer.css('width', view.width + 'px')
+          .css('height', view.height + 'px');
+      documentViewer.css('width', view.width + 'px')
+          .css('height', view.height + 'px')
+          .css('background-color', '#222222');
+    }
+    return documentViewer;
+  }
+
+
+  /*
+  ATTACHMENT VIEWER AS CONTENT
+   */
+
+  window.AttachmentsAsContentViewer = function(options) {
+    var __context = {
+      options : extendsObject({
+        domSelector : undefined,
+        componentInstanceId : undefined,
+        resourceId : undefined,
+        resourceType : undefined,
+        contentLanguage : 'fr',
+        documentType : 'attachment',
+        highestUserRole : undefined,
+        enableImage : true,
+        enableVideo : true,
+        enableAudio : true,
+        enableViewable : true,
+        enableSimpleText : true
+      }, options)
+    };
+    if (!__context.options.domSelector || !__context.options.componentInstanceId ||
+        !__context.options.resourceId || !__context.options.resourceType) {
+      sp.log.error("domSelector, componentInstanceId, resourceId or resourceType is missing");
+      return;
+    }
+
+    var __loadAttachments = function() {
+      return sp.ajaxRequest(webContext + "/services/documents/" +
+          __context.options.componentInstanceId + "/resource/" + __context.options.resourceId +
+          "/types/" + __context.options.documentType + "/" +
+          __context.options.contentLanguage)
+          .withParam("viewIndicators", true)
+          .withParam("highestUserRole", __context.options.highestUserRole)
+          .sendAndPromiseJsonResponse();
+    };
+    var __initPromise = __loadAttachments();
+
+    var __renderContainer = function(attachment, __renderCallback) {
+      var $attContainer = document.createElement('div');
+      $attContainer.classList.add('attachment-container');
+      var $title = document.createElement('h3');
+      $title.classList.add('title');
+      $title.innerText = attachment.title ? attachment.title : attachment.fileName;
+      var $description = document.createElement('p');
+      $description.classList.add('description');
+      $description.innerText = attachment.description;
+      $attContainer.appendChild($title);
+      if (StringUtil.isDefined(attachment.description)) {
+        $attContainer.appendChild($description);
+      }
+      var $renderedContent = __renderCallback(attachment);
+      $renderedContent.classList.add('content');
+      $attContainer.appendChild($renderedContent);
+      return $attContainer;
+    };
+
+    var __renderSimpleText = function(attachment) {
+      var $simpleText = document.createElement("div");
+      sp.ajaxRequest(webContext + attachment.downloadUrl).send().then(function(request) {
+        $simpleText.innerText = request.responseText;
+      });
+      return $simpleText;
+    };
+    var __renderImage = function(attachment) {
+      var $imageContainer = document.createElement("div");
+      var $img = document.createElement("img");
+      $img.src = webContext + attachment.downloadUrl.replace(/(\/lang\/[a-z]+\/)(name\/)/g, '$1size/600x/$2');
+      $imageContainer.appendChild($img);
+      return $imageContainer;
+    };
+    var __renderMedia = function(attachment) {
+      var $mediaContainer = document.createElement("div");
+      jQuery($mediaContainer).embedPlayer({
+        url : webContext + attachment.downloadUrl
+      });
+      return $mediaContainer;
+    };
+    var __renderViewable = function(attachment) {
+      var $viewableContainer = document.createElement("div");
+      jQuery($viewableContainer).view("viewAttachment", {
+        componentInstanceId: attachment.instanceId,
+        attachmentId: attachment.id,
+        lang: attachment.lang,
+        insertMode : true
+      });
+      return $viewableContainer;
+    };
+    whenSilverpeasReady(function() {
+      this.$rootContainer = document.querySelector(__context.options.domSelector);
+      __initPromise.then(function(attachments) {
+        attachments.forEach(function(attachment) {
+          if (!attachment.displayAsContent) {
+            return;
+          }
+          var $renderedContainer;
+          if (__context.options.enableViewable && attachment.viewable) {
+            $renderedContainer = __renderContainer(attachment, __renderViewable);
+            $renderedContainer.classList.add('viewable');
+          } else if (__context.options.enableAudio && attachment.contentType.startsWith('audio')) {
+            $renderedContainer = __renderContainer(attachment, __renderMedia);
+            $renderedContainer.classList.add('audio');
+          } else if (__context.options.enableVideo && attachment.contentType.startsWith('video')) {
+            $renderedContainer = __renderContainer(attachment, __renderMedia);
+            $renderedContainer.classList.add('video');
+          } else if (__context.options.enableImage && attachment.contentType.startsWith('image')) {
+            $renderedContainer = __renderContainer(attachment, __renderImage);
+            $renderedContainer.classList.add('image');
+          } else if (__context.options.enableSimpleText && attachment.contentType.startsWith('text')) {
+            $renderedContainer = __renderContainer(attachment, __renderSimpleText);
+            $renderedContainer.classList.add('simple-text');
+          } else {
+            sp.log.debug("AttachmentsAsContentViewer - no renderer for " + JSON.stringify(attachment));
+          }
+          if ($renderedContainer) {
+            this.$rootContainer.appendChild($renderedContainer);
+          }
+        }.bind(this));
+      }.bind(this));
+    });
   }
 })(jQuery);

--- a/core-war/src/main/webapp/util/styleSheets/silverpeas-main.css
+++ b/core-war/src/main/webapp/util/styleSheets/silverpeas-main.css
@@ -6574,6 +6574,26 @@ THESE TWO NEXT CLASSES ARE USED BY RESIZE WINDOW MECHANISM
   height: auto;
 }
 
+.attachments-as-content .attachment-container {
+  margin-bottom: 2em;
+}
+
+.attachments-as-content .content {
+  text-align: center;
+}
+
+.attachments-as-content .simple-text .content {
+  text-align: inherit;
+  white-space: pre-wrap;
+  padding: 10px;
+  margin: 0 20px 0 20px;
+  border: 2px solid #717171;
+}
+
+.attachments-as-content .content img {
+  max-width: 100%;
+}
+
 /**
  * JSP fragments : confirmation of wysiwyg backup manager
  */

--- a/core-web/src/main/java/org/silverpeas/core/web/attachment/tag/SimpleDocumentContextualMenu.java
+++ b/core-web/src/main/java/org/silverpeas/core/web/attachment/tag/SimpleDocumentContextualMenu.java
@@ -23,15 +23,15 @@
  */
 package org.silverpeas.core.web.attachment.tag;
 
-import org.silverpeas.core.admin.user.model.User;
-import org.silverpeas.core.web.mvc.controller.MainSessionController;
-import org.silverpeas.core.admin.user.model.UserDetail;
 import org.apache.commons.lang3.StringEscapeUtils;
+import org.silverpeas.core.admin.user.model.User;
+import org.silverpeas.core.admin.user.model.UserDetail;
 import org.silverpeas.core.contribution.attachment.model.SimpleDocument;
+import org.silverpeas.core.i18n.I18NHelper;
 import org.silverpeas.core.util.LocalizationBundle;
 import org.silverpeas.core.util.ResourceLocator;
 import org.silverpeas.core.util.StringUtil;
-import org.silverpeas.core.i18n.I18NHelper;
+import org.silverpeas.core.web.mvc.controller.MainSessionController;
 
 import javax.servlet.jsp.JspException;
 import javax.servlet.jsp.tagext.TagSupport;
@@ -39,6 +39,8 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 
 import static org.silverpeas.core.admin.service.AdministrationServiceProvider.getAdminService;
+import static org.silverpeas.core.contribution.attachment.util.AttachmentSettings
+    .isDisplayableAsContentForComponentInstanceId;
 import static org.silverpeas.core.util.StringUtil.newline;
 
 /**
@@ -168,6 +170,15 @@ public class SimpleDocumentContextualMenu extends TagSupport {
     }
     prepareMenuItem(builder, "switchDownloadAllowedForReaders('" + attachment.getId() + "', " +
         !isDownloadAllowedForReaders + ");", message);
+    if (isDisplayableAsContentForComponentInstanceId(attachment.getInstanceId())) {
+      message = resources.getString("attachment.displayAsContent.enable");
+      boolean isDisplayAsContentEnabled = attachment.isDisplayableAsContent();
+      if (isDisplayAsContentEnabled) {
+        message = resources.getString("attachment.displayAsContent.disable");
+      }
+      prepareMenuItem(builder, "switchDisplayAsContentEnabled('" + attachment.getId() + "', " +
+          !isDisplayAsContentEnabled + ");", message);
+    }
     builder.append("</ul>").append(newline);
     builder.append("<ul>").append(newline);
     prepareMenuItem(builder, "ShareAttachment('" + attachmentId + "');", resources.getString(

--- a/core-web/src/main/java/org/silverpeas/core/web/util/viewgenerator/html/IncludeJSPluginTag.java
+++ b/core-web/src/main/java/org/silverpeas/core/web/util/viewgenerator/html/IncludeJSPluginTag.java
@@ -73,7 +73,7 @@ public class IncludeJSPluginTag extends SimpleTagSupport {
   }
 
   protected LookHelper getLookHelper() {
-    return (LookHelper) getSessionAttribute(LookHelper.SESSION_ATT);
+    return getSessionAttribute(LookHelper.SESSION_ATT);
   }
 
   protected String getLanguage() {

--- a/core-web/src/main/java/org/silverpeas/core/webapi/attachment/AttachmentEntity.java
+++ b/core-web/src/main/java/org/silverpeas/core/webapi/attachment/AttachmentEntity.java
@@ -23,18 +23,17 @@
  */
 package org.silverpeas.core.webapi.attachment;
 
-import org.silverpeas.core.webapi.base.WebEntity;
-import org.silverpeas.core.util.URLUtil;
-
-import org.apache.commons.lang3.CharEncoding;
+import org.silverpeas.core.SilverpeasRuntimeException;
 import org.silverpeas.core.contribution.attachment.AttachmentException;
 import org.silverpeas.core.contribution.attachment.model.SimpleDocument;
+import org.silverpeas.core.util.Charsets;
+import org.silverpeas.core.util.URLUtil;
 import org.silverpeas.core.util.logging.SilverLogger;
+import org.silverpeas.core.webapi.base.WebEntity;
 
 import javax.ws.rs.core.UriBuilder;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
-
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -79,8 +78,7 @@ public class AttachmentEntity implements WebEntity {
     try {
       entity.uri = new URI(URLUtil.getSimpleURL(URLUtil.URL_FILE, detail.getId()));
     } catch (URISyntaxException e) {
-      throw new AttachmentException("AttachmentEntity.fromAttachment(",
-          AttachmentException.ERROR, "Couldn't build the URI to the attachment", e);
+      throw new AttachmentException("Couldn't build the URI to the attachment", e);
     }
     entity.id = detail.getId();
     entity.instanceId = detail.getInstanceId();
@@ -113,34 +111,34 @@ public class AttachmentEntity implements WebEntity {
   }
 
   public void withSharedUri(String baseURI, String token) {
-    URI sharedUri;
+    URI theUri;
     try {
-      sharedUri = UriBuilder.fromUri(baseURI)
+      theUri = UriBuilder.fromUri(baseURI)
           .path("sharing/attachments")
           .path(instanceId)
           .path(token)
           .path(id)
-          .path(URLEncoder.encode(logicalName, CharEncoding.UTF_8))
+          .path(URLEncoder.encode(logicalName, Charsets.UTF_8.name()))
           .build();
     } catch (UnsupportedEncodingException ex) {
       SilverLogger.getLogger(this).error(ex.getMessage(), ex);
-      throw new RuntimeException(ex.getMessage(), ex);
+      throw new SilverpeasRuntimeException(ex.getMessage(), ex);
     }
-    this.sharedUri = sharedUri;
+    this.sharedUri = theUri;
   }
 
-  public void withUri(String baseURI) {
+  public void withBaseUri(String baseURI) {
     URI privateUri;
     try {
       privateUri = UriBuilder.fromUri(baseURI)
           .path("private/attachments")
           .path(instanceId)
           .path(id)
-          .path(URLEncoder.encode(logicalName, CharEncoding.UTF_8))
+          .path(URLEncoder.encode(logicalName, Charsets.UTF_8.name()))
           .build();
     } catch (UnsupportedEncodingException ex) {
       SilverLogger.getLogger(this).error(ex.getMessage(), ex);
-      throw new RuntimeException(ex.getMessage(), ex);
+      throw new SilverpeasRuntimeException(ex.getMessage(), ex);
     }
     this.uri = privateUri;
   }

--- a/core-web/src/main/java/org/silverpeas/core/webapi/attachment/SimpleDocumentEntity.java
+++ b/core-web/src/main/java/org/silverpeas/core/webapi/attachment/SimpleDocumentEntity.java
@@ -77,6 +77,12 @@ public class SimpleDocumentEntity implements WebEntity {
   private String comment;
   @XmlElement(defaultValue = "false")
   private String versioned;
+  @XmlElement
+  private Boolean prewiewable;
+  @XmlElement
+  private Boolean viewable;
+  @XmlElement
+  private Boolean displayAsContent;
 
   public static SimpleDocumentEntity fromAttachment(SimpleDocument document) {
     SimpleDocumentEntity entity = new SimpleDocumentEntity();
@@ -192,4 +198,30 @@ public class SimpleDocumentEntity implements WebEntity {
     return versioned;
   }
 
+  public Boolean getPrewiewable() {
+    return prewiewable;
+  }
+
+  public SimpleDocumentEntity prewiewable(final boolean prewiewable) {
+    this.prewiewable = prewiewable;
+    return this;
+  }
+
+  public Boolean getViewable() {
+    return viewable;
+  }
+
+  public SimpleDocumentEntity viewable(final boolean viewable) {
+    this.viewable = viewable;
+    return this;
+  }
+
+  public Boolean getDisplayAsContent() {
+    return displayAsContent;
+  }
+
+  public SimpleDocumentEntity displayAsContent(final boolean displayAsContent) {
+    this.displayAsContent = displayAsContent;
+    return this;
+  }
 }

--- a/core-web/src/main/java/org/silverpeas/core/webapi/attachment/SimpleDocumentEntity.java
+++ b/core-web/src/main/java/org/silverpeas/core/webapi/attachment/SimpleDocumentEntity.java
@@ -23,16 +23,14 @@
  */
 package org.silverpeas.core.webapi.attachment;
 
-import java.net.URI;
-import java.net.URISyntaxException;
-
-import javax.xml.bind.annotation.XmlElement;
-
-import org.silverpeas.core.webapi.base.WebEntity;
 import org.silverpeas.core.contribution.attachment.AttachmentException;
 import org.silverpeas.core.contribution.attachment.model.SimpleDocument;
-
 import org.silverpeas.core.util.URLUtil;
+import org.silverpeas.core.webapi.base.WebEntity;
+
+import javax.xml.bind.annotation.XmlElement;
+import java.net.URI;
+import java.net.URISyntaxException;
 
 /**
  *
@@ -89,8 +87,7 @@ public class SimpleDocumentEntity implements WebEntity {
     try {
       entity.uri = new URI(URLUtil.getSimpleURL(URLUtil.URL_FILE, document.getId()));
     } catch (URISyntaxException e) {
-      throw new AttachmentException("AttachmentEntity.fromAttachment(",
-          AttachmentException.ERROR, "Couldn't build the URI to the attachment", e);
+      throw new AttachmentException("Couldn't build the URI to the attachment", e);
     }
     entity.id = document.getId();
     entity.instanceId = document.getInstanceId();

--- a/core-web/src/main/java/org/silverpeas/core/webapi/attachment/SimpleDocumentListResource.java
+++ b/core-web/src/main/java/org/silverpeas/core/webapi/attachment/SimpleDocumentListResource.java
@@ -24,21 +24,30 @@
 package org.silverpeas.core.webapi.attachment;
 
 import org.silverpeas.core.ResourceReference;
+import org.silverpeas.core.admin.user.model.SilverpeasRole;
 import org.silverpeas.core.annotation.RequestScoped;
 import org.silverpeas.core.annotation.Service;
 import org.silverpeas.core.contribution.attachment.AttachmentServiceProvider;
 import org.silverpeas.core.contribution.attachment.model.DocumentType;
 import org.silverpeas.core.contribution.attachment.model.SimpleDocument;
+import org.silverpeas.core.util.StringUtil;
+import org.silverpeas.core.viewer.service.PreviewService;
+import org.silverpeas.core.viewer.service.ViewService;
 import org.silverpeas.core.webapi.base.annotation.Authorized;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+
+import static org.silverpeas.core.admin.user.model.SilverpeasRole.reader;
+import static org.silverpeas.core.admin.user.model.SilverpeasRole.user;
 
 @Service
 @RequestScoped
@@ -48,6 +57,12 @@ public class SimpleDocumentListResource extends AbstractSimpleDocumentResource {
 
   @PathParam("id")
   private String resourceId;
+
+  @QueryParam("viewIndicators")
+  private boolean viewIndicators = false;
+
+  @QueryParam("highestUserRole")
+  private SilverpeasRole highestUserRole = null;
 
   public String getResourceId() {
     return resourceId;
@@ -95,10 +110,22 @@ public class SimpleDocumentListResource extends AbstractSimpleDocumentResource {
   }
 
   private List<SimpleDocumentEntity> asWebEntities(List<SimpleDocument> docs) {
-    List<SimpleDocumentEntity> entities = new ArrayList<>();
-    for (SimpleDocument doc : docs) {
-      entities.add(SimpleDocumentEntity.fromAttachment(doc));
-    }
+    final List<SimpleDocumentEntity> entities = new ArrayList<>();
+    final SilverpeasRole userRole = highestUserRole != null ? highestUserRole : getHighestUserRole();
+    docs.stream().map(d -> {
+      if (d.isVersioned() && !d.isPublic() && (userRole == user || userRole == reader)) {
+        return d.getLastPublicVersion();
+      }
+      return d;
+    }).forEach(d -> {
+      final SimpleDocumentEntity entity = SimpleDocumentEntity.fromAttachment(d);
+      entities.add(entity);
+      if (viewIndicators) {
+        entity.prewiewable(PreviewService.get().isPreviewable(new File(d.getAttachmentPath())))
+            .viewable(ViewService.get().isViewable(new File(d.getAttachmentPath())))
+            .displayAsContent(d.isDisplayableAsContent());
+      }
+    });
     return entities;
   }
 

--- a/core-web/src/main/java/org/silverpeas/core/webapi/attachment/SimpleDocumentResource.java
+++ b/core-web/src/main/java/org/silverpeas/core/webapi/attachment/SimpleDocumentResource.java
@@ -502,6 +502,26 @@ public class SimpleDocumentResource extends AbstractSimpleDocumentResource {
   }
 
   /**
+   * Enable or not the display as content of an attachment.
+   * @return JSON display as content state. displayableAsContent = true or false.
+   */
+  @POST
+  @Path("switchDisplayAsContentEnabled")
+  @Produces(MediaType.APPLICATION_JSON)
+  public String switchDisplayAsContentEnabled(@FormParam("enabled") final boolean enabled) {
+
+    // Performing the request
+    SimpleDocument document = getSimpleDocument(null);
+    AttachmentServiceProvider.getAttachmentService()
+        .switchEnableDisplayAsContent(document.getPk(), enabled);
+
+    // JSON Response.
+    return MessageFormat.format(
+        "'{'\"displayableAsContent\":{0}, \"id\":{1,number,#}, \"attachmentId\":\"{2}\"}",
+        enabled, document.getOldSilverpeasId(), document.getId());
+  }
+
+  /**
    * Return the current document
    * @param lang
    * @return SimpleDocument

--- a/core-web/src/main/java/org/silverpeas/core/webapi/publication/AbstractPublicationResource.java
+++ b/core-web/src/main/java/org/silverpeas/core/webapi/publication/AbstractPublicationResource.java
@@ -75,15 +75,17 @@ public abstract class AbstractPublicationResource extends RESTWebService {
 
   protected PublicationEntity getPublicationEntity(PublicationDetail publication, boolean withAttachments) {
     if (publication.isValid()) {
-      URI uri = getURI(publication);
+      URI uri = getPublicationUri(publication);
       PublicationEntity entity = PublicationEntity.fromPublicationDetail(publication, uri);
       if (withAttachments) {
         AttachmentService attachmentService = AttachmentServiceProvider.getAttachmentService();
         // expose regular files
         Collection<SimpleDocument> attachments =
-            attachmentService.listDocumentsByForeignKey(publication.getPK(), null);
+            attachmentService.listDocumentsByForeignKey(publication.getPK().toResourceReference(),
+                null);
         // and files attached to form too...
-        attachments.addAll(attachmentService.listDocumentsByForeignKeyAndType(publication.getPK(),
+        attachments.addAll(attachmentService.listDocumentsByForeignKeyAndType(
+            publication.getPK().toResourceReference(),
             DocumentType.form, null));
         entity.withAttachments(attachments);
       }
@@ -94,14 +96,14 @@ public abstract class AbstractPublicationResource extends RESTWebService {
 
   protected abstract boolean isNodeReadable(NodePK nodePK);
 
-  private URI getURI(PublicationDetail publication) {
+  private URI getPublicationUri(PublicationDetail publication) {
     return getUri().getAbsolutePathBuilder()
         .path("publication")
         .path(publication.getPK().getId())
         .build();
   }
 
-  protected NodeService geetNodeService() {
+  protected NodeService getNodeService() {
     try {
       return NodeService.get();
     } catch (Exception e) {

--- a/core-web/src/main/java/org/silverpeas/core/webapi/publication/PublicationResource.java
+++ b/core-web/src/main/java/org/silverpeas/core/webapi/publication/PublicationResource.java
@@ -124,7 +124,7 @@ public class PublicationResource extends AbstractPublicationResource {
         List<AttachmentEntity> attachments = publication.getAttachments();
         if (attachments != null) {
           for (AttachmentEntity attachment : attachments) {
-            attachment.withUri(getUri().getBaseUri().toString());
+            attachment.withBaseUri(getUri().getBaseUri().toString());
           }
         }
       }

--- a/core-web/src/main/java/org/silverpeas/core/webapi/publication/SharedPublicationResource.java
+++ b/core-web/src/main/java/org/silverpeas/core/webapi/publication/SharedPublicationResource.java
@@ -122,7 +122,7 @@ public class SharedPublicationResource extends AbstractPublicationResource {
   @Override
   protected boolean isNodeReadable(NodePK nodePK) {
     nodePK.setComponentName(getComponentId());
-    NodeDetail node = super.geetNodeService().getDetail(nodePK);
+    NodeDetail node = super.getNodeService().getDetail(nodePK);
     ShareableNode nodeResource = new ShareableNode(token, node);
     return this.ticket.getAccessControl().isReadable(nodeResource);
   }


### PR DESCRIPTION
- adding new viewable JCR mixin with property displayableAsContent for a SimpleDocument
- implementing a Vanilla Javascript Plugin in order to view directly the attachment contents linked to a contribution
- modifying document list resource in order to get optionally the indicators about the viewing capacities
- improving viewer services in order to handle more precisely performances

Linked to PR https://github.com/Silverpeas/Silverpeas-Components/pull/608