### PR TITLE
Feature 10255

### DIFF
--- a/core-api/src/main/java/org/silverpeas/core/notification/user/NotificationContext.java
+++ b/core-api/src/main/java/org/silverpeas/core/notification/user/NotificationContext.java
@@ -16,6 +16,19 @@ import static org.apache.commons.lang3.StringUtils.split;
 public class NotificationContext extends HashMap<String, String> {
   private static final long serialVersionUID = 341715544034127254L;
 
+  /**
+   * The predefined key in the context mapped with the unique identifier of a Silverpeas component
+   * instance.
+   */
+  public static final String COMPONENT_ID = "componentId";
+
+  /**
+   * The predefined key in the context mapped with the unique identifier of a contribution in
+   * Silverpeas. If the contribution is managed by a given component instance, then the key
+   * {@link NotificationContext#COMPONENT_ID} must be defined.
+   */
+  public static final String CONTRIBUTION_ID = "contributionId";
+
   public List<String> getAsList(final String key) {
     final String value = get(key);
     return asList(split(value, ","));

--- a/core-api/src/main/java/org/silverpeas/core/notification/user/NotificationContext.java
+++ b/core-api/src/main/java/org/silverpeas/core/notification/user/NotificationContext.java
@@ -25,9 +25,22 @@ public class NotificationContext extends HashMap<String, String> {
   /**
    * The predefined key in the context mapped with the unique identifier of a contribution in
    * Silverpeas. If the contribution is managed by a given component instance, then the key
-   * {@link NotificationContext#COMPONENT_ID} must be defined.
+   * {@link NotificationContext#COMPONENT_ID} must be defined. This key is used by the user
+   * notification mechanism to get any attachments of such a contribution in order to automatically
+   * indicate them in the notification message. (Those links to attachment can be or not processed
+   * by the notification service at the endpoint.)
    */
   public static final String CONTRIBUTION_ID = "contributionId";
+
+  /**
+   * The predefined key in the context mapped with the unique identifier of a publication. Used to
+   * specify the unique identifier of a contribution with attachments. In the case the contributions
+   * managed by a Silverpeas component don't have attachments in themselves but another resource
+   * mapped with them, this key is a way to specify the identifier of that resource in order to get
+   * the attachments to automatically indicate in the notification message. (Those links to
+   * attachment can be or not processed by the notification service at the endpoint.)
+   */
+  public static final String PUBLICATION_ID = "publicationId";
 
   public List<String> getAsList(final String key) {
     final String value = get(key);

--- a/core-api/src/main/java/org/silverpeas/core/notification/user/client/NotificationMetaData.java
+++ b/core-api/src/main/java/org/silverpeas/core/notification/user/client/NotificationMetaData.java
@@ -36,10 +36,18 @@ import org.silverpeas.core.util.StringUtil;
 import org.silverpeas.core.util.WebEncodeHelper;
 import org.silverpeas.core.util.logging.SilverLogger;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
-import static org.silverpeas.core.notification.user.client.NotificationTemplateKey.notification_receiver_groups;
-import static org.silverpeas.core.notification.user.client.NotificationTemplateKey.notification_receiver_users;
+import static org.silverpeas.core.notification.user.client.NotificationTemplateKey.NOTIFICATION_RECEIVER_GROUPS;
+import static org.silverpeas.core.notification.user.client.NotificationTemplateKey.NOTIFICATION_RECEIVER_USERS;
 import static org.silverpeas.core.ui.DisplayI18NHelper.verifyLanguage;
 import static org.silverpeas.core.util.StringUtil.isDefined;
 
@@ -49,12 +57,12 @@ public class NotificationMetaData implements java.io.Serializable {
   public static final String BEFORE_MESSAGE_FOOTER_TAG = "<!--BEFORE_MESSAGE_FOOTER-->";
   public static final String AFTER_MESSAGE_FOOTER_TAG = "<!--AFTER_MESSAGE_FOOTER-->";
   private static final String SENDER_MESSAGE_ATTRIBUTE = "senderMessage";
+  private static final String BREAK_LINE_REGEXP = "[\\n\\r]";
 
   private int messageType;
   private Date date;
   private String sender;
   private String source;
-  private String link;
   private String sessionId;
   private final Collection<UserRecipient> userRecipients = new ArrayList<>();
   private final Collection<UserRecipient> userRecipientsToExclude = new ArrayList<>();
@@ -65,13 +73,11 @@ public class NotificationMetaData implements java.io.Serializable {
   private String fileName;
   private boolean sendImmediately = false;
   private NotifAction action;
-  private Map<String, NotificationResourceData> notificationResourceData =
+  private final Map<String, NotificationResourceData> notificationResourceData =
       new HashMap<>();
-
-  private Map<String, String> titles = new HashMap<>();
-  private Map<String, String> contents = new HashMap<>();
-  private Map<String, String> linkLabels = new HashMap<>();
-
+  private final Map<String, String> titles = new HashMap<>();
+  private final Map<String, String> contents = new HashMap<>();
+  private final Map<String, Link> links = new HashMap<>();
   private Map<String, SilverpeasTemplate> templates;
   private Map<String, SilverpeasTemplate> templatesMessageFooter;
 
@@ -79,9 +85,6 @@ public class NotificationMetaData implements java.io.Serializable {
   private boolean displayReceiversInFooter = false;
 
   private boolean isManualUserOne = false;
-
-  protected NotificationManager notificationManager = null;
-
 
   /**
    * Default Constructor
@@ -119,7 +122,6 @@ public class NotificationMetaData implements java.io.Serializable {
     date = new Date();
     sender = "";
     source = "";
-    link = "";
     sessionId = "";
     componentId = "";
     isAnswerAllowed = false;
@@ -245,12 +247,12 @@ public class NotificationMetaData implements java.io.Serializable {
         String receiverUsers = getUserReceiverFormattedList();
         if (StringUtil.isDefined(receiverUsers)) {
           templateMessageFooter
-              .setAttribute(notification_receiver_users.toString(), receiverUsers);
+              .setAttribute(NOTIFICATION_RECEIVER_USERS.toString(), receiverUsers);
         }
         String receiverGroups = getGroupReceiverFormattedList();
         if (StringUtil.isDefined(receiverGroups)) {
           templateMessageFooter
-              .setAttribute(notification_receiver_groups.toString(), receiverGroups);
+              .setAttribute(NOTIFICATION_RECEIVER_GROUPS.toString(), receiverGroups);
         }
       } catch (NotificationException e) {
         SilverLogger.getLogger(this).error(e);
@@ -258,7 +260,7 @@ public class NotificationMetaData implements java.io.Serializable {
 
       String messageFooter =
           templateMessageFooter.applyFileTemplate("messageFooter" + '_' + language)
-              .replaceAll("[\\n\\r]", "");
+              .replaceAll(BREAK_LINE_REGEXP, "");
       if (messageFooter.length() > 0) {
         result.append(messageFooter);
       }
@@ -295,8 +297,8 @@ public class NotificationMetaData implements java.io.Serializable {
       final String language) {
     final String extraMessage = getOriginalExtraMessage();
     if (isDefined(extraMessage) && !messageContent.toString()
-        .replaceAll("[\\n\\r]", "")
-        .contains(extraMessage.replaceAll("[\\n\\r]", ""))) {
+        .replaceAll(BREAK_LINE_REGEXP, "")
+        .contains(extraMessage.replaceAll(BREAK_LINE_REGEXP, ""))) {
       SilverpeasTemplate templateRepository =
           SilverpeasTemplateFactory.createSilverpeasTemplateOnCore("notification");
       templateRepository.setAttribute(SENDER_MESSAGE_ATTRIBUTE, extraMessage);
@@ -354,19 +356,32 @@ public class NotificationMetaData implements java.io.Serializable {
   }
 
   /**
+   * Gets message link in the default language of the platform.
+   * @return the message link
+   */
+  public Link getLink() {
+    return getLink(DisplayI18NHelper.getDefaultLanguage());
+  }
+
+  /**
+   * Gets the message link in the given language.
+   * @param language the ISO 631-1 code of a language supported by Silverpeas.
+   * @return the message link.
+   */
+  public Link getLink(final String language) {
+    final Link link = this.links.get(language);
+    if (link == null) {
+      return Link.EMPTY_LINK;
+    }
+    return link;
+  }
+
+  /**
    * Set message link
    * @param link the link to be set
    */
   public void setLink(String link) {
-    this.link = link;
-  }
-
-  /**
-   * Get message link
-   * @return the message link
-   */
-  public String getLink() {
-    return link;
+    this.links.put(DisplayI18NHelper.getDefaultLanguage(), new Link(link, ""));
   }
 
   /**
@@ -383,20 +398,7 @@ public class NotificationMetaData implements java.io.Serializable {
    * @param language the language of the linkLabel
    */
   public void setLink(Link link, String language) {
-    this.link = link.getLinkUrl();
-    linkLabels.put(language, link.getLinkLabel());
-  }
-
-  /**
-   * Get message linkLabel
-   * @return the message linkLabel
-   */
-  public String getLinkLabel() {
-    return getLinkLabel(DisplayI18NHelper.getDefaultLanguage());
-  }
-
-  public String getLinkLabel(String language) {
-    return linkLabels.get(language);
+    this.links.put(language, link);
   }
 
   /**
@@ -413,6 +415,19 @@ public class NotificationMetaData implements java.io.Serializable {
    */
   public String getSessionId() {
     return sessionId;
+  }
+
+  /**
+   * Sets the unique identifier of a resource in Silverpeas that can have attachments. The target
+   * is set for each {@link NotificationResourceData} instances embedded by this metadata.
+   * @param attachmentTargetId the unique identifier of a resource. Generally, the one of a
+   * contribution. If not defined, then nothing is done.
+   */
+  public void setAttachmentTargetId(final String attachmentTargetId) {
+    if (StringUtil.isDefined(attachmentTargetId)) {
+      this.notificationResourceData.forEach(
+          (key, value) -> value.setAttachmentTargetId(attachmentTargetId));
+    }
   }
 
   /**
@@ -704,9 +719,9 @@ public class NotificationMetaData implements java.io.Serializable {
     allUniqueUserRecipients.addAll(users);
 
     // Then get users included in groups
+    final NotificationManager notificationManager = getNotificationManager();
     for (GroupRecipient group : groups) {
-      allUniqueUserRecipients
-          .addAll(getNotificationManager().getUsersFromGroup(group.getGroupId()));
+      allUniqueUserRecipients.addAll(notificationManager.getUsersFromGroup(group.getGroupId()));
     }
 
     // Then exclude users that don't have to be notified
@@ -720,9 +735,10 @@ public class NotificationMetaData implements java.io.Serializable {
       throws NotificationException {
     HashSet<UserRecipient> usersSet = new HashSet<>();
     usersSet.addAll(getUserRecipients());
+    final NotificationManager notificationManager = getNotificationManager();
     for (GroupRecipient group : getGroupRecipients()) {
       if (!displayGroup(group.getGroupId())) {
-        usersSet.addAll(getNotificationManager().getUsersFromGroup(group.getGroupId()));
+        usersSet.addAll(notificationManager.getUsersFromGroup(group.getGroupId()));
       }
     }
 
@@ -820,9 +836,6 @@ public class NotificationMetaData implements java.io.Serializable {
    * @return the notification manager instance.
    */
   private NotificationManager getNotificationManager() {
-    if (notificationManager == null) {
-      notificationManager = NotificationManager.get();
-    }
-    return notificationManager;
+    return NotificationManager.get();
   }
 }

--- a/core-api/src/main/java/org/silverpeas/core/notification/user/client/NotificationMetaData.java
+++ b/core-api/src/main/java/org/silverpeas/core/notification/user/client/NotificationMetaData.java
@@ -294,8 +294,9 @@ public class NotificationMetaData implements java.io.Serializable {
   private void appendExtraMessageHtmlFragment(final StringBuilder messageContent,
       final String language) {
     final String extraMessage = getOriginalExtraMessage();
-    if (isDefined(extraMessage) &&
-        !messageContent.toString().replace("\r", "").contains(extraMessage.replace("\r", ""))) {
+    if (isDefined(extraMessage) && !messageContent.toString()
+        .replaceAll("[\\n\\r]", "")
+        .contains(extraMessage.replaceAll("[\\n\\r]", ""))) {
       SilverpeasTemplate templateRepository =
           SilverpeasTemplateFactory.createSilverpeasTemplateOnCore("notification");
       templateRepository.setAttribute(SENDER_MESSAGE_ATTRIBUTE, extraMessage);

--- a/core-api/src/main/java/org/silverpeas/core/notification/user/client/NotificationParameters.java
+++ b/core-api/src/main/java/org/silverpeas/core/notification/user/client/NotificationParameters.java
@@ -29,6 +29,7 @@ package org.silverpeas.core.notification.user.client;
 import org.silverpeas.core.notification.user.client.constant.BuiltInNotifAddress;
 import org.silverpeas.core.notification.user.client.constant.NotifAction;
 import org.silverpeas.core.notification.user.model.NotificationResourceData;
+import org.silverpeas.core.util.Link;
 import org.silverpeas.core.util.logging.SilverLogger;
 
 import java.util.Date;
@@ -69,8 +70,7 @@ public class NotificationParameters {
   private String sTitle = "";
   private String senderName = "";
   private String sMessage = "";
-  private String sURL = "";
-  private String sLinkLabel = "";
+  private Link link = Link.EMPTY_LINK;
   private String sSource = "";
   private String sSessionId = "";
   private String sOriginalExtraMessage = null;
@@ -158,21 +158,12 @@ public class NotificationParameters {
     return this;
   }
 
-  public String getURL() {
-    return sURL;
+  public Link getLink() {
+    return link;
   }
 
-  public NotificationParameters setURL(final String sURL) {
-    this.sURL = sURL;
-    return this;
-  }
-
-  public String getLinkLabel() {
-    return sLinkLabel;
-  }
-
-  public NotificationParameters setLinkLabel(final String sLinkLabel) {
-    this.sLinkLabel = sLinkLabel;
+  public NotificationParameters setLink(final Link link) {
+    this.link = link;
     return this;
   }
 

--- a/core-api/src/main/java/org/silverpeas/core/notification/user/client/NotificationTemplateKey.java
+++ b/core-api/src/main/java/org/silverpeas/core/notification/user/client/NotificationTemplateKey.java
@@ -24,11 +24,23 @@
 package org.silverpeas.core.notification.user.client;
 
 public enum NotificationTemplateKey {
-  notification_sendername,
-  notification_senderemail,
-  notification_receiver_users,
-  notification_receiver_groups,
-  notification_serverurl,
-  notification_link,
-  notification_linkLabel;
+  NOTIFICATION_SENDER_NAME("notification_sendername"),
+  NOTIFICATION_SENDER_EMAIL("notification_senderemail"),
+  NOTIFICATION_RECEIVER_USERS("notification_receiver_users"),
+  NOTIFICATION_RECEIVER_GROUPS("notification_receiver_groups"),
+  NOTIFICATION_SERVER_URL("notification_serverurl"),
+  NOTIFICATION_LINK("notification_link"),
+  NOTIFICATION_LINK_LABEL("notification_linkLabel"),
+  NOTIFICATION_ATTACHMENTS("notification_attachments");
+
+  private final String name;
+
+  NotificationTemplateKey(final String name) {
+    this.name = name;
+  }
+
+  @Override
+  public String toString() {
+    return this.name;
+  }
 }

--- a/core-api/src/main/java/org/silverpeas/core/notification/user/model/NotificationResourceData.java
+++ b/core-api/src/main/java/org/silverpeas/core/notification/user/model/NotificationResourceData.java
@@ -48,10 +48,9 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
         query = "delete from NotificationResourceData r where not exists (from DelayedNotificationData d where d.resource.id = r.id)")
 })
 public class NotificationResourceData
-    extends BasicJpaEntity<NotificationResourceData, UniqueLongIdentifier>
-    implements Cloneable {
+    extends BasicJpaEntity<NotificationResourceData, UniqueLongIdentifier> {
 
-  public final static String LOCATION_SEPARATOR = "@#@#@";
+  public static final String LOCATION_SEPARATOR = "@#@#@";
 
   @Column(name = "resourceId", nullable = false)
   private String resourceId;
@@ -62,17 +61,20 @@ public class NotificationResourceData
   @Column(name = "resourceName", nullable = false)
   private String resourceName;
 
-  @Column(name = "resourceDescription", nullable = true)
+  @Column(name = "resourceDescription")
   private String resourceDescription;
 
   @Column(name = "resourceLocation", nullable = false)
   private String resourceLocation;
 
-  @Column(name = "resourceUrl", nullable = true)
+  @Column(name = "resourceUrl")
   private String resourceUrl;
 
   @Column(name = "componentInstanceId", nullable = false)
   private String componentInstanceId;
+
+  @Column(name = "attachmentTargetId")
+  private String attachmentTargetId;
 
   /**
    * Copying all data from the given resource excepted the id
@@ -86,6 +88,7 @@ public class NotificationResourceData
     setResourceLocation(notificationResourceData.getResourceLocation());
     setResourceUrl(notificationResourceData.getResourceUrl());
     setComponentInstanceId(notificationResourceData.getComponentInstanceId());
+    setAttachmentTargetId(notificationResourceData.getAttachmentTargetId());
   }
 
   @Override
@@ -183,5 +186,23 @@ public class NotificationResourceData
 
   public void setComponentInstanceId(final String componentInstanceId) {
     this.componentInstanceId = componentInstanceId;
+  }
+
+  public void setAttachmentTargetId(final String targetId) {
+    this.attachmentTargetId = targetId;
+  }
+
+  public String getAttachmentTargetId() {
+    return this.attachmentTargetId;
+  }
+
+  @Override
+  public int hashCode() {
+    return super.hashCode();
+  }
+
+  @Override
+  public boolean equals(final Object obj) {
+    return super.equals(obj);
   }
 }

--- a/core-api/src/main/java/org/silverpeas/core/util/FileLink.java
+++ b/core-api/src/main/java/org/silverpeas/core/util/FileLink.java
@@ -1,0 +1,33 @@
+package org.silverpeas.core.util;
+
+/**
+ * A link to a file that can be accessed through the Web.
+ * @author mmoquillon
+ */
+public class FileLink extends Link {
+
+  private final long size;
+
+  /**
+   * Constructs a new link with the specified URL, labels and file size.
+   * @param linkUrl the URL of the linked file.
+   * @param linkLabel the label to render for that link.
+   * @param linkSize the size in byte of the linked file.
+   */
+  public FileLink(final String linkUrl, final String linkLabel, final long linkSize) {
+    super(linkUrl, linkLabel);
+    if (linkSize < 0) {
+      throw new AssertionError("The size of the linked file must be non-negative");
+    }
+    this.size = linkSize;
+  }
+
+  /**
+   * Gets the size of the file referred by this link.
+   * @return the size in bytes of the linked file.
+   */
+  public long getLinkSize() {
+    return size;
+  }
+}
+  

--- a/core-api/src/main/java/org/silverpeas/core/util/Link.java
+++ b/core-api/src/main/java/org/silverpeas/core/util/Link.java
@@ -23,29 +23,48 @@
  */
 package org.silverpeas.core.util;
 
+import java.util.Objects;
+
+/**
+ * Link to a given web resource. The resource is defined by the URL at which it can be accessed
+ * through the Web.
+ */
 public class Link {
 
-  private String linkUrl;
-  private String linkLabel;
+  /**
+   * An empty link is a link whose the URL and label is an empty string.
+   */
+  public static final Link EMPTY_LINK = new Link("", "");
 
-  public Link(String linkUrl, String linkLabel) {
+  private final String linkUrl;
+  private final String linkLabel;
+
+  /**
+   * Constructs a new link with the specified URL and labels.
+   * @param linkUrl the URL of the linked resource.
+   * @param linkLabel the label to render for that link.
+   */
+  public Link(final String linkUrl, final String linkLabel) {
+    Objects.requireNonNull(linkUrl);
+    Objects.requireNonNull(linkLabel);
     this.linkUrl = linkUrl;
     this.linkLabel = linkLabel;
   }
 
+  /**
+   * Gets the URL of the resource referred by this link.
+   * @return the resource URL.
+   */
   public String getLinkUrl() {
     return linkUrl;
   }
 
-  public void setLinkUrl(String linkUrl) {
-    this.linkUrl = linkUrl;
-  }
-
+  /**
+   * Gets the label with which this link should be referred.
+   * @return this link's label.
+   */
   public String getLinkLabel() {
     return linkLabel;
   }
 
-  public void setLinkLabel(String linkLabel) {
-    this.linkLabel = linkLabel;
-  }
 }

--- a/core-api/src/main/java/org/silverpeas/core/util/memory/MemoryUnit.java
+++ b/core-api/src/main/java/org/silverpeas/core/util/memory/MemoryUnit.java
@@ -34,7 +34,7 @@ import static org.silverpeas.core.util.StringUtil.defaultStringIfNotDefined;
 /**
  * User: Yohann Chastagnier
  * Date: 15/11/13
- */ /* Byte, Kilo-Byte, Mega-Byte, ... */
+ */
 public enum MemoryUnit {
   B(1, "o", "bytes"), KB(2, "ko", "Kb"), MB(3, "mo", "Mb"), GB(4, "go", "Gb"), TB(5, "to", "Tb");
   private final String bundleKey;
@@ -63,6 +63,11 @@ public enum MemoryUnit {
     return defaultStringIfNotDefined(getStringTranslation(getBundleKey()), getBundleDefault());
   }
 
+  public String getLabel(final String language) {
+    return defaultStringIfNotDefined(getStringTranslation(getBundleKey(), language),
+        getBundleDefault());
+  }
+
   public BigDecimal getLimit() {
     if (limit == null) {
       limit = byteMultiplier.pow(power);
@@ -74,13 +79,11 @@ public enum MemoryUnit {
     return power;
   }
 
-  /**
-   * Gets the translation of an element
-   * @param key
-   * @return
-   */
   private static String getStringTranslation(final String key) {
-    String language = MessageManager.getLanguage();
+    return getStringTranslation(key, MessageManager.getLanguage());
+  }
+
+  private static String getStringTranslation(final String key, final String language) {
     LocalizationBundle rl =
         ResourceLocator.getLocalizationBundle("org.silverpeas.util.multilang.util", language);
     return rl.getString(key);

--- a/core-configuration/src/main/config/migrations/db/h2/notificationManager/007/clean.sql
+++ b/core-configuration/src/main/config/migrations/db/h2/notificationManager/007/clean.sql
@@ -1,0 +1,5 @@
+DELETE FROM ST_NotifChannel WHERE id = 1;
+DELETE FROM ST_NotifChannel WHERE id = 2;
+DELETE FROM ST_NotifChannel WHERE id = 3;
+DELETE FROM ST_NotifChannel WHERE id = 4;
+DELETE FROM ST_NotifChannel WHERE id = 5;

--- a/core-configuration/src/main/config/migrations/db/h2/notificationManager/007/create_constraint.sql
+++ b/core-configuration/src/main/config/migrations/db/h2/notificationManager/007/create_constraint.sql
@@ -1,0 +1,37 @@
+ALTER TABLE ST_NotifChannel ADD	CONSTRAINT PK_NotifChannel PRIMARY KEY(id) ;
+
+ALTER TABLE ST_NotifDefaultAddress ADD CONSTRAINT PK_ST_NotifDefaultAddress PRIMARY KEY(id);
+ALTER TABLE ST_NotifDefaultAddress ADD CONSTRAINT FK_NotifDefaultAddress_1 FOREIGN KEY(userId) REFERENCES ST_User(id);
+
+ALTER TABLE ST_NotifPreference ADD CONSTRAINT PK_NotifAddr_Component PRIMARY KEY(id);
+ALTER TABLE ST_NotifPreference ADD CONSTRAINT FK_NotifPreference_1 FOREIGN KEY(componentInstanceId) REFERENCES ST_ComponentInstance (id);
+ALTER TABLE ST_NotifPreference ADD CONSTRAINT FK_NotifPreference_2 FOREIGN KEY(userId) REFERENCES ST_User(id);
+
+ALTER TABLE ST_NotifAddress ADD CONSTRAINT PK_NotifAddress PRIMARY KEY(id);
+ALTER TABLE ST_NotifAddress ADD CONSTRAINT FK_NotifAddress_1 FOREIGN KEY(notifChannelId) REFERENCES ST_NotifChannel(id);
+ALTER TABLE ST_NotifAddress ADD	CONSTRAINT FK_NotifAddress_2 FOREIGN KEY(userId) REFERENCES ST_User(id);
+
+ALTER TABLE ST_NotifSended ADD CONSTRAINT PK_NotifSended PRIMARY KEY(notifId);
+
+ALTER TABLE ST_NotifSendedReceiver ADD CONSTRAINT PK_NotifSendedReceiver PRIMARY KEY(notifId, userId);
+
+ALTER TABLE st_delayednotifusersetting
+        ADD CONSTRAINT const_st_dnus_pk
+        PRIMARY KEY (id);
+ALTER TABLE st_delayednotifusersetting
+        ADD CONSTRAINT const_st_dnus_fk_userId
+		FOREIGN KEY (userId) REFERENCES ST_User(id);
+
+ALTER TABLE st_notificationresource
+        ADD CONSTRAINT const_st_nr_pk
+        PRIMARY KEY (id);
+
+ALTER TABLE st_delayednotification
+        ADD CONSTRAINT const_st_dn_pk
+        PRIMARY KEY (id);
+ALTER TABLE st_delayednotification
+		ADD CONSTRAINT const_st_dn_fk_nrId
+		FOREIGN KEY (notificationResourceId) REFERENCES st_notificationresource(id);
+ALTER TABLE st_delayednotification
+        ADD CONSTRAINT const_st_dn_fk_userId
+		FOREIGN KEY (userId) REFERENCES ST_User(id);

--- a/core-configuration/src/main/config/migrations/db/h2/notificationManager/007/create_index.sql
+++ b/core-configuration/src/main/config/migrations/db/h2/notificationManager/007/create_index.sql
@@ -1,0 +1,14 @@
+CREATE INDEX IN_NotifAddress_1 ON ST_NotifAddress(userId);
+
+CREATE UNIQUE INDEX IN_NotifPreference_1 ON ST_NotifPreference(userId, componentInstanceId, messageType);
+
+CREATE INDEX IN_NotifSendedReceiver ON ST_NotifSendedReceiver(notifId);
+
+CREATE INDEX idx_st_dnus_userId ON st_delayednotifusersetting(userId);
+CREATE INDEX idx_st_dnus_channel ON st_delayednotifusersetting(channel);
+CREATE UNIQUE INDEX idx_st_dnus_uc ON st_delayednotifusersetting(userId, channel);
+
+CREATE INDEX idx_st_nr_resourceId ON st_notificationresource(resourceId);
+
+CREATE INDEX idx_st_dn_userId ON st_delayednotification(userId);
+CREATE INDEX idx_st_dn_channel ON st_delayednotification(channel);

--- a/core-configuration/src/main/config/migrations/db/h2/notificationManager/007/create_table.sql
+++ b/core-configuration/src/main/config/migrations/db/h2/notificationManager/007/create_table.sql
@@ -1,0 +1,84 @@
+CREATE TABLE ST_NotifChannel (
+	id int NOT NULL ,
+	name varchar (20) NOT NULL ,
+	description varchar (200) NULL ,
+	couldBeAdded char (1) NOT NULL DEFAULT ('Y') ,
+	fromAvailable char (1) NOT NULL DEFAULT ('N') ,
+	subjectAvailable char (1) NOT NULL DEFAULT ('N')
+)
+;
+
+CREATE TABLE ST_NotifAddress (
+	id int NOT NULL ,
+	userId int NOT NULL ,
+	notifName varchar (20) NOT NULL ,
+	notifChannelId int NOT NULL ,
+	address varchar (250) NOT NULL ,
+	usage varchar (20) NULL ,
+	priority int NOT NULL
+)
+;
+
+CREATE TABLE ST_NotifDefaultAddress (
+	id int NOT NULL ,
+	userId int NOT NULL ,
+	notifAddressId int NOT NULL
+)
+;
+
+CREATE TABLE ST_NotifPreference (
+	id int NOT NULL ,
+	notifAddressId int NOT NULL ,
+	componentInstanceId int NOT NULL ,
+	userId int NOT NULL ,
+	messageType int NOT NULL
+)
+;
+
+CREATE TABLE ST_NotifSended (
+	notifId		int		NOT NULL,
+	userId		int		NOT NULL,
+	messageType	int		NULL,
+	notifDate	char (13)	NOT NULL,
+	title		varchar (255)	NULL,
+	link		varchar (255)	NULL,
+	sessionId	varchar (255)	NULL,
+	componentId	varchar (255)	NULL,
+	body		int		NULL
+);
+
+CREATE TABLE ST_NotifSendedReceiver (
+	notifId		int		NOT NULL,
+	userId		int		NOT NULL
+);
+
+CREATE TABLE st_delayednotifusersetting (
+   id 			int NOT NULL ,
+   userId		int NOT NULL ,
+   channel		int NOT NULL ,
+   frequency	varchar (4) NOT NULL
+);
+
+CREATE TABLE st_notificationresource (
+   id 					int8 NOT NULL ,
+   componentInstanceId	varchar(50) NOT NULL ,
+   resourceId			varchar(500) NOT NULL ,
+   resourceType			varchar(50) NOT NULL ,
+   resourceName			varchar(500) NOT NULL ,
+   resourceDescription	varchar(2000) NULL ,
+   resourceLocation		varchar(500) NOT NULL ,
+   resourceUrl			varchar(1000) NULL,
+	 attachmentTargetId varchar(500) NULL
+);
+
+CREATE TABLE st_delayednotification (
+   id 						int8 NOT NULL ,
+   userId					int NOT NULL ,
+   fromUserId				int NOT NULL ,
+   channel					int NOT NULL ,
+   action					int NOT NULL ,
+   notificationResourceId	int8 NOT NULL ,
+   language					varchar(2) NOT NULL ,
+   creationDate				timestamp NOT NULL ,
+   message					varchar(2000) NULL
+);

--- a/core-configuration/src/main/config/migrations/db/h2/notificationManager/007/init.sql
+++ b/core-configuration/src/main/config/migrations/db/h2/notificationManager/007/init.sql
@@ -1,0 +1,6 @@
+INSERT INTO ST_NotifChannel VALUES (1,'SMTP','','Y','E','Y');
+INSERT INTO ST_NotifChannel VALUES (2,'SMS','','Y',' ','N');
+INSERT INTO ST_NotifChannel VALUES (3,'POPUP','','N','I','N');
+INSERT INTO ST_NotifChannel VALUES (4,'SILVERMAIL','','N','I','Y');
+INSERT INTO ST_NotifChannel VALUES (5,'REMOVE','','N',' ','N');
+INSERT INTO ST_NotifChannel VALUES (6,'SERVER','','N',' ','N');

--- a/core-configuration/src/main/config/migrations/db/h2/notificationManager/up006/update_table.sql
+++ b/core-configuration/src/main/config/migrations/db/h2/notificationManager/up006/update_table.sql
@@ -1,0 +1,2 @@
+ALTER TABLE st_notificationresource
+  ADD COLUMN attachmentTargetId VARCHAR(500);

--- a/core-configuration/src/main/config/migrations/db/mssql/notificationManager/007/create_constraint.sql
+++ b/core-configuration/src/main/config/migrations/db/mssql/notificationManager/007/create_constraint.sql
@@ -1,0 +1,37 @@
+ALTER TABLE ST_NotifChannel WITH NOCHECK ADD CONSTRAINT PK_NotifChannel PRIMARY KEY CLUSTERED(id) ;
+
+ALTER TABLE ST_NotifDefaultAddress WITH NOCHECK ADD CONSTRAINT PK_ST_NotifDefaultAddress PRIMARY KEY CLUSTERED(id);
+ALTER TABLE ST_NotifDefaultAddress ADD CONSTRAINT FK_NotifDefaultAddress_1 FOREIGN KEY(userId) REFERENCES ST_User(id);
+
+ALTER TABLE ST_NotifPreference WITH NOCHECK ADD CONSTRAINT PK_NotifAddr_Component PRIMARY KEY CLUSTERED(id);
+ALTER TABLE ST_NotifPreference ADD CONSTRAINT FK_NotifPreference_1 FOREIGN KEY(componentInstanceId) REFERENCES ST_ComponentInstance (id);
+ALTER TABLE ST_NotifPreference ADD CONSTRAINT FK_NotifPreference_2 FOREIGN KEY(userId) REFERENCES ST_User(id);
+
+ALTER TABLE ST_NotifAddress WITH NOCHECK ADD CONSTRAINT PK_NotifAddress PRIMARY KEY CLUSTERED(id);
+ALTER TABLE ST_NotifAddress ADD CONSTRAINT FK_NotifAddress_1 FOREIGN KEY(notifChannelId) REFERENCES ST_NotifChannel(id);
+ALTER TABLE ST_NotifAddress ADD	CONSTRAINT FK_NotifAddress_2 FOREIGN KEY(userId) REFERENCES ST_User(id);
+
+ALTER TABLE ST_NotifSended ADD CONSTRAINT PK_NotifSended PRIMARY KEY CLUSTERED(notifId);
+
+ALTER TABLE ST_NotifSendedReceiver ADD CONSTRAINT PK_NotifSendedReceiver PRIMARY KEY CLUSTERED(notifId, userId);
+
+ALTER TABLE st_delayednotifusersetting
+        ADD CONSTRAINT const_st_dnus_pk
+        PRIMARY KEY CLUSTERED(id);
+ALTER TABLE st_delayednotifusersetting
+        ADD CONSTRAINT const_st_dnus_fk_userId
+		FOREIGN KEY (userId) REFERENCES ST_User(id);
+
+ALTER TABLE st_notificationresource
+        ADD CONSTRAINT const_st_nr_pk
+        PRIMARY KEY CLUSTERED(id);
+
+ALTER TABLE st_delayednotification
+        ADD CONSTRAINT const_st_dn_pk
+        PRIMARY KEY CLUSTERED(id);
+ALTER TABLE st_delayednotification
+		ADD CONSTRAINT const_st_dn_fk_nrId
+		FOREIGN KEY (notificationResourceId) REFERENCES st_notificationresource(id);
+ALTER TABLE st_delayednotification
+        ADD CONSTRAINT const_st_dn_fk_userId
+		FOREIGN KEY (userId) REFERENCES ST_User(id);

--- a/core-configuration/src/main/config/migrations/db/mssql/notificationManager/007/create_index.sql
+++ b/core-configuration/src/main/config/migrations/db/mssql/notificationManager/007/create_index.sql
@@ -1,0 +1,14 @@
+CREATE INDEX IN_NotifAddress_1 ON ST_NotifAddress(userId);
+
+CREATE UNIQUE INDEX IN_NotifPreference_1 ON ST_NotifPreference(userId, componentInstanceId, messageType);
+
+CREATE INDEX IN_NotifSendedReceiver ON ST_NotifSendedReceiver(notifId);
+
+CREATE INDEX idx_st_dnus_userId ON st_delayednotifusersetting(userId);
+CREATE INDEX idx_st_dnus_channel ON st_delayednotifusersetting(channel);
+CREATE UNIQUE INDEX idx_st_dnus_uc ON st_delayednotifusersetting(userId, channel);
+
+CREATE INDEX idx_st_nr_resourceId ON st_notificationresource(resourceId);
+
+CREATE INDEX idx_st_dn_userId ON st_delayednotification(userId);
+CREATE INDEX idx_st_dn_channel ON st_delayednotification(channel);

--- a/core-configuration/src/main/config/migrations/db/mssql/notificationManager/007/create_table.sql
+++ b/core-configuration/src/main/config/migrations/db/mssql/notificationManager/007/create_table.sql
@@ -1,0 +1,84 @@
+CREATE TABLE ST_NotifChannel (
+	id int NOT NULL ,
+	name varchar (20) NOT NULL ,
+	description varchar (200) NULL ,
+	couldBeAdded char (1) NOT NULL DEFAULT ('Y') ,
+	fromAvailable char (1) NOT NULL DEFAULT ('N') ,
+	subjectAvailable char (1) NOT NULL DEFAULT ('N')
+)
+;
+
+CREATE TABLE ST_NotifAddress (
+	id int NOT NULL ,
+	userId int NOT NULL ,
+	notifName varchar (20) NOT NULL ,
+	notifChannelId int NOT NULL ,
+	address varchar (250) NOT NULL ,
+	usage varchar (20) NULL ,
+	priority int NOT NULL
+)
+;
+
+CREATE TABLE ST_NotifDefaultAddress (
+	id int NOT NULL ,
+	userId int NOT NULL ,
+	notifAddressId int NOT NULL
+)
+;
+
+CREATE TABLE ST_NotifPreference (
+	id int NOT NULL ,
+	notifAddressId int NOT NULL ,
+	componentInstanceId int NOT NULL ,
+	userId int NOT NULL ,
+	messageType int NOT NULL
+)
+;
+
+CREATE TABLE ST_NotifSended (
+	notifId		int		NOT NULL,
+	userId		int		NOT NULL,
+	messageType	int		NULL,
+	notifDate	char (13)	NOT NULL,
+	title		varchar (255)	NULL,
+	link		varchar (255)	NULL,
+	sessionId	varchar (255)	NULL,
+	componentId	varchar (255)	NULL,
+	body		int		NULL
+);
+
+CREATE TABLE ST_NotifSendedReceiver (
+	notifId		int		NOT NULL,
+	userId		int		NOT NULL
+);
+
+CREATE TABLE st_delayednotifusersetting (
+   id 			int NOT NULL ,
+   userId		int NOT NULL ,
+   channel		int NOT NULL ,
+   frequency	varchar (4) NOT NULL
+);
+
+CREATE TABLE st_notificationresource (
+   id 					bigint NOT NULL ,
+   componentInstanceId	varchar(50) NOT NULL ,
+   resourceId			varchar(500) NOT NULL ,
+   resourceType			varchar(50) NOT NULL ,
+   resourceName			varchar(500) NOT NULL ,
+   resourceDescription	varchar(2000) NULL ,
+   resourceLocation		varchar(500) NOT NULL ,
+   resourceUrl			varchar(1000) NULL,
+   attachmentTargetId VARCHAR(500) NULL
+);
+
+CREATE TABLE st_delayednotification (
+   id 						bigint NOT NULL ,
+   userId					int NOT NULL ,
+   fromUserId				int NOT NULL ,
+   channel					int NOT NULL ,
+   action					int NOT NULL ,
+   notificationResourceId	bigint NOT NULL ,
+   language					varchar(2) NOT NULL ,
+   creationDate				datetime NOT NULL ,
+   message					varchar(2000) NULL
+);

--- a/core-configuration/src/main/config/migrations/db/mssql/notificationManager/007/init.sql
+++ b/core-configuration/src/main/config/migrations/db/mssql/notificationManager/007/init.sql
@@ -1,0 +1,6 @@
+INSERT INTO ST_NotifChannel VALUES (1,'SMTP','','Y','E','Y');
+INSERT INTO ST_NotifChannel VALUES (2,'SMS','','Y',' ','N');
+INSERT INTO ST_NotifChannel VALUES (3,'POPUP','','N','I','N');
+INSERT INTO ST_NotifChannel VALUES (4,'SILVERMAIL','','N','I','Y');
+INSERT INTO ST_NotifChannel VALUES (5,'REMOVE','','N',' ','N');
+INSERT INTO ST_NotifChannel VALUES (6,'SERVER','','N',' ','N');

--- a/core-configuration/src/main/config/migrations/db/mssql/notificationManager/up006/update_table.sql
+++ b/core-configuration/src/main/config/migrations/db/mssql/notificationManager/up006/update_table.sql
@@ -1,0 +1,2 @@
+ALTER TABLE st_notificationresource
+  ADD attachmentTargetId VARCHAR(500) NULL;

--- a/core-configuration/src/main/config/migrations/db/oracle/notificationManager/007/create_constraint.sql
+++ b/core-configuration/src/main/config/migrations/db/oracle/notificationManager/007/create_constraint.sql
@@ -1,0 +1,37 @@
+ALTER TABLE ST_NotifChannel ADD	CONSTRAINT PK_NotifChannel PRIMARY KEY(id) ;
+
+ALTER TABLE ST_NotifDefaultAddress ADD CONSTRAINT PK_ST_NotifDefaultAddress PRIMARY KEY(id);
+ALTER TABLE ST_NotifDefaultAddress ADD CONSTRAINT FK_NotifDefaultAddress_1 FOREIGN KEY(userId) REFERENCES ST_User(id);
+
+ALTER TABLE ST_NotifPreference ADD CONSTRAINT PK_NotifAddr_Component PRIMARY KEY(id);
+ALTER TABLE ST_NotifPreference ADD CONSTRAINT FK_NotifPreference_1 FOREIGN KEY(componentInstanceId) REFERENCES ST_ComponentInstance (id);
+ALTER TABLE ST_NotifPreference ADD CONSTRAINT FK_NotifPreference_2 FOREIGN KEY(userId) REFERENCES ST_User(id);
+
+ALTER TABLE ST_NotifAddress ADD CONSTRAINT PK_NotifAddress PRIMARY KEY(id);
+ALTER TABLE ST_NotifAddress ADD CONSTRAINT FK_NotifAddress_1 FOREIGN KEY(notifChannelId) REFERENCES ST_NotifChannel(id);
+ALTER TABLE ST_NotifAddress ADD	CONSTRAINT FK_NotifAddress_2 FOREIGN KEY(userId) REFERENCES ST_User(id);
+
+ALTER TABLE ST_NotifSended ADD CONSTRAINT PK_NotifSended PRIMARY KEY(notifId);
+
+ALTER TABLE ST_NotifSendedReceiver ADD CONSTRAINT PK_NotifSendedReceiver PRIMARY KEY(notifId, userId);
+
+ALTER TABLE st_delayednotifusersetting
+        ADD CONSTRAINT const_st_dnus_pk
+        PRIMARY KEY (id);
+ALTER TABLE st_delayednotifusersetting
+        ADD CONSTRAINT const_st_dnus_fk_userId
+		FOREIGN KEY (userId) REFERENCES ST_User(id);
+
+ALTER TABLE st_notificationresource
+        ADD CONSTRAINT const_st_nr_pk
+        PRIMARY KEY (id);
+
+ALTER TABLE st_delayednotification
+        ADD CONSTRAINT const_st_dn_pk
+        PRIMARY KEY (id);
+ALTER TABLE st_delayednotification
+		ADD CONSTRAINT const_st_dn_fk_nrId
+		FOREIGN KEY (notificationResourceId) REFERENCES st_notificationresource(id);
+ALTER TABLE st_delayednotification
+        ADD CONSTRAINT const_st_dn_fk_userId
+		FOREIGN KEY (userId) REFERENCES ST_User(id);

--- a/core-configuration/src/main/config/migrations/db/oracle/notificationManager/007/create_index.sql
+++ b/core-configuration/src/main/config/migrations/db/oracle/notificationManager/007/create_index.sql
@@ -1,0 +1,14 @@
+CREATE INDEX IN_NotifAddress_1 ON ST_NotifAddress(userId);
+
+CREATE UNIQUE INDEX IN_NotifPreference_1 ON ST_NotifPreference(userId, componentInstanceId, messageType);
+
+CREATE INDEX IN_NotifSendedReceiver ON ST_NotifSendedReceiver(notifId);
+
+CREATE INDEX idx_st_dnus_userId ON st_delayednotifusersetting(userId);
+CREATE INDEX idx_st_dnus_channel ON st_delayednotifusersetting(channel);
+CREATE UNIQUE INDEX idx_st_dnus_uc ON st_delayednotifusersetting(userId, channel);
+
+CREATE INDEX idx_st_nr_resourceId ON st_notificationresource(resourceId);
+
+CREATE INDEX idx_st_dn_userId ON st_delayednotification(userId);
+CREATE INDEX idx_st_dn_channel ON st_delayednotification(channel);

--- a/core-configuration/src/main/config/migrations/db/oracle/notificationManager/007/create_table.sql
+++ b/core-configuration/src/main/config/migrations/db/oracle/notificationManager/007/create_table.sql
@@ -1,0 +1,84 @@
+CREATE TABLE ST_NotifChannel (
+	id int NOT NULL ,
+	name varchar (20) NOT NULL ,
+	description varchar (200) NULL ,
+	couldBeAdded char (1) DEFAULT ('Y') NOT NULL ,
+	fromAvailable char (1) DEFAULT ('N') NOT NULL ,
+	subjectAvailable char (1) DEFAULT ('N') NOT NULL
+)
+;
+
+CREATE TABLE ST_NotifAddress (
+	id int NOT NULL ,
+	userId int NOT NULL ,
+	notifName varchar (20) NOT NULL ,
+	notifChannelId int NOT NULL ,
+	address varchar (250) NOT NULL ,
+	usage varchar (20) NULL ,
+	priority int NOT NULL
+)
+;
+
+CREATE TABLE ST_NotifDefaultAddress (
+	id int NOT NULL ,
+	userId int NOT NULL ,
+	notifAddressId int NOT NULL
+)
+;
+
+CREATE TABLE ST_NotifPreference (
+	id int NOT NULL ,
+	notifAddressId int NOT NULL ,
+	componentInstanceId int NOT NULL ,
+	userId int NOT NULL ,
+	messageType int NOT NULL
+)
+;
+
+CREATE TABLE ST_NotifSended (
+	notifId		int		NOT NULL,
+	userId		int		NOT NULL,
+	messageType	int		NULL,
+	notifDate	char (13)	NOT NULL,
+	title		varchar (255)	NULL,
+	link		varchar (255)	NULL,
+	sessionId	varchar (255)	NULL,
+	componentId	varchar (255)	NULL,
+	body		int		NULL
+);
+
+CREATE TABLE ST_NotifSendedReceiver (
+	notifId		int		NOT NULL,
+	userId		int		NOT NULL
+);
+
+CREATE TABLE st_delayednotifusersetting (
+   id 			int NOT NULL ,
+   userId		int NOT NULL ,
+   channel		int NOT NULL ,
+   frequency	varchar (4) NOT NULL
+);
+
+CREATE TABLE st_notificationresource (
+   id 					number(19,0) NOT NULL ,
+   componentInstanceId	varchar(50) NOT NULL ,
+   resourceId			varchar(500) NOT NULL ,
+   resourceType			varchar(50) NOT NULL ,
+   resourceName			varchar(500) NOT NULL ,
+   resourceDescription	varchar(2000) NULL ,
+   resourceLocation		varchar(500) NOT NULL ,
+   resourceUrl			varchar(1000) NULL,
+	 attachmentTargetId	varchar(500) NULL
+);
+
+CREATE TABLE st_delayednotification (
+   id 						number(19,0) NOT NULL ,
+   userId					int NOT NULL ,
+   fromUserId				int NOT NULL ,
+   channel					int NOT NULL ,
+   action					int NOT NULL ,
+   notificationResourceId	number(19,0) NOT NULL ,
+   language					varchar(2) NOT NULL ,
+   creationDate				timestamp NOT NULL ,
+   message					varchar(2000) NULL
+);

--- a/core-configuration/src/main/config/migrations/db/oracle/notificationManager/007/init.sql
+++ b/core-configuration/src/main/config/migrations/db/oracle/notificationManager/007/init.sql
@@ -1,0 +1,6 @@
+INSERT INTO ST_NotifChannel VALUES (1,'SMTP','','Y','E','Y');
+INSERT INTO ST_NotifChannel VALUES (2,'SMS','','Y',' ','N');
+INSERT INTO ST_NotifChannel VALUES (3,'POPUP','','N','I','N');
+INSERT INTO ST_NotifChannel VALUES (4,'SILVERMAIL','','N','I','Y');
+INSERT INTO ST_NotifChannel VALUES (5,'REMOVE','','N',' ','N');
+INSERT INTO ST_NotifChannel VALUES (6,'SERVER','','N',' ','N');

--- a/core-configuration/src/main/config/migrations/db/oracle/notificationManager/up006/update_table.sql
+++ b/core-configuration/src/main/config/migrations/db/oracle/notificationManager/up006/update_table.sql
@@ -1,0 +1,2 @@
+ALTER TABLE st_notificationresource
+  ADD attachmentTargetId VARCHAR(500) NULL;

--- a/core-configuration/src/main/config/migrations/db/postgresql/notificationManager/007/clean.sql
+++ b/core-configuration/src/main/config/migrations/db/postgresql/notificationManager/007/clean.sql
@@ -1,0 +1,5 @@
+DELETE FROM ST_NotifChannel WHERE id = 1;
+DELETE FROM ST_NotifChannel WHERE id = 2;
+DELETE FROM ST_NotifChannel WHERE id = 3;
+DELETE FROM ST_NotifChannel WHERE id = 4;
+DELETE FROM ST_NotifChannel WHERE id = 5;

--- a/core-configuration/src/main/config/migrations/db/postgresql/notificationManager/007/create_constraint.sql
+++ b/core-configuration/src/main/config/migrations/db/postgresql/notificationManager/007/create_constraint.sql
@@ -1,0 +1,37 @@
+ALTER TABLE ST_NotifChannel ADD	CONSTRAINT PK_NotifChannel PRIMARY KEY(id) ;
+
+ALTER TABLE ST_NotifDefaultAddress ADD CONSTRAINT PK_ST_NotifDefaultAddress PRIMARY KEY(id);
+ALTER TABLE ST_NotifDefaultAddress ADD CONSTRAINT FK_NotifDefaultAddress_1 FOREIGN KEY(userId) REFERENCES ST_User(id);
+
+ALTER TABLE ST_NotifPreference ADD CONSTRAINT PK_NotifAddr_Component PRIMARY KEY(id);
+ALTER TABLE ST_NotifPreference ADD CONSTRAINT FK_NotifPreference_1 FOREIGN KEY(componentInstanceId) REFERENCES ST_ComponentInstance (id);
+ALTER TABLE ST_NotifPreference ADD CONSTRAINT FK_NotifPreference_2 FOREIGN KEY(userId) REFERENCES ST_User(id);
+
+ALTER TABLE ST_NotifAddress ADD CONSTRAINT PK_NotifAddress PRIMARY KEY(id);
+ALTER TABLE ST_NotifAddress ADD CONSTRAINT FK_NotifAddress_1 FOREIGN KEY(notifChannelId) REFERENCES ST_NotifChannel(id);
+ALTER TABLE ST_NotifAddress ADD	CONSTRAINT FK_NotifAddress_2 FOREIGN KEY(userId) REFERENCES ST_User(id);
+
+ALTER TABLE ST_NotifSended ADD CONSTRAINT PK_NotifSended PRIMARY KEY(notifId);
+
+ALTER TABLE ST_NotifSendedReceiver ADD CONSTRAINT PK_NotifSendedReceiver PRIMARY KEY(notifId, userId);
+
+ALTER TABLE st_delayednotifusersetting
+        ADD CONSTRAINT const_st_dnus_pk
+        PRIMARY KEY (id);
+ALTER TABLE st_delayednotifusersetting
+        ADD CONSTRAINT const_st_dnus_fk_userId
+		FOREIGN KEY (userId) REFERENCES ST_User(id);
+
+ALTER TABLE st_notificationresource
+        ADD CONSTRAINT const_st_nr_pk
+        PRIMARY KEY (id);
+
+ALTER TABLE st_delayednotification
+        ADD CONSTRAINT const_st_dn_pk
+        PRIMARY KEY (id);
+ALTER TABLE st_delayednotification
+		ADD CONSTRAINT const_st_dn_fk_nrId
+		FOREIGN KEY (notificationResourceId) REFERENCES st_notificationresource(id);
+ALTER TABLE st_delayednotification
+        ADD CONSTRAINT const_st_dn_fk_userId
+		FOREIGN KEY (userId) REFERENCES ST_User(id);

--- a/core-configuration/src/main/config/migrations/db/postgresql/notificationManager/007/create_index.sql
+++ b/core-configuration/src/main/config/migrations/db/postgresql/notificationManager/007/create_index.sql
@@ -1,0 +1,14 @@
+CREATE INDEX IN_NotifAddress_1 ON ST_NotifAddress(userId);
+
+CREATE UNIQUE INDEX IN_NotifPreference_1 ON ST_NotifPreference(userId, componentInstanceId, messageType);
+
+CREATE INDEX IN_NotifSendedReceiver ON ST_NotifSendedReceiver(notifId);
+
+CREATE INDEX idx_st_dnus_userId ON st_delayednotifusersetting(userId);
+CREATE INDEX idx_st_dnus_channel ON st_delayednotifusersetting(channel);
+CREATE UNIQUE INDEX idx_st_dnus_uc ON st_delayednotifusersetting(userId, channel);
+
+CREATE INDEX idx_st_nr_resourceId ON st_notificationresource(resourceId);
+
+CREATE INDEX idx_st_dn_userId ON st_delayednotification(userId);
+CREATE INDEX idx_st_dn_channel ON st_delayednotification(channel);

--- a/core-configuration/src/main/config/migrations/db/postgresql/notificationManager/007/create_table.sql
+++ b/core-configuration/src/main/config/migrations/db/postgresql/notificationManager/007/create_table.sql
@@ -1,0 +1,84 @@
+CREATE TABLE ST_NotifChannel (
+	id int NOT NULL ,
+	name varchar (20) NOT NULL ,
+	description varchar (200) NULL ,
+	couldBeAdded char (1) NOT NULL DEFAULT ('Y') ,
+	fromAvailable char (1) NOT NULL DEFAULT ('N') ,
+	subjectAvailable char (1) NOT NULL DEFAULT ('N')
+)
+;
+
+CREATE TABLE ST_NotifAddress (
+	id int NOT NULL ,
+	userId int NOT NULL ,
+	notifName varchar (20) NOT NULL ,
+	notifChannelId int NOT NULL ,
+	address varchar (250) NOT NULL ,
+	usage varchar (20) NULL ,
+	priority int NOT NULL
+)
+;
+
+CREATE TABLE ST_NotifDefaultAddress (
+	id int NOT NULL ,
+	userId int NOT NULL ,
+	notifAddressId int NOT NULL
+)
+;
+
+CREATE TABLE ST_NotifPreference (
+	id int NOT NULL ,
+	notifAddressId int NOT NULL ,
+	componentInstanceId int NOT NULL ,
+	userId int NOT NULL ,
+	messageType int NOT NULL
+)
+;
+
+CREATE TABLE ST_NotifSended (
+	notifId		int		NOT NULL,
+	userId		int		NOT NULL,
+	messageType	int		NULL,
+	notifDate	char (13)	NOT NULL,
+	title		varchar (255)	NULL,
+	link		varchar (255)	NULL,
+	sessionId	varchar (255)	NULL,
+	componentId	varchar (255)	NULL,
+	body		int		NULL
+);
+
+CREATE TABLE ST_NotifSendedReceiver (
+	notifId		int		NOT NULL,
+	userId		int		NOT NULL
+);
+
+CREATE TABLE st_delayednotifusersetting (
+   id 			int NOT NULL ,
+   userId		int NOT NULL ,
+   channel		int NOT NULL ,
+   frequency	varchar (4) NOT NULL
+);
+
+CREATE TABLE st_notificationresource (
+   id 					int8 NOT NULL ,
+   componentInstanceId	varchar(50) NOT NULL ,
+   resourceId			varchar(500) NOT NULL ,
+   resourceType			varchar(50) NOT NULL ,
+   resourceName			varchar(500) NOT NULL ,
+   resourceDescription	varchar(2000) NULL ,
+   resourceLocation		varchar(500) NOT NULL ,
+   resourceUrl			varchar(1000) NULL,
+	 attachmentTargetId	varchar(500) NULL
+);
+
+CREATE TABLE st_delayednotification (
+   id 						int8 NOT NULL ,
+   userId					int NOT NULL ,
+   fromUserId				int NOT NULL ,
+   channel					int NOT NULL ,
+   action					int NOT NULL ,
+   notificationResourceId	int8 NOT NULL ,
+   language					varchar(2) NOT NULL ,
+   creationDate				timestamp NOT NULL ,
+   message					varchar(2000) NULL
+);

--- a/core-configuration/src/main/config/migrations/db/postgresql/notificationManager/007/init.sql
+++ b/core-configuration/src/main/config/migrations/db/postgresql/notificationManager/007/init.sql
@@ -1,0 +1,6 @@
+INSERT INTO ST_NotifChannel VALUES (1,'SMTP','','Y','E','Y');
+INSERT INTO ST_NotifChannel VALUES (2,'SMS','','Y',' ','N');
+INSERT INTO ST_NotifChannel VALUES (3,'POPUP','','N','I','N');
+INSERT INTO ST_NotifChannel VALUES (4,'SILVERMAIL','','N','I','Y');
+INSERT INTO ST_NotifChannel VALUES (5,'REMOVE','','N',' ','N');
+INSERT INTO ST_NotifChannel VALUES (6,'SERVER','','N',' ','N');

--- a/core-configuration/src/main/config/migrations/db/postgresql/notificationManager/up006/update_table.sql
+++ b/core-configuration/src/main/config/migrations/db/postgresql/notificationManager/up006/update_table.sql
@@ -1,0 +1,2 @@
+ALTER TABLE st_notificationresource
+  ADD COLUMN attachmentTargetId VARCHAR(500) NULL ;

--- a/core-configuration/src/main/config/migrations/modules/notificationManager-migration.xml
+++ b/core-configuration/src/main/config/migrations/modules/notificationManager-migration.xml
@@ -29,14 +29,14 @@
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://silverpeas.org/xml/ns/migration https://www.silverpeas.org/xsd/migration.xsd">
 
-  <current version="006">
+  <current version="007">
     <script name="create_table.sql" type="sql"/>
     <script name="create_constraint.sql" type="sql"/>
     <script name="create_index.sql" type="sql"/>
     <script name="init.sql" type="sql"/>
   </current>
 
-  <upgrade fromVersion="005">
+  <upgrade fromVersion="006">
     <script name="update_table.sql" type="sql"/>
   </upgrade>
 

--- a/core-configuration/src/main/config/resources/StringTemplates/core/notification/SMTPmessageFooter_before_de.st
+++ b/core-configuration/src/main/config/resources/StringTemplates/core/notification/SMTPmessageFooter_before_de.st
@@ -1,3 +1,8 @@
+$if(notification_attachments)$
+<p>Angehängte Dateien:</p>
+  $notification_attachments:attachmentLinks_de(attachment=it)$
+$endif$
+
 $if(notification_link)$
   <div itemscope itemtype="http://schema.org/EmailMessage">
     <div itemprop="action" itemscope itemtype="http://schema.org/ViewAction">

--- a/core-configuration/src/main/config/resources/StringTemplates/core/notification/SMTPmessageFooter_before_en.st
+++ b/core-configuration/src/main/config/resources/StringTemplates/core/notification/SMTPmessageFooter_before_en.st
@@ -1,3 +1,8 @@
+$if(notification_attachments)$
+<p>Attachments:</p>
+  $notification_attachments:attachmentLinks_en(attachment=it)$
+$endif$
+
 $if(notification_link)$
   <div itemscope itemtype="http://schema.org/EmailMessage">
     <div itemprop="action" itemscope itemtype="http://schema.org/ViewAction">

--- a/core-configuration/src/main/config/resources/StringTemplates/core/notification/SMTPmessageFooter_before_fr.st
+++ b/core-configuration/src/main/config/resources/StringTemplates/core/notification/SMTPmessageFooter_before_fr.st
@@ -1,3 +1,8 @@
+$if(notification_attachments)$
+<p>Fichiers joints&nbsp;:</p>
+  $notification_attachments:attachmentLinks_fr(attachment=it)$
+$endif$
+
 $if(notification_link)$
   <div itemscope itemtype="http://schema.org/EmailMessage">
     <div itemprop="action" itemscope itemtype="http://schema.org/ViewAction">

--- a/core-configuration/src/main/config/resources/StringTemplates/core/notification/attachmentLinks_de.st
+++ b/core-configuration/src/main/config/resources/StringTemplates/core/notification/attachmentLinks_de.st
@@ -1,0 +1,3 @@
+<a target="_blank" href="$attachment.linkUrl$" style="white-space: nowrap; margin:0 10px 10px 0;display:inline-block; font-size:12px; color:#333;text-decoration:none;padding:10px;background-color:#FFF;border:1px solid #cccccc;">
+<span style="color:#1a73e8;text-decoration:underline">$attachment.linkLabel$</span><span style="margin:0 0 0 10px; ">($attachment.formattedLinkSize$)</span>
+</a>

--- a/core-configuration/src/main/config/resources/StringTemplates/core/notification/attachmentLinks_en.st
+++ b/core-configuration/src/main/config/resources/StringTemplates/core/notification/attachmentLinks_en.st
@@ -1,0 +1,3 @@
+<a target="_blank" href="$attachment.linkUrl$" style="white-space: nowrap; margin:0 10px 10px 0;display:inline-block; font-size:12px; color:#333;text-decoration:none;padding:10px;background-color:#FFF;border:1px solid #cccccc;">
+<span style="color:#1a73e8;text-decoration:underline">$attachment.linkLabel$</span><span style="margin:0 0 0 10px; ">($attachment.formattedLinkSize$)</span>
+</a>

--- a/core-configuration/src/main/config/resources/StringTemplates/core/notification/attachmentLinks_fr.st
+++ b/core-configuration/src/main/config/resources/StringTemplates/core/notification/attachmentLinks_fr.st
@@ -1,0 +1,3 @@
+<a target="_blank" href="$attachment.linkUrl$" style="white-space: nowrap; margin:0 10px 10px 0;display:inline-block; font-size:12px; color:#333;text-decoration:none;padding:10px;background-color:#FFF;border:1px solid #cccccc;">
+<span style="color:#1a73e8;text-decoration:underline">$attachment.linkLabel$</span><span style="margin:0 0 0 10px; ">($attachment.formattedLinkSize$)</span>
+</a>

--- a/core-configuration/src/main/config/resources/StringTemplates/core/notification/delayed/attachmentLinks_de.st
+++ b/core-configuration/src/main/config/resources/StringTemplates/core/notification/delayed/attachmentLinks_de.st
@@ -1,0 +1,3 @@
+<a target="_blank" href="$attachment.linkUrl$" style="white-space: nowrap; margin:0 10px 10px 0;display:inline-block; font-size:12px; color:#333;text-decoration:none;padding:10px;background-color:#FFF;border:1px solid #cccccc;">
+<span style="color:#1a73e8;text-decoration:underline">$attachment.linkLabel$</span><span style="margin:0 0 0 10px; ">($attachment.formattedLinkSize$)</span>
+</a>

--- a/core-configuration/src/main/config/resources/StringTemplates/core/notification/delayed/attachmentLinks_en.st
+++ b/core-configuration/src/main/config/resources/StringTemplates/core/notification/delayed/attachmentLinks_en.st
@@ -1,0 +1,3 @@
+<a target="_blank" href="$attachment.linkUrl$" style="white-space: nowrap; margin:0 10px 10px 0;display:inline-block; font-size:12px; color:#333;text-decoration:none;padding:10px;background-color:#FFF;border:1px solid #cccccc;">
+<span style="color:#1a73e8;text-decoration:underline">$attachment.linkLabel$</span><span style="margin:0 0 0 10px; ">($attachment.formattedLinkSize$)</span>
+</a>

--- a/core-configuration/src/main/config/resources/StringTemplates/core/notification/delayed/attachmentLinks_fr.st
+++ b/core-configuration/src/main/config/resources/StringTemplates/core/notification/delayed/attachmentLinks_fr.st
@@ -1,0 +1,3 @@
+<a target="_blank" href="$attachment.linkUrl$" style="white-space: nowrap; margin:0 10px 10px 0;display:inline-block; font-size:12px; color:#333;text-decoration:none;padding:10px;background-color:#FFF;border:1px solid #cccccc;">
+<span style="color:#1a73e8;text-decoration:underline">$attachment.linkLabel$</span><span style="margin:0 0 0 10px; ">($attachment.formattedLinkSize$)</span>
+</a>

--- a/core-configuration/src/main/config/resources/StringTemplates/core/notification/delayed/messageBodyResourceItem_de.st
+++ b/core-configuration/src/main/config/resources/StringTemplates/core/notification/delayed/messageBodyResourceItem_de.st
@@ -2,5 +2,9 @@
 	<h2 style="border-bottom:1px solid #CCCCCC; padding:0 0 5px; margin:0; font-weight:100; font-size:12px; color:#444444">$resource.location$ &gt; $if(resource.url)$<a style="color:#DF6900" target="_blank" href="$resource.url$">$resource.name$</a>$else$$resource.name$$endif$</h2>
 	$if(resource.description)$<p style="border-left: 6px solid #D6D4D4; padding: 6px; color:#915E47; margin:5px 0 0;">$resource.description$</p>$endif$
 	<ul style="margin:0 0 0 15px; padding:15px 0 0 15px; list-style-type: disc;">$resource.notifications:messageBodyResourceNotificationItem_de(notification=it)$</ul>
+	$if(!resource.attachmentLinks.empty)$
+  <p>Angehängte Dateien:</p>
+    resource.attachmentLinks:attachmentLinks_de(attachment=it)$
+  $endif$
 	$if(resource.url)$<div style="height:40px;"><a target="_blank" href="$resource.url$" style="display:inline-block; float:right;  margin:0;border-radius:10px; border:1px solid #ccc; font-size:12px; color:#333; font-weight:bold;text-decoration:none;padding:10px;background: linear-gradient(#fff, #eee) repeat scroll 0 0 #eee;"> &#9658; gehen Sie zum Beitrag</a></div>$endif$
 </div>

--- a/core-configuration/src/main/config/resources/StringTemplates/core/notification/delayed/messageBodyResourceItem_en.st
+++ b/core-configuration/src/main/config/resources/StringTemplates/core/notification/delayed/messageBodyResourceItem_en.st
@@ -2,5 +2,9 @@
 	<h2 style="border-bottom:1px solid #CCCCCC; padding:0 0 5px; margin:0; font-weight:100; font-size:12px; color:#444444">$resource.location$ &gt; $if(resource.url)$<a style="color:#DF6900" target="_blank" href="$resource.url$">$resource.name$</a>$else$$resource.name$$endif$</h2>
 	$if(resource.description)$<p style="border-left: 6px solid #D6D4D4; padding: 6px; color:#915E47; margin:5px 0 0;">$resource.description$</p>$endif$
 	<ul style="margin:0 0 0 15px; padding:15px 0 0 15px; list-style-type: disc;">$resource.notifications:messageBodyResourceNotificationItem_en(notification=it)$</ul>
+	$if(!resource.attachmentLinks.empty)$
+  <p>Attachments:</p>
+    $resource.attachmentLinks:attachmentLinks_en(attachment=it)$
+  $endif$
 	$if(resource.url)$<div style="height:40px;"><a target="_blank" href="$resource.url$" style="display:inline-block; float:right;  margin:0;border-radius:10px; border:1px solid #ccc; font-size:12px; color:#333; font-weight:bold;text-decoration:none;padding:10px;background: linear-gradient(#fff, #eee) repeat scroll 0 0 #eee;"> &#9658; Go to the contribution</a></div>$endif$
 </div>

--- a/core-configuration/src/main/config/resources/StringTemplates/core/notification/delayed/messageBodyResourceItem_fr.st
+++ b/core-configuration/src/main/config/resources/StringTemplates/core/notification/delayed/messageBodyResourceItem_fr.st
@@ -2,5 +2,10 @@
 	<h2 style="border-bottom:1px solid #CCCCCC; padding:0 0 5px; margin:0; font-weight:100; font-size:12px; color:#444444">$resource.location$ &gt; $if(resource.url)$<a style="color:#DF6900" target="_blank" href="$resource.url$">$resource.name$</a>$else$$resource.name$$endif$</h2>
 	$if(resource.description)$<p style="border-left: 6px solid #D6D4D4; padding: 6px; color:#915E47; margin:5px 0 0;">$resource.description$</p>$endif$
 	<ul style="margin:0 0 0 15px; padding:15px 0 0 15px; list-style-type: disc;">$resource.notifications:messageBodyResourceNotificationItem_fr(notification=it)$</ul>
+	$if(!resource.attachmentLinks.empty)$
+  <p>Fichiers joints&nbsp;:</p>
+    $resource.attachmentLinks:attachmentLinks_fr(attachment=it)$
+  $endif$
+
 	$if(resource.url)$<div style="height:40px;"><a target="_blank" href="$resource.url$" style="display:inline-block; float:right;  margin:0;border-radius:10px; border:1px solid #ccc; font-size:12px; color:#333; font-weight:bold;text-decoration:none;padding:10px;background: linear-gradient(#fff, #eee) repeat scroll 0 0 #eee;"> &#9658; Voir la contribution</a></div>$endif$
 </div>

--- a/core-library/src/integration-test/java/org/silverpeas/core/test/WarBuilder4LibCore.java
+++ b/core-library/src/integration-test/java/org/silverpeas/core/test/WarBuilder4LibCore.java
@@ -107,6 +107,7 @@ import org.silverpeas.core.io.media.Definition;
 import org.silverpeas.core.io.media.MetaData;
 import org.silverpeas.core.io.media.MetadataExtractor;
 import org.silverpeas.core.mail.extractor.Mail;
+import org.silverpeas.core.notification.user.AttachmentLink;
 import org.silverpeas.core.notification.user.UserSubscriptionNotificationSendingHandler;
 import org.silverpeas.core.notification.user.client.NotificationManagerSettings;
 import org.silverpeas.core.notification.user.client.constant.NotifChannel;
@@ -585,7 +586,8 @@ public class WarBuilder4LibCore extends WarBuilder<WarBuilder4LibCore> {
       addPackages(true, "org.silverpeas.core.notification.user.client");
       addPackages(true, "org.silverpeas.core.notification.user.server");
       addAsResource("org/silverpeas/notificationManager");
-      addClasses(AbstractTable.class, UserSubscriptionNotificationSendingHandler.class);
+      addClasses(AbstractTable.class, UserSubscriptionNotificationSendingHandler.class,
+          AttachmentLink.class);
       // Centralized features
       addSilverpeasUrlFeatures();
     }

--- a/core-library/src/integration-test/resources/org/silverpeas/core/notification/user/delayed/create-database.sql
+++ b/core-library/src/integration-test/resources/org/silverpeas/core/notification/user/delayed/create-database.sql
@@ -19,7 +19,8 @@ CREATE TABLE st_notificationresource (
    resourceName			varchar(500) NOT NULL ,
    resourceDescription	varchar(2000) NULL ,
    resourceLocation		varchar(500) NOT NULL ,
-   resourceUrl			varchar(1000) NULL
+   resourceUrl			varchar(1000) NULL,
+   attachmentTargetId varchar(500) NULL
 );
 
 CREATE TABLE st_delayednotification (

--- a/core-library/src/integration-test/resources/org/silverpeas/core/notification/user/delayed/delegate/create-database.sql
+++ b/core-library/src/integration-test/resources/org/silverpeas/core/notification/user/delayed/delegate/create-database.sql
@@ -19,7 +19,8 @@ CREATE TABLE st_notificationresource (
    resourceName			varchar(500) NOT NULL ,
    resourceDescription	varchar(2000) NULL ,
    resourceLocation		varchar(500) NOT NULL ,
-   resourceUrl			varchar(1000) NULL
+   resourceUrl			varchar(1000) NULL,
+   attachmentTargetId varchar(500) NULL
 );
 
 CREATE TABLE st_delayednotification (

--- a/core-library/src/main/java/org/silverpeas/core/contribution/publication/dao/SeeAlsoDAO.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/publication/dao/SeeAlsoDAO.java
@@ -30,7 +30,7 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.silverpeas.core.contribution.publication.model.Link;
+import org.silverpeas.core.contribution.publication.model.PublicationLink;
 import org.silverpeas.core.contribution.publication.model.PublicationPK;
 import org.silverpeas.core.persistence.jdbc.sql.JdbcSqlQuery;
 import org.silverpeas.core.ResourceReference;
@@ -132,7 +132,7 @@ public class SeeAlsoDAO {
    * @throws SQLException
    *
    */
-  public static List<Link> getLinks(Connection con, PublicationPK pubPK) throws SQLException {
+  public static List<PublicationLink> getLinks(Connection con, PublicationPK pubPK) throws SQLException {
     ResultSet rs = null;
     String selectStatement = "select id, targetId, targetInstanceId from "
         + SEEALSO_TABLENAME + " where objectId  = ? AND objectInstanceId = ? ";
@@ -143,7 +143,7 @@ public class SeeAlsoDAO {
       prepStmt.setString(2, pubPK.getInstanceId());
       rs = prepStmt.executeQuery();
 
-      List<Link> list = new ArrayList<>();
+      List<PublicationLink> list = new ArrayList<>();
       while (rs.next()) {
         list.add(getLink(pubPK, rs));
       }
@@ -160,7 +160,7 @@ public class SeeAlsoDAO {
    * @return a list of publication identifier
    * @throws SQLException
    */
-  public static List<Link> getReverseLinks(Connection con, PublicationPK pubPK)
+  public static List<PublicationLink> getReverseLinks(Connection con, PublicationPK pubPK)
       throws SQLException {
     ResultSet rs = null;
     String selectStatement = "select id, objectId, objectInstanceId  from "
@@ -172,9 +172,9 @@ public class SeeAlsoDAO {
       prepStmt.setString(2, pubPK.getInstanceId());
       rs = prepStmt.executeQuery();
 
-      List<Link> list = new ArrayList<>();
+      List<PublicationLink> list = new ArrayList<>();
       while (rs.next()) {
-        Link link = getLink(pubPK, rs);
+        PublicationLink link = getLink(pubPK, rs);
         link.setReverse(true);
         list.add(link);
       }
@@ -184,12 +184,12 @@ public class SeeAlsoDAO {
     }
   }
 
-  private static Link getLink(PublicationPK pubPK, ResultSet rs) throws SQLException {
+  private static PublicationLink getLink(PublicationPK pubPK, ResultSet rs) throws SQLException {
     String id = Integer.toString(rs.getInt(1));
     String targetId = Integer.toString(rs.getInt(2));
     String targetInstanceId = rs.getString(3);
     ResourceReference targetPK = new ResourceReference(targetId, targetInstanceId);
 
-    return new Link(id, pubPK, targetPK);
+    return new PublicationLink(id, pubPK, targetPK);
   }
 }

--- a/core-library/src/main/java/org/silverpeas/core/contribution/publication/model/CompletePublication.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/publication/model/CompletePublication.java
@@ -45,12 +45,12 @@ public class CompletePublication implements Serializable {
   /**
    * The publications linked to the current publication
    */
-  private List<Link> linkList;
+  private List<PublicationLink> linkList;
 
   /**
    * The publications which are a reference to the current publication
    */
-  private List<Link> reverseLinkList;
+  private List<PublicationLink> reverseLinkList;
 
   private List<ValidationStep> validationSteps = null;
 
@@ -59,8 +59,8 @@ public class CompletePublication implements Serializable {
    * @param linkList The publications linked to the current publication
    * @param reverseLinkList The publications which are a reference to the current publication
    */
-  public CompletePublication(PublicationDetail pubDetail, List<Link> linkList,
-      List<Link> reverseLinkList) {
+  public CompletePublication(PublicationDetail pubDetail, List<PublicationLink> linkList,
+      List<PublicationLink> reverseLinkList) {
     this.pubDetail = pubDetail;
     this.linkList = linkList;
     this.reverseLinkList = reverseLinkList;
@@ -78,14 +78,14 @@ public class CompletePublication implements Serializable {
   /**
    * @return the linkList
    */
-  public List<Link> getLinkList() {
+  public List<PublicationLink> getLinkList() {
     return linkList;
   }
 
   /**
    * @return the reverseLinkList
    */
-  public List<Link> getReverseLinkList() {
+  public List<PublicationLink> getReverseLinkList() {
     return reverseLinkList;
   }
 
@@ -97,11 +97,11 @@ public class CompletePublication implements Serializable {
     return validationSteps;
   }
 
-  public List<Link> getLinkedPublications(String userId) {
-    List<Link> publications = getAuthorizedLinks(userId, linkList);
+  public List<PublicationLink> getLinkedPublications(String userId) {
+    List<PublicationLink> publications = getAuthorizedLinks(userId, linkList);
     // remove reverse link linked by the same publication
-    List<Link> reverseLinkListWithoutDuplicates = new ArrayList<>();
-    for (Link reverseLink : reverseLinkList) {
+    List<PublicationLink> reverseLinkListWithoutDuplicates = new ArrayList<>();
+    for (PublicationLink reverseLink : reverseLinkList) {
       if (!isReverseLinkADuplication(publications, reverseLink)) {
         reverseLinkListWithoutDuplicates.add(reverseLink);
       }
@@ -110,8 +110,8 @@ public class CompletePublication implements Serializable {
     return publications;
   }
 
-  private boolean isReverseLinkADuplication(List<Link> links, Link linkToTest) {
-    for (Link link : links) {
+  private boolean isReverseLinkADuplication(List<PublicationLink> links, PublicationLink linkToTest) {
+    for (PublicationLink link : links) {
       if (link.getTarget().equals(linkToTest.getTarget())) {
         return true;
       }
@@ -119,12 +119,12 @@ public class CompletePublication implements Serializable {
     return false;
   }
 
-  private List<Link> getAuthorizedLinks(String userId, List<Link> links) {
+  private List<PublicationLink> getAuthorizedLinks(String userId, List<PublicationLink> links) {
     PublicationService publicationService = PublicationService.get();
     PublicationAccessController accessController =
         ServiceProvider.getService(PublicationAccessController.class);
-    List<Link> authorizedLinks = new ArrayList<>();
-    for (Link link : links) {
+    List<PublicationLink> authorizedLinks = new ArrayList<>();
+    for (PublicationLink link : links) {
       PublicationPK pk = new PublicationPK(link.getTarget().getLocalId(),
           link.getTarget().getComponentInstanceId());
       if (accessController.isUserAuthorized(userId, pk)) {

--- a/core-library/src/main/java/org/silverpeas/core/contribution/publication/model/PublicationLink.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/publication/model/PublicationLink.java
@@ -4,7 +4,10 @@ import org.silverpeas.core.ResourceReference;
 
 import java.io.Serializable;
 
-public class Link implements Serializable {
+/**
+ * Links from a publication to a contribution.
+ */
+public class PublicationLink implements Serializable {
 
   private String id;
   private PublicationPK pubPK;
@@ -12,7 +15,7 @@ public class Link implements Serializable {
   private PublicationDetail pub;
   private boolean reverse = false;
 
-  public Link(String id, PublicationPK pubPK, ResourceReference target) {
+  public PublicationLink(String id, PublicationPK pubPK, ResourceReference target) {
     setId(id);
     setPubPK(pubPK);
     setTarget(target);

--- a/core-library/src/main/java/org/silverpeas/core/contribution/publication/service/DefaultPublicationService.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/publication/service/DefaultPublicationService.java
@@ -41,7 +41,7 @@ import org.silverpeas.core.contribution.publication.dao.SeeAlsoDAO;
 import org.silverpeas.core.contribution.publication.dao.ValidationStepsDAO;
 import org.silverpeas.core.contribution.publication.model.Alias;
 import org.silverpeas.core.contribution.publication.model.CompletePublication;
-import org.silverpeas.core.contribution.publication.model.Link;
+import org.silverpeas.core.contribution.publication.model.PublicationLink;
 import org.silverpeas.core.contribution.publication.model.PublicationDetail;
 import org.silverpeas.core.contribution.publication.model.PublicationI18N;
 import org.silverpeas.core.contribution.publication.model.PublicationPK;
@@ -930,8 +930,8 @@ public class DefaultPublicationService implements PublicationService, ComponentI
       if (I18NHelper.isI18nContentActivated) {
         setTranslations(con, singletonList(detail));
       }
-      List<Link> links = SeeAlsoDAO.getLinks(con, pubPK);
-      List<Link> reverseLinks = SeeAlsoDAO.getReverseLinks(con, pubPK);
+      List<PublicationLink> links = SeeAlsoDAO.getLinks(con, pubPK);
+      List<PublicationLink> reverseLinks = SeeAlsoDAO.getReverseLinks(con, pubPK);
       CompletePublication cp = new CompletePublication(detail, links, reverseLinks);
       cp.setValidationSteps(getValidationSteps(pubPK));
       return cp;

--- a/core-library/src/main/java/org/silverpeas/core/notification/user/AttachmentLink.java
+++ b/core-library/src/main/java/org/silverpeas/core/notification/user/AttachmentLink.java
@@ -1,0 +1,79 @@
+package org.silverpeas.core.notification.user;
+
+import org.silverpeas.core.ResourceReference;
+import org.silverpeas.core.contribution.attachment.AttachmentService;
+import org.silverpeas.core.ui.DisplayI18NHelper;
+import org.silverpeas.core.util.FileLink;
+import org.silverpeas.core.util.StringUtil;
+import org.silverpeas.core.util.memory.MemoryUnit;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * A Web link to an attachment of a contribution in Silverpeas to render in a notification message.
+ * It extends the {@link FileLink} class by providing useful methods for templates.
+ * @author mmoquillon
+ */
+public class AttachmentLink extends FileLink {
+  private final String language;
+
+  /**
+   * Gets all the web links to all of the documents attached to the specified contribution in
+   * Silverpeas and for the given language.
+   * @param resource a reference to the contribution in Silverpeas.
+   * @param language the ISO 631-1 code of the language in which the attachments have to be get.
+   * @return a list of Web links to the attachments. If the contribution have no attachments, then
+   * an empty list is returned.
+   */
+  public static List<AttachmentLink> getForContribution(final ResourceReference resource,
+      final String language) {
+    final AttachmentService attachmentService = AttachmentService.get();
+    return attachmentService.listDocumentsByForeignKey(resource, language).stream().map(d -> {
+      final String label = StringUtil.isDefined(d.getTitle()) ? d.getTitle() : d.getFilename();
+      return new AttachmentLink(d.getAttachmentURL(), label, d.getSize(), language);
+    }).collect(Collectors.toList());
+  }
+
+  /**
+   * Constructs a new link with the specified URL, labels and file size.
+   * @param linkUrl the URL of the linked file.
+   * @param linkLabel the label to render for that link.
+   * @param linkSize the size in byte of the linked file.
+   * @param language the language of the attachment.
+   */
+  public AttachmentLink(final String linkUrl, final String linkLabel, final long linkSize,
+      final String language) {
+    super(linkUrl, linkLabel, linkSize);
+    this.language = language == null ? DisplayI18NHelper.getDefaultLanguage():language;
+  }
+
+  /**
+   * Gets the size of the file referred by this link in text format. This method is used by
+   * templates to indicate the size of the attached document targeted by this link.
+   * @return the size of the linked file expressed into the more suitable size unit.
+   */
+  public String getFormattedLinkSize() {
+    return formatFileSize(this.getLinkSize(), language);
+  }
+
+  private String formatFileSize(final long size, final String language) {
+    final long divider;
+    final String unit;
+    if (size >= MemoryUnit.MB.getLimit().longValue()) {
+      divider = MemoryUnit.MB.getLimit().longValue();
+      unit = MemoryUnit.GB.getLabel(language);
+    } else if (size >= MemoryUnit.KB.getLimit().longValue()) {
+      divider = MemoryUnit.KB.getLimit().longValue();
+      unit = MemoryUnit.MB.getLabel(language);
+    } else if (size >= MemoryUnit.B.getLimit().longValue()) {
+      divider = MemoryUnit.B.getLimit().longValue();
+      unit = MemoryUnit.KB.getLabel(language);
+    } else {
+      divider = 1;
+      unit = MemoryUnit.B.getLabel(language);
+    }
+    return (size / divider) + " " + unit;
+  }
+}
+  

--- a/core-library/src/main/java/org/silverpeas/core/notification/user/builder/AbstractResourceUserNotificationBuilder.java
+++ b/core-library/src/main/java/org/silverpeas/core/notification/user/builder/AbstractResourceUserNotificationBuilder.java
@@ -30,9 +30,10 @@ import org.silverpeas.core.contribution.model.SilverpeasContent;
 import org.silverpeas.core.contribution.model.SilverpeasToolContent;
 import org.silverpeas.core.notification.user.DefaultUserNotification;
 import org.silverpeas.core.notification.user.UserNotification;
+import org.silverpeas.core.notification.user.client.NotificationMetaData;
 import org.silverpeas.core.notification.user.client.constant.NotifAction;
 import org.silverpeas.core.notification.user.model.NotificationResourceData;
-import org.silverpeas.core.util.StringUtil;
+import org.silverpeas.core.util.Link;
 import org.silverpeas.core.util.URLUtil;
 import org.silverpeas.core.web.mvc.route.ComponentInstanceRoutingMapProvider;
 import org.silverpeas.core.web.mvc.route.ComponentInstanceRoutingMapProviderByInstance;
@@ -72,7 +73,7 @@ public abstract class AbstractResourceUserNotificationBuilder<T>
     performBuild(resource);
     performNotificationResource(resource);
     if (getAction() == NotifAction.DELETE) {
-      getNotificationMetaData().setLink(StringUtil.EMPTY);
+      getNotificationMetaData().setLink(Link.EMPTY_LINK);
     }
   }
 
@@ -90,9 +91,10 @@ public abstract class AbstractResourceUserNotificationBuilder<T>
   }
 
   protected NotificationResourceData initializeNotificationResourceData() {
+    final NotificationMetaData metaData = getNotificationMetaData();
     final NotificationResourceData notificationResourceData = new NotificationResourceData();
-    notificationResourceData.setComponentInstanceId(getNotificationMetaData().getComponentId());
-    notificationResourceData.setResourceUrl(getNotificationMetaData().getLink());
+    notificationResourceData.setComponentInstanceId(metaData.getComponentId());
+    notificationResourceData.setResourceUrl(metaData.getLink().getLinkUrl());
     if (resource instanceof SilverpeasContent) {
       fill(notificationResourceData, (SilverpeasContent) resource);
     } else if (resource instanceof Contribution) {

--- a/core-library/src/main/java/org/silverpeas/core/notification/user/client/DefaultNotificationManager.java
+++ b/core-library/src/main/java/org/silverpeas/core/notification/user/client/DefaultNotificationManager.java
@@ -73,6 +73,8 @@ import java.util.Properties;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.silverpeas.core.notification.user.client.NotificationParameterNames.*;
+
 /**
  * Title: Notification Manager Description: La fonction de ce manager est de décider en fonction de
  * règles pré-établies, de la destination des messages qu'il est chargé d'envoyer. La fonction
@@ -84,7 +86,7 @@ import java.util.stream.Stream;
  */
 @Transactional
 public class DefaultNotificationManager extends AbstractNotification
-    implements NotificationParameterNames, ComponentInstanceDeletion, NotificationManager {
+    implements ComponentInstanceDeletion, NotificationManager {
 
   private static final String FROM_UID = "I";
   private static final String FROM_EMAIL = "E";
@@ -770,9 +772,10 @@ public class DefaultNotificationManager extends AbstractNotification
     setSenderAddress(params, theMessage, theExtraParams, ncr, nd, senderName);
 
     // Set Url parameter
-    if (StringUtil.isDefined(params.getURL())) {
-      theExtraParams.put(URL, (params.getURL().startsWith("http") ? params.getURL() :
-          getUserAutoRedirectURL(aUserId, params.getURL())));
+    final String url = params.getLink().getLinkUrl();
+    if (StringUtil.isDefined(url)) {
+      theExtraParams.put(URL,
+          (url.startsWith("http") ? url : getUserAutoRedirectURL(aUserId, url)));
     }
 
     // Set Source parameter
@@ -831,9 +834,9 @@ public class DefaultNotificationManager extends AbstractNotification
 
     String senderName = getSenderName(params);
     setSenderEmail(params, theExtraParams, senderName);
-    if (StringUtil.isDefined(params.getURL())) {
-      theExtraParams.put(URL, params.getURL());
-      theExtraParams.put(LINKLABEL, params.getLinkLabel());
+    if (StringUtil.isDefined(params.getLink().getLinkUrl())) {
+      theExtraParams.put(URL, params.getLink().getLinkUrl());
+      theExtraParams.put(LINKLABEL, params.getLink().getLinkLabel());
     }
 
     // Set Source parameter
@@ -944,9 +947,16 @@ public class DefaultNotificationManager extends AbstractNotification
 
       // Set Url parameter
       theExtraParams.put(SERVERURL, getUserAutoRedirectSilverpeasServerURL(aUserId));
-      if (StringUtil.isDefined(params.getURL())) {
-        theExtraParams.put(URL, computeURL(aUserId, params.getURL()));
-        theExtraParams.put(LINKLABEL, params.getLinkLabel());
+      if (StringUtil.isDefined(params.getLink().getLinkUrl())) {
+        theExtraParams.put(URL, computeURL(aUserId, params.getLink().getLinkUrl()));
+        theExtraParams.put(LINKLABEL, params.getLink().getLinkLabel());
+      }
+
+      if (StringUtil.isDefined(params.getNotificationResourceData().getAttachmentTargetId())) {
+        theExtraParams.put(ATTACHMENT_TARGETID,
+            params.getNotificationResourceData().getAttachmentTargetId());
+        theExtraParams.put(COMPONENTID,
+            params.getNotificationResourceData().getComponentInstanceId());
       }
 
       // Set Source parameter
@@ -1036,11 +1046,5 @@ public class DefaultNotificationManager extends AbstractNotification
    */
   List<NotifChannel> getDefaultNotificationChannels() {
     return NotificationManagerSettings.getDefaultChannels();
-  }
-
-  @FunctionalInterface
-  private interface Callback {
-
-    void call() throws NotificationException;
   }
 }

--- a/core-library/src/main/java/org/silverpeas/core/notification/user/client/NotificationParameterNames.java
+++ b/core-library/src/main/java/org/silverpeas/core/notification/user/client/NotificationParameterNames.java
@@ -23,17 +23,23 @@
  */
 package org.silverpeas.core.notification.user.client;
 
-public interface NotificationParameterNames {
-  String SOURCE = "SOURCE";
-  String SERVERURL = "SERVERURL";
-  String URL = "URL";
-  String LINKLABEL = "LINKLABEL";
-  String FROM = "FROM";
-  String SUBJECT = "SUBJECT";
-  String SESSIONID = "SESSIONID";
-  String DATE = "DATE";
-  String LANGUAGE = "LANGUAGE";
-  String COMMUNICATION = "COMMUNICATION";
-  String ATTACHMENTID = "ATTACHMENTID";
-  String HIDESMTPHEADERFOOTER = "HIDESMTPHEADERFOOTER";
+public class NotificationParameterNames {
+  public static final String SOURCE = "SOURCE";
+  public static final String SERVERURL = "SERVERURL";
+  public static final String URL = "URL";
+  public static final String LINKLABEL = "LINKLABEL";
+  public static final String FROM = "FROM";
+  public static final String SUBJECT = "SUBJECT";
+  public static final String SESSIONID = "SESSIONID";
+  public static final String DATE = "DATE";
+  public static final String LANGUAGE = "LANGUAGE";
+  public static final String COMMUNICATION = "COMMUNICATION";
+  public static final String ATTACHMENTID = "ATTACHMENTID";
+  public static final String HIDESMTPHEADERFOOTER = "HIDESMTPHEADERFOOTER";
+  public static final String COMPONENTID = "COMPONENTID";
+  public static final String ATTACHMENT_TARGETID = "ATTACHMENT_TARGETID";
+
+  private NotificationParameterNames() {
+
+  }
 }

--- a/core-library/src/main/java/org/silverpeas/core/notification/user/client/NotificationSender.java
+++ b/core-library/src/main/java/org/silverpeas/core/notification/user/client/NotificationSender.java
@@ -173,7 +173,7 @@ public class NotificationSender implements java.io.Serializable {
       throws NotificationException {
     final NotificationParameters params = getNotificationParameters(addressId, metaData);
     params.setTitle(metaData.getTitle(language))
-        .setLinkLabel(metaData.getLinkLabel(language))
+        .setLink(metaData.getLink(language))
         .setMessage(metaData.getContent(language))
         .setLanguage(language);
     if (!userIds.isEmpty()) {
@@ -204,14 +204,12 @@ public class NotificationSender implements java.io.Serializable {
 
   private NotificationParameters getNotificationParameters(int aMediaType,
       NotificationMetaData metaData) {
-    NotificationParameters params = new NotificationParameters();
-
+    final NotificationParameters params = new NotificationParameters();
     params.setMessagePriority(metaData.getMessageType())
         .setDate(metaData.getDate())
         .setTitle(metaData.getTitle())
         .setMessage(metaData.getContent())
         .setSource(metaData.getSource())
-        .setURL(metaData.getLink())
         .setSessionId(metaData.getSessionId())
         .setOriginalExtraMessage(metaData.getOriginalExtraMessage())
         .setSendImmediately(metaData.isSendImmediately())

--- a/core-library/src/main/java/org/silverpeas/core/notification/user/client/model/SentNotificationInterfaceImpl.java
+++ b/core-library/src/main/java/org/silverpeas/core/notification/user/client/model/SentNotificationInterfaceImpl.java
@@ -59,8 +59,8 @@ public class SentNotificationInterfaceImpl implements SentNotificationInterface 
       SentNotificationDetail notif =
           new SentNotificationDetail(Integer.parseInt(metaData.getSender()), metaData.
           getMessageType(), metaData.getDate(), metaData.getTitle(language), metaData.getSource(),
-          metaData.getLink(), metaData.getSessionId(), metaData.getComponentId(), metaData.
-          getContent(language));
+              metaData.getLink().getLinkUrl(), metaData.getSessionId(), metaData.getComponentId(),
+              metaData.getContent(language));
       notif.setUsers(users);
       int id = SentNotificationDAO.saveNotifUser(con, notif);
       notif.setNotifId(id);

--- a/core-library/src/main/java/org/silverpeas/core/notification/user/delayed/delegate/DelayedNotificationDelegate.java
+++ b/core-library/src/main/java/org/silverpeas/core/notification/user/delayed/delegate/DelayedNotificationDelegate.java
@@ -24,6 +24,7 @@
 package org.silverpeas.core.notification.user.delayed.delegate;
 
 import org.apache.commons.lang3.StringUtils;
+import org.silverpeas.core.ResourceReference;
 import org.silverpeas.core.admin.service.AdminException;
 import org.silverpeas.core.admin.service.AdministrationServiceProvider;
 import org.silverpeas.core.admin.user.model.UserDetail;
@@ -42,6 +43,7 @@ import org.silverpeas.core.notification.user.model.NotificationResourceData;
 import org.silverpeas.core.notification.user.server.NotificationData;
 import org.silverpeas.core.notification.user.server.NotificationServer;
 import org.silverpeas.core.notification.user.server.NotificationServerException;
+import org.silverpeas.core.notification.user.AttachmentLink;
 import org.silverpeas.core.template.SilverpeasTemplate;
 import org.silverpeas.core.template.SilverpeasTemplateFactory;
 import org.silverpeas.core.util.CollectionUtil;
@@ -49,6 +51,7 @@ import org.silverpeas.core.util.DateUtil;
 import org.silverpeas.core.util.LocalizationBundle;
 import org.silverpeas.core.util.MapUtil;
 import org.silverpeas.core.util.ResourceLocator;
+import org.silverpeas.core.util.StringUtil;
 import org.silverpeas.core.util.WebEncodeHelper;
 import org.silverpeas.core.util.comparator.AbstractComplexComparator;
 
@@ -407,6 +410,15 @@ public class DelayedNotificationDelegate extends AbstractNotification {
       syntheseResource.setUrl(computeURL(synthese.getUserId(), syntheseResource.getUrl()));
     }
 
+    if (StringUtil.isDefined(resource.getAttachmentTargetId()) &&
+        StringUtil.isDefined(resource.getComponentInstanceId())) {
+      ResourceReference attachmentTarget = new ResourceReference(resource.getAttachmentTargetId(),
+          resource.getComponentInstanceId());
+      final List<AttachmentLink> attachmentLinks =
+          AttachmentLink.getForContribution(attachmentTarget, synthese.getLanguage());
+      syntheseResource.setAttachmentLinks(attachmentLinks);
+    }
+
     // Browsing notifications
     SyntheseResourceNotification syntheseNotification;
     boolean isPreviousHasMessage = false;
@@ -563,6 +575,7 @@ public class DelayedNotificationDelegate extends AbstractNotification {
     // Hide Header and Footer in SMTP message
     notificationData.getTargetParam().put(NotificationParameterNames.HIDESMTPHEADERFOOTER,
         true);
+
 
     // Set the message
     notificationData.setMessage(synthese.getMessage());

--- a/core-library/src/main/java/org/silverpeas/core/notification/user/delayed/synthese/SyntheseResource.java
+++ b/core-library/src/main/java/org/silverpeas/core/notification/user/delayed/synthese/SyntheseResource.java
@@ -23,7 +23,10 @@
  */
 package org.silverpeas.core.notification.user.delayed.synthese;
 
+import org.silverpeas.core.notification.user.AttachmentLink;
+
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -35,6 +38,7 @@ public class SyntheseResource {
   private String description;
   private String location;
   private String url;
+  private List<AttachmentLink> attachmentLinks = null;
   private final List<SyntheseResourceNotification> notifications = new ArrayList<>();
 
   public String getName() {
@@ -67,6 +71,14 @@ public class SyntheseResource {
 
   public void setUrl(final String url) {
     this.url = url;
+  }
+
+  public void setAttachmentLinks(final List<AttachmentLink> attachmentLinks) {
+    this.attachmentLinks = attachmentLinks;
+  }
+
+  public List<AttachmentLink> getAttachmentLinks() {
+    return this.attachmentLinks == null ? Collections.emptyList():this.attachmentLinks;
   }
 
   public List<SyntheseResourceNotification> getNotifications() {

--- a/core-library/src/test/java/org/silverpeas/core/notification/user/client/NotificationMetaDataTest.java
+++ b/core-library/src/test/java/org/silverpeas/core/notification/user/client/NotificationMetaDataTest.java
@@ -53,6 +53,8 @@ public class NotificationMetaDataTest {
 
   @RegisterExtension
   FieldMocker mocker = new FieldMocker();
+  @TestManagedMock
+  private NotificationManager notificationManager;
   private NotificationMetaData current;
   private SettingBundle mockedSettings;
 
@@ -82,9 +84,7 @@ public class NotificationMetaDataTest {
     });
 
     // Notification Manager
-    final NotificationManager mockedNotificationManager =
-        mocker.mockField(current, NotificationManager.class, "notificationManager");
-    when(mockedNotificationManager.getUsersFromGroup(anyString()))
+    when(notificationManager.getUsersFromGroup(anyString()))
         .thenAnswer((Answer<Collection<UserRecipient>>) invocation -> {
           String groupId = (String) invocation.getArguments()[0];
           return Arrays

--- a/core-war/src/main/java/org/silverpeas/web/notificationuser/control/UserNotificationSessionController.java
+++ b/core-war/src/main/java/org/silverpeas/web/notificationuser/control/UserNotificationSessionController.java
@@ -140,9 +140,12 @@ public class UserNotificationSessionController extends AbstractComponentSessionC
    */
   public void sendNotification(final NotificationContext context) {
     final UserNotificationWrapper userNotification = getUserNotification(context);
+    final String contributionId = context.containsKey(NotificationContext.PUBLICATION_ID) ?
+        context.get(NotificationContext.PUBLICATION_ID) :
+        context.get(NotificationContext.CONTRIBUTION_ID);
     userNotification.setTitle(context.get("title"))
         .setContent(context.get("content").replaceAll("[\\n\\r]", ""))
-        .setAttachmentLinks(context.get(NotificationContext.CONTRIBUTION_ID))
+        .setAttachmentLinksFor(contributionId)
         .setSender(getUserDetail())
         .setRecipientUsers(context.getAsList("recipientUsers"))
         .setRecipientGroups(context.getAsList("recipientGroups"))

--- a/core-war/src/main/java/org/silverpeas/web/notificationuser/control/UserNotificationSessionController.java
+++ b/core-war/src/main/java/org/silverpeas/web/notificationuser/control/UserNotificationSessionController.java
@@ -141,7 +141,8 @@ public class UserNotificationSessionController extends AbstractComponentSessionC
   public void sendNotification(final NotificationContext context) {
     final UserNotificationWrapper userNotification = getUserNotification(context);
     userNotification.setTitle(context.get("title"))
-        .setContent(context.get("content"))
+        .setContent(context.get("content").replaceAll("[\\n\\r]", ""))
+        .setAttachmentLinks(context.get(NotificationContext.CONTRIBUTION_ID))
         .setSender(getUserDetail())
         .setRecipientUsers(context.getAsList("recipientUsers"))
         .setRecipientGroups(context.getAsList("recipientGroups"))
@@ -151,7 +152,8 @@ public class UserNotificationSessionController extends AbstractComponentSessionC
   }
 
   private UserNotificationWrapper supplyUserNotification(final NotificationContext context) {
-    final String componentId = context.getOrDefault("componentId", getComponentRootName());
+    final String componentId =
+        context.getOrDefault(NotificationContext.COMPONENT_ID, getComponentRootName());
     final String componentName;
     if (!getComponentRootName().equals(componentId) &&
         !PersonalComponentInstance.from(componentId).isPresent()) {

--- a/core-war/src/main/java/org/silverpeas/web/notificationuser/control/UserNotificationWrapper.java
+++ b/core-war/src/main/java/org/silverpeas/web/notificationuser/control/UserNotificationWrapper.java
@@ -1,10 +1,7 @@
 package org.silverpeas.web.notificationuser.control;
 
 import org.owasp.encoder.Encode;
-import org.silverpeas.core.ResourceReference;
 import org.silverpeas.core.admin.user.model.User;
-import org.silverpeas.core.contribution.attachment.AttachmentService;
-import org.silverpeas.core.contribution.attachment.model.SimpleDocument;
 import org.silverpeas.core.notification.user.UserNotification;
 import org.silverpeas.core.notification.user.client.GroupRecipient;
 import org.silverpeas.core.notification.user.client.NotificationMetaData;
@@ -12,13 +9,11 @@ import org.silverpeas.core.notification.user.client.UserRecipient;
 import org.silverpeas.core.notification.user.client.constant.BuiltInNotifAddress;
 import org.silverpeas.core.template.SilverpeasTemplate;
 import org.silverpeas.core.ui.DisplayI18NHelper;
-import org.silverpeas.core.util.Link;
 import org.silverpeas.core.util.LocalizationBundle;
 import org.silverpeas.core.util.ResourceLocator;
 import org.silverpeas.core.util.StringUtil;
 
 import java.util.Collection;
-import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
@@ -88,17 +83,9 @@ public class UserNotificationWrapper implements UserNotification {
    * from which this notification was built.
    * @return itself.
    */
-  public UserNotificationWrapper setAttachmentLinks(final String contributionId) {
+  public UserNotificationWrapper setAttachmentLinksFor(final String contributionId) {
     if (StringUtil.isDefined(contributionId)) {
-      final AttachmentService attachmentService = AttachmentService.get();
-      final NotificationMetaData metaData = notification.getNotificationMetaData();
-      for (String lang : DisplayI18NHelper.getLanguages()) {
-        final ResourceReference ref =
-            new ResourceReference(contributionId, metaData.getComponentId());
-        final List<SimpleDocument> documents =
-            attachmentService.listDocumentsByForeignKey(ref, lang);
-        documents.forEach(d -> metaData.setLink(new Link(d.getAttachmentURL(), d.getTitle()), lang));
-      }
+      notification.getNotificationMetaData().setAttachmentTargetId(contributionId);
     }
     return this;
   }

--- a/core-war/src/main/java/org/silverpeas/web/notificationuser/servlets/UserNotificationRequestRouter.java
+++ b/core-war/src/main/java/org/silverpeas/web/notificationuser/servlets/UserNotificationRequestRouter.java
@@ -32,8 +32,10 @@ import org.silverpeas.core.web.mvc.controller.MainSessionController;
 import org.silverpeas.core.web.mvc.route.ComponentRequestRouter;
 import org.silverpeas.web.notificationuser.control.UserNotificationSessionController;
 
+import javax.servlet.annotation.WebServlet;
 import java.util.Enumeration;
 
+@WebServlet()
 public class UserNotificationRequestRouter
     extends ComponentRequestRouter<UserNotificationSessionController> {
 

--- a/core-war/src/main/java/org/silverpeas/web/notificationuser/servlets/UserNotificationRequestRouter.java
+++ b/core-war/src/main/java/org/silverpeas/web/notificationuser/servlets/UserNotificationRequestRouter.java
@@ -41,7 +41,6 @@ public class UserNotificationRequestRouter
 
   private static final long serialVersionUID = -5858231857279380747L;
   private static final String RECIPIENT_EDITION_PARAM = "recipientEdition";
-  private static final String COMPONENT_ID = "componentId";
   private static final String RECIPIENT_USERS = "recipientUsers";
   private static final String RECIPIENT_GROUPS = "recipientGroups";
   private static final String MESSAGE_TITLE = "title";
@@ -85,7 +84,6 @@ public class UserNotificationRequestRouter
           request.setAttribute(RECIPIENT_USERS, nuSC.getUsersFrom(recipientUsers));
           request.setAttribute(RECIPIENT_GROUPS, nuSC.getGroupsFrom(recipientGroups));
         }
-        final String instanceId = request.getParameter(COMPONENT_ID);
         final String param = request.getParameter(RECIPIENT_EDITION_PARAM);
         final boolean areRecipientsEditable;
         if (StringUtil.isDefined(param)) {
@@ -93,7 +91,8 @@ public class UserNotificationRequestRouter
         } else {
           areRecipientsEditable = true;
         }
-        request.setAttribute(COMPONENT_ID, instanceId);
+        request.setAttribute(NotificationContext.COMPONENT_ID,
+            context.get(NotificationContext.COMPONENT_ID));
         request.setAttribute(RECIPIENT_EDITION_PARAM, areRecipientsEditable);
         destination = "/userNotification/jsp/notificationSender.jsp";
       } else if (SENDING_FUNCTION.equals(function)) {

--- a/core-war/src/main/webapp/userNotification/jsp/notificationSender.jsp
+++ b/core-war/src/main/webapp/userNotification/jsp/notificationSender.jsp
@@ -49,11 +49,16 @@
 <c:set var="requiredReceiversErrorMessage"><fmt:message key="GML.thefield"/> <b><fmt:message key="addressees"/></b> <fmt:message key="GML.isRequired"/></c:set>
 <c:set var="requiredSubjectErrorMessage"><fmt:message key="GML.thefield"/> <b><fmt:message key="GML.notification.subject"/></b> <fmt:message key="GML.isRequired"/></c:set>
 <view:link href="/util/styleSheets/fieldset.css"/>
+<view:includePlugin name="wysiwyg"/>
 <view:loadScript src="/util/javaScript/checkForm.js"/>
 <script type="text/javascript">
   var userSelectApi;
 
   function onPageReady() {
+     <view:wysiwyg replace="content" language="${language}"
+                   toolbar="userNotification"
+                   activateWysiwygBackupManager="false"
+                   height="300"/>
     ${recipientsEditable ? 'userSelectApi.focus();' : 'document.querySelector("#notification-data-subject").focus();'}
   }
 
@@ -68,7 +73,7 @@
     }
     if (!SilverpeasError.show()) {
       var elements = ['#notification-data-manual', 'recipientUsers', 'recipientGroups',
-        '#notification-data-subject', '#notification-data-message'];
+        '#notification-data-subject'];
       for (var i = 0; i < elements.length; i++) {
         var $input;
         if (elements[i].indexOf('#') === 0) {
@@ -78,6 +83,7 @@
         }
         notification[$input.name] = $input.value;
       }
+      notification['content'] = CKEDITOR.instances['notification-data-message'].getData();
       return sp.messager.send(notification);
     }
     return false;

--- a/core-war/src/main/webapp/userNotification/jsp/notificationSender.jsp
+++ b/core-war/src/main/webapp/userNotification/jsp/notificationSender.jsp
@@ -44,6 +44,7 @@
 <c:set var="groups" value="${requestScope.recipientGroups}"/>
 <c:set var="recipientsEditable" value="${requestScope.recipientEdition}"/>
 <c:set var="componentId" value="${requestScope.componentId}"/>
+<c:set var="contributionId" value="${requestScope.contributionId}"/>
 <c:set var="subject" value="${requestScope.title}"/>
 
 <c:set var="requiredReceiversErrorMessage"><fmt:message key="GML.thefield"/> <b><fmt:message key="addressees"/></b> <fmt:message key="GML.isRequired"/></c:set>

--- a/core-war/src/main/webapp/util/javaScript/angularjs/controllers/calendar/silverpeas-calendar.js
+++ b/core-war/src/main/webapp/util/javaScript/angularjs/controllers/calendar/silverpeas-calendar.js
@@ -79,7 +79,7 @@
           };
 
           $scope.notifyEventOccurrence = function(occurrence) {
-            sp.messager.open(context.component, {eventId: occurrence.id});
+            sp.messager.open(context.component, {contributionId: occurrence.id});
           };
           $scope.gotToEventOccurrence = function(occurrence) {
             spWindow.loadPermalink(occurrence.occurrencePermalinkUrl);

--- a/core-war/src/main/webapp/util/javaScript/angularjs/controllers/calendar/silverpeas-calendar.js
+++ b/core-war/src/main/webapp/util/javaScript/angularjs/controllers/calendar/silverpeas-calendar.js
@@ -79,7 +79,8 @@
           };
 
           $scope.notifyEventOccurrence = function(occurrence) {
-            sp.messager.open(context.component, {contributionId: occurrence.id});
+            sp.messager.open(context.component, {contributionId: occurrence.id,
+              publicationId: occurrence.eventId});
           };
           $scope.gotToEventOccurrence = function(occurrence) {
             spWindow.loadPermalink(occurrence.occurrencePermalinkUrl);

--- a/core-war/src/main/webapp/util/javaScript/silverpeas-messager.js
+++ b/core-war/src/main/webapp/util/javaScript/silverpeas-messager.js
@@ -41,6 +41,7 @@
        * Opens the messager window to write a message. The window's content is provided by the
        * userNotification/jsp/notificationSender.jsp JSP. Parameters can be passed to customize the
        * message to send. Among the parameters, some of them are predefined:
+       * - contributionId: the unique identifier of a contribution for which the messager is opened.
        * - recipientUsers: a preselected coma-separated list of the recipient user's identifiers
        * - recipientGroups: a preselected coma-separated list of the recipient group's identifiers
        * - recipientEdition: a boolean indicated if the recipient(s) of the message can be selected
@@ -91,6 +92,8 @@
        * Sends the message described by the specified notification descriptor. The descriptor is an
        * object with at least the following attributes:
        * - 'componentId' with the unique identifier of a component instance. Can be not set.
+       * - 'contributionId' with the unique identifier of a contribution. If set, then any
+       * attachments are searching in order to referring them automatically in the message.
        * - 'recipientUsers' with a comma-separated list of recipient user's identifiers,
        * - 'recipientGroups' with a comma-separated list of recipient group's identifiers.
        * - 'manual' with a boolean indicating if the message is set explicitly by a user (true) or

--- a/core-war/src/main/webapp/wysiwyg/jsp/ckeditor/silverconfig.js
+++ b/core-war/src/main/webapp/wysiwyg/jsp/ckeditor/silverconfig.js
@@ -52,10 +52,8 @@ CKEDITOR.editorConfig = function( config )
   ];
 
   config.toolbar_Basic = [
-    { name: 'clipboard',   items : [ 'Cut','Copy','Paste','PasteText','-','Undo','Redo' ] },
-    { name: 'basicstyles', items : [ 'Bold','Italic','Underline','Strike','Subscript','Superscript','-','RemoveFormat' ] },
-    { name: 'paragraph',   items : [ 'NumberedList','BulletedList','-','Outdent','Indent','-','Blockquote','CreateDiv','-','JustifyLeft','JustifyCenter','JustifyRight','JustifyBlock' ] },
-    { name: 'colors',      items : [ 'TextColor','BGColor' ] }
+    { name: 'basicstyles', items : [ 'Bold','Italic','Underline','Strike','-','RemoveFormat' ] },
+    { name: 'paragraph',   items : [ 'NumberedList','BulletedList','-','Outdent','Indent' ] }
   ];
 
   config.toolbar_calendar = config.toolbar_Default;

--- a/core-war/src/main/webapp/wysiwyg/jsp/ckeditor/silverconfig.js
+++ b/core-war/src/main/webapp/wysiwyg/jsp/ckeditor/silverconfig.js
@@ -51,6 +51,13 @@ CKEDITOR.editorConfig = function( config )
     { name: 'styles',      items : [ 'Styles','Format','Font','FontSize' ] }
   ];
 
+  config.toolbar_Basic = [
+    { name: 'clipboard',   items : [ 'Cut','Copy','Paste','PasteText','-','Undo','Redo' ] },
+    { name: 'basicstyles', items : [ 'Bold','Italic','Underline','Strike','Subscript','Superscript','-','RemoveFormat' ] },
+    { name: 'paragraph',   items : [ 'NumberedList','BulletedList','-','Outdent','Indent','-','Blockquote','CreateDiv','-','JustifyLeft','JustifyCenter','JustifyRight','JustifyBlock' ] },
+    { name: 'colors',      items : [ 'TextColor','BGColor' ] }
+  ];
+
   config.toolbar_calendar = config.toolbar_Default;
   config.toolbar_forum = config.toolbar_Light;
   config.toolbar_blog = config.toolbar_Default;
@@ -59,5 +66,6 @@ CKEDITOR.editorConfig = function( config )
   config.toolbar_XMLForm = config.toolbar_Default;
   config.toolbar_questionReply = config.toolbar_Light;
   config.toolbar_suggestionBox = config.toolbar_Light;
+  config.toolbar_userNotification = config.toolbar_Basic;
 
 };

--- a/core-web/src/main/java/org/silverpeas/core/web/calendar/AbstractCalendarWebController.java
+++ b/core-web/src/main/java/org/silverpeas/core/web/calendar/AbstractCalendarWebController.java
@@ -30,6 +30,7 @@ import org.silverpeas.core.admin.user.model.UserDetail;
 import org.silverpeas.core.calendar.CalendarEventOccurrence;
 import org.silverpeas.core.calendar.notification.user.CalendarEventOccurrenceNotifyUserNotificationBuilder;
 import org.silverpeas.core.notification.user.ManualUserNotificationSupplier;
+import org.silverpeas.core.notification.user.NotificationContext;
 import org.silverpeas.core.util.Pair;
 import org.silverpeas.core.util.ResourceLocator;
 import org.silverpeas.core.util.StringUtil;
@@ -118,7 +119,7 @@ public abstract class AbstractCalendarWebController<C extends AbstractCalendarWe
   @Override
   public ManualUserNotificationSupplier getManualUserNotificationSupplier() {
     return c -> {
-      final String occurrenceId = c.get("eventId");
+      final String occurrenceId = c.get(NotificationContext.CONTRIBUTION_ID);
       final CalendarEventOccurrence occurrence =
           AbstractCalendarWebRequestContext.getCalendarEventOccurrence(occurrenceId);
       return new CalendarEventOccurrenceNotifyUserNotificationBuilder(occurrence,

--- a/core-web/src/main/java/org/silverpeas/core/web/mvc/webcomponent/WebComponentController.java
+++ b/core-web/src/main/java/org/silverpeas/core/web/mvc/webcomponent/WebComponentController.java
@@ -23,13 +23,9 @@
  */
 package org.silverpeas.core.web.mvc.webcomponent;
 
-import org.silverpeas.core.notification.user.UserNotification;
 import org.silverpeas.core.web.mvc.controller.AbstractComponentSessionController;
 import org.silverpeas.core.web.mvc.controller.ComponentContext;
 import org.silverpeas.core.web.mvc.controller.MainSessionController;
-
-import java.util.Map;
-import java.util.function.Function;
 
 /**
  * Base class for all web component controller.
@@ -42,16 +38,6 @@ public abstract class WebComponentController<T extends WebComponentRequestContex
     extends AbstractComponentSessionController {
 
   boolean onCreationCalled = false;
-
-  /**
-   * This static method has to be implemented by each web component controller concrete class if
-   * the corresponding Silverpeas component supports the manual notification.
-   * @return a provider of {@link UserNotification} objects for manual notification. By default,
-   * returns null.
-   */
-  public static Function<Map<String, String>, UserNotification> getManualUserNotificationProvider() {
-    return null;
-  }
 
   public WebComponentController(final MainSessionController controller, final String spaceId,
       final String componentId) {

--- a/core-web/src/main/java/org/silverpeas/core/webapi/publication/PublicationResource.java
+++ b/core-web/src/main/java/org/silverpeas/core/webapi/publication/PublicationResource.java
@@ -24,7 +24,7 @@
 package org.silverpeas.core.webapi.publication;
 
 import org.silverpeas.core.contribution.publication.model.CompletePublication;
-import org.silverpeas.core.contribution.publication.model.Link;
+import org.silverpeas.core.contribution.publication.model.PublicationLink;
 import org.silverpeas.core.contribution.publication.model.PublicationPK;
 import org.silverpeas.core.security.authorization.AccessControlContext;
 import org.silverpeas.core.security.authorization.AccessControlOperation;
@@ -107,8 +107,8 @@ public class PublicationResource extends AbstractPublicationResource {
       throw new WebApplicationException(Response.Status.FORBIDDEN);
     }
 
-    List<Link> links = publication.getLinkList();
-    for (Link link : links) {
+    List<PublicationLink> links = publication.getLinkList();
+    for (PublicationLink link : links) {
       if (link.getId().equals(linkId)) {
         getPublicationService().deleteLink(linkId);
         return Response.ok().build();


### PR DESCRIPTION
Now the user manual notification has the following improvements:

- the notification window text area is replaced by a WYSIWYG editor to write a more rich text for notification message.
- for manual notifications on a contribution that have attachments, a link to each of the documents attached to the contribution in Silverpeas is automatically added in the notification message when such notifications are sent through SMTP. This concerns both the immediate and the delayed transmission.

Don't forget to merge the PR https://github.com/Silverpeas/Silverpeas-Components/pull/629 after this one
 