### PR TITLE
Feature #9387: avoiding to use pdf2swf

### DIFF
--- a/core-library/src/main/java/org/silverpeas/core/util/DocumentInfo.java
+++ b/core-library/src/main/java/org/silverpeas/core/util/DocumentInfo.java
@@ -21,9 +21,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.silverpeas.core.viewer.util;
-
-import java.util.Collection;
+package org.silverpeas.core.util;
 
 /**
  * Information about the pdf to be converted.
@@ -33,40 +31,8 @@ import java.util.Collection;
 public class DocumentInfo {
 
   private int nbPages = 0;
-  private int maxWidh = 0;
+  private int maxWidth = 0;
   private int maxHeight = 0;
-
-  /**
-   * Initializing data from output SwfTools query
-   *
-   * @param swfOutput
-   * @return
-   */
-  protected DocumentInfo addFromSwfToolsOutput(final Collection<String> swfOutput) {
-    for (final String outputLine : swfOutput) {
-      try {
-        boolean widthOk = false;
-        boolean heightOk = false;
-        for (final String info : outputLine.split(" ")) {
-          if (info.contains("width")) {
-            maxWidh = Math.max(maxWidh, Integer.valueOf(info.replaceAll("width=", "").replaceAll(
-                "\\.[0-9]+", "")));
-            widthOk = true;
-          } else if (info.contains("height")) {
-            maxHeight = Math.max(maxHeight, Integer.valueOf(info.replaceAll("height=", "")
-                .replaceAll("\\.[0-9]+", "")));
-            heightOk = true;
-          }
-        }
-        if (widthOk && heightOk) {
-          nbPages++;
-        }
-      } catch (final NumberFormatException e) {
-        // Nothing to do, just pass to the next line
-      }
-    }
-    return this;
-  }
 
   /**
    * @return the nbPage
@@ -75,11 +41,19 @@ public class DocumentInfo {
     return nbPages;
   }
 
+  public void setNbPages(final int nbPages) {
+    this.nbPages = nbPages;
+  }
+
   /**
-   * @return the maxWidh
+   * @return the maxWidth
    */
-  public int getMaxWidh() {
-    return maxWidh;
+  public int getMaxWidth() {
+    return maxWidth;
+  }
+
+  public void setMaxWidth(final int maxWidth) {
+    this.maxWidth = maxWidth;
   }
 
   /**
@@ -87,5 +61,9 @@ public class DocumentInfo {
    */
   public int getMaxHeight() {
     return maxHeight;
+  }
+
+  public void setMaxHeight(final int maxHeight) {
+    this.maxHeight = maxHeight;
   }
 }

--- a/core-services/viewer/src/integration-test/java/org/silverpeas/core/viewer/service/PreviewServiceWithoutSwfrenderIT.java
+++ b/core-services/viewer/src/integration-test/java/org/silverpeas/core/viewer/service/PreviewServiceWithoutSwfrenderIT.java
@@ -65,7 +65,6 @@ public class PreviewServiceWithoutSwfrenderIT extends AbstractViewerIT {
         .thenReturn(false);
     when(mockedSettings.getBoolean(eq("viewer.conversion.strategy.split.enabled"), anyBoolean()))
         .thenReturn(false);
-    reflectionRule.setField(SwfToolManager.class, false, "isSwfRenderActivated");
   }
 
   @After
@@ -298,11 +297,11 @@ public class PreviewServiceWithoutSwfrenderIT extends AbstractViewerIT {
   }
 
   private void assertPptDocumentPreview(Preview preview) {
-    assertDocumentPreview(preview, 720, 540, false, "png");
+    assertDocumentPreview(preview, 720, 540, false, "jpg");
   }
 
   private void assertPptDocumentPreviewWithCacheManagement(Preview preview) {
-    assertDocumentPreview(preview, 720, 540, true, "png");
+    assertDocumentPreview(preview, 720, 540, true, "jpg");
   }
 
   private void assertImageDocumentPreview(Preview preview) {
@@ -314,11 +313,11 @@ public class PreviewServiceWithoutSwfrenderIT extends AbstractViewerIT {
   }
 
   private void assertOfficeOrPdfDocumentPreview(Preview preview) {
-    assertDocumentPreview(preview, 595, 842, false, "png");
+    assertDocumentPreview(preview, 595, 842, false, "jpg");
   }
 
   private void assertOfficeOrPdfDocumentPreviewWithCacheManagement(Preview preview) {
-    assertDocumentPreview(preview, 595, 842, true, "png");
+    assertDocumentPreview(preview, 595, 842, true, "jpg");
   }
 
   private void assertDocumentPreview(Preview preview, int width, int height,

--- a/core-services/viewer/src/main/java/org/silverpeas/core/viewer/flexpaper/TemporaryFlexPaperView.java
+++ b/core-services/viewer/src/main/java/org/silverpeas/core/viewer/flexpaper/TemporaryFlexPaperView.java
@@ -23,8 +23,8 @@
  */
 package org.silverpeas.core.viewer.flexpaper;
 
+import org.silverpeas.core.util.DocumentInfo;
 import org.silverpeas.core.viewer.model.AbstractView;
-import org.silverpeas.core.viewer.util.DocumentInfo;
 
 import java.io.File;
 
@@ -43,7 +43,7 @@ public class TemporaryFlexPaperView extends AbstractView {
   public TemporaryFlexPaperView(final String documentId, final String language,
       final String originalFileName, final File physicalFile, final DocumentInfo info) {
     super(documentId, language, originalFileName, physicalFile, info.getNbPages());
-    width = info.getMaxWidh();
+    width = info.getMaxWidth();
     height = info.getMaxHeight();
   }
 

--- a/core-services/viewer/src/main/java/org/silverpeas/core/viewer/model/TemporaryPdfView.java
+++ b/core-services/viewer/src/main/java/org/silverpeas/core/viewer/model/TemporaryPdfView.java
@@ -23,7 +23,7 @@
  */
 package org.silverpeas.core.viewer.model;
 
-import org.silverpeas.core.viewer.util.DocumentInfo;
+import org.silverpeas.core.util.DocumentInfo;
 
 import java.io.File;
 
@@ -42,7 +42,7 @@ public class TemporaryPdfView extends AbstractView {
   public TemporaryPdfView(final String documentId, final String language,
       final String originalFileName, final File physicalFile, final DocumentInfo info) {
     super(documentId, language, originalFileName, physicalFile, 0);
-    width = info.getMaxWidh();
+    width = info.getMaxWidth();
     height = info.getMaxHeight();
   }
 

--- a/core-services/viewer/src/main/java/org/silverpeas/core/viewer/service/DefaultPreviewService.java
+++ b/core-services/viewer/src/main/java/org/silverpeas/core/viewer/service/DefaultPreviewService.java
@@ -26,15 +26,15 @@ package org.silverpeas.core.viewer.service;
 import org.silverpeas.core.contribution.converter.DocumentFormat;
 import org.silverpeas.core.contribution.converter.DocumentFormatConverterProvider;
 import org.silverpeas.core.contribution.converter.option.PageRangeFilterOption;
-import org.silverpeas.core.viewer.model.Preview;
-import org.silverpeas.core.viewer.model.TemporaryPreview;
 import org.silverpeas.core.io.media.image.ImageTool;
 import org.silverpeas.core.io.media.image.ImageToolDirective;
 import org.silverpeas.core.io.media.image.option.DimensionOption;
 import org.silverpeas.core.thread.ManagedThreadPool;
-import org.silverpeas.core.util.file.FileUtil;
 import org.silverpeas.core.util.MimeTypes;
-import org.silverpeas.core.viewer.util.SwfUtil;
+import org.silverpeas.core.util.PdfUtil;
+import org.silverpeas.core.util.file.FileUtil;
+import org.silverpeas.core.viewer.model.Preview;
+import org.silverpeas.core.viewer.model.TemporaryPreview;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -162,8 +162,8 @@ public class DefaultPreviewService extends AbstractViewerService implements Prev
    */
   private File toImage(File source, File destination) {
     boolean deleteSource = false;
-    if (SwfUtil.isPdfToImageActivated() && FileUtil.isPdf(source.getPath())) {
-      SwfUtil.fromPdfToImage(source, destination);
+    if (FileUtil.isPdf(source.getPath())) {
+      PdfUtil.firstPageAsImage(source, destination);
       source = destination;
       destination = changeFileExtension(destination, JPG_IMAGE_EXTENSION);
       deleteSource = !source.equals(destination);

--- a/core-services/viewer/src/main/java/org/silverpeas/core/viewer/service/SwfToolManager.java
+++ b/core-services/viewer/src/main/java/org/silverpeas/core/viewer/service/SwfToolManager.java
@@ -24,9 +24,9 @@
 package org.silverpeas.core.viewer.service;
 
 import org.apache.commons.exec.CommandLine;
-import org.silverpeas.core.util.exec.ExternalExecution;
-import org.silverpeas.core.util.exec.ExternalExecution.Config;
 import org.silverpeas.core.initialization.Initialization;
+import org.silverpeas.core.util.exec.ExternalExecution;
+import org.silverpeas.core.util.logging.SilverLogger;
 
 import java.util.Map;
 
@@ -36,14 +36,13 @@ import java.util.Map;
 public class SwfToolManager implements Initialization {
 
   private static boolean isActivated = false;
-  private static boolean isSwfRenderActivated = false;
 
   @Override
-  public void init() throws Exception {
+  public synchronized void init() {
 
     // SwfTools settings
     for (final Map.Entry<String, String> entry : System.getenv().entrySet()) {
-      if ("path".equals(entry.getKey().toLowerCase())) {
+      if ("path".equalsIgnoreCase(entry.getKey())) {
         try {
           CommandLine commandLine = new CommandLine("pdf2swf");
           commandLine.addArgument("--version");
@@ -51,17 +50,7 @@ public class SwfToolManager implements Initialization {
           isActivated = true;
         } catch (final Exception e) {
           // SwfTool is not installed
-          System.err.println("pdf2swf is not installed");
-        }
-        try {
-          CommandLine commandLine = new CommandLine("swfrender");
-          commandLine.addArgument("--help");
-          ExternalExecution.exec(commandLine,
-              Config.init().successfulExitStatusValueIs(1).doNotDisplayErrorTrace());
-          isSwfRenderActivated = true;
-        } catch (final Exception e) {
-          // SwfTool is not installed
-          System.err.println("swfrender is not installed");
+          SilverLogger.getLogger(this).warn("pdf2swf is not installed");
         }
       }
     }
@@ -73,13 +62,5 @@ public class SwfToolManager implements Initialization {
    */
   public static boolean isActivated() {
     return isActivated;
-  }
-
-  /**
-   * Indicates if swfrender is activated
-   * @return
-   */
-  public static boolean isSwfRenderActivated() {
-    return isSwfRenderActivated;
   }
 }

--- a/core-services/viewer/src/main/java/org/silverpeas/core/viewer/util/SwfUtil.java
+++ b/core-services/viewer/src/main/java/org/silverpeas/core/viewer/util/SwfUtil.java
@@ -23,21 +23,16 @@
  */
 package org.silverpeas.core.viewer.util;
 
-import java.io.File;
-import java.nio.file.Files;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
+import org.apache.commons.exec.CommandLine;
+import org.silverpeas.core.util.StringUtil;
 import org.silverpeas.core.util.exec.ExternalExecution;
 import org.silverpeas.core.util.exec.ExternalExecutionException;
 import org.silverpeas.core.viewer.service.SwfToolManager;
 import org.silverpeas.core.viewer.service.ViewerException;
 
-import org.silverpeas.core.util.StringUtil;
-
-import org.apache.commons.exec.CommandLine;
-import org.apache.commons.io.FileUtils;
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.apache.commons.io.FilenameUtils.*;
 
@@ -63,53 +58,6 @@ public class SwfUtil extends ExternalExecution {
   }
 
   /**
-   * Indicates if swfrender0 tool is activated
-   * @return
-   */
-  public static boolean isPdfToImageActivated() {
-    return isPdfToSwfActivated() && SwfToolManager.isSwfRenderActivated();
-  }
-
-  /**
-   * Converts a PDF file into an image file.
-   *
-   * @param fileIn the pdf file
-   * @param fileOut the image file
-   */
-  public static void fromPdfToImage(final File fileIn, final File fileOut) {
-    // First Step : converting first page of PDF file into a SWF file
-    final File swfFile = changeFileExtension(fileOut, SWF_DOCUMENT_EXTENSION);
-    fromPdfToSwf(fileIn, swfFile, false, "-p 1-1");
-    // Secong Step : converting SFW file into image file
-    fromSwfToImage(swfFile, fileOut);
-    FileUtils.deleteQuietly(swfFile);
-  }
-
-  /**
-   * Converts a SWF file into an image file.
-   *
-   * @param fileIn the Swf file
-   * @param fileOut the image file
-   */
-  private static void fromSwfToImage(final File fileIn, final File fileOut) {
-    try {
-      exec(buildSwfToImageCommandLine(fileIn, fileOut));
-    } catch (ExternalExecutionException e) {
-      throw new ViewerException(e);
-    }
-  }
-
-  /**
-   * Converts a PDF file into a SWF file.
-   *
-   * @param fileIn the pdf file
-   * @param fileOut the swf file
-   */
-  public static void fromPdfToSwf(final File fileIn, final File fileOut) {
-    fromPdfToSwf(fileIn, fileOut, false);
-  }
-
-  /**
    * Converts a PDF file into a SWF file.
    *
    * @param fileIn the pdf file
@@ -129,7 +77,7 @@ public class SwfUtil extends ExternalExecution {
    * @param oneFilePerPage if true it activates one swf file per page
    * @param endingCommand
    */
-  public static void fromPdfToSwf(final File fileIn, final File fileOut,
+  private static void fromPdfToSwf(final File fileIn, final File fileOut,
       final boolean oneFilePerPage, final String endingCommand) {
     File outputFile = fileOut;
     if (oneFilePerPage) {
@@ -148,33 +96,6 @@ public class SwfUtil extends ExternalExecution {
     }
   }
 
-  /**
-   * Return some document info from a PDF file
-   *
-   * @param pdfFile
-   * @return
-   */
-  public static DocumentInfo getPdfDocumentInfo(final File pdfFile) {
-    List<String> execResult;
-    try {
-      execResult = exec(buildPdfDocumentInfoCommandLine(pdfFile));
-    } catch (ExternalExecutionException e) {
-      throw new ExternalExecutionException(e);
-    }
-    return new DocumentInfo().addFromSwfToolsOutput(execResult);
-  }
-
-  /**
-   * Changes the extension of a file
-   *
-   * @param fileExtension
-   * @return
-   */
-  private static File changeFileExtension(final File file, final String fileExtension) {
-    return new File(
-        getFullPath(file.getPath()) + getBaseName(file.getPath()) + '.' + fileExtension);
-  }
-
   static CommandLine buildPdfToSwfCommandLine(final String endingCommand, File inputFile,
       File outputFile) {
     Map<String, File> files = new HashMap<>(2);
@@ -188,29 +109,6 @@ public class SwfUtil extends ExternalExecution {
     if (StringUtil.isDefined(endingCommand)) {
       commandLine.addArguments(endingCommand, false);
     }
-    commandLine.setSubstitutionMap(files);
-    return commandLine;
-  }
-
-  static CommandLine buildPdfDocumentInfoCommandLine(File file) {
-    Map<String, File> files = new HashMap<>(1);
-    files.put("file", file);
-    CommandLine commandLine = new CommandLine("pdf2swf");
-    commandLine.addArgument("-qq");
-    commandLine.addArgument("${file}", false);
-    commandLine.addArgument("--info");
-    commandLine.setSubstitutionMap(files);
-    return commandLine;
-  }
-
-  static CommandLine buildSwfToImageCommandLine(File inputFile, File outputFile) {
-    Map<String, File> files = new HashMap<>(2);
-    files.put("inputFile", inputFile);
-    files.put("outputFile", outputFile);
-    CommandLine commandLine = new CommandLine("swfrender");
-    commandLine.addArgument("${inputFile}", false);
-    commandLine.addArgument(OUTPUT_COMMAND);
-    commandLine.addArgument("${outputFile}", false);
     commandLine.setSubstitutionMap(files);
     return commandLine;
   }

--- a/core-services/viewer/src/test/java/org/silverpeas/core/viewer/util/SwfUtilTest.java
+++ b/core-services/viewer/src/test/java/org/silverpeas/core/viewer/util/SwfUtilTest.java
@@ -74,33 +74,6 @@ public class SwfUtilTest {
   }
 
   /**
-   * Test of buildPdfDocumentInfoCommandLine method, of class SwfUtil.
-   */
-  @Test
-  public void testLinuxBuildPdfDocumentInfoCommandLine() {
-    System.setProperty(OS_KEY, "Linux");
-    File file = new File("/silverpeas/viewer/", "file ' - '' .pdf");
-    CommandLine result = SwfUtil.buildPdfDocumentInfoCommandLine(file);
-    assertThat(result, is(notNullValue()));
-    assertThat(separatorsToUnix(String.join(" ", result.toStrings())),
-        is("pdf2swf -qq " + "/silverpeas/viewer/file ' - '' .pdf --info"));
-  }
-
-  /**
-   * Test of buildSwfToImageCommandLine method, of class SwfUtil.
-   */
-  @Test
-  public void testLinuxBuildSwfToImageCommandLine() {
-    System.setProperty(OS_KEY, "Linux");
-    File inputFile = new File("/silverpeas/viewer/", "file ' - '' .pdf");
-    File outputFile = new File("/silverpeas/viewer/", "file ' - '' .swf");
-    CommandLine result = SwfUtil.buildSwfToImageCommandLine(inputFile, outputFile);
-    assertThat(result, is(notNullValue()));
-    assertThat(separatorsToUnix(String.join(" ", result.toStrings())), is("swfrender " +
-        "/silverpeas/viewer/file ' - '' .pdf -o /silverpeas/viewer/file ' - '' .swf"));
-  }
-
-  /**
    * Test of buildPdfToSwfCommandLine method, of class SwfUtil.
    */
   @Test
@@ -114,33 +87,6 @@ public class SwfUtilTest {
     assertThat(separatorsToUnix(String.join(" ", result.toStrings())),
         is("pdf2swf /silverpeas/viewer/file ' - '' .pdf" +
             " -o /silverpeas/viewer/file ' - '' .swf -f -T 9 -t -s storeallcharacters"));
-  }
-
-  /**
-   * Test of buildPdfDocumentInfoCommandLine method, of class SwfUtil.
-   */
-  @Test
-  public void testBuildPdfDocumentInfoCommandLine() {
-    System.setProperty(OS_KEY, "Windows XP");
-    File file = new File("/silverpeas/viewer/", "file ' - '' .pdf");
-    CommandLine result = SwfUtil.buildPdfDocumentInfoCommandLine(file);
-    assertThat(result, is(notNullValue()));
-    assertThat(separatorsToUnix(String.join(" ", result.toStrings())),
-        is("pdf2swf -qq " + "/silverpeas/viewer/file ' - '' .pdf" + " --info"));
-  }
-
-  /**
-   * Test of buildSwfToImageCommandLine method, of class SwfUtil.
-   */
-  @Test
-  public void testBuildSwfToImageCommandLine() {
-    System.setProperty(OS_KEY, "Windows XP");
-    File inputFile = new File("/silverpeas/viewer/", "file ' - '' .pdf");
-    File outputFile = new File("/silverpeas/viewer/", "file ' - '' .swf");
-    CommandLine result = SwfUtil.buildSwfToImageCommandLine(inputFile, outputFile);
-    assertThat(result, is(notNullValue()));
-    assertThat(separatorsToUnix(String.join(" ", result.toStrings())), is("swfrender " +
-        "/silverpeas/viewer/file ' - '' .pdf -o /silverpeas/viewer/file ' - '' .swf"));
   }
 
   private static String separatorsToUnix(String filePath) {


### PR DESCRIPTION
- getting document info from iText instead of using external tool which is difficult to handle with on an environment side
- replacing pdf2swf calls by other tool calls (but keeping yet the tool for special requirements)
- fixing sonar feedback