### PR TITLE
Feature 9827

### DIFF
--- a/core-configuration/src/main/config/properties/org/silverpeas/jobDomainPeas/multilang/jobDomainPeasBundle.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/jobDomainPeas/multilang/jobDomainPeasBundle.properties
@@ -158,3 +158,7 @@ JDP.rights.assign.sourceRightsUserPanel = S\u00e9lectionnez l'utilisateur ou le 
 JDP.rights.assign.nodeAssignRights = Attribuer aussi les droits sur les dossiers de la GED
 JDP.rights.assign.MessageOk = Les droits d'acc\u00e8s ont \u00e9t\u00e9 attribu\u00e9s
 JDP.rights.assign.MessageNOk = Probl\u00e8me lors de l'attribution des droits d'acc\u00e8s
+JDP.deletedUserAccess=Afficher les utilisateurs supprim\u00e9s
+JDP.deletedUsers=utilisateurs supprim\u00e9s
+JDP.userDeletionDate=Date de suppression de l'utilisateur
+JDP.blankUser=Appliquer le droit \u00e0 l'oubli

--- a/core-configuration/src/main/config/properties/org/silverpeas/jobDomainPeas/multilang/jobDomainPeasBundle_de.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/jobDomainPeas/multilang/jobDomainPeasBundle_de.properties
@@ -159,3 +159,7 @@ JDP.rights.assign.sourceRightsUserPanel = W\u00e4hlen Sie den Benutzer oder die 
 JDP.rights.assign.nodeAssignRights = Auch zuweisen Rechten f\u00fcr Ordner der EDM
 JDP.rights.assign.MessageOk = Die Zugriffsrechte wurden assign
 JDP.rights.assign.MessageNOk = Problem bei der Vergabe von Zugriffsrechten
+JDP.deletedUserAccess=Zeige gelöschte Benutzer
+JDP.deletedUsers=Benutzer gelöscht
+JDP.userDeletionDate=Datum des Löschens des Benutzers
+JDP.blankUser=Anonymisieren

--- a/core-configuration/src/main/config/properties/org/silverpeas/jobDomainPeas/multilang/jobDomainPeasBundle_en.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/jobDomainPeas/multilang/jobDomainPeasBundle_en.properties
@@ -158,3 +158,7 @@ JDP.rights.assign.sourceRightsUserPanel = Select the user or group
 JDP.rights.assign.nodeAssignRights = Also assign rights to the folders of the EDM
 JDP.rights.assign.MessageOk = The access rights have been assigned
 JDP.rights.assign.MessageNOk = Problem while assigning access rights
+JDP.deletedUserAccess=Show the deleted users
+JDP.deletedUsers=deleted users
+JDP.userDeletionDate=Date of the user deletion
+JDP.blankUser=Anonymize

--- a/core-configuration/src/main/config/properties/org/silverpeas/jobDomainPeas/multilang/jobDomainPeasBundle_fr.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/jobDomainPeas/multilang/jobDomainPeasBundle_fr.properties
@@ -158,3 +158,7 @@ JDP.rights.assign.sourceRightsUserPanel = S\u00e9lectionnez l'utilisateur ou le 
 JDP.rights.assign.nodeAssignRights = Attribuer aussi les droits sur les dossiers de la GED
 JDP.rights.assign.MessageOk = Les droits d'acc\u00e8s ont \u00e9t\u00e9 attribu\u00e9s
 JDP.rights.assign.MessageNOk = Probl\u00e8me lors de l'attribution des droits d'acc\u00e8s
+JDP.deletedUserAccess=Afficher les utilisateurs supprim\u00e9s
+JDP.deletedUsers=utilisateurs supprim\u00e9s
+JDP.userDeletionDate=Date de suppression de l'utilisateur
+JDP.blankUser=Appliquer le droit \u00e0 l'oubli

--- a/core-configuration/src/main/config/properties/org/silverpeas/jobDomainPeas/settings/jobDomainPeasIcons.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/jobDomainPeas/settings/jobDomainPeasIcons.properties
@@ -67,6 +67,7 @@ JDP.userDel = /util/icons/user_to_del.gif
 JDP.userImport = /util/icons/user_add_to_domain.gif
 JDP.userManage = /util/icons/manage_user.gif
 JDP.userPanelAccess = /util/icons/userPanel_access.gif
+JDP.deletedUserAccess = /util/icons/user_to_del.gif
 JDP.userRemove = /util/icons/user_del_to_group.gif
 JDP.userSynchro = /util/icons/user_synchro.gif
 JDP.userUnsynchro = /util/icons/user_unsynchro.gif

--- a/core-configuration/src/main/config/properties/org/silverpeas/multilang/generalMultilang.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/multilang/generalMultilang.properties
@@ -470,3 +470,4 @@ GML.reminder=Rappel
 GML.before=avant
 GML.action.selection.delete=Supprimer la s\u00e9lection
 GML.action.selection.delete.confirm=Etes-vous s\u00fbr(e) de vouloir supprimer d\u00e9finitivement votre s\u00e9lection ?
+GML.Anonymous=Anonyme

--- a/core-configuration/src/main/config/properties/org/silverpeas/multilang/generalMultilang_de.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/multilang/generalMultilang_de.properties
@@ -469,3 +469,4 @@ GML.reminder=Reminder
 GML.before=before
 GML.action.selection.delete=Auswahl l\u00f6schen
 GML.action.selection.delete.confirm=M\u00f6chten Sie Ihre Auswahl wirklich dauerhaft l\u00f6schen?
+GML.Anonymous=anonym

--- a/core-configuration/src/main/config/properties/org/silverpeas/multilang/generalMultilang_en.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/multilang/generalMultilang_en.properties
@@ -470,3 +470,4 @@ GML.reminder=Reminder
 GML.before=before
 GML.action.selection.delete=Delete selection
 GML.action.selection.delete.confirm=Are you sure you want to permanently delete your selection?
+GML.Anonymous=Anonymous

--- a/core-configuration/src/main/config/properties/org/silverpeas/multilang/generalMultilang_fr.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/multilang/generalMultilang_fr.properties
@@ -471,3 +471,4 @@ GML.url.path.notFound=Le chemin de l''URL ''{0}'' n''est pas pris en charge
 GML.content=Contenu
 GML.reminder=Rappel
 GML.before=avant
+GML.Anonymous=Anonyme

--- a/core-library/src/integration-test/java/org/silverpeas/core/admin/StubbedAdministration.java
+++ b/core-library/src/integration-test/java/org/silverpeas/core/admin/StubbedAdministration.java
@@ -98,84 +98,83 @@ public class StubbedAdministration implements Administration {
   }
 
   @Override
-  public String addSpaceInst(final String userId, final SpaceInst spaceInst) throws AdminException {
+  public String addSpaceInst(final String userId, final SpaceInst spaceInst) {
     return null;
   }
 
   @Override
   public String deleteSpaceInstById(final String userId, final String spaceId,
-      final boolean definitive) throws AdminException {
+      final boolean definitive) {
     return null;
   }
 
   @Override
-  public void restoreSpaceFromBasket(final String spaceId) throws AdminException {
+  public void restoreSpaceFromBasket(final String spaceId) {
 
   }
 
   @Override
-  public SpaceInst getSpaceInstById(final String spaceId) throws AdminException {
+  public SpaceInst getSpaceInstById(final String spaceId) {
     return null;
   }
 
   @Override
-  public SpaceInst getPersonalSpace(final String userId) throws AdminException {
+  public SpaceInst getPersonalSpace(final String userId) {
     return null;
   }
 
   @Override
-  public String[] getAllSubSpaceIds(final String domainFatherId) throws AdminException {
+  public String[] getAllSubSpaceIds(final String domainFatherId) {
     return new String[0];
   }
 
   @Override
-  public String updateSpaceInst(final SpaceInst spaceInstNew) throws AdminException {
+  public String updateSpaceInst(final SpaceInst spaceInstNew) {
     return null;
   }
 
   @Override
-  public void updateSpaceOrderNum(final String spaceId, final int orderNum) throws AdminException {
+  public void updateSpaceOrderNum(final String spaceId, final int orderNum) {
 
   }
 
   @Override
-  public boolean isSpaceInstExist(final String spaceId) throws AdminException {
+  public boolean isSpaceInstExist(final String spaceId) {
     return false;
   }
 
   @Override
-  public String[] getAllRootSpaceIds() throws AdminException {
+  public String[] getAllRootSpaceIds() {
     return new String[0];
   }
 
   @Override
-  public List<SpaceInstLight> getPathToComponent(final String componentId) throws AdminException {
+  public List<SpaceInstLight> getPathToComponent(final String componentId) {
     return null;
   }
 
   @Override
-  public List<SpaceInstLight> getPathToSpace(final String spaceId, final boolean includeTarget)
-      throws AdminException {
+  public List<SpaceInstLight> getPathToSpace(final String spaceId, final boolean includeTarget) {
     return null;
   }
 
   @Override
-  public String[] getAllSpaceIds() throws AdminException {
+  public String[] getAllSpaceIds() {
     return new String[0];
   }
 
   @Override
-  public List<SpaceInstLight> getRemovedSpaces() throws AdminException {
+  public List<SpaceInstLight> getRemovedSpaces() {
     return null;
   }
 
   @Override
-  public List<ComponentInstLight> getRemovedComponents() throws AdminException {
+  public List<ComponentInstLight> getRemovedComponents() {
     return null;
   }
 
   @Override
-  public String[] getSpaceNames(final String[] asClientSpaceIds) throws AdminException {
+  public String[] getSpaceNames(final String[] asClientSpaceIds) {
     return new String[0];
   }
 
@@ -185,18 +184,18 @@ public class StubbedAdministration implements Administration {
   }
 
   @Override
-  public ComponentInst getComponentInst(final String sClientComponentId) throws AdminException {
+  public ComponentInst getComponentInst(final String sClientComponentId) {
     return null;
   }
 
   @Override
-  public SilverpeasComponentInstance getComponentInstance(final String componentInstanceIdentifier)
-      throws AdminException {
+  public SilverpeasComponentInstance getComponentInstance(
+      final String componentInstanceIdentifier) {
     return null;
   }
 
   @Override
-  public ComponentInstLight getComponentInstLight(final String componentId) throws AdminException {
+  public ComponentInstLight getComponentInstLight(final String componentId) {
     return null;
   }
 
@@ -217,7 +216,7 @@ public class StubbedAdministration implements Administration {
   }
 
   @Override
-  public void restoreComponentFromBasket(final String componentId) throws AdminException {
+  public void restoreComponentFromBasket(final String componentId) {
 
   }
 
@@ -233,7 +232,7 @@ public class StubbedAdministration implements Administration {
 
   @Override
   public void deleteAllComponentIndexes() {
-    
+
   }
 
   @Override
@@ -244,54 +243,51 @@ public class StubbedAdministration implements Administration {
 
   @Override
   public String deleteComponentInst(final String userId, final String componentId,
-      final boolean definitive) throws AdminException {
+      final boolean definitive) {
     return null;
   }
 
   @Override
-  public void updateComponentOrderNum(final String componentId, final int orderNum)
-      throws AdminException {
+  public void updateComponentOrderNum(final String componentId, final int orderNum) {
 
   }
 
   @Override
-  public String updateComponentInst(final ComponentInst component) throws AdminException {
+  public String updateComponentInst(final ComponentInst component) {
     return null;
   }
 
   @Override
-  public void setSpaceProfilesToSubSpace(final SpaceInst subSpace, final SpaceInst space)
-      throws AdminException {
+  public void setSpaceProfilesToSubSpace(final SpaceInst subSpace, final SpaceInst space) {
 
   }
 
   @Override
   public void setSpaceProfilesToSubSpace(final SpaceInst subSpace, final SpaceInst space,
-      final boolean persist, final boolean startNewTransaction) throws AdminException {
+      final boolean persist, final boolean startNewTransaction) {
 
   }
 
   @Override
-  public void setSpaceProfilesToComponent(final ComponentInst component, final SpaceInst space)
-      throws AdminException {
+  public void setSpaceProfilesToComponent(final ComponentInst component, final SpaceInst space) {
 
   }
 
 
   @Override
-  public void moveSpace(final String spaceId, final String fatherId) throws AdminException {
+  public void moveSpace(final String spaceId, final String fatherId) {
 
   }
 
   @Override
   public void moveComponentInst(final String spaceId, final String componentId,
-      final String idComponentBefore, final ComponentInst[] componentInsts) throws AdminException {
+      final String idComponentBefore, final ComponentInst[] componentInsts) {
 
   }
 
   @Override
   public void setComponentPlace(final String componentId, final String idComponentBefore,
-      final ComponentInst[] m_BrothersComponents) throws AdminException {
+      final ComponentInst[] brothersComponents) {
 
   }
 
@@ -312,212 +308,202 @@ public class StubbedAdministration implements Administration {
   }
 
   @Override
-  public ProfileInst getProfileInst(final String sProfileId) throws AdminException {
+  public ProfileInst getProfileInst(final String sProfileId) {
     return null;
   }
 
   @Override
   public List<ProfileInst> getProfilesByObject(final String objectId, final String objectType,
-      final String componentId) throws AdminException {
+      final String componentId) {
     return null;
   }
 
   @Override
   public String[] getProfilesByObjectAndUserId(final int objectId, final String objectType,
-      final String componentId, final String userId) throws AdminException {
+      final String componentId, final String userId) {
     return new String[0];
   }
 
   @Override
   public Map<Integer, List<String>> getProfilesByObjectTypeAndUserId(final String objectType,
-      final String componentId, final String userId) throws AdminException {
+      final String componentId, final String userId) {
     return null;
   }
 
   @Override
   public boolean isObjectAvailable(final String componentId, final int objectId,
-      final String objectType, final String userId) throws AdminException {
+      final String objectType, final String userId) {
     return false;
   }
 
   @Override
-  public String addProfileInst(final ProfileInst profileInst) throws AdminException {
+  public String addProfileInst(final ProfileInst profileInst) {
     return null;
   }
 
   @Override
-  public String addProfileInst(final ProfileInst profileInst, final String userId)
-      throws AdminException {
+  public String addProfileInst(final ProfileInst profileInst, final String userId) {
     return null;
   }
 
   @Override
-  public String deleteProfileInst(final String sProfileId, final String userId)
-      throws AdminException {
+  public String deleteProfileInst(final String sProfileId, final String userId) {
     return null;
   }
 
   @Override
-  public String updateProfileInst(final ProfileInst profileInstNew) throws AdminException {
+  public String updateProfileInst(final ProfileInst profileInstNew) {
     return null;
   }
 
   @Override
-  public String updateProfileInst(final ProfileInst profileInstNew, final String userId)
-      throws AdminException {
+  public String updateProfileInst(final ProfileInst profileInstNew, final String userId) {
     return null;
   }
 
   @Override
-  public SpaceProfileInst getSpaceProfileInst(final String spaceProfileId) throws AdminException {
+  public SpaceProfileInst getSpaceProfileInst(final String spaceProfileId) {
     return null;
   }
 
   @Override
-  public String addSpaceProfileInst(final SpaceProfileInst spaceProfile, final String userId)
-      throws AdminException {
+  public String addSpaceProfileInst(final SpaceProfileInst spaceProfile, final String userId) {
     return null;
   }
 
   @Override
-  public String deleteSpaceProfileInst(final String sSpaceProfileId, final String userId)
-      throws AdminException {
+  public String deleteSpaceProfileInst(final String sSpaceProfileId, final String userId) {
     return null;
   }
 
   @Override
-  public String updateSpaceProfileInst(final SpaceProfileInst newSpaceProfile, final String userId)
-      throws AdminException {
+  public String updateSpaceProfileInst(final SpaceProfileInst newSpaceProfile,
+      final String userId) {
     return null;
   }
 
   @Override
-  public String[] getGroupNames(final String[] groupIds) throws AdminException {
+  public String[] getGroupNames(final String[] groupIds) {
     return new String[0];
   }
 
   @Override
-  public String getGroupName(final String sGroupId) throws AdminException {
+  public String getGroupName(final String sGroupId) {
     return null;
   }
 
   @Override
-  public List<GroupDetail> getAllGroups() throws AdminException {
+  public List<GroupDetail> getAllGroups() {
     return Collections.emptyList();
   }
 
   @Override
-  public boolean isGroupExist(final String groupName) throws AdminException {
+  public boolean isGroupExist(final String groupName) {
     return false;
   }
 
   @Override
-  public GroupDetail getGroup(final String groupId) throws AdminException {
+  public GroupDetail getGroup(final String groupId) {
     return null;
   }
 
   @Override
-  public List<String> getPathToGroup(final String groupId) throws AdminException {
+  public List<String> getPathToGroup(final String groupId) {
     return null;
   }
 
   @Override
-  public GroupDetail getGroupByNameInDomain(final String groupName, final String domainFatherId)
-      throws AdminException {
+  public GroupDetail getGroupByNameInDomain(final String groupName, final String domainFatherId) {
     return null;
   }
 
   @Override
-  public GroupDetail[] getGroups(final String[] asGroupId) throws AdminException {
+  public GroupDetail[] getGroups(final String[] asGroupId) {
     return new GroupDetail[0];
   }
 
   @Override
-  public String addGroup(final GroupDetail group) throws AdminException {
+  public String addGroup(final GroupDetail group) {
     return null;
   }
 
   @Override
-  public String addGroup(final GroupDetail group, final boolean onlyInSilverpeas) throws AdminException {
+  public String addGroup(final GroupDetail group, final boolean onlyInSilverpeas) {
     return null;
   }
 
   @Override
-  public String deleteGroupById(final String sGroupId) throws AdminException {
+  public String deleteGroupById(final String sGroupId) {
     return null;
   }
 
   @Override
-  public String deleteGroupById(final String sGroupId, final boolean onlyInSilverpeas)
-      throws AdminException {
+  public String deleteGroupById(final String sGroupId, final boolean onlyInSilverpeas) {
     return null;
   }
 
   @Override
-  public String updateGroup(final GroupDetail group) throws AdminException {
+  public String updateGroup(final GroupDetail group) {
     return null;
   }
 
   @Override
-  public String updateGroup(final GroupDetail group, final boolean onlyInSilverpeas)
-      throws AdminException {
+  public String updateGroup(final GroupDetail group, final boolean onlyInSilverpeas) {
     return null;
   }
 
   @Override
-  public void removeUserFromGroup(final String sUserId, final String sGroupId)
-      throws AdminException {
+  public void removeUserFromGroup(final String sUserId, final String sGroupId) {
 
   }
 
   @Override
-  public void addUserInGroup(final String sUserId, final String sGroupId) throws AdminException {
+  public void addUserInGroup(final String sUserId, final String sGroupId) {
 
   }
 
   @Override
-  public List<GroupDetail> getAllRootGroups() throws AdminException {
+  public List<GroupDetail> getAllRootGroups() {
     return Collections.emptyList();
   }
 
   @Override
-  public GroupProfileInst getGroupProfileInst(final String groupId) throws AdminException {
+  public GroupProfileInst getGroupProfileInst(final String groupId) {
     return null;
   }
 
   @Override
-  public String addGroupProfileInst(final GroupProfileInst spaceProfileInst) throws AdminException {
+  public String addGroupProfileInst(final GroupProfileInst spaceProfileInst) {
     return null;
   }
 
   @Override
-  public String deleteGroupProfileInst(final String groupId) throws AdminException {
+  public String deleteGroupProfileInst(final String groupId) {
     return null;
   }
 
   @Override
-  public String updateGroupProfileInst(final GroupProfileInst groupProfileInstNew)
-      throws AdminException {
+  public String updateGroupProfileInst(final GroupProfileInst groupProfileInstNew) {
     return null;
   }
 
   @Override
-  public void indexAllGroups() throws AdminException {
+  public void indexAllGroups() {
 
   }
 
   @Override
-  public void indexGroups(final String domainId) throws AdminException {
+  public void indexGroups(final String domainId) {
 
   }
 
   @Override
-  public String[] getAllUsersIds() throws AdminException {
+  public String[] getAllUsersIds() {
     return new String[0];
   }
 
   @Override
-  public UserDetail getUserDetail(final String sUserId) throws AdminException {
+  public UserDetail getUserDetail(final String sUserId) {
     return null;
   }
 
@@ -527,101 +513,97 @@ public class StubbedAdministration implements Administration {
   }
 
   @Override
-  public List<UserDetail> getAllUsers() throws AdminException {
+  public List<UserDetail> getAllUsers() {
     return null;
   }
 
   @Override
-  public List<UserDetail> getAllUsersFromNewestToOldest() throws AdminException {
+  public List<UserDetail> getAllUsersFromNewestToOldest() {
     return null;
   }
 
   @Override
-  public boolean isEmailExisting(final String email) throws AdminException {
+  public boolean isEmailExisting(final String email) {
     return false;
   }
 
   @Override
-  public String getUserIdByLoginAndDomain(final String sLogin, final String sDomainId)
-      throws AdminException {
+  public String getUserIdByLoginAndDomain(final String sLogin, final String sDomainId) {
     return null;
   }
 
   @Override
-  public String getUserIdByAuthenticationKey(final String authenticationKey) throws AdminException {
+  public String getUserIdByAuthenticationKey(final String authenticationKey) {
     return null;
   }
 
   @Override
-  public UserFull getUserFull(final String sUserId) throws AdminException {
+  public UserFull getUserFull(final String sUserId) {
     return null;
   }
 
   @Override
-  public UserFull getUserFull(final String domainId, final String specificId) throws Exception {
+  public UserFull getUserFull(final String domainId, final String specificId) {
     return null;
   }
 
   @Override
-  public String addUser(final UserDetail userDetail) throws AdminException {
+  public String addUser(final UserDetail userDetail) {
     return null;
   }
 
   @Override
-  public String addUser(final UserDetail userDetail, final boolean addOnlyInSilverpeas)
-      throws AdminException {
+  public String addUser(final UserDetail userDetail, final boolean addOnlyInSilverpeas) {
     return null;
   }
 
   @Override
-  public void migrateUser(final UserDetail userDetail, final String targetDomainId)
-      throws AdminException {
+  public void migrateUser(final UserDetail userDetail, final String targetDomainId) {
 
   }
 
   @Override
-  public void blockUser(final String userId) throws AdminException {
+  public void blockUser(final String userId) {
 
   }
 
   @Override
-  public void unblockUser(final String userId) throws AdminException {
+  public void unblockUser(final String userId) {
 
   }
 
   @Override
-  public void deactivateUser(final String userId) throws AdminException {
+  public void deactivateUser(final String userId) {
 
   }
 
   @Override
-  public void activateUser(final String userId) throws AdminException {
+  public void activateUser(final String userId) {
 
   }
 
   @Override
-  public void userAcceptsTermsOfService(final String userId) throws AdminException {
+  public void userAcceptsTermsOfService(final String userId) {
 
   }
 
   @Override
-  public String deleteUser(final String sUserId) throws AdminException {
+  public String deleteUser(final String sUserId) {
     return null;
   }
 
   @Override
-  public String deleteUser(final String sUserId, final boolean onlyInSilverpeas)
-      throws AdminException {
+  public String deleteUser(final String sUserId, final boolean onlyInSilverpeas) {
     return null;
   }
 
   @Override
-  public String updateUser(final UserDetail user) throws AdminException {
+  public String updateUser(final UserDetail user) {
     return null;
   }
 
   @Override
-  public String updateUserFull(final UserFull user) throws AdminException {
+  public String updateUserFull(final UserFull user) {
     return null;
   }
 
@@ -631,203 +613,194 @@ public class StubbedAdministration implements Administration {
   }
 
   @Override
-  public String[] getClientSpaceIds(final String[] asDriverSpaceIds) throws Exception {
+  public String[] getClientSpaceIds(final String[] asDriverSpaceIds) {
     return new String[0];
   }
 
   @Override
-  public String getNextDomainId() throws AdminException {
+  public String getNextDomainId() {
     return null;
   }
 
   @Override
-  public String addDomain(final Domain theDomain) throws AdminException {
+  public String addDomain(final Domain theDomain) {
     return null;
   }
 
   @Override
-  public String updateDomain(final Domain domain) throws AdminException {
+  public String updateDomain(final Domain domain) {
     return null;
   }
 
   @Override
-  public String removeDomain(final String domainId) throws AdminException {
+  public String removeDomain(final String domainId) {
     return null;
   }
 
   @Override
-  public Domain[] getAllDomains() throws AdminException {
+  public Domain[] getAllDomains() {
     return new Domain[0];
   }
 
   @Override
-  public List<String> getAllDomainIdsForLogin(final String login) throws AdminException {
+  public List<String> getAllDomainIdsForLogin(final String login) {
     return null;
   }
 
   @Override
-  public Domain getDomain(final String domainId) throws AdminException {
+  public Domain getDomain(final String domainId) {
     return null;
   }
 
   @Override
-  public long getDomainActions(final String domainId) throws AdminException {
+  public long getDomainActions(final String domainId) {
     return 0;
   }
 
   @Override
-  public GroupDetail[] getRootGroupsOfDomain(final String domainId) throws AdminException {
+  public GroupDetail[] getRootGroupsOfDomain(final String domainId) {
     return new GroupDetail[0];
   }
 
   @Override
-  public List<GroupDetail> getSynchronizedGroups() throws AdminException {
+  public List<GroupDetail> getSynchronizedGroups() {
     return Collections.emptyList();
   }
 
   @Override
-  public UserDetail[] getAllUsersOfGroup(final String groupId) throws AdminException {
+  public UserDetail[] getAllUsersOfGroup(final String groupId) {
     return new UserDetail[0];
   }
 
   @Override
-  public UserDetail[] getUsersOfDomain(final String domainId) throws AdminException {
+  public UserDetail[] getUsersOfDomain(final String domainId) {
     return new UserDetail[0];
   }
 
   @Override
-  public List<UserDetail> getUsersOfDomains(final List<String> domainIds) throws AdminException {
+  public List<UserDetail> getUsersOfDomains(final List<String> domainIds) {
     return null;
   }
 
   @Override
-  public List<UserDetail> getUsersOfDomainsFromNewestToOldest(final List<String> domainIds)
-      throws AdminException {
+  public List<UserDetail> getUsersOfDomainsFromNewestToOldest(final List<String> domainIds) {
     return null;
   }
 
   @Override
-  public String[] getUserIdsOfDomain(final String domainId) throws AdminException {
+  public String[] getUserIdsOfDomain(final String domainId) {
     return new String[0];
   }
 
   @Override
   public String identify(final String sKey, final String sSessionId,
-      final boolean isAppInMaintenance) throws AdminException {
+      final boolean isAppInMaintenance) {
     return null;
   }
 
   @Override
   public String identify(final String sKey, final String sSessionId,
-      final boolean isAppInMaintenance, final boolean removeKey) throws AdminException {
+      final boolean isAppInMaintenance, final boolean removeKey) {
     return null;
   }
 
   @Override
-  public List<GroupDetail> getDirectGroupsOfUser(final String userId) throws AdminException {
+  public List<GroupDetail> getDirectGroupsOfUser(final String userId) {
     return Collections.emptyList();
   }
 
   @Override
-  public String[] getUserSpaceIds(final String sUserId) throws AdminException {
+  public String[] getUserSpaceIds(final String sUserId) {
     return new String[0];
   }
 
   @Override
-  public String[] getUserRootSpaceIds(final String sUserId) throws AdminException {
+  public String[] getUserRootSpaceIds(final String sUserId) {
     return new String[0];
   }
 
   @Override
-  public String[] getUserSubSpaceIds(final String sUserId, final String spaceId)
-      throws AdminException {
+  public String[] getUserSubSpaceIds(final String sUserId, final String spaceId) {
     return new String[0];
   }
 
   @Override
-  public boolean isSpaceAvailable(final String userId, final String spaceId) throws AdminException {
+  public boolean isSpaceAvailable(final String userId, final String spaceId) {
     return false;
   }
 
   @Override
-  public List<SpaceInstLight> getSubSpacesOfUser(final String userId, final String spaceId)
-      throws AdminException {
+  public List<SpaceInstLight> getSubSpacesOfUser(final String userId, final String spaceId) {
     return null;
   }
 
   @Override
-  public List<SpaceInstLight> getSubSpaces(final String spaceId) throws AdminException {
+  public List<SpaceInstLight> getSubSpaces(final String spaceId) {
     return null;
   }
 
   @Override
-  public List<ComponentInstLight> getAvailCompoInSpace(final String userId, final String spaceId)
-      throws AdminException {
+  public List<ComponentInstLight> getAvailCompoInSpace(final String userId, final String spaceId) {
     return null;
   }
 
   @Override
-  public Map<String, SpaceAndChildren> getTreeView(final String userId, final String spaceId)
-      throws AdminException {
+  public Map<String, SpaceAndChildren> getTreeView(final String userId, final String spaceId) {
     return null;
   }
 
   @Override
-  public List<SpaceInstLight> getUserSpaceTreeview(final String userId) throws Exception {
+  public List<SpaceInstLight> getUserSpaceTreeview(final String userId) {
     return null;
   }
 
   @Override
-  public String[] getAllowedSubSpaceIds(final String userId, final String spaceFatherId)
-      throws AdminException {
+  public String[] getAllowedSubSpaceIds(final String userId, final String spaceFatherId) {
     return new String[0];
   }
 
   @Override
-  public SpaceInstLight getSpaceInstLightById(final String sClientSpaceId) throws AdminException {
+  public SpaceInstLight getSpaceInstLightById(final String sClientSpaceId) {
     return null;
   }
 
   @Override
-  public SpaceInstLight getRootSpace(final String spaceId) throws AdminException {
+  public SpaceInstLight getRootSpace(final String spaceId) {
     return null;
   }
 
   @Override
-  public String[] getGroupManageableSpaceIds(final String sGroupId) throws AdminException {
+  public String[] getGroupManageableSpaceIds(final String sGroupId) {
     return new String[0];
   }
 
   @Override
-  public String[] getUserManageableSpaceIds(final String sUserId) throws AdminException {
+  public String[] getUserManageableSpaceIds(final String sUserId) {
     return new String[0];
   }
 
   @Override
-  public String[] getUserManageableSpaceRootIds(final String sUserId) throws AdminException {
+  public String[] getUserManageableSpaceRootIds(final String sUserId) {
     return new String[0];
   }
 
   @Override
-  public String[] getUserManageableSubSpaceIds(final String sUserId, final String sParentSpaceId)
-      throws AdminException {
+  public String[] getUserManageableSubSpaceIds(final String sUserId, final String sParentSpaceId) {
     return new String[0];
   }
 
   @Override
-  public SpaceProfile getSpaceProfile(final String spaceId, final SilverpeasRole role)
-      throws AdminException {
+  public SpaceProfile getSpaceProfile(final String spaceId, final SilverpeasRole role) {
     return null;
   }
 
   @Override
-  public List<String> getUserManageableGroupIds(final String sUserId) throws AdminException {
+  public List<String> getUserManageableGroupIds(final String sUserId) {
     return null;
   }
 
   @Override
-  public String[] getAvailCompoIds(final String sClientSpaceId, final String sUserId)
-      throws AdminException {
+  public String[] getAvailCompoIds(final String sClientSpaceId, final String sUserId) {
     return new String[0];
   }
 
@@ -837,82 +810,77 @@ public class StubbedAdministration implements Administration {
   }
 
   @Override
-  public boolean isComponentAvailable(final String componentId, final String userId)
-      throws AdminException {
+  public boolean isComponentAvailable(final String componentId, final String userId) {
     return false;
   }
 
   @Override
-  public boolean isComponentManageable(final String componentId, final String userId)
-      throws AdminException {
+  public boolean isComponentManageable(final String componentId, final String userId) {
     return false;
   }
 
   @Override
-  public String[] getAvailCompoIdsAtRoot(final String sClientSpaceId, final String sUserId)
-      throws AdminException {
+  public String[] getAvailCompoIdsAtRoot(final String sClientSpaceId, final String sUserId) {
     return new String[0];
   }
 
   @Override
   public List<String> getAvailCompoIdsAtRoot(final String sClientSpaceId, final String sUserId,
-      final String componentNameRoot) throws AdminException {
+      final String componentNameRoot) {
     return null;
   }
 
   @Override
-  public String[] getAvailCompoIds(final String userId) throws AdminException {
+  public String[] getAvailCompoIds(final String userId) {
     return new String[0];
   }
 
   @Override
-  public String[] getAvailDriverCompoIds(final String sClientSpaceId, final String sUserId)
-      throws AdminException {
+  public String[] getAvailDriverCompoIds(final String sClientSpaceId, final String sUserId) {
     return new String[0];
   }
 
   @Override
-  public String[] getComponentIdsByNameAndUserId(final String sUserId, final String sComponentName)
-      throws AdminException {
+  public String[] getComponentIdsByNameAndUserId(final String sUserId,
+      final String sComponentName) {
     return new String[0];
   }
 
   @Override
   public List<ComponentInstLight> getAvailComponentInstLights(final String userId,
-      final String componentName) throws AdminException {
+      final String componentName) {
     return null;
   }
 
   @Override
   public List<SpaceInstLight> getRootSpacesContainingComponent(final String userId,
-      final String componentName) throws AdminException {
+      final String componentName) {
     return null;
   }
 
   @Override
   public List<SpaceInstLight> getSubSpacesContainingComponent(final String spaceId,
-      final String userId, final String componentName) throws AdminException {
+      final String userId, final String componentName) {
     return null;
   }
 
   @Override
-  public CompoSpace[] getCompoForUser(final String sUserId, final String sComponentName)
-      throws AdminException {
+  public CompoSpace[] getCompoForUser(final String sUserId, final String sComponentName) {
     return new CompoSpace[0];
   }
 
   @Override
-  public String[] getCompoId(final String sComponentName) throws AdminException {
+  public String[] getCompoId(final String sComponentName) {
     return new String[0];
   }
 
   @Override
-  public String[] getProfileIds(final String sUserId) throws AdminException {
+  public String[] getProfileIds(final String sUserId) {
     return new String[0];
   }
 
   @Override
-  public String[] getProfileIdsOfGroup(final String sGroupId) throws AdminException {
+  public String[] getProfileIdsOfGroup(final String sGroupId) {
     return new String[0];
   }
 
@@ -922,45 +890,44 @@ public class StubbedAdministration implements Administration {
   }
 
   @Override
-  public String[] getCurrentProfiles(final String sUserId, final String componentId)
-      throws AdminException {
+  public String[] getCurrentProfiles(final String sUserId, final String componentId) {
     return new String[0];
   }
 
   @Override
   public UserDetail[] getUsers(final boolean bAllProfiles, final String sProfile,
-      final String sClientSpaceId, final String sClientComponentId) throws AdminException {
+      final String sClientSpaceId, final String sClientComponentId) {
     return new UserDetail[0];
   }
 
   @Override
-  public GroupDetail[] getAllSubGroups(final String parentGroupId) throws AdminException {
+  public GroupDetail[] getAllSubGroups(final String parentGroupId) {
     return new GroupDetail[0];
   }
 
   @Override
-  public GroupDetail[] getRecursivelyAllSubGroups(String parentGroupId) throws AdminException {
+  public GroupDetail[] getRecursivelyAllSubGroups(String parentGroupId) {
     return new GroupDetail[0];
   }
 
   @Override
-  public UserDetail[] getFiltredDirectUsers(final String sGroupId, final String sUserLastNameFilter)
-      throws AdminException {
+  public UserDetail[] getFiltredDirectUsers(final String sGroupId,
+      final String sUserLastNameFilter) {
     return new UserDetail[0];
   }
 
   @Override
-  public int getAllSubUsersNumber(final String sGroupId) throws AdminException {
+  public int getAllSubUsersNumber(final String sGroupId) {
     return 0;
   }
 
   @Override
-  public int getUsersNumberOfDomain(final String domainId) throws AdminException {
+  public int getUsersNumberOfDomain(final String domainId) {
     return 0;
   }
 
   @Override
-  public String[] getAdministratorUserIds(final String fromUserId) throws AdminException {
+  public String[] getAdministratorUserIds(final String fromUserId) {
     return new String[0];
   }
 
@@ -980,128 +947,122 @@ public class StubbedAdministration implements Administration {
   }
 
   @Override
-  public String[] getAllSpaceIds(final String sUserId) throws Exception {
+  public String[] getAllSpaceIds(final String sUserId) {
     return new String[0];
   }
 
   @Override
-  public String[] getAllRootSpaceIds(final String sUserId) throws Exception {
+  public String[] getAllRootSpaceIds(final String sUserId) {
     return new String[0];
   }
 
   @Override
-  public String[] getAllSubSpaceIds(final String sSpaceId, final String sUserId) throws Exception {
+  public String[] getAllSubSpaceIds(final String sSpaceId, final String sUserId) {
     return new String[0];
   }
 
   @Override
-  public String[] getAllComponentIds(final String sSpaceId) throws Exception {
+  public String[] getAllComponentIds(final String sSpaceId) {
     return new String[0];
   }
 
   @Override
-  public String[] getAllComponentIdsRecur(final String sSpaceId) throws Exception {
+  public String[] getAllComponentIdsRecur(final String sSpaceId) {
     return new String[0];
   }
 
   @Override
   public String[] getAllComponentIdsRecur(final String sSpaceId, final String sUserId,
-      final String componentNameRoot, final boolean inCurrentSpace, final boolean inAllSpaces)
-      throws Exception {
+      final String componentNameRoot, final boolean inCurrentSpace, final boolean inAllSpaces) {
     return new String[0];
   }
 
   @Override
-  public void synchronizeGroupByRule(final String groupId, final boolean scheduledMode)
-      throws AdminException {
+  public void synchronizeGroupByRule(final String groupId, final boolean scheduledMode) {
 
   }
 
   @Override
-  public String synchronizeGroup(final String groupId, final boolean recurs) throws Exception {
+  public String synchronizeGroup(final String groupId, final boolean recurs) {
     return null;
   }
 
   @Override
   public String synchronizeImportGroup(final String domainId, final String groupKey,
-      final String askedParentId, final boolean recurs, final boolean isIdKey) throws Exception {
+      final String askedParentId, final boolean recurs, final boolean isIdKey) {
     return null;
   }
 
   @Override
-  public String synchronizeRemoveGroup(final String groupId) throws Exception {
+  public String synchronizeRemoveGroup(final String groupId) {
     return null;
   }
 
   @Override
-  public String synchronizeUser(final String userId, final boolean recurs) throws Exception {
+  public String synchronizeUser(final String userId, final boolean recurs) {
     return null;
   }
 
   @Override
   public String synchronizeImportUserByLogin(final String domainId, final String userLogin,
-      final boolean recurs) throws Exception {
+      final boolean recurs) {
     return null;
   }
 
   @Override
   public String synchronizeImportUser(final String domainId, final String specificId,
-      final boolean recurs) throws Exception {
+      final boolean recurs) {
     return null;
   }
 
   @Override
   public List<DomainProperty> getSpecificPropertiesToImportUsers(final String domainId,
-      final String language) throws Exception {
+      final String language) {
     return null;
   }
 
   @Override
-  public UserDetail[] searchUsers(final String domainId, final Map<String, String> query)
-      throws Exception {
+  public UserDetail[] searchUsers(final String domainId, final Map<String, String> query) {
     return new UserDetail[0];
   }
 
   @Override
-  public String synchronizeRemoveUser(final String userId) throws Exception {
+  public String synchronizeRemoveUser(final String userId) {
     return null;
   }
 
   @Override
-  public String synchronizeSilverpeasWithDomain(final String sDomainId) throws Exception {
+  public String synchronizeSilverpeasWithDomain(final String sDomainId) {
     return null;
   }
 
   @Override
-  public String synchronizeSilverpeasWithDomain(final String sDomainId, final boolean threaded)
-      throws AdminException {
+  public String synchronizeSilverpeasWithDomain(final String sDomainId, final boolean threaded) {
     return null;
   }
 
   @Override
-  public List<String> searchUserIdsByProfile(final List<String> profileIds) throws AdminException {
+  public List<String> searchUserIdsByProfile(final List<String> profileIds) {
     return Collections.emptyList();
   }
 
   @Override
-  public ListSlice<UserDetail> searchUsers(final UserDetailsSearchCriteria searchCriteria)
-      throws AdminException {
+  public ListSlice<UserDetail> searchUsers(final UserDetailsSearchCriteria searchCriteria) {
     return null;
   }
 
   @Override
-  public ListSlice<GroupDetail> searchGroups(final GroupsSearchCriteria searchCriteria)
-      throws AdminException {
+  public ListSlice<GroupDetail> searchGroups(final GroupsSearchCriteria searchCriteria) {
     return null;
   }
 
   @Override
-  public void indexAllUsers() throws AdminException {
+  public void indexAllUsers() {
 
   }
 
   @Override
-  public void indexUsers(final String domainId) throws AdminException {
+  public void indexUsers(final String domainId) {
 
   }
 
@@ -1120,28 +1081,28 @@ public class StubbedAdministration implements Administration {
   @Override
   public void assignRightsFromUserToUser(final RightAssignationContext.MODE operationMode,
       final String sourceUserId, final String targetUserId, final boolean nodeAssignRights,
-      final String authorId) throws AdminException {
+      final String authorId) {
 
   }
 
   @Override
   public void assignRightsFromUserToGroup(final RightAssignationContext.MODE operationMode,
       final String sourceUserId, final String targetGroupId, final boolean nodeAssignRights,
-      final String authorId) throws AdminException {
+      final String authorId) {
 
   }
 
   @Override
   public void assignRightsFromGroupToUser(final RightAssignationContext.MODE operationMode,
       final String sourceGroupId, final String targetUserId, final boolean nodeAssignRights,
-      final String authorId) throws AdminException {
+      final String authorId) {
 
   }
 
   @Override
   public void assignRightsFromGroupToGroup(final RightAssignationContext.MODE operationMode,
       final String sourceGroupId, final String targetGroupId, final boolean nodeAssignRights,
-      final String authorId) throws AdminException {
+      final String authorId) {
 
   }
 
@@ -1157,14 +1118,22 @@ public class StubbedAdministration implements Administration {
   }
 
   @Override
-  public SpaceWithSubSpacesAndComponents getAllowedFullTreeview(final String userId)
-      throws AdminException {
+  public SpaceWithSubSpacesAndComponents getAllowedFullTreeview(final String userId) {
     return null;
   }
 
   @Override
   public SpaceWithSubSpacesAndComponents getAllowedFullTreeview(final String userId,
-      final String spaceId) throws AdminException {
+      final String spaceId) {
     return null;
+  }
+
+  @Override
+  public List<UserDetail> getNonBlankedDeletedUsers(final String... domainIds) {
+    return null;
+  }
+
+  @Override
+  public void blankDeletedUsers(final String targetDomainId, final List<String> userIds) {
   }
 }

--- a/core-library/src/main/java/org/silverpeas/core/admin/service/Admin.java
+++ b/core-library/src/main/java/org/silverpeas/core/admin/service/Admin.java
@@ -2287,7 +2287,7 @@ class Admin implements Administration {
   }
 
   @Override
-  public UserFull getUserFull(String domainId, String specificId) throws Exception {
+  public UserFull getUserFull(String domainId, String specificId) throws AdminException {
     DomainDriver synchroDomain = domainDriverManager.getDomainDriver(domainId);
     return synchroDomain.getUserFull(specificId);
   }
@@ -2483,7 +2483,7 @@ class Admin implements Administration {
   }
 
   @Override
-  public String[] getClientSpaceIds(String[] asDriverSpaceIds) throws Exception {
+  public String[] getClientSpaceIds(String[] asDriverSpaceIds) {
     String[] asClientSpaceIds = new String[asDriverSpaceIds.length];
     for (int nI = 0; nI < asDriverSpaceIds.length; nI++) {
       asClientSpaceIds[nI] = getClientSpaceId(asDriverSpaceIds[nI]);
@@ -3013,7 +3013,7 @@ class Admin implements Administration {
   }
 
   @Override
-  public List<SpaceInstLight> getUserSpaceTreeview(String userId) throws Exception {
+  public List<SpaceInstLight> getUserSpaceTreeview(String userId) throws AdminException {
 
     Set<String> componentsId = new HashSet<>(Arrays.asList(getAvailCompoIds(userId)));
     Set<Integer> authorizedIds = new HashSet<>(100);
@@ -3097,6 +3097,22 @@ class Admin implements Administration {
       throws AdminException {
     List<String> componentIds = getAllowedComponentIds(userId);
     return getAllowedTreeview(componentIds, spaceId);
+  }
+
+  @Override
+  public List<UserDetail> getNonBlankedDeletedUsers(final String... domainIds) throws AdminException {
+    return userManager.getNonBlankedDeletedUserOfDomains(domainIds);
+  }
+
+  @Override
+  public void blankDeletedUsers(final String targetDomainId, final List<String> userIds)
+      throws AdminException {
+    final UserDetail[] users = getUserDetails(userIds.toArray(new String[0]));
+    for (final UserDetail user : users) {
+      if (user.getDomainId().equals(targetDomainId)) {
+        userManager.blankUser(user);
+      }
+    }
   }
 
   private SpaceWithSubSpacesAndComponents getAllowedTreeview(List<String> componentIds,
@@ -3391,7 +3407,7 @@ class Admin implements Administration {
 
   @Override
   public boolean isAnAdminTool(String toolId) {
-    return ADMIN_COMPONENT_ID.equals(toolId);
+    return Constants.ADMIN_COMPONENT_ID.equals(toolId);
   }
 
   @Override
@@ -3858,23 +3874,23 @@ class Admin implements Administration {
   // RE-INDEXATION
   // -------------------------------------------------------------------
   @Override
-  public String[] getAllSpaceIds(String sUserId) throws Exception {
+  public String[] getAllSpaceIds(String sUserId) throws AdminException {
     return getClientSpaceIds(getUserSpaceIds(sUserId));
   }
 
   @Override
-  public String[] getAllRootSpaceIds(String sUserId) throws Exception {
+  public String[] getAllRootSpaceIds(String sUserId) throws AdminException {
     return getClientSpaceIds(getUserRootSpaceIds(sUserId));
   }
 
   @Override
   public String[] getAllSubSpaceIds(String sSpaceId, String sUserId)
-      throws Exception {
+      throws AdminException {
     return getUserSubSpaceIds(sUserId, sSpaceId);
   }
 
   @Override
-  public String[] getAllComponentIds(String sSpaceId) throws Exception {
+  public String[] getAllComponentIds(String sSpaceId) throws AdminException {
     List<String> alCompoIds = new ArrayList<>();
 
     // Get the compo of this space
@@ -3911,7 +3927,7 @@ class Admin implements Administration {
 
   @Override
   public String[] getAllComponentIdsRecur(String sSpaceId, String sUserId, String componentNameRoot,
-      boolean inCurrentSpace, boolean inAllSpaces) throws Exception {
+      boolean inCurrentSpace, boolean inAllSpaces) throws AdminException {
     ArrayList<String> alCompoIds = new ArrayList<>();
     // In All silverpeas
     if (inAllSpaces) {
@@ -3938,7 +3954,7 @@ class Admin implements Administration {
    * @author dlesimple
    */
   private ArrayList<String> getAllComponentIdsRecur(String sSpaceId, String sUserId,
-      String componentNameRoot, boolean inCurrentSpace) throws Exception {
+      String componentNameRoot, boolean inCurrentSpace) throws AdminException {
     ArrayList<String> alCompoIds = new ArrayList<>();
     getComponentIdsByNameAndUserId(sUserId, componentNameRoot);
     // Get components in the root of the space
@@ -4043,7 +4059,7 @@ class Admin implements Administration {
   // Synchronization tools
   // //////////////////////////////////////////////////////////
   private List<String> translateGroupIds(String sDomainId, String[] groupSpecificIds,
-      boolean recursGroups) throws Exception {
+      boolean recursGroups) {
     List<String> convertedGroupIds = new ArrayList<>();
     String groupId;
     for (String groupSpecificId : groupSpecificIds) {
@@ -4073,8 +4089,7 @@ class Admin implements Administration {
     return convertedGroupIds;
   }
 
-  private String[] translateUserIds(String sDomainId, String[] userSpecificIds)
-      throws Exception {
+  private String[] translateUserIds(String sDomainId, String[] userSpecificIds) {
     List<String> convertedUserIds = new ArrayList<>();
     String userId = null;
     for (String userSpecificId : userSpecificIds) {
@@ -4094,11 +4109,11 @@ class Admin implements Administration {
         convertedUserIds.add(userId);
       }
     }
-    return convertedUserIds.toArray(new String[convertedUserIds.size()]);
+    return convertedUserIds.toArray(new String[0]);
   }
 
   @Override
-  public String synchronizeGroup(String groupId, boolean recurs) throws Exception {
+  public String synchronizeGroup(String groupId, boolean recurs) throws AdminException {
 
     GroupDetail theGroup = getGroup(groupId);
     if (theGroup.isSynchronized()) {
@@ -4117,7 +4132,7 @@ class Admin implements Administration {
 
   @Override
   public String synchronizeImportGroup(String domainId, String groupKey, String askedParentId,
-      boolean recurs, boolean isIdKey) throws Exception {
+      boolean recurs, boolean isIdKey) throws AdminException {
     DomainDriver synchroDomain = domainDriverManager.getDomainDriver(domainId);
     GroupDetail gr;
 
@@ -4174,7 +4189,7 @@ class Admin implements Administration {
   }
 
   @Override
-  public String synchronizeRemoveGroup(String groupId) throws Exception {
+  public String synchronizeRemoveGroup(String groupId) throws AdminException {
     GroupDetail theGroup = getGroup(groupId);
     DomainDriver synchroDomain = domainDriverManager.getDomainDriver(theGroup.getDomainId());
     synchroDomain.removeGroup(theGroup.getSpecificId());
@@ -4182,7 +4197,7 @@ class Admin implements Administration {
   }
 
   protected void internalSynchronizeGroup(DomainDriver synchroDomain,
-      GroupDetail latestGroup, boolean recurs) throws Exception {
+      GroupDetail latestGroup, boolean recurs) throws AdminException {
     latestGroup.setUserIds(translateUserIds(latestGroup.getDomainId(),
         latestGroup.getUserIds()));
     updateGroup(latestGroup, true);
@@ -4211,7 +4226,7 @@ class Admin implements Administration {
   }
 
   @Override
-  public String synchronizeUser(String userId, boolean recurs) throws Exception {
+  public String synchronizeUser(String userId, boolean recurs) throws AdminException {
     Collection<UserDetail> listUsersUpdate = new ArrayList<>();
     try {
       UserDetail theUserDetail = getUserDetail(userId);
@@ -4267,7 +4282,7 @@ class Admin implements Administration {
 
   @Override
   public String synchronizeImportUserByLogin(String domainId, String userLogin, boolean recurs)
-      throws Exception {
+      throws AdminException {
     DomainDriver synchroDomain = domainDriverManager.getDomainDriver(domainId);
     UserDetail ud = synchroDomain.importUser(userLogin);
     ud.setDomainId(domainId);
@@ -4279,7 +4294,7 @@ class Admin implements Administration {
 
   @Override
   public String synchronizeImportUser(String domainId, String specificId, boolean recurs) throws
-      Exception {
+      AdminException {
     DomainDriver synchroDomain = domainDriverManager.getDomainDriver(domainId);
     UserDetail ud = synchroDomain.getUser(specificId);
 
@@ -4292,20 +4307,20 @@ class Admin implements Administration {
 
   @Override
   public List<DomainProperty> getSpecificPropertiesToImportUsers(String domainId, String language)
-      throws Exception {
+      throws AdminException {
     DomainDriver synchroDomain = domainDriverManager.getDomainDriver(domainId);
     return synchroDomain.getPropertiesToImport(language);
   }
 
   @Override
   public UserDetail[] searchUsers(String domainId, Map<String, String> query)
-      throws Exception {
+      throws AdminException {
     DomainDriver synchroDomain = domainDriverManager.getDomainDriver(domainId);
     return synchroDomain.getUsersByQuery(query);
   }
 
   @Override
-  public String synchronizeRemoveUser(String userId) throws Exception {
+  public String synchronizeRemoveUser(String userId) throws AdminException {
     UserDetail theUserDetail = getUserDetail(userId);
     DomainDriver synchroDomain = domainDriverManager.getDomainDriver(theUserDetail.getDomainId());
     synchroDomain.removeUser(theUserDetail.getSpecificId());
@@ -4317,7 +4332,7 @@ class Admin implements Administration {
   }
 
   @Override
-  public String synchronizeSilverpeasWithDomain(String sDomainId) throws Exception {
+  public String synchronizeSilverpeasWithDomain(String sDomainId) throws AdminException {
     return synchronizeSilverpeasWithDomain(sDomainId, false);
   }
 

--- a/core-library/src/main/java/org/silverpeas/core/admin/service/AdminController.java
+++ b/core-library/src/main/java/org/silverpeas/core/admin/service/AdminController.java
@@ -76,10 +76,8 @@ import org.silverpeas.core.util.logging.SilverLogger;
 
 import javax.inject.Inject;
 import javax.transaction.Transactional;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -148,7 +146,7 @@ public class AdminController implements java.io.Serializable {
       return admin.getPathToComponent(componentId);
     } catch (Exception e) {
       SilverLogger.getLogger(this).error(e.getLocalizedMessage(), e);
-      return null;
+      return Collections.emptyList();
     }
   }
 
@@ -158,30 +156,7 @@ public class AdminController implements java.io.Serializable {
       return admin.getPathToSpace(spaceId, includeTarget);
     } catch (Exception e) {
       SilverLogger.getLogger(this).error(e.getLocalizedMessage(), e);
-      return null;
-    }
-  }
-
-  /** Return the space Instance corresponding to the given space id */
-  public String[] getUserManageableSpaceRootIds(String sUserId) {
-
-    try {
-      return admin.getUserManageableSpaceRootIds(sUserId);
-    } catch (Exception e) {
-      SilverLogger.getLogger(this).error(e.getLocalizedMessage(), e);
-      return null;
-    }
-  }
-
-  /** Return the space Instance corresponding to the given space id */
-  public String[] getUserManageableSubSpaceIds(String sUserId,
-      String sParentSpace) {
-
-    try {
-      return admin.getUserManageableSubSpaceIds(sUserId, sParentSpace);
-    } catch (Exception e) {
-      SilverLogger.getLogger(this).error(e.getLocalizedMessage(), e);
-      return null;
+      return Collections.emptyList();
     }
   }
 
@@ -194,7 +169,7 @@ public class AdminController implements java.io.Serializable {
       return admin.getUserManageableSpaceIds(sUserId);
     } catch (Exception e) {
       SilverLogger.getLogger(this).error(e.getLocalizedMessage(), e);
-      return null;
+      return ArrayUtil.EMPTY_STRING_ARRAY;
     }
   }
 
@@ -213,7 +188,7 @@ public class AdminController implements java.io.Serializable {
       }
     } catch (Exception e) {
       SilverLogger.getLogger(this).error(e.getLocalizedMessage(), e);
-      return null;
+      return ArrayUtil.EMPTY_STRING_ARRAY;
     }
   }
 
@@ -353,7 +328,7 @@ public class AdminController implements java.io.Serializable {
       return admin.getAllWAComponents();
     } catch (Exception e) {
       SilverLogger.getLogger(this).error(e.getLocalizedMessage(), e);
-      return new HashMap<String, WAComponent>();
+      return Collections.emptyMap();
     }
   }
 
@@ -512,7 +487,7 @@ public class AdminController implements java.io.Serializable {
       return admin.getRemovedSpaces();
     } catch (Exception e) {
       SilverLogger.getLogger(this).error(e.getLocalizedMessage(), e);
-      return null;
+      return Collections.emptyList();
     }
   }
 
@@ -521,7 +496,7 @@ public class AdminController implements java.io.Serializable {
       return admin.getRemovedComponents();
     } catch (Exception e) {
       SilverLogger.getLogger(this).error(e.getLocalizedMessage(), e);
-      return null;
+      return Collections.emptyList();
     }
   }
 
@@ -573,7 +548,7 @@ public class AdminController implements java.io.Serializable {
       return admin.getProfilesByObject(objectId, objectType, componentId);
     } catch (Exception e) {
       SilverLogger.getLogger(this).error(e.getLocalizedMessage(), e);
-      return null;
+      return Collections.emptyList();
     }
   }
 
@@ -678,7 +653,7 @@ public class AdminController implements java.io.Serializable {
       return admin.getProfileIds(sUserId);
     } catch (Exception e) {
       SilverLogger.getLogger(this).error(e.getLocalizedMessage(), e);
-      return null;
+      return ArrayUtil.EMPTY_STRING_ARRAY;
     }
   }
 
@@ -695,7 +670,7 @@ public class AdminController implements java.io.Serializable {
       return admin.getProfileIdsOfGroup(sGroupId);
     } catch (Exception e) {
       SilverLogger.getLogger(this).error(e.getLocalizedMessage(), e);
-      return null;
+      return ArrayUtil.EMPTY_STRING_ARRAY;
     }
   }
 
@@ -914,7 +889,7 @@ public class AdminController implements java.io.Serializable {
       return admin.getAllDomains();
     } catch (Exception e) {
       SilverLogger.getLogger(this).error(e.getLocalizedMessage(), e);
-      return null;
+      return new Domain[0];
     }
   }
 
@@ -1016,7 +991,7 @@ public class AdminController implements java.io.Serializable {
       return admin.getAllUsersIds();
     } catch (Exception e) {
       SilverLogger.getLogger(this).error(e.getLocalizedMessage(), e);
-      return null;
+      return ArrayUtil.EMPTY_STRING_ARRAY;
     }
   }
 
@@ -1030,7 +1005,7 @@ public class AdminController implements java.io.Serializable {
       return admin.getGroupManageableSpaceIds(sGroupId);
     } catch (Exception e) {
       SilverLogger.getLogger(this).error(e.getLocalizedMessage(), e);
-      return null;
+      return ArrayUtil.EMPTY_STRING_ARRAY;
     }
   }
 
@@ -1155,7 +1130,7 @@ public class AdminController implements java.io.Serializable {
       return new UserDetail[0];
     } catch (Exception e) {
       SilverLogger.getLogger(this).error(e.getLocalizedMessage(), e);
-      return null;
+      return new UserDetail[0];
     }
   }
 
@@ -1326,7 +1301,7 @@ public class AdminController implements java.io.Serializable {
       return admin.getPathToGroup(groupId);
     } catch (Exception e) {
       SilverLogger.getLogger(this).error(e.getLocalizedMessage(), e);
-      return null;
+      return Collections.emptyList();
     }
   }
 
@@ -1435,7 +1410,7 @@ public class AdminController implements java.io.Serializable {
       return admin.getSpecificPropertiesToImportUsers(domainId, language);
     } catch (Exception e) {
       SilverLogger.getLogger(this).error(e.getLocalizedMessage(), e);
-      return null;
+      return Collections.emptyList();
     }
   }
 
@@ -1445,7 +1420,7 @@ public class AdminController implements java.io.Serializable {
       return Arrays.asList(admin.searchUsers(domainId, query));
     } catch (Exception e) {
       SilverLogger.getLogger(this).error(e.getLocalizedMessage(), e);
-      return new ArrayList<UserDetail>();
+      return Collections.emptyList();
     }
   }
 
@@ -1481,18 +1456,19 @@ public class AdminController implements java.io.Serializable {
 
     try {
       return admin.synchronizeGroup(groupId, true);
-    } catch (Exception e) {
+    } catch (AdminException e) {
       SilverLogger.getLogger(this).error(e.getLocalizedMessage(), e);
-      if (e instanceof AdminException &&
-          ((AdminException) e).getCause() instanceof GroupSynchronizationRule.Error) {
-        GroupSynchronizationRule.Error error =
-            (GroupSynchronizationRule.Error) ((AdminException) e).getCause();
+      if (e.getCause() instanceof GroupSynchronizationRule.Error) {
+        GroupSynchronizationRule.Error error = (GroupSynchronizationRule.Error) e.getCause();
         if (error instanceof GroupSynchronizationRule.GroundRuleError) {
           return error.getHandledMessage() + "|" +
               ((GroupSynchronizationRule.GroundRuleError) error).getBaseRulePart();
         }
         return error.getHandledMessage();
       }
+      return "";
+    } catch (Exception e) {
+      SilverLogger.getLogger(this).error(e.getLocalizedMessage(), e);
       return "";
     }
   }
@@ -1557,4 +1533,12 @@ public class AdminController implements java.io.Serializable {
     return false;
   }
 
+  public List<UserDetail> getDeletedUsersInDomain(final String domainId) throws AdminException {
+    return admin.getNonBlankedDeletedUsers(domainId);
+  }
+
+  public void blankDeletedUsers(final String targetDomainId, final List<String> userIds)
+      throws AdminException {
+    admin.blankDeletedUsers(targetDomainId, userIds);
+  }
 }

--- a/core-library/src/main/java/org/silverpeas/core/admin/service/Administration.java
+++ b/core-library/src/main/java/org/silverpeas/core/admin/service/Administration.java
@@ -59,8 +59,15 @@ import java.util.Map;
  * @author Yohann Chastagnier
  */
 public interface Administration {
-  String ADMIN_COMPONENT_ID = "ADMIN";
-  String basketSuffix = " (Restauré)";
+
+  class Constants {
+    public static final String ADMIN_COMPONENT_ID = "ADMIN";
+    public static final String BASKET_SUFFIX = " (Restauré)";
+
+    private Constants() {
+
+    }
+  }
 
   static Administration get() {
     return ServiceProvider.getService(Administration.class);
@@ -332,7 +339,7 @@ public interface Administration {
       ComponentInst[] componentInsts) throws AdminException;
 
   void setComponentPlace(String componentId, String idComponentBefore,
-      ComponentInst[] m_BrothersComponents) throws AdminException;
+      ComponentInst[] brothersComponents) throws AdminException;
 
   String getRequestRouter(String sComponentName);
 
@@ -612,7 +619,7 @@ public interface Administration {
    */
   UserFull getUserFull(String sUserId) throws AdminException;
 
-  UserFull getUserFull(String domainId, String specificId) throws Exception;
+  UserFull getUserFull(String domainId, String specificId) throws AdminException;
 
   /**
    * Add the given user in Silverpeas and specific domain.
@@ -698,7 +705,7 @@ public interface Administration {
   /**
    * Converts driver space ids to client space ids
    */
-  String[] getClientSpaceIds(String[] asDriverSpaceIds) throws Exception;
+  String[] getClientSpaceIds(String[] asDriverSpaceIds);
 
   /**
    * Create a new domain
@@ -836,7 +843,7 @@ public interface Administration {
    * @throws Exception
    * @author neysseri
    */
-  List<SpaceInstLight> getUserSpaceTreeview(String userId) throws Exception;
+  List<SpaceInstLight> getUserSpaceTreeview(String userId) throws AdminException;
 
   String[] getAllowedSubSpaceIds(String userId, String spaceFatherId) throws AdminException;
 
@@ -1081,31 +1088,31 @@ public interface Administration {
   // -------------------------------------------------------------------
   // RE-INDEXATION
   // -------------------------------------------------------------------
-  String[] getAllSpaceIds(String sUserId) throws Exception;
+  String[] getAllSpaceIds(String sUserId) throws AdminException;
 
   /**
    * Return all the root spaces Id available in webactiv
    */
-  String[] getAllRootSpaceIds(String sUserId) throws Exception;
+  String[] getAllRootSpaceIds(String sUserId) throws AdminException;
 
   /**
    * Return all the subSpaces Id available in webactiv given a space id (driver format)
    */
-  String[] getAllSubSpaceIds(String sSpaceId, String sUserId) throws Exception;
+  String[] getAllSubSpaceIds(String sSpaceId, String sUserId) throws AdminException;
 
   /**
    * Returns all the component identifiers of the space represented by the given identifier.
    * <p>Component instance of sub spaces are not retrieved.</p>
    * <p>It returns also ids of {@link SilverpeasPersonalComponentInstance} instances.</p>
    */
-  String[] getAllComponentIds(String sSpaceId) throws Exception;
+  String[] getAllComponentIds(String sSpaceId) throws AdminException;
 
   /**
    * Returns all the component identifiers of the space, and its sub spaces, represented by the
    * given identifier.
    * <p>It returns also ids of {@link SilverpeasPersonalComponentInstance} instances.</p>
    */
-  String[] getAllComponentIdsRecur(String sSpaceId) throws Exception;
+  String[] getAllComponentIdsRecur(String sSpaceId) throws AdminException;
 
   /**
    * Return all the components Id recursively in (Space+subspaces, or only subspaces or in
@@ -1122,46 +1129,46 @@ public interface Administration {
    */
   @Deprecated
   String[] getAllComponentIdsRecur(String sSpaceId, String sUserId, String componentNameRoot,
-      boolean inCurrentSpace, boolean inAllSpaces) throws Exception;
+      boolean inCurrentSpace, boolean inAllSpaces) throws AdminException;
 
   void synchronizeGroupByRule(String groupId, boolean scheduledMode) throws AdminException;
 
   /**
    *
    */
-  String synchronizeGroup(String groupId, boolean recurs) throws Exception;
+  String synchronizeGroup(String groupId, boolean recurs) throws AdminException;
 
   /**
    *
    */
   String synchronizeImportGroup(String domainId, String groupKey, String askedParentId,
-      boolean recurs, boolean isIdKey) throws Exception;
+      boolean recurs, boolean isIdKey) throws AdminException;
 
   /**
    *
    */
-  String synchronizeRemoveGroup(String groupId) throws Exception;
+  String synchronizeRemoveGroup(String groupId) throws AdminException;
 
   /**
    * Synchronize Users and groups between cache and domain's datastore
    */
-  String synchronizeUser(String userId, boolean recurs) throws Exception;
+  String synchronizeUser(String userId, boolean recurs) throws AdminException;
 
   /**
    * Synchronize Users and groups between cache and domain's datastore
    */
   String synchronizeImportUserByLogin(String domainId, String userLogin, boolean recurs)
-      throws Exception;
+      throws AdminException;
 
   /**
    * Synchronize Users and groups between cache and domain's datastore
    */
-  String synchronizeImportUser(String domainId, String specificId, boolean recurs) throws Exception;
+  String synchronizeImportUser(String domainId, String specificId, boolean recurs) throws AdminException;
 
   List<DomainProperty> getSpecificPropertiesToImportUsers(String domainId, String language)
-      throws Exception;
+      throws AdminException;
 
-  UserDetail[] searchUsers(String domainId, Map<String, String> query) throws Exception;
+  UserDetail[] searchUsers(String domainId, Map<String, String> query) throws AdminException;
 
   /**
    * Synchronize Users and groups between cache and domain's datastore.
@@ -1169,9 +1176,9 @@ public interface Administration {
    * @return
    * @throws Exception
    */
-  String synchronizeRemoveUser(String userId) throws Exception;
+  String synchronizeRemoveUser(String userId) throws AdminException;
 
-  String synchronizeSilverpeasWithDomain(String sDomainId) throws Exception;
+  String synchronizeSilverpeasWithDomain(String sDomainId) throws AdminException;
 
   /**
    * Synchronize Users and groups between cache and domain's datastore
@@ -1256,4 +1263,21 @@ public interface Administration {
 
   SpaceWithSubSpacesAndComponents getAllowedFullTreeview(String userId, String spaceId)
       throws AdminException;
+
+  /**
+   * Gets all the users that were deleted in the specified domains and that weren't blanked.
+   * If no domains are specified, then all the domains are taken into account.
+   * @param domainIds the unique identifiers of the domains.
+   * @return a list of users or an empty list if there is no deleted users in the specified domains.
+   */
+  List<UserDetail> getNonBlankedDeletedUsers(String ... domainIds) throws AdminException;
+
+  /**
+   * Blanks the specified users in the specified domain. The users have to be deleted in Silverpeas,
+   * otherwise an {@link AdminException} exception is thrown.
+   * @param targetDomainId the unique identifier of the domain.
+   * @param userIds a list of unique identifiers of deleted users in the specified domain.
+   * @throws AdminException if an error occurs while blanking the deleted users.
+   */
+  void blankDeletedUsers(String targetDomainId, List<String> userIds) throws AdminException;
 }

--- a/core-library/src/main/java/org/silverpeas/core/admin/service/ComponentInstManager.java
+++ b/core-library/src/main/java/org/silverpeas/core/admin/service/ComponentInstManager.java
@@ -167,7 +167,7 @@ public class ComponentInstManager {
     int retry = 0;
     String deletedComponentName = null;
     while (!nameOK) {
-      String componentName = componentInst.getLabel() + Admin.basketSuffix;
+      String componentName = componentInst.getLabel() + Admin.Constants.BASKET_SUFFIX;
       if (retry > 0) {
         componentName += " " + retry;
       }

--- a/core-library/src/main/java/org/silverpeas/core/admin/service/SpaceInstManager.java
+++ b/core-library/src/main/java/org/silverpeas/core/admin/service/SpaceInstManager.java
@@ -523,7 +523,7 @@ public class SpaceInstManager {
     int retry = 0;
     String deletedSpaceName = null;
     while (!nameOK) {
-      String spaceName = spaceInst.getName() + Admin.basketSuffix;
+      String spaceName = spaceInst.getName() + Admin.Constants.BASKET_SUFFIX;
       if (retry > 0) {
         spaceName += " " + retry;
       }

--- a/core-library/src/main/java/org/silverpeas/core/admin/user/dao/UserDAO.java
+++ b/core-library/src/main/java/org/silverpeas/core/admin/user/dao/UserDAO.java
@@ -25,10 +25,13 @@ package org.silverpeas.core.admin.user.dao;
 
 import org.silverpeas.core.admin.user.constant.UserAccessLevel;
 import org.silverpeas.core.admin.user.constant.UserState;
+import org.silverpeas.core.admin.user.model.User;
 import org.silverpeas.core.admin.user.model.UserDetail;
 import org.silverpeas.core.persistence.jdbc.DBUtil;
 import org.silverpeas.core.persistence.jdbc.sql.JdbcSqlQuery;
 import org.silverpeas.core.util.ListSlice;
+import org.silverpeas.core.util.LocalizationBundle;
+import org.silverpeas.core.util.ResourceLocator;
 import org.silverpeas.core.util.StringUtil;
 
 import javax.inject.Singleton;
@@ -38,7 +41,9 @@ import java.sql.SQLException;
 import java.time.Instant;
 import java.util.Date;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Singleton
 public class UserDAO {
@@ -50,7 +55,8 @@ public class UserDAO {
       + "loginQuestion,loginAnswer,creationDate,saveDate,version,tosAcceptanceDate,"
       + "lastLoginDate,nbSuccessfulLoginAttempts,lastLoginCredentialUpdateDate,expirationDate,"
       + "state,stateSaveDate, notifManualReceiverLimit";
-  private static final String STATE_CRITERION = "state <> ?";
+  private static final String STATE_CRITERION_NOT = "state <> ?";
+  private static final String STATE_CRITERION = "state = ?";
   private static final String ID_CRITERION = "id = ?";
   private static final String DOMAIN_ID_CRITERION = "domainId = ?";
   private static final String ACCESS_LEVEL_CRITERION = "accessLevel = ?";
@@ -61,10 +67,10 @@ public class UserDAO {
   private static final String DOMAIN_ID = "domainId";
   private static final String SPECIFIC_ID = "specificId";
   private static final String STATE = "state";
-  public static final String LOGIN = "login";
-  public static final String SAVE_DATE = "saveDate";
-  public static final String STATE_SAVE_DATE = "stateSaveDate";
-
+  private static final String LOGIN = "login";
+  private static final String SAVE_DATE = "saveDate";
+  private static final String STATE_SAVE_DATE = "stateSaveDate";
+  private static final String BLANK_NAME = "_Anonymous_";
 
   protected UserDAO() {
   }
@@ -135,8 +141,7 @@ public class UserDAO {
       throws SQLException {
     return JdbcSqlQuery.createSelect("COUNT(id)")
         .from(USER_TABLE)
-        .where(ID_CRITERION, Integer.parseInt(id))
-        .and(STATE_CRITERION, UserState.DELETED)
+        .where(ID_CRITERION, Integer.parseInt(id)).and(STATE_CRITERION_NOT, UserState.DELETED)
         .executeUniqueWith(connection, row -> row.getInt(1)) == 1;
   }
 
@@ -158,13 +163,36 @@ public class UserDAO {
         .executeWith(connection, UserDAO::fetchUser);
   }
 
+  /**
+   * Gets all the users that were deleted in the specified domains and that weren't yet blanked.
+   * @param connection a connection to the data source.
+   * @param domainIds zero, one or more unique identifiers of Silverpeas domains. If no domains
+   * are passed, then all the domains are taken by the request.
+   * @return a list of user details.
+   * @throws SQLException if an error while requesting the users.
+   */
+  public List<UserDetail> getNonBlankedDeletedUsers(final Connection connection, final String... domainIds)
+      throws SQLException {
+    Objects.requireNonNull(connection);
+    Objects.requireNonNull(domainIds);
+    JdbcSqlQuery query = JdbcSqlQuery.createSelect(USER_COLUMNS)
+        .from(USER_TABLE)
+        .where(STATE_CRITERION, UserState.DELETED)
+        .and("firstName <> ?", BLANK_NAME);
+    final List<Integer> requestedDomainIds =
+        Stream.of(domainIds).map(Integer::parseInt).collect(Collectors.toList());
+    if (!requestedDomainIds.isEmpty()) {
+      query = query.and(DOMAIN_ID).in(requestedDomainIds);
+    }
+    return query.executeWith(connection, UserDAO::fetchUser);
+  }
+
   public UserDetail getUserByLogin(final Connection connection, final String domainId,
       final String login) throws SQLException {
     return JdbcSqlQuery.createSelect(USER_COLUMNS)
         .from(USER_TABLE)
         .where(DOMAIN_ID_CRITERION, Integer.parseInt(domainId))
-        .and("lower(login) = lower(?)", login)
-        .and(STATE_CRITERION, UserState.DELETED)
+        .and("lower(login) = lower(?)", login).and(STATE_CRITERION_NOT, UserState.DELETED)
         .executeUniqueWith(connection, UserDAO::fetchUser);
   }
 
@@ -192,6 +220,18 @@ public class UserDAO {
         .and("login = ?", login)
         .orderBy(DOMAIN_ID)
         .executeWith(connection, row -> row.getString("domain"));
+  }
+
+  /**
+   * Updates the specified user by blanking some of its profile information.
+   * @param connection a connection to the data source.
+   * @param user the user to blank.
+   * @throws SQLException if the update fails.
+   */
+  public void blankUser(final Connection connection, final UserDetail user) throws SQLException {
+    user.setFirstName(BLANK_NAME);
+    user.setLastName("");
+    updateUser(connection, user);
   }
 
   /**
@@ -263,25 +303,25 @@ public class UserDAO {
     return JdbcSqlQuery.createSelect(USER_COLUMNS)
         .from(USER_TABLE, GROUP_USER_REL_TABLE)
         .where(USER_ID_JOINTURE).and("groupid").in(groupIdsAsInt)
-        .and(STATE_CRITERION, UserState.DELETED)
+        .and(STATE_CRITERION_NOT, UserState.DELETED)
         .orderBy(LAST_NAME)
         .executeWith(con, UserDAO::fetchUser);
   }
 
   public List<String> getAllUserIds(Connection connection) throws SQLException {
     return JdbcSqlQuery.createSelect("id")
-        .from(USER_TABLE)
-        .where(STATE_CRITERION, UserState.DELETED)
+        .from(USER_TABLE).where(STATE_CRITERION_NOT, UserState.DELETED)
         .orderBy(LAST_NAME)
         .executeWith(connection, row -> Integer.toString(row.getInt(1)));
   }
 
   public List<String> getAllAdminIds(Connection connection, final UserDetail fromUser)
       throws SQLException {
-    JdbcSqlQuery query =
-        JdbcSqlQuery.createSelect("id").from(USER_TABLE).where(STATE_CRITERION, UserState.DELETED);
+    JdbcSqlQuery query = JdbcSqlQuery.createSelect("id")
+        .from(USER_TABLE)
+        .where(STATE_CRITERION_NOT, UserState.DELETED);
     if (fromUser.isAccessAdmin() || fromUser.isAccessDomainManager()) {
-      query.and("accessLevel = ?", UserAccessLevel.ADMINISTRATOR.code());
+      query.and(ACCESS_LEVEL_CRITERION, UserAccessLevel.ADMINISTRATOR.code());
     } else {
       query.and(DOMAIN_ID_CRITERION, Integer.parseInt(fromUser.getDomainId()))
           .and("(accessLevel = ? or accessLevel = ?)", UserAccessLevel.ADMINISTRATOR.code(),
@@ -295,8 +335,7 @@ public class UserDAO {
     return JdbcSqlQuery.createSelect("id")
         .from(USER_TABLE, GROUP_USER_REL_TABLE)
         .where(USER_ID_JOINTURE)
-        .and("groupId = ?", Integer.parseInt(groupId))
-        .and(STATE_CRITERION, UserState.DELETED)
+        .and("groupId = ?", Integer.parseInt(groupId)).and(STATE_CRITERION_NOT, UserState.DELETED)
         .orderBy(LAST_NAME)
         .executeWith(connection, row -> Integer.toString(row.getInt(1)));
   }
@@ -308,7 +347,7 @@ public class UserDAO {
     return JdbcSqlQuery.createSelect("id")
         .from(USER_TABLE, GROUP_USER_REL_TABLE)
         .where(USER_ID_JOINTURE).and("groupid").in(groupIdsAsInt)
-        .and(STATE_CRITERION, UserState.DELETED)
+        .and(STATE_CRITERION_NOT, UserState.DELETED)
         .orderBy(LAST_NAME)
         .executeWith(con, row -> Integer.toString(row.getInt(1)));
   }
@@ -316,8 +355,7 @@ public class UserDAO {
   public List<String> getUserIdsInDomain(Connection connection, final String domainId)
       throws SQLException {
     return JdbcSqlQuery.createSelect("id")
-        .from(USER_TABLE)
-        .where(STATE_CRITERION, UserState.DELETED)
+        .from(USER_TABLE).where(STATE_CRITERION_NOT, UserState.DELETED)
         .and(DOMAIN_ID_CRITERION, Integer.parseInt(domainId))
         .orderBy(LAST_NAME)
         .executeWith(connection, row -> Integer.toString(row.getInt(1)));
@@ -326,8 +364,7 @@ public class UserDAO {
   public List<String> getUserIdsByAccessLevel(final Connection connection,
       final UserAccessLevel accessLevel) throws SQLException {
     return JdbcSqlQuery.createSelect("id")
-        .from(USER_TABLE)
-        .where(STATE_CRITERION, UserState.DELETED)
+        .from(USER_TABLE).where(STATE_CRITERION_NOT, UserState.DELETED)
         .and(ACCESS_LEVEL_CRITERION, accessLevel.code())
         .orderBy(LAST_NAME)
         .executeWith(connection, row -> Integer.toString(row.getInt(1)));
@@ -336,8 +373,7 @@ public class UserDAO {
   public List<String> getUserIdsByAccessLevelInDomain(Connection connection,
       final UserAccessLevel accessLevel, final String domainId) throws SQLException {
     return JdbcSqlQuery.createSelect("id")
-        .from(USER_TABLE)
-        .where(STATE_CRITERION, UserState.DELETED)
+        .from(USER_TABLE).where(STATE_CRITERION_NOT, UserState.DELETED)
         .and(DOMAIN_ID_CRITERION, Integer.parseInt(domainId))
         .and(ACCESS_LEVEL_CRITERION, accessLevel.code())
         .orderBy(LAST_NAME)
@@ -350,7 +386,7 @@ public class UserDAO {
         .from(USER_TABLE, "ST_UserRole_User_Rel")
         .where(USER_ID_JOINTURE)
         .and("userRoleId = ?", Integer.parseInt(userRoleId))
-        .and(STATE_CRITERION, UserState.DELETED)
+        .and(STATE_CRITERION_NOT, UserState.DELETED)
         .orderBy(LAST_NAME)
         .executeWith(connection, row -> Integer.toString(row.getInt(1)));
   }
@@ -367,7 +403,7 @@ public class UserDAO {
         .from(USER_TABLE, "ST_SpaceUserRole_User_Rel")
         .where(USER_ID_JOINTURE)
         .and("spaceUserRoleId = ?", Integer.parseInt(spaceUserRoleId))
-        .and(STATE_CRITERION, UserState.DELETED)
+        .and(STATE_CRITERION_NOT, UserState.DELETED)
         .orderBy(LAST_NAME)
         .executeWith(connection, row -> Integer.toString(row.getInt(1)));
   }
@@ -378,7 +414,7 @@ public class UserDAO {
         .from(USER_TABLE, "ST_GroupUserRole_User_Rel")
         .where(USER_ID_JOINTURE)
         .and("groupUserRoleId = ?", Integer.parseInt(groupUserRoleId))
-        .and(STATE_CRITERION, UserState.DELETED)
+        .and(STATE_CRITERION_NOT, UserState.DELETED)
         .orderBy(LAST_NAME)
         .executeWith(connection, row -> Integer.toString(row.getInt(1)));
   }
@@ -395,8 +431,7 @@ public class UserDAO {
       throws SQLException {
     final String order = StringUtil.isDefined(orderBy) ? orderBy : LAST_NAME;
     JdbcSqlQuery query = JdbcSqlQuery.createSelect(USER_COLUMNS)
-        .from(USER_TABLE)
-        .where(STATE_CRITERION, UserState.DELETED);
+        .from(USER_TABLE).where(STATE_CRITERION_NOT, UserState.DELETED);
     if (domainIds != null && !domainIds.isEmpty()) {
       final List<Integer> domainIdsAsInt =
           domainIds.stream().map(Integer::parseInt).collect(Collectors.toList());
@@ -424,7 +459,16 @@ public class UserDAO {
     u.setSpecificId(rs.getString(2));
     u.setDomainId(Integer.toString(rs.getInt(3)));
     u.setLogin(rs.getString(4));
-    u.setFirstName(rs.getString(5));
+    String firstName = rs.getString(5);
+    if (BLANK_NAME.equals(firstName)) {
+      User user = User.getCurrentRequester();
+      if (user != null) {
+        final String language = user.getUserPreferences().getLanguage();
+        LocalizationBundle generalBundle = ResourceLocator.getGeneralLocalizationBundle(language);
+        firstName = generalBundle.getString("GML.Anonymous");
+      }
+    }
+    u.setFirstName(firstName);
     u.setLastName(rs.getString(6));
     u.seteMail(rs.getString(8));
     u.setAccessLevel(UserAccessLevel.fromCode(rs.getString(9)));

--- a/core-library/src/main/java/org/silverpeas/core/scheduler/quartz/QuartzScheduler.java
+++ b/core-library/src/main/java/org/silverpeas/core/scheduler/quartz/QuartzScheduler.java
@@ -154,7 +154,6 @@ public abstract class QuartzScheduler implements Scheduler, Initialization {
   private JobDetail buildJobDetail(final Job job, final SchedulerEventListener listener) {
     JobDetail jobDetail = JobBuilder.newJob(getJobExecutor()).withIdentity(job.getName()).build();
     jobDetail.getJobDataMap().put(ACTUAL_JOB, encodeJob(job));
-    jobDetail.getJobDataMap().put(JOB_SCHEDULED, true);
     if (listener != null) {
       jobDetail.getJobDataMap().put(JOB_LISTENER, encodeEventListener(listener));
     }
@@ -205,6 +204,7 @@ public abstract class QuartzScheduler implements Scheduler, Initialization {
       if (isInPast(quartzTrigger)) {
         fireNow(quartzTrigger.getFinalFireTime(), theJob, listener);
       } else {
+        jobDetail.getJobDataMap().put(JOB_SCHEDULED, true);
         execute(() -> this.quartz.scheduleJob(jobDetail, quartzTrigger));
       }
       return new QuartzScheduledJob(quartzTrigger);

--- a/core-war/src/main/java/org/silverpeas/web/jobdomain/control/JobDomainPeasSessionController.java
+++ b/core-war/src/main/java/org/silverpeas/web/jobdomain/control/JobDomainPeasSessionController.java
@@ -2311,4 +2311,11 @@ public class JobDomainPeasSessionController extends AbstractComponentSessionCont
     return getSessionUsers().get(currentIndex.getNextIndex());
   }
 
+  public List<UserDetail> getDeletedUsers() throws AdminException {
+    return adminCtrl.getDeletedUsersInDomain(this.targetDomainId);
+  }
+
+  public void blankDeletedUsers(final List<String> userIds) throws AdminException {
+    adminCtrl.blankDeletedUsers(targetDomainId, userIds);
+  }
 }

--- a/core-war/src/main/java/org/silverpeas/web/jobdomain/servlets/JobDomainPeasRequestRouter.java
+++ b/core-war/src/main/java/org/silverpeas/web/jobdomain/servlets/JobDomainPeasRequestRouter.java
@@ -153,6 +153,21 @@ public class JobDomainPeasRequestRouter extends
         }
       }
 
+      if ("blankUsers".equals(function)) {
+        final Enumeration<String> paramNames = request.getParameterNames();
+        final List<String> userIds = new ArrayList<>();
+        while(paramNames.hasMoreElements()) {
+          final String paramName = paramNames.nextElement();
+          if (paramName.startsWith("blank_")) {
+            userIds.add(request.getParameter(paramName));
+          }
+        }
+        if (!userIds.isEmpty()) {
+          jobDomainSC.blankDeletedUsers(userIds);
+        }
+        function = "domainContent";
+      }
+
       if (function.startsWith("Main")) {
         jobDomainSC.returnIntoGroup(null);
         jobDomainSC.setDefaultTargetDomain();
@@ -648,6 +663,12 @@ public class JobDomainPeasRequestRouter extends
         } else if (function.startsWith("displayDynamicSynchroReport")) {
           SynchroDomainReport.setReportLevel(Level.valueOf(request.getParameter("IdTraceLevel")));
           destination = "dynamicSynchroReport.jsp";
+        } else if (function.startsWith("displayDeletedUsers")) {
+          List<UserDetail> deletedUsers = jobDomainSC.getDeletedUsers();
+          request.setAttribute("deletedUsers", deletedUsers);
+          request.setAttribute("domain", jobDomainSC.getTargetDomain());
+          request.setAttribute("theUser", jobDomainSC.getUserDetail());
+          destination = "deletedUsers.jsp";
         }
       } else if (function.startsWith("welcome")) {
         jobDomainSC.returnIntoGroup(null);

--- a/core-war/src/main/java/org/silverpeas/web/jobstartpage/control/JobStartPagePeasSessionController.java
+++ b/core-war/src/main/java/org/silverpeas/web/jobstartpage/control/JobStartPagePeasSessionController.java
@@ -497,19 +497,16 @@ public class JobStartPagePeasSessionController extends AbstractComponentSessionC
 
   public String addSpaceInst(SpaceInst spaceInst) {
     String res = adminController.addSpaceInst(spaceInst);
-    if (res == null || res.length() == 0) {
-      return res;
+    if (StringUtil.isDefined(res)) {
+      // Finally refresh the cache
+      m_NavBarMgr.addSpaceInCache(res);
+
+      // Component space storage quota
+      initializeComponentSpaceQuota(spaceInst);
+
+      // Data storage quota
+      initializeDataStorageQuota(spaceInst);
     }
-
-    // Finally refresh the cache
-    m_NavBarMgr.addSpaceInCache(res);
-
-    // Component space storage quota
-    initializeComponentSpaceQuota(spaceInst);
-
-    // Data storage quota
-    initializeDataStorageQuota(spaceInst);
-
     return res;
   }
 
@@ -789,17 +786,15 @@ public class JobStartPagePeasSessionController extends AbstractComponentSessionC
    */
   public List<SpaceInstLight> getRemovedSpaces() {
     List<SpaceInstLight> removedSpaces = adminController.getRemovedSpaces();
-    SpaceInstLight space;
     String name;
-    for (int s = 0; removedSpaces != null && s < removedSpaces.size(); s++) {
-      space = removedSpaces.get(s);
+    for (SpaceInstLight space: removedSpaces) {
       space.setRemoverName(getOrganisationController().getUserDetail(String.valueOf(space.
           getRemovedBy())).getDisplayedName());
       space.setPath(adminController.getPathToSpace(space.getId(), false));
 
       // Remove suffix
       name = space.getName();
-      name = name.substring(0, name.indexOf(Administration.basketSuffix));
+      name = name.substring(0, name.indexOf(Administration.Constants.BASKET_SUFFIX));
       space.setName(name);
     }
     return removedSpaces;
@@ -807,17 +802,15 @@ public class JobStartPagePeasSessionController extends AbstractComponentSessionC
 
   public List<ComponentInstLight> getRemovedComponents() {
     List<ComponentInstLight> removedComponents = adminController.getRemovedComponents();
-    ComponentInstLight component;
     String name;
-    for (int s = 0; removedComponents != null && s < removedComponents.size(); s++) {
-      component = removedComponents.get(s);
+    for (ComponentInstLight component: removedComponents) {
       component.setRemoverName(getOrganisationController().getUserDetail(String.valueOf(component.
           getRemovedBy())).getDisplayedName());
       component.setPath(adminController.getPathToComponent(component.getId()));
 
       // Remove suffix
       name = component.getLabel();
-      name = name.substring(0, name.indexOf(Administration.basketSuffix));
+      name = name.substring(0, name.indexOf(Administration.Constants.BASKET_SUFFIX));
       component.setLabel(name);
     }
     return removedComponents;

--- a/core-war/src/main/java/org/silverpeas/web/silverstatistics/control/PubliPieChartBuilder.java
+++ b/core-war/src/main/java/org/silverpeas/web/silverstatistics/control/PubliPieChartBuilder.java
@@ -23,19 +23,19 @@
  */
 package org.silverpeas.web.silverstatistics.control;
 
-import org.silverpeas.core.silvertrace.SilverTrace;
 import org.silverpeas.core.admin.service.AdministrationServiceProvider;
-import org.silverpeas.core.admin.space.SpaceInstLight;
-import org.silverpeas.core.chart.pie.PieChart;
 import org.silverpeas.core.admin.service.OrganizationController;
 import org.silverpeas.core.admin.service.OrganizationControllerProvider;
+import org.silverpeas.core.admin.space.SpaceInstLight;
+import org.silverpeas.core.chart.pie.PieChart;
 import org.silverpeas.core.util.LocalizationBundle;
 import org.silverpeas.core.util.StringUtil;
+import org.silverpeas.core.util.logging.SilverLogger;
 
 import java.sql.SQLException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
-import java.util.Vector;
 
 /**
  * <p>
@@ -87,8 +87,7 @@ public class PubliPieChartBuilder extends AbstractPieChartBuilder {
             + space.getName() + "\" ";
       }
     } catch (Exception e) {
-      SilverTrace.error("silverStatisticsPeas", "PubliPieChartBuilder.getChartTitle()",
-          "root.EX_SQL_QUERY_FAILED", e);
+      SilverLogger.getLogger(this).error(e);
     }
     title += message.getString("silverStatisticsPeas.Until") + " " + this.dateFormate;
     return title;
@@ -101,20 +100,18 @@ public class PubliPieChartBuilder extends AbstractPieChartBuilder {
    */
   @Override
   Map<String, String[]> getCmpStats() {
-    // Hashtable key=componentId, value=new String[3] {tout, groupe, user}
-    Map<String, String[]> cmpStats = new HashMap<String, String[]>();
+    Map<String, String[]> cmpStats = new HashMap<>();
     try {
       cmpStats.putAll(SilverStatisticsPeasDAOAccesVolume.getStatsPublicationsVentil(dateStat,
           filterIdGroup, filterIdUser));
     } catch (SQLException e) {
-      SilverTrace.error("silverStatisticsPeas",
-          "PubliPieChartBuilder.getCmpStats()", "root.EX_SQL_QUERY_FAILED", e);
+      SilverLogger.getLogger(this).error(e);
     }
     return cmpStats;
   }
 
   @Override
-  public PieChart getChart(String spaceId, Vector<String[]> currentStats) {
+  public PieChart getChart(String spaceId, List<String[]> currentStats) {
     setScope(AbstractPieChartBuilder.FINESSE_TOUS);
     if (StringUtil.isDefined(filterIdGroup)) {
       setScope(AbstractPieChartBuilder.FINESSE_GROUPE);

--- a/core-war/src/main/java/org/silverpeas/web/silverstatistics/control/SilverStatisticsPeasSessionController.java
+++ b/core-war/src/main/java/org/silverpeas/web/silverstatistics/control/SilverStatisticsPeasSessionController.java
@@ -48,7 +48,6 @@ import org.silverpeas.core.pdc.pdc.service.PdcManager;
 import org.silverpeas.core.security.session.SessionInfo;
 import org.silverpeas.core.security.session.SessionManagement;
 import org.silverpeas.core.security.session.SessionManagementProvider;
-import org.silverpeas.core.silvertrace.SilverTrace;
 import org.silverpeas.core.util.ArrayUtil;
 import org.silverpeas.core.util.Pair;
 import org.silverpeas.core.util.ResourceLocator;
@@ -79,7 +78,6 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Vector;
 
 import static org.silverpeas.core.util.ResourceLocator.getGeneralLocalizationBundle;
 
@@ -91,6 +89,13 @@ public class SilverStatisticsPeasSessionController extends AbstractComponentSess
 
   public static final int INDICE_VALUE = 0;
   public static final int INDICE_LIB = 1;
+  private static final String STP_FROM_APRIL_AUGUST_OCTOBER =
+      "silverStatisticsPeas.FromAprilAugustOctober";
+  private static final String STP_FROM = "silverStatisticsPeas.From";
+  private static final String STP_TO = "silverStatisticsPeas.To";
+  private static final String STP_LOGIN_NUMBER = "silverStatisticsPeas.LoginNumber";
+  private static final String STP_CONNECTIONS = "silverStatisticsPeas.Connections";
+  private static final String SELECTED_TAG = " selected";
   private String monthBegin = null;
   private String yearBegin = null;
   private String monthEnd = null;
@@ -110,8 +115,8 @@ public class SilverStatisticsPeasSessionController extends AbstractComponentSess
   /**
    * current stats list
    */
-  private Vector<String[]> currentStats = new Vector<>();
-  private Vector<String[]> path = new Vector<>();
+  private List<String[]> currentStats = new ArrayList<>();
+  private List<String[]> path = new ArrayList<>();
   private Collection<String> yearsConnection = null;
   private Collection<String> yearsAccess = null;
   private Collection<String> yearsVolume = null;
@@ -122,22 +127,19 @@ public class SilverStatisticsPeasSessionController extends AbstractComponentSess
     try {
       yearsConnection = initYears(SilverStatisticsPeasDAOConnexion.getYears());
     } catch (Exception e) {
-      SilverTrace.error("silverStatisticsPeas", "SilverStatisticsPeasSessionController.initYears",
-          "root.EX_SQL_QUERY_FAILED", e);
+      SilverLogger.getLogger(this).error(e);
     }
 
     try {
       yearsAccess = initYears(SilverStatisticsPeasDAOAccesVolume.getAccessYears());
     } catch (Exception e) {
-      SilverTrace.error("silverStatisticsPeas", "SilverStatisticsPeasSessionController.initYears",
-          "root.EX_SQL_QUERY_FAILED", e);
+      SilverLogger.getLogger(this).error(e);
     }
 
     try {
       yearsVolume = initYears(SilverStatisticsPeasDAOAccesVolume.getVolumeYears());
     } catch (Exception e) {
-      SilverTrace.error("silverStatisticsPeas", "SilverStatisticsPeasSessionController.initYears",
-          "root.EX_SQL_QUERY_FAILED", e);
+      SilverLogger.getLogger(this).error(e);
     }
   }
 
@@ -149,7 +151,7 @@ public class SilverStatisticsPeasSessionController extends AbstractComponentSess
    * @return a never null collection of years as string.
    */
   private Collection<String> initYears(Collection<String> yearsFromStatistics) {
-    Collection<String> result = new LinkedHashSet<String>();
+    Collection<String> result = new LinkedHashSet<>();
     if (yearsFromStatistics != null) {
       result.addAll(yearsFromStatistics);
     }
@@ -182,9 +184,6 @@ public class SilverStatisticsPeasSessionController extends AbstractComponentSess
     if (!ArrayUtil.isEmpty(manageableSpaceIds)) {
       userProfile = UserAccessLevel.SPACE_ADMINISTRATOR;
     }
-    SilverTrace
-        .info("silverStatisticsPeas", "SilverStatisticsPeasSessionController.getUserProfile()",
-            "root.MSG_GEN_PARAM_VALUE", "userProfile=" + userProfile);
     return userProfile;
   }
 
@@ -198,9 +197,7 @@ public class SilverStatisticsPeasSessionController extends AbstractComponentSess
     try {
       c = SilverStatisticsPeasDAOConnexion.getStatsConnexionAllAll(dateBegin, dateEnd);
     } catch (Exception e) {
-      SilverTrace.error("silverStatisticsPeas",
-          "SilverStatisticsPeasSessionController.getStatsConnexionAllAll()",
-          "root.EX_SQL_QUERY_FAILED", e);
+      SilverLogger.getLogger(this).error(e);
     }
     return c;
   }
@@ -250,7 +247,6 @@ public class SilverStatisticsPeasSessionController extends AbstractComponentSess
   public PeriodChart getDistinctUserConnectionsChart(String dateBegin, String dateEnd) {
     PeriodChart axisChart = null;
     try {
-      // new Collection[]{dates, counts};
       Collection[] statsUsers = SilverStatisticsPeasDAOConnexion.getStatsUser(dateBegin, dateEnd);
 
       // title
@@ -259,14 +255,14 @@ public class SilverStatisticsPeasSessionController extends AbstractComponentSess
       if ("04".equals(mois) || "08".equals(mois) || "10".equals(mois)) {// Avril,
         // Aout,
         // Octobre
-        title += this.getString("silverStatisticsPeas.FromAprilAugustOctober");
+        title += this.getString(STP_FROM_APRIL_AUGUST_OCTOBER);
 
       } else {
-        title += this.getString("silverStatisticsPeas.From") + " ";
+        title += this.getString(STP_FROM) + " ";
       }
 
       title += formatDate(dateBegin) + " ";
-      title += this.getString("silverStatisticsPeas.To") + " ";
+      title += this.getString(STP_TO) + " ";
       title += formatDate(dateEnd);
 
       axisChart = getMonthPeriodChartFrom((List<String>) statsUsers[0], (List) statsUsers[1])
@@ -274,9 +270,7 @@ public class SilverStatisticsPeasSessionController extends AbstractComponentSess
       axisChart.getAxisY()
           .setTitle(getGeneralLocalizationBundle(getLanguage()).getString("GML.users"));
     } catch (Exception se) {
-      SilverTrace.error("silverStatisticsPeas",
-          "SilverStatisticsPeasSessionController.getDistinctUserConnectionsChart()",
-          "root.EX_SQL_QUERY_FAILED", se);
+      SilverLogger.getLogger(this).error(se);
     }
 
     return axisChart;
@@ -293,27 +287,25 @@ public class SilverStatisticsPeasSessionController extends AbstractComponentSess
 
       // title
       StringBuilder title = new StringBuilder();
-      title.append(this.getString("silverStatisticsPeas.LoginNumber")).append(" ");
+      title.append(this.getString(STP_LOGIN_NUMBER)).append(" ");
       String mois = dateBegin.substring(5, 7);
       if ("04".equals(mois) || "08".equals(mois) || "10".equals(mois)) {// Avril,
         // Aout, Octobre
-        title.append(this.getString("silverStatisticsPeas.FromAprilAugustOctober"));
+        title.append(this.getString(STP_FROM_APRIL_AUGUST_OCTOBER));
       } else {
-        title.append(this.getString("silverStatisticsPeas.From")).append(" ");
+        title.append(this.getString(STP_FROM)).append(" ");
       }
 
       title.append(formatDate(dateBegin)).append(" ");
-      title.append(this.getString("silverStatisticsPeas.To")).append(" ");
+      title.append(this.getString(STP_TO)).append(" ");
       title.append(formatDate(dateEnd));
 
       axisChart =
           getMonthPeriodChartFrom((List<String>) statsConnection[0], (List) statsConnection[1])
               .withTitle(title.toString());
-      axisChart.getAxisY().setTitle(this.getString("silverStatisticsPeas.Connections"));
+      axisChart.getAxisY().setTitle(this.getString(STP_CONNECTIONS));
     } catch (Exception se) {
-      SilverTrace.error("silverStatisticsPeas",
-          "SilverStatisticsPeasSessionController.getUserConnectionsChart()",
-          "root.EX_SQL_QUERY_FAILED", se);
+      SilverLogger.getLogger(this).error(se);
     }
 
     return axisChart;
@@ -334,30 +326,28 @@ public class SilverStatisticsPeasSessionController extends AbstractComponentSess
           SilverStatisticsPeasDAOConnexion.getStatsUserConnexion(dateBegin, dateEnd, idUser);
 
       // title
-      String title = this.getString("silverStatisticsPeas.LoginNumber") + " " +
+      String title = this.getString(STP_LOGIN_NUMBER) + " " +
           this.getString("silverStatisticsPeas.OfUser") + " " + lastName + " ";
       String mois = dateBegin.substring(5, 7);
       if ("04".equals(mois) || "08".equals(mois) || "10".equals(mois)) {// Avril,
         // Aout,
         // Octobre
-        title += this.getString("silverStatisticsPeas.FromAprilAugustOctober");
+        title += this.getString(STP_FROM_APRIL_AUGUST_OCTOBER);
       } else {
-        title += this.getString("silverStatisticsPeas.From") + " ";
+        title += this.getString(STP_FROM) + " ";
       }
 
       title += formatDate(dateBegin) + " ";
-      title += this.getString("silverStatisticsPeas.To") + " ";
+      title += this.getString(STP_TO) + " ";
       title += formatDate(dateEnd);
 
       axisChart =
           getMonthPeriodChartFrom((List<String>) statsConnection[0], (List) statsConnection[1])
               .withTitle(title);
-      axisChart.getAxisY().setTitle(this.getString("silverStatisticsPeas.Connections"));
+      axisChart.getAxisY().setTitle(this.getString(STP_CONNECTIONS));
 
     } catch (Exception se) {
-      SilverTrace.error("silverStatisticsPeas",
-          "SilverStatisticsPeasSessionController.getUserConnectionsUserChart()",
-          "root.EX_SQL_QUERY_FAILED", se);
+      SilverLogger.getLogger(this).error(se);
     }
 
     return axisChart;
@@ -378,9 +368,7 @@ public class SilverStatisticsPeasSessionController extends AbstractComponentSess
       c = SilverStatisticsPeasDAOConnexion
           .getStatsConnexionAllGroup(dateBegin, dateEnd, Integer.parseInt(idGroup));
     } catch (Exception e) {
-      SilverTrace.error("silverStatisticsPeas",
-          "SilverStatisticsPeasSessionController.getStatsConnexionAllGroup()",
-          "root.EX_SQL_QUERY_FAILED", e);
+      SilverLogger.getLogger(this).error(e);
     }
     return c;
   }
@@ -399,31 +387,29 @@ public class SilverStatisticsPeasSessionController extends AbstractComponentSess
           SilverStatisticsPeasDAOConnexion.getStatsGroupConnexion(dateBegin, dateEnd, idGroup);
 
       // title
-      String title = this.getString("silverStatisticsPeas.LoginNumber") + " " +
+      String title = this.getString(STP_LOGIN_NUMBER) + " " +
           this.getString("silverStatisticsPeas.OfGroup") + " " +
           AdministrationServiceProvider.getAdminService().getGroupName(idGroup) + " ";
       String mois = dateBegin.substring(5, 7);
       if ("04".equals(mois) || "08".equals(mois) || "10".equals(mois)) {// Avril,
         // Aout,
         // Octobre
-        title += this.getString("silverStatisticsPeas.FromAprilAugustOctober");
+        title += this.getString(STP_FROM_APRIL_AUGUST_OCTOBER);
       } else {
-        title += this.getString("silverStatisticsPeas.From") + " ";
+        title += this.getString(STP_FROM) + " ";
       }
 
       title += formatDate(dateBegin) + " ";
-      title += this.getString("silverStatisticsPeas.To") + " ";
+      title += this.getString(STP_TO) + " ";
       title += formatDate(dateEnd);
 
       axisChart =
           getMonthPeriodChartFrom((List<String>) statsConnection[0], (List) statsConnection[1])
-              .withTitle(title.toString());
-      axisChart.getAxisY().setTitle(this.getString("silverStatisticsPeas.Connections"));
+              .withTitle(title);
+      axisChart.getAxisY().setTitle(this.getString(STP_CONNECTIONS));
 
     } catch (Exception se) {
-      SilverTrace.error("silverStatisticsPeas",
-          "SilverStatisticsPeasSessionController.getUserConnectionsGroupChart()",
-          "root.EX_SQL_QUERY_FAILED", se);
+      SilverLogger.getLogger(this).error(se);
     }
 
     return axisChart;
@@ -436,9 +422,7 @@ public class SilverStatisticsPeasSessionController extends AbstractComponentSess
     try {
       c = SilverStatisticsPeasDAOConnexion.getStatsConnexionGroupAll(dateBegin, dateEnd);
     } catch (Exception e) {
-      SilverTrace.error("silverStatisticsPeas",
-          "SilverStatisticsPeasDAOConnexion.getStatsConnexionGroupAll", "root.EX_SQL_QUERY_FAILED",
-          e);
+      SilverLogger.getLogger(this).error(e);
     }
     return c;
   }
@@ -453,9 +437,7 @@ public class SilverStatisticsPeasSessionController extends AbstractComponentSess
       c = SilverStatisticsPeasDAOConnexion
           .getStatsConnexionAllGroup(dateBegin, dateEnd, Integer.parseInt(idUser));
     } catch (Exception e) {
-      SilverTrace.error("silverStatisticsPeas",
-          "SilverStatisticsPeasDAOConnexion.getStatsConnexionGroupUser", "root.EX_SQL_QUERY_FAILED",
-          e);
+      SilverLogger.getLogger(this).error(e);
     }
     return c;
   }
@@ -467,9 +449,7 @@ public class SilverStatisticsPeasSessionController extends AbstractComponentSess
     try {
       c = SilverStatisticsPeasDAOConnexion.getStatsConnexionUserAll(dateBegin, dateEnd);
     } catch (Exception e) {
-      SilverTrace.error("silverStatisticsPeas",
-          "SilverStatisticsPeasDAOConnexion.getStatsConnexionUserAll", "root.EX_SQL_QUERY_FAILED",
-          e);
+      SilverLogger.getLogger(this).error(e);
     }
     return c;
   }
@@ -489,11 +469,11 @@ public class SilverStatisticsPeasSessionController extends AbstractComponentSess
   }
 
   protected Selection communInitUserPanel(String compoName, String operation) {
-    String m_context = URLUtil.getApplicationURL();
-    String hostSpaceName = getString("silverStatisticsPeas.statistics");// getSpaceLabel();
+    String context = URLUtil.getApplicationURL();
+    String hostSpaceName = getString("silverStatisticsPeas.statistics");
     Pair<String, String> hostComponentName =
-        new Pair<>(getComponentLabel(), m_context + getComponentUrl() + compoName);
-    String hostUrl = m_context + getComponentUrl() + operation;
+        new Pair<>(getComponentLabel(), context + getComponentUrl() + compoName);
+    String hostUrl = context + getComponentUrl() + operation;
 
     Selection sel = getSelection();
     sel.resetAll();
@@ -510,7 +490,7 @@ public class SilverStatisticsPeasSessionController extends AbstractComponentSess
     return sel;
   }
 
-  public void KickSession(String sessionId) {
+  public void kickSession(String sessionId) {
     SessionManagement sessionManagement = SessionManagementProvider.getSessionManagement();
     sessionManagement.closeSession(sessionId);
   }
@@ -532,9 +512,7 @@ public class SilverStatisticsPeasSessionController extends AbstractComponentSess
 
       notificationSender.notifyUser(NotificationParameters.ADDRESS_BASIC_POPUP, notifMetaData);
     } catch (Exception ex) {
-      SilverTrace
-          .error("silverStatisticsPeas", "SilverStatisticsPeasSessionController.NotifySession",
-              "root.EX_SQL_QUERY_FAILED", ex);
+      SilverLogger.getLogger(this).error(ex);
     }
   }
 
@@ -544,7 +522,7 @@ public class SilverStatisticsPeasSessionController extends AbstractComponentSess
    * @param message
    */
   public void notifyAllSessions(Collection<SessionInfo> listUserDetail, String message) {
-    List<String> notifiedUsers = new ArrayList<String>();
+    List<String> notifiedUsers = new ArrayList<>();
 
     if (listUserDetail != null) {
       for (SessionInfo sessionInfo : listUserDetail) {
@@ -622,21 +600,22 @@ public class SilverStatisticsPeasSessionController extends AbstractComponentSess
 
       // title
       String title = this.getString("silverStatisticsPeas.ConnectionNumberOfDistinctUsers") + " ";
-      title += this.getString("silverStatisticsPeas.From") + " " + minFreq + " " +
-          this.getString("silverStatisticsPeas.To") + " " + maxFreq + " " +
+      title +=
+          this.getString(STP_FROM) + " " + minFreq + " " + this.getString(STP_TO) + " " + maxFreq +
+              " " +
           this.getString("silverStatisticsPeas.Times") + " ";
 
       String mois = dateBegin.substring(5, 7);
       if ("04".equals(mois) || "08".equals(mois) || "10".equals(mois)) {// Avril,
         // Aout,
         // Octobre
-        title += this.getString("silverStatisticsPeas.FromAprilAugustOctober");
+        title += this.getString(STP_FROM_APRIL_AUGUST_OCTOBER);
       } else {
-        title += this.getString("silverStatisticsPeas.From") + " ";
+        title += this.getString(STP_FROM) + " ";
       }
 
       title += formatDate(dateBegin) + " ";
-      title += this.getString("silverStatisticsPeas.To") + " ";
+      title += this.getString(STP_TO) + " ";
       title += formatDate(dateEnd);
 
       axisChart = getMonthPeriodChartFrom((List<String>) statsUsersFq[0], (List) statsUsersFq[1])
@@ -644,9 +623,7 @@ public class SilverStatisticsPeasSessionController extends AbstractComponentSess
       axisChart.getAxisY().setTitle(getGeneralLocalizationBundle(getLanguage()).getString("GML.users"));
 
     } catch (Exception se) {
-      SilverTrace.error("silverStatisticsPeas",
-          "SilverStatisticsPeasSessionController.getUserConnectionsFqChart()",
-          "root.EX_SQL_QUERY_FAILED", se);
+      SilverLogger.getLogger(this).error(se);
     }
 
     return axisChart;
@@ -699,37 +676,10 @@ public class SilverStatisticsPeasSessionController extends AbstractComponentSess
     return Selection.getSelectionURL();
   }
 
-  /*
-   * Retour du UserPanel
-   */
-  public void retourVolumeUserPanelGroup() {
-    Selection sel = getSelection();
-    String theGroup = sel.getFirstSelectedSet();
-
-    // update FilterType and FilterLib, FilterId
-    if (theGroup != null && theGroup.length() != 0) {
-      setAccessFilterIdGroup(theGroup);
-      setAccessFilterLibGroup(getOrganisationController().getGroup(theGroup).getName());
-    }
-  }
-
   public String initVolumeUserPanelUser() {
     Selection sel = communInitUserPanel("VolumeCallUserPanelUser", "VolumeReturnFromUserPanelUser");
     sel.setSetSelectable(false);
     return Selection.getSelectionURL();
-  }
-
-  /*
-   * Retour du UserPanel
-   */
-  public void retourVolumeUserPanelUser() {
-    Selection sel = getSelection();
-    String theUser = sel.getFirstSelectedElement();
-
-    if (theUser != null && theUser.length() != 0) {
-      setAccessFilterIdUser(theUser);
-      setAccessFilterLibUser(getOrganisationController().getUserDetail(theUser).getLastName());
-    }
   }
 
   public PieChart getUserVentilChart(String dateStat, String filterIdGroup,
@@ -753,8 +703,8 @@ public class SilverStatisticsPeasSessionController extends AbstractComponentSess
       Collection<String[]> statsUserAccess = SilverStatisticsPeasDAOAccesVolume.
           getStatsUserEvolution(entite, entiteId, filterIdGroup, filterIdUser);
       Iterator<String[]> itStats = statsUserAccess.iterator();
-      List<String> x = new ArrayList<String>();
-      List<Long> y = new ArrayList<Long>();
+      List<String> x = new ArrayList<>();
+      List<Long> y = new ArrayList<>();
       while (itStats.hasNext()) {
         String[] values = itStats.next();
         x.add(values[0]);
@@ -793,9 +743,7 @@ public class SilverStatisticsPeasSessionController extends AbstractComponentSess
       axisChart.getAxisY().setTitle(this.getString("silverStatisticsPeas.Access"));
 
     } catch (Exception se) {
-      SilverTrace.error("silverStatisticsPeas",
-          "SilverStatisticsPeasSessionController.getEvolutionUserChart()",
-          "root.EX_SQL_QUERY_FAILED", se);
+      SilverLogger.getLogger(this).error(se);
     }
 
     return axisChart;
@@ -809,11 +757,10 @@ public class SilverStatisticsPeasSessionController extends AbstractComponentSess
       try {
         SpaceInstLight space =
             AdministrationServiceProvider.getAdminService().getSpaceInstLightById(spaceId);
-        path.insertElementAt(new String[]{spaceId, space.getName()}, 0);
+        path.add(0, new String[]{spaceId, space.getName()});
         buildPath("WA" + space.getFatherId());
       } catch (AdminException e) {
-        SilverTrace.error("silverStatisticsPeas", "SilverStatisticsPeasSessionController.buildPath",
-            "root.EX_SQL_QUERY_FAILED", e);
+        SilverLogger.getLogger(this).error(e);
       }
 
     }
@@ -850,9 +797,7 @@ public class SilverStatisticsPeasSessionController extends AbstractComponentSess
           getPieChartFrom((List<String>) statsKMsInstances[0], (List) statsKMsInstances[1])
               .withTitle(getString("silverStatisticsPeas.ServicesNumber"));
     } catch (Exception se) {
-      SilverTrace.error("silverStatisticsPeas",
-          "SilverStatisticsPeasSessionController.getVolumeServicesChart()",
-          "root.EX_SQL_QUERY_FAILED", se);
+      SilverLogger.getLogger(this).error(se);
     }
 
     return pieChart;
@@ -900,8 +845,8 @@ public class SilverStatisticsPeasSessionController extends AbstractComponentSess
           SilverStatisticsPeasDAOVolumeServer.getStatsVolumeServer();
       Iterator<String[]> itStats = statsDocsSize.iterator();
       String[] values;
-      List<String> dates = new ArrayList<String>(statsDocsSize.size());
-      List<BigDecimal> size = new ArrayList<BigDecimal>(statsDocsSize.size());
+      List<String> dates = new ArrayList<>(statsDocsSize.size());
+      List<BigDecimal> size = new ArrayList<>(statsDocsSize.size());
       while (itStats.hasNext()) {
         values = itStats.next();
         dates.add(values[0]);
@@ -918,9 +863,7 @@ public class SilverStatisticsPeasSessionController extends AbstractComponentSess
               "(" + MemoryUnit.MB.getLabel() + ")");
 
     } catch (Exception se) {
-      SilverTrace.error("silverStatisticsPeas",
-          "SilverStatisticsPeasSessionController.getEvolutionDocsSizeChart()",
-          "root.EX_SQL_QUERY_FAILED", se);
+      SilverLogger.getLogger(this).error(se);
     }
 
     return axisChart;
@@ -955,8 +898,8 @@ public class SilverStatisticsPeasSessionController extends AbstractComponentSess
   }
 
   private Collection<String[]> getFormYear(String yearValue, Collection<String> years) {
-    List<String[]> myList = new ArrayList<String[]>();
-    String stat[] = null;
+    List<String[]> myList = new ArrayList<>();
+    String[] stat;
 
     if (years != null) {
       for (String indice : years) {
@@ -965,7 +908,7 @@ public class SilverStatisticsPeasSessionController extends AbstractComponentSess
         stat[INDICE_LIB] = stat[INDICE_VALUE];
 
         if (stat[INDICE_VALUE].equals(yearValue)) {
-          stat[INDICE_VALUE] += " selected";
+          stat[INDICE_VALUE] += SELECTED_TAG;
         }
         myList.add(stat);
       }
@@ -975,8 +918,8 @@ public class SilverStatisticsPeasSessionController extends AbstractComponentSess
   }
 
   public Collection<String[]> getFormMonth(String monthValue) {
-    ArrayList<String[]> myList = new ArrayList<String[]>();
-    String stat[] = null;
+    ArrayList<String[]> myList = new ArrayList<>();
+    String[] stat;
 
     for (int i = 0; i < 12; i++) {
       stat = new String[2];
@@ -984,7 +927,7 @@ public class SilverStatisticsPeasSessionController extends AbstractComponentSess
       stat[INDICE_LIB] = "GML.mois" + i;
 
       if (stat[INDICE_VALUE].equals(monthValue)) {
-        stat[INDICE_VALUE] += " selected";
+        stat[INDICE_VALUE] += SELECTED_TAG;
       }
       myList.add(stat);
     }
@@ -993,15 +936,15 @@ public class SilverStatisticsPeasSessionController extends AbstractComponentSess
   }
 
   public Collection<String[]> getDetail(String value) {
-    List<String[]> myList = new ArrayList<String[]>();
-    String stat[] = null;
+    List<String[]> myList = new ArrayList<>();
+    String[] stat;
 
     stat = new String[2];
     stat[INDICE_VALUE] = "0";
     stat[INDICE_LIB] = "GML.allMP";
 
     if (stat[INDICE_VALUE].equals(value)) {
-      stat[INDICE_VALUE] += " selected";
+      stat[INDICE_VALUE] += SELECTED_TAG;
     }
 
     myList.add(stat);
@@ -1011,7 +954,7 @@ public class SilverStatisticsPeasSessionController extends AbstractComponentSess
     stat[INDICE_LIB] = "silverStatisticsPeas.group";
 
     if (stat[INDICE_VALUE].equals(value)) {
-      stat[INDICE_VALUE] += " selected";
+      stat[INDICE_VALUE] += SELECTED_TAG;
     }
 
     myList.add(stat);
@@ -1021,7 +964,7 @@ public class SilverStatisticsPeasSessionController extends AbstractComponentSess
     stat[INDICE_LIB] = "GML.user";
 
     if (stat[INDICE_VALUE].equals(value)) {
-      stat[INDICE_VALUE] += " selected";
+      stat[INDICE_VALUE] += SELECTED_TAG;
     }
 
     myList.add(stat);
@@ -1030,15 +973,15 @@ public class SilverStatisticsPeasSessionController extends AbstractComponentSess
   }
 
   public Collection<String[]> getFrequenceDetail(String value) {
-    List<String[]> myList = new ArrayList<String[]>();
-    String stat[] = null;
+    List<String[]> myList = new ArrayList<>();
+    String[] stat;
 
     stat = new String[2];
     stat[INDICE_VALUE] = "0";
     stat[INDICE_LIB] = "[0 - 5[";
 
     if (stat[INDICE_VALUE].equals(value)) {
-      stat[INDICE_VALUE] += " selected";
+      stat[INDICE_VALUE] += SELECTED_TAG;
     }
 
     myList.add(stat);
@@ -1048,7 +991,7 @@ public class SilverStatisticsPeasSessionController extends AbstractComponentSess
     stat[INDICE_LIB] = "[5 - 10[";
 
     if (stat[INDICE_VALUE].equals(value)) {
-      stat[INDICE_VALUE] += " selected";
+      stat[INDICE_VALUE] += SELECTED_TAG;
     }
 
     myList.add(stat);
@@ -1058,7 +1001,7 @@ public class SilverStatisticsPeasSessionController extends AbstractComponentSess
     stat[INDICE_LIB] = "[10 - 15[";
 
     if (stat[INDICE_VALUE].equals(value)) {
-      stat[INDICE_VALUE] += " selected";
+      stat[INDICE_VALUE] += SELECTED_TAG;
     }
 
     myList.add(stat);
@@ -1068,7 +1011,7 @@ public class SilverStatisticsPeasSessionController extends AbstractComponentSess
     stat[INDICE_LIB] = "[15 - 20[";
 
     if (stat[INDICE_VALUE].equals(value)) {
-      stat[INDICE_VALUE] += " selected";
+      stat[INDICE_VALUE] += SELECTED_TAG;
     }
 
     myList.add(stat);
@@ -1078,7 +1021,7 @@ public class SilverStatisticsPeasSessionController extends AbstractComponentSess
     stat[INDICE_LIB] = "[20 - 25[";
 
     if (stat[INDICE_VALUE].equals(value)) {
-      stat[INDICE_VALUE] += " selected";
+      stat[INDICE_VALUE] += SELECTED_TAG;
     }
 
     myList.add(stat);
@@ -1088,7 +1031,7 @@ public class SilverStatisticsPeasSessionController extends AbstractComponentSess
     stat[INDICE_LIB] = "[25 - ++[";
 
     if (stat[INDICE_VALUE].equals(value)) {
-      stat[INDICE_VALUE] += " selected";
+      stat[INDICE_VALUE] += SELECTED_TAG;
     }
 
     myList.add(stat);
@@ -1096,9 +1039,7 @@ public class SilverStatisticsPeasSessionController extends AbstractComponentSess
     return myList;
   }
 
-  /**
-   *
-   */
+  @Override
   public SettingBundle getSettings() {
     return ResourceLocator.getSettingBundle(
         "org.silverpeas.silverStatisticsPeas.settings.silverStatisticsSettings");
@@ -1238,7 +1179,7 @@ public class SilverStatisticsPeasSessionController extends AbstractComponentSess
   /**
    * @return Returns the currentStats.
    */
-  public Vector<String[]> getCurrentStats() {
+  public List<String[]> getCurrentStats() {
     return currentStats;
   }
 
@@ -1252,7 +1193,7 @@ public class SilverStatisticsPeasSessionController extends AbstractComponentSess
   /**
    * @return Returns the path.
    */
-  public Vector<String[]> getPath() {
+  public List<String[]> getPath() {
     return path;
   }
 
@@ -1270,7 +1211,7 @@ public class SilverStatisticsPeasSessionController extends AbstractComponentSess
    * @return @throws PdcException
    */
   public List<StatisticAxisVO> getPrimaryAxis() throws PdcException {
-    List<StatisticAxisVO> statsAxes = new ArrayList<StatisticAxisVO>();
+    List<StatisticAxisVO> statsAxes = new ArrayList<>();
     List<AxisHeader> axes = getPdcManager().getAxisByType("P");
     for (AxisHeader axisHeader : axes) {
       StatisticAxisVO axis =
@@ -1288,7 +1229,7 @@ public class SilverStatisticsPeasSessionController extends AbstractComponentSess
    */
   public List<StatisticVO> getAxisStats(AxisStatsFilter statsFilter) {
     // Result list
-    List<StatisticVO> stats = new ArrayList<StatisticVO>();
+    List<StatisticVO> stats = new ArrayList<>();
 
     // Retrieve all the list of components
     List<String> components = buildCustomComponentListWhereToSearch();
@@ -1338,8 +1279,9 @@ public class SilverStatisticsPeasSessionController extends AbstractComponentSess
           String curAxisValue = curValue.getFullPath();
           int nbAxisAccess = 0;
           // Check axis level number
-          if (axisFilter && curAxisValue.startsWith(axisValue) &&
-              curValue.getLevelNumber() == curLevel) {
+          if ((axisFilter && curAxisValue.startsWith(axisValue) &&
+              curValue.getLevelNumber() == curLevel) ||
+              (!axisFilter && curValue.getLevelNumber() == 1)) {
             // Retrieve all the current axis publications
             gSC = getPdCPublications(Integer.toString(curAxisId), curAxisValue, components);
             nbAxisAccess = computeAxisAccessStatistics(accessPublis, gSC);
@@ -1351,28 +1293,11 @@ public class SilverStatisticsPeasSessionController extends AbstractComponentSess
             curStat.setAxisLevel(curValue.getLevelNumber());
             // Add this statistic to list
             stats.add(curStat);
-          } else if (!axisFilter && curValue.getLevelNumber() == 1) {
-            // Retrieve all the current axis publications
-            gSC = getPdCPublications(Integer.toString(curAxisId), curAxisValue, components);
-            nbAxisAccess = computeAxisAccessStatistics(accessPublis, gSC);
-            // Create a new statistic value object
-            StatisticVO curStat = new StatisticVO(Integer.toString(curAxisId), curValue.getName(),
-                curValue.getDescription(), nbAxisAccess);
-            curStat.setAxisValue(curValue.getFullPath());
-            curStat.setAxisLevel(curValue.getLevelNumber());
-            // Add this statistic to list
-            stats.add(curStat);
           }
         }
       }
-    } catch (PdcException e) {
-      SilverTrace.error("silverStatisticsPeas",
-          SilverStatisticsPeasSessionController.class.getName() + ".getAxisStats",
-          "Problem to access the PDC");
-    } catch (SQLException sqlEx) {
-      SilverTrace.error("silverStatisticsPeas",
-          SilverStatisticsPeasSessionController.class.getName() + ".getAxisStats",
-          "Problem to retrieve statistics on axis.");
+    } catch (PdcException | SQLException e) {
+      SilverLogger.getLogger(this).error(e);
     }
     return stats;
   }
@@ -1393,15 +1318,12 @@ public class SilverStatisticsPeasSessionController extends AbstractComponentSess
 
     // Retrieve the list of PDC publications using EJB call
     List<GlobalSilverContent> silverContentsMetier = null;
-    PdcManager pdcManager = PdcManager.get();
-    if (pdcManager != null) {
-      if (!componentIds.isEmpty()) {
-        try {
-          silverContentsMetier =
-              pdcManager.findGlobalSilverContents(context, componentIds, true, true);
-        } catch (Exception e) {
-          SilverTrace.error("silverStatisticsPeas", "SilverStatisticsPeasSessionController.getPdCPublications", "getPdCPublications exception", e);
-        }
+    if (!componentIds.isEmpty()) {
+      try {
+        silverContentsMetier =
+            getPdcManager().findGlobalSilverContents(context, componentIds, true, true);
+      } catch (Exception e) {
+        SilverLogger.getLogger(this).error(e);
       }
     }
     return silverContentsMetier;
@@ -1417,15 +1339,12 @@ public class SilverStatisticsPeasSessionController extends AbstractComponentSess
       List<String> componentIds) {
     // Retrieve the list of PDC publications using EJB call
     List<GlobalSilverContent> silverContentsMetier = null;
-    PdcManager pdcManager = PdcManager.get();
-    if (pdcManager != null) {
-      if (componentIds.size() > 0) {
-        try {
-          silverContentsMetier =
-              pdcManager.findGlobalSilverContents(searchContext, componentIds, true, true);
-        } catch (Exception e) {
-          SilverTrace.error("silverStatisticsPeas", "SilverStatisticsPeasSessionController.getPdCPublications", "getPdCPublications exception", e);
-        }
+    if (!componentIds.isEmpty()) {
+      try {
+        silverContentsMetier =
+            getPdcManager().findGlobalSilverContents(searchContext, componentIds, true, true);
+      } catch (Exception e) {
+        SilverLogger.getLogger(this).error(e);
       }
     }
     return silverContentsMetier;
@@ -1435,7 +1354,7 @@ public class SilverStatisticsPeasSessionController extends AbstractComponentSess
    * This method allow user to search over multiple component selection
    */
   public List<String> buildCustomComponentListWhereToSearch() {
-    List<String> componentList = new ArrayList<String>();
+    List<String> componentList = new ArrayList<>();
     String[] allowedComponentIds = getUserAvailComponentIds();
     // Il n'y a pas de restriction sur un espace particulier
     for (String allowedComponentId : allowedComponentIds) {
@@ -1465,7 +1384,7 @@ public class SilverStatisticsPeasSessionController extends AbstractComponentSess
   public CrossStatisticVO getCrossAxisStats(CrossAxisStatsFilter statsFilter) {
     // Cross PDC statistics
     CrossStatisticVO crossStat = null;
-    List<List<CrossAxisAccessVO>> stats = new ArrayList<List<CrossAxisAccessVO>>();
+    List<List<CrossAxisAccessVO>> stats = new ArrayList<>();
 
     // Retrieve all the list of components
     List<String> components = buildCustomComponentListWhereToSearch();
@@ -1487,8 +1406,8 @@ public class SilverStatisticsPeasSessionController extends AbstractComponentSess
       List<Value> secondValues = getPdcManager().getAxisValues(statsFilter.getSecondAxisId());
 
       // Header and first row list declaration
-      List<String> headerColumn = new ArrayList<String>();
-      List<String> firstRow = new ArrayList<String>();
+      List<String> headerColumn = new ArrayList<>();
+      List<String> firstRow = new ArrayList<>();
 
       // Initialize header column name
       for (Value value : secondValues) {
@@ -1496,7 +1415,7 @@ public class SilverStatisticsPeasSessionController extends AbstractComponentSess
       }
 
       for (Value firstValue : firstValues) {
-        List<CrossAxisAccessVO> listRowStats = new ArrayList<CrossAxisAccessVO>();
+        List<CrossAxisAccessVO> listRowStats = new ArrayList<>();
         String fValue = firstValue.getFullPath();
         String fValueName = firstValue.getName();
         firstRow.add(fValueName);
@@ -1505,7 +1424,6 @@ public class SilverStatisticsPeasSessionController extends AbstractComponentSess
           // Loop variable declaration
           int nbAxisAccess = 0;
           String sValue = secondValue.getFullPath();
-          // String sValueName = secondValue.getName();
 
           // Build PDC search context
           SearchContext searchCtx = new SearchContext(this.getUserId());
@@ -1522,14 +1440,8 @@ public class SilverStatisticsPeasSessionController extends AbstractComponentSess
         stats.add(listRowStats);
       }
       crossStat = new CrossStatisticVO(headerColumn, firstRow, stats);
-    } catch (PdcException e) {
-      SilverTrace.error("silverStatisticsPeas",
-          SilverStatisticsPeasSessionController.class.getName() + ".getCrossAxisStats",
-          "Problem to access the PDC", e);
-    } catch (SQLException sqlEx) {
-      SilverTrace.error("silverStatisticsPeas",
-          SilverStatisticsPeasSessionController.class.getName() + ".getCrossAxisStats",
-          "Problem to access statistics table", sqlEx);
+    } catch (PdcException | SQLException e) {
+      SilverLogger.getLogger(this).error(e);
     }
     return crossStat;
   }

--- a/core-war/src/main/java/org/silverpeas/web/silverstatistics/control/UserPieChartBuilder.java
+++ b/core-war/src/main/java/org/silverpeas/web/silverstatistics/control/UserPieChartBuilder.java
@@ -23,19 +23,19 @@
  */
 package org.silverpeas.web.silverstatistics.control;
 
-import org.silverpeas.core.silvertrace.SilverTrace;
 import org.silverpeas.core.admin.service.AdministrationServiceProvider;
-import org.silverpeas.core.admin.space.SpaceInstLight;
-import org.silverpeas.core.chart.pie.PieChart;
 import org.silverpeas.core.admin.service.OrganizationController;
 import org.silverpeas.core.admin.service.OrganizationControllerProvider;
+import org.silverpeas.core.admin.space.SpaceInstLight;
+import org.silverpeas.core.chart.pie.PieChart;
 import org.silverpeas.core.util.LocalizationBundle;
 import org.silverpeas.core.util.StringUtil;
+import org.silverpeas.core.util.logging.SilverLogger;
 
 import java.sql.SQLException;
-import java.util.Hashtable;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
-import java.util.Vector;
 
 /**
  * @author BERTINL
@@ -85,8 +85,7 @@ public class UserPieChartBuilder extends AbstractPieChartBuilder {
             + space.getName() + "\" ";
       }
     } catch (Exception e) {
-      SilverTrace.error("silverStatisticsPeas",
-          "UserPieChartBuilder.getChartTitle()", "root.EX_SQL_QUERY_FAILED", e);
+      SilverLogger.getLogger(this).error(e);
     }
 
     title += message.getString("silverStatisticsPeas.In") + " " + this.dateFormate;
@@ -94,26 +93,20 @@ public class UserPieChartBuilder extends AbstractPieChartBuilder {
     return title;
   }
 
-  /*
-   * (non-Javadoc)
-   * @see com.stratelia.silverpeas.silverStatisticsPeas.control.AbstractPieChartBuilder
-   * #getCmpStats()
-   */
   Map<String, String[]> getCmpStats() {
 
-    Hashtable<String, String[]> cmpStats = new Hashtable<>();
+    Map<String, String[]> cmpStats = new HashMap<>();
     try {
-      cmpStats.putAll(SilverStatisticsPeasDAOAccesVolume.getStatsUserVentil(
-          dateStat, filterIdGroup, filterIdUser));
+      cmpStats.putAll(SilverStatisticsPeasDAOAccesVolume.getStatsUserVentil(dateStat, filterIdGroup,
+          filterIdUser));
     } catch (SQLException e) {
-      SilverTrace.error("silverStatisticsPeas",
-          "UserPieChartBuilder.getCmpStats()", "root.EX_SQL_QUERY_FAILED", e);
+      SilverLogger.getLogger(this).error(e);
     }
     return cmpStats;
   }
 
   @Override
-  public PieChart getChart(String spaceId, Vector<String[]> currentStats) {
+  public PieChart getChart(String spaceId, List<String[]> currentStats) {
     setScope(AbstractPieChartBuilder.FINESSE_TOUS);
     if (StringUtil.isDefined(filterIdGroup)) {
       setScope(AbstractPieChartBuilder.FINESSE_GROUPE);

--- a/core-war/src/main/java/org/silverpeas/web/silverstatistics/servlets/SilverStatisticsPeasRequestRouter.java
+++ b/core-war/src/main/java/org/silverpeas/web/silverstatistics/servlets/SilverStatisticsPeasRequestRouter.java
@@ -113,7 +113,7 @@ public class SilverStatisticsPeasRequestRouter extends
             .getConnectedUsersList());
         destination = "/silverStatisticsPeas/jsp/connections.jsp";
       } else if (function.equals("KickSession")) {
-        statsSC.KickSession(request.getParameter("theSessionId"));
+        statsSC.kickSession(request.getParameter("theSessionId"));
         request.setAttribute("ConnectedUsersList", statsSC.getConnectedUsersList());
         destination = "/silverStatisticsPeas/jsp/connections.jsp";
       } else if (function.equals("DisplayNotifySession")) {

--- a/core-war/src/main/webapp/jobDomainPeas/jsp/deletedUsers.jsp
+++ b/core-war/src/main/webapp/jobDomainPeas/jsp/deletedUsers.jsp
@@ -1,0 +1,108 @@
+<%--
+  ~ Copyright (C) 2000 - 2018 Silverpeas
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as
+  ~ published by the Free Software Foundation, either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ As a special exception to the terms and conditions of version 3.0 of
+  ~ the GPL, you may redistribute this Program in connection with Free/Libre
+  ~ Open Source Software ("FLOSS") applications as described in Silverpeas's
+  ~ FLOSS exception.  You should have received a copy of the text describing
+  ~ the FLOSS exception, and it is also available here:
+  ~ "https://www.silverpeas.org/legal/floss_exception.html"
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  --%>
+<%@page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn" %>
+<%@ taglib uri="http://www.silverpeas.com/tld/silverFunctions" prefix="silfn" %>
+<%@ taglib uri="http://www.silverpeas.com/tld/viewGenerator" prefix="view" %>
+<%@ taglib tagdir="/WEB-INF/tags/silverpeas/util" prefix="viewTags" %>
+<c:set var="language" value="${sessionScope.sessionController.language}"/>
+<fmt:setLocale value="${language}"/>
+<view:setBundle bundle="${requestScope.resources.multilangBundle}"/>
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <view:looknfeel withFieldsetStyle="true"/>
+  <script type="application/javascript">
+    function validate() {
+      document.BlankUsers.submit();
+    }
+
+    function cancel() {
+      document.BlankUsers.action = 'domainContent';
+      document.BlankUsers.submit();
+    }
+  </script>
+</head>
+<c:set var="domain"       value="${requestScope.domain}"/>
+<c:set var="deletedUsers" value="${requestScope.deletedUsers}"/>
+<c:set var="currentUser"  value="${requestScope.theUser}"/>
+<jsp:useBean id="domain"
+             type="org.silverpeas.core.admin.domain.model.Domain"/>
+<jsp:useBean id="deletedUsers"
+             type="java.util.List<org.silverpeas.core.admin.user.model.UserDetail>"/>
+<jsp:useBean id="currentUser"
+             type="org.silverpeas.core.admin.user.model.UserDetail"/>
+<body id="domainContent" class="page_content_admin">
+<fmt:message var="domainTitle" key="JDP.domains"/>
+<view:browseBar componentId="${domainTitle}">
+  <view:browseBarElt label="${silfn:escapeHtml(domain.name)}" link="domainContent?Iddomain=${domain.id}"/>
+</view:browseBar>
+<view:window>
+  <view:frame>
+    <div class="principalContent">
+      <h2 class="principal-content-title sql-domain">${silfn:escapeHtml(domain.name)}</h2>
+      <div id="number-user-group-domainContent">
+        <span id="number-user-domainContent">${deletedUsers.size()} <fmt:message key="JDP.deletedUsers"/></span>
+      </div>
+      <c:if test="${fn:length(domain.description) > 0}">
+        <p id="description-domainContent">${silfn:escapeHtml(domain.description)}</p>
+      </c:if>
+    </div>
+    <c:if test="${currentUser.accessAdmin}">
+      <fmt:message var="firstName"    key="GML.surname"/>
+      <fmt:message var="lastName"     key="GML.lastName"/>
+      <fmt:message var="deletionDate" key="JDP.userDeletionDate"/>
+      <fmt:message var="anonymize"    key="JDP.blankUser"/>
+      <fmt:message var="validate"     key="GML.validate"/>
+      <fmt:message var="cancel"       key="GML.cancel"/>
+      <form name="BlankUsers" action="blankUsers" method="POST">
+        <view:arrayPane var="deletedUsers" routingAddress="displayDeletedUsers" numberLinesPerPage="25">
+          <view:arrayColumn title="${lastName}"     compareOn="${u -> u.lastName}" />
+          <view:arrayColumn title="${firstName}"    compareOn="${u -> u.firstName}"/>
+          <view:arrayColumn title="${deletionDate}" compareOn="${u -> u.stateSaveDate}"/>
+          <view:arrayColumn title="${anonymize}"    sortable="false"/>
+          <view:arrayLines var="aUser" items="${deletedUsers}">
+            <jsp:useBean id="aUser" type="org.silverpeas.core.admin.user.model.UserDetail"/>
+            <view:arrayLine>
+              <view:arrayCellText text="${silfn:escapeHtml(aUser.lastName)}"/>
+              <view:arrayCellText text="${silfn:escapeHtml(aUser.firstName)}"/>
+              <view:arrayCellText text="${silfn:formatDateAndHour(aUser.stateSaveDate, language)}"/>
+              <view:arrayCellCheckbox name="blank_${aUser.id}" value="${aUser.id}" checked="false"/>
+            </view:arrayLine>
+          </view:arrayLines>
+        </view:arrayPane>
+        <span>&nbsp;</span>
+        <view:buttonPane>
+          <view:button label="${validate}" action="javascript:onClick=validate()"/>
+          <view:button label="${cancel}"   action="javascript:onClick=cancel()"/>
+        </view:buttonPane>
+      </form>
+    </c:if>
+  </view:frame>
+</view:window>
+</body>
+

--- a/core-war/src/main/webapp/jobDomainPeas/jsp/domainContent.jsp
+++ b/core-war/src/main/webapp/jobDomainPeas/jsp/domainContent.jsp
@@ -74,6 +74,7 @@
 	if (theUser.isAccessAdmin())
 	{
 	    if (!mixedDomain) {
+	      operationPane.addOperation(resource.getIcon("JDP.deletedUserAccess"), resource.getString("JDP.deletedUserAccess"), "displayDeletedUsers");
 		    operationPane.addLine();
 		if(isDomainSql) {
 		        operationPane.addOperation(resource.getIcon("JDP.domainSqlUpdate"),resource.getString("JDP.domainSQLUpdate"),"displayDomainSQLModify");

--- a/core-war/src/main/webapp/jobDomainPeas/jsp/domainNavigation.jsp
+++ b/core-war/src/main/webapp/jobDomainPeas/jsp/domainNavigation.jsp
@@ -23,32 +23,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 --%>
-<%@ page import="org.silverpeas.core.util.WebEncodeHelper" %><%--
-
-    Copyright (C) 2000 - 2018 Silverpeas
-
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as
-    published by the Free Software Foundation, either version 3 of the
-    License, or (at your option) any later version.
-
-    As a special exception to the terms and conditions of version 3.0 of
-    the GPL, you may redistribute this Program in connection with Free/Libre
-    Open Source Software ("FLOSS") applications as described in Silverpeas's
-    FLOSS exception.  You should have received a copy of the text describing
-    the FLOSS exception, and it is also available here:
-    "http://www.silverpeas.org/docs/core/legal/floss_exception.html"
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
---%>
-
+<%@ page import="org.silverpeas.core.util.WebEncodeHelper" %>
 <%@page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
 <%@ taglib uri="http://www.silverpeas.com/tld/viewGenerator" prefix="view"%>

--- a/core-war/src/main/webapp/silverStatisticsPeas/jsp/exportDataAccess.jsp
+++ b/core-war/src/main/webapp/silverStatisticsPeas/jsp/exportDataAccess.jsp
@@ -34,7 +34,7 @@ response.setContentType("text/html");
 	Iterator   iter1 = null;
 	String filterIdGroup = (String) request.getAttribute("FilterIdGroup");
 		String filterIdUser = (String) request.getAttribute("FilterIdUser");
-        Vector vStatsData = (Vector) request.getAttribute("StatsData");
+        List vStatsData = (List) request.getAttribute("StatsData");
 		String separatorCSV = ",";
 
         String Organisation = resources.getString("silverStatisticsPeas.organisation");

--- a/core-war/src/main/webapp/silverStatisticsPeas/jsp/viewAccess.jsp
+++ b/core-war/src/main/webapp/silverStatisticsPeas/jsp/viewAccess.jsp
@@ -53,8 +53,8 @@
 	String filterLibUser = (String)request.getAttribute("FilterLibUser");
 	String filterIdUser = (String) request.getAttribute("FilterIdUser");
 	String spaceId = (String) request.getAttribute("SpaceId");
-	Vector vPath = (Vector) request.getAttribute("Path");
-  Vector vStatsData = (Vector)request.getAttribute("StatsData");
+	List vPath = (List) request.getAttribute("Path");
+  List vStatsData = (List)request.getAttribute("StatsData");
   UserAccessLevel userProfile = (UserAccessLevel) request.getAttribute("UserProfile");
   PieChart chart = (PieChart) request.getAttribute("Chart");
 %>

--- a/core-war/src/main/webapp/silverStatisticsPeas/jsp/viewEvolutionAccess.jsp
+++ b/core-war/src/main/webapp/silverStatisticsPeas/jsp/viewEvolutionAccess.jsp
@@ -92,7 +92,7 @@
 	String filterLibUser = (String)request.getAttribute("FilterLibUser");
 	String filterIdUser = (String) request.getAttribute("FilterIdUser");
     String spaceId = (String) request.getAttribute("SpaceId");
-	Vector vPath = (Vector) request.getAttribute("Path");
+	List vPath = (List) request.getAttribute("Path");
 	PeriodChart chart = (PeriodChart) request.getAttribute("Chart");
 	UserAccessLevel userProfile = (UserAccessLevel)request.getAttribute("UserProfile");
 %>

--- a/core-war/src/main/webapp/silverStatisticsPeas/jsp/viewEvolutionVolumeSizeServer.jsp
+++ b/core-war/src/main/webapp/silverStatisticsPeas/jsp/viewEvolutionVolumeSizeServer.jsp
@@ -75,7 +75,7 @@
 %>
 
 <%
-  Vector<String[]> vStatsData = (Vector<String[]>)request.getAttribute("StatsData");
+  List<String[]> vStatsData = (List<String[]>)request.getAttribute("StatsData");
   UserAccessLevel userProfile = (UserAccessLevel)request.getAttribute("UserProfile");
 
 	TabbedPane tabbedPane = gef.getTabbedPane();

--- a/core-war/src/main/webapp/silverStatisticsPeas/jsp/viewVolume.jsp
+++ b/core-war/src/main/webapp/silverStatisticsPeas/jsp/viewVolume.jsp
@@ -52,8 +52,8 @@
 	}
 	  String filterIdUser = (String) request.getAttribute("FilterIdUser");
 	  String spaceId = (String) request.getAttribute("SpaceId");
-	  Vector<String[]> vPath = (Vector<String[]>) request.getAttribute("Path");
-    Vector<String[]> vStatsData = (Vector<String[]>)request.getAttribute("StatsData");
+	  List<String[]> vPath = (List<String[]>) request.getAttribute("Path");
+    List<String[]> vStatsData = (List<String[]>)request.getAttribute("StatsData");
     UserAccessLevel userProfile = (UserAccessLevel)request.getAttribute("UserProfile");
 
     int totalNumberOfContributions = 0;

--- a/core-war/src/main/webapp/silverStatisticsPeas/jsp/viewVolumeServer.jsp
+++ b/core-war/src/main/webapp/silverStatisticsPeas/jsp/viewVolumeServer.jsp
@@ -37,8 +37,8 @@
 <%
 //Recuperation des parametres
 String spaceId = (String) request.getAttribute("SpaceId");
-Vector<String[]> vPath = (Vector<String[]>) request.getAttribute("Path");
-Vector<String[]> vStatsData = (Vector<String[]>)request.getAttribute("StatsData");
+List<String[]> vPath = (List<String[]>) request.getAttribute("Path");
+List<String[]> vStatsData = (List<String[]>)request.getAttribute("StatsData");
 UserAccessLevel userProfile = (UserAccessLevel)request.getAttribute("UserProfile");
 PieChart chart = (PieChart) request.getAttribute("Chart");
 

--- a/core-war/src/main/webapp/silverStatisticsPeas/jsp/viewVolumeSizeServer.jsp
+++ b/core-war/src/main/webapp/silverStatisticsPeas/jsp/viewVolumeSizeServer.jsp
@@ -37,8 +37,8 @@
 
 <%
   String spaceId = (String) request.getAttribute("SpaceId");
-	Vector<String[]> vPath = (Vector<String[]>) request.getAttribute("Path");
-  Vector<String[]> vStatsData = (Vector<String[]>)request.getAttribute("StatsData");
+	List<String[]> vPath = (List<String[]>) request.getAttribute("Path");
+  List<String[]> vStatsData = (List<String[]>)request.getAttribute("StatsData");
   UserAccessLevel userProfile = (UserAccessLevel)request.getAttribute("UserProfile");
   PieChart chart = (PieChart) request.getAttribute("Chart");
 

--- a/core-web/src/main/java/org/silverpeas/core/webapi/security/CipherKeyResource.java
+++ b/core-web/src/main/java/org/silverpeas/core/webapi/security/CipherKeyResource.java
@@ -74,7 +74,7 @@ public class CipherKeyResource extends RESTWebService {
 
   @Override
   public String getComponentId() {
-    return Administration.ADMIN_COMPONENT_ID;
+    return Administration.Constants.ADMIN_COMPONENT_ID;
   }
 
   @GET


### PR DESCRIPTION
Add a way to blank some profile information of deleted users in the back office. For instance, only the first and the last names are blanked: 

- the first name is set to a key in the general l10n bundle from which the localized word Anonymous can be used as the first name of such a user.
- the last name is simply blanked

So, any contributions for such users will be seen as done by an anonymous user and no more by a distinct person with his full name.

Once a deleted user has been blanked, he cannot be more listed in the back office.