### PR TITLE
Fix bug #10358

### DIFF
--- a/core-library/src/integration-test/java/org/silverpeas/core/process/management/interceptor/DefaultEjbService.java
+++ b/core-library/src/integration-test/java/org/silverpeas/core/process/management/interceptor/DefaultEjbService.java
@@ -30,6 +30,7 @@ import org.silverpeas.core.ActionType;
 import org.silverpeas.core.util.annotation.Action;
 import org.silverpeas.core.util.annotation.SourceObject;
 import org.silverpeas.core.util.annotation.TargetPK;
+import org.silverpeas.core.util.logging.SilverLogger;
 
 import javax.ejb.Stateless;
 import javax.transaction.Transactional;
@@ -61,13 +62,13 @@ public class DefaultEjbService implements EjbService {
   @Override
   public void delete(@SourceObject final InterceptorTestFile file,
       @TargetPK final ResourceReference destination) {
-    SilverTrace.info("InterceptorTest", "DefaultEjbService", "delete called");
+    SilverLogger.getLogger(this).info("InterceptorTest", "DefaultEjbService", "delete called");
   }
 
   @SimulationActionProcess(elementLister = InterceptorTestFileElementLister.class)
   @Action(ActionType.MOVE)
   @Override
   public void move(final ResourceReference from, @TargetPK final ResourceReference destination) {
-    SilverTrace.info("InterceptorTest", "DefaultEjbService", "move called");
+    SilverLogger.getLogger(this).info("InterceptorTest", "DefaultEjbService", "move called");
   }
 }

--- a/core-library/src/integration-test/java/org/silverpeas/core/process/management/interceptor/DefaultSimpleService.java
+++ b/core-library/src/integration-test/java/org/silverpeas/core/process/management/interceptor/DefaultSimpleService.java
@@ -23,13 +23,13 @@
  */
 package org.silverpeas.core.process.management.interceptor;
 
-import org.silverpeas.core.ResourceReference;
-import org.silverpeas.core.silvertrace.SilverTrace;
-import org.silverpeas.core.process.annotation.SimulationActionProcess;
 import org.silverpeas.core.ActionType;
+import org.silverpeas.core.ResourceReference;
+import org.silverpeas.core.process.annotation.SimulationActionProcess;
 import org.silverpeas.core.util.annotation.Action;
 import org.silverpeas.core.util.annotation.SourceObject;
 import org.silverpeas.core.util.annotation.TargetPK;
+import org.silverpeas.core.util.logging.SilverLogger;
 
 import javax.inject.Singleton;
 
@@ -44,7 +44,7 @@ public class DefaultSimpleService implements SimpleService {
   @Override
   public InterceptorTestFile create(@SourceObject final InterceptorTestFile file,
       @TargetPK final ResourceReference destination) {
-    SilverTrace.info("InterceptorTest", "DefaultSimpleService", "create called");
+    SilverLogger.getLogger(this).info("DefaultSimpleService", "create called");
     return null;
   }
 
@@ -52,13 +52,13 @@ public class DefaultSimpleService implements SimpleService {
   @Action(ActionType.DELETE)
   @Override
   public void delete(@SourceObject final InterceptorTestFile file, final ResourceReference destination) {
-    SilverTrace.info("InterceptorTest", "DefaultSimpleService", "delete called");
+    SilverLogger.getLogger(this).info("DefaultSimpleService", "delete called");
   }
 
   @SimulationActionProcess(elementLister = InterceptorTestFileElementLister.class)
   @Action(ActionType.MOVE)
   @Override
   public void move(final ResourceReference from, final ResourceReference destination) {
-    SilverTrace.info("InterceptorTest", "DefaultSimpleService", "move called");
+    SilverLogger.getLogger(this).info("DefaultSimpleService", "move called");
   }
 }

--- a/core-library/src/integration-test/resources/org/silverpeas/util/logging/processLogging.properties
+++ b/core-library/src/integration-test/resources/org/silverpeas/util/logging/processLogging.properties
@@ -1,0 +1,37 @@
+#
+# Copyright (C) 2000 - 2018 Silverpeas
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# As a special exception to the terms and conditions of version 3.0 of
+# the GPL, you may redistribute this Program in connection with Free/Libre
+# Open Source Software ("FLOSS") applications as described in Silverpeas's
+# FLOSS exception.  You should have received a copy of the text describing
+# the FLOSS exception, and it is also available here:
+# "http://www.silverpeas.org/legal/licensing"
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+#
+# Logger definition.
+# Each logger is defined by its unique namespace and by a logging level.
+#
+# - namespace: identifies uniquely a logger and represents the hierarchical category to which
+#              messages are logged with the logger. Each substring before a dot is the namespace
+#              of a parent logger.
+# - level: defines the minimum level at which will be accepted the logged messages. If not
+#          set, the first defined parent logger's level will be then taken into account. Possible
+#          value is: ERROR, WARNING, INFO, DEBUG
+#
+namespace=process
+level=INFO

--- a/core-library/src/main/java/org/silverpeas/core/node/service/DefaultNodeService.java
+++ b/core-library/src/main/java/org/silverpeas/core/node/service/DefaultNodeService.java
@@ -116,14 +116,7 @@ public class DefaultNodeService implements NodeService, ComponentInstanceDeletio
   public NodeDetail getDetailByNameAndFatherId(NodePK pk, String name, int nodeFatherId) {
     Connection con = getConnection();
     try {
-      NodeDetail nodeDetail = nodeDAO.selectByNameAndFatherId(con, pk, name, nodeFatherId);
-      if (nodeDetail != null) {
-        return nodeDetail;
-      } else {
-        throw new NodeRuntimeException(
-            "Node not found nodeId = " + pk.getId() + ",name=" + name + "nodeFatherId=" +
-                nodeFatherId);
-      }
+      return nodeDAO.selectByNameAndFatherId(con, pk, name, nodeFatherId);
     } catch (SQLException e) {
       throw new NodeRuntimeException(e);
     } finally {

--- a/core-library/src/main/java/org/silverpeas/core/process/annotation/SimulationActionProcessAnnotationInterceptor.java
+++ b/core-library/src/main/java/org/silverpeas/core/process/annotation/SimulationActionProcessAnnotationInterceptor.java
@@ -23,18 +23,19 @@
  */
 package org.silverpeas.core.process.annotation;
 
+import org.jetbrains.annotations.NotNull;
 import org.silverpeas.core.ActionType;
 import org.silverpeas.core.WAPrimaryKey;
 import org.silverpeas.core.cache.service.CacheServiceProvider;
 import org.silverpeas.core.process.ProcessProvider;
 import org.silverpeas.core.process.management.ProcessExecutionContext;
-import org.silverpeas.core.silvertrace.SilverTrace;
 import org.silverpeas.core.util.annotation.Action;
 import org.silverpeas.core.util.annotation.AnnotationUtil;
 import org.silverpeas.core.util.annotation.Language;
 import org.silverpeas.core.util.annotation.SourceObject;
 import org.silverpeas.core.util.annotation.SourcePK;
 import org.silverpeas.core.util.annotation.TargetPK;
+import org.silverpeas.core.util.logging.SilverLogger;
 
 import javax.annotation.Priority;
 import javax.interceptor.AroundInvoke;
@@ -76,48 +77,29 @@ public class SimulationActionProcessAnnotationInterceptor {
 
   @SuppressWarnings({"unchecked", "SuspiciousMethodCalls"})
   protected Object perform(InvocationContext context,
-      Map<Class<Annotation>, Annotation> methodAnnotations,
-      Map<Class<Annotation>, List<Object>> annotatedParametersValues) throws Exception {
+      Map<Class<Annotation>, Annotation> methodAnnotations, Map<Class<Annotation>, List<Object>> annotatedParametersValues) throws Exception {
 
     // Simulation is processed only if no simulation is already working
-    if (CacheServiceProvider.getRequestCacheService()
-        .getCache()
-        .get(SIMULATION_PROCESS_PERFORMED) == null) {
+    if (CacheServiceProvider.getRequestCacheService().getCache().get(SIMULATION_PROCESS_PERFORMED) == null) {
       try {
 
         // Master annotation
-        SimulationActionProcess simulationActionProcess =
-            (SimulationActionProcess) methodAnnotations.get(SimulationActionProcess.class);
-
-        // Technical assertion
-        if (simulationActionProcess == null) {
-          // This verification is not a stupid one. Indeed, the interceptor can be specified
-          // directly via EJB @Interceptors annotation and it can be forgotten to specify the
-          // required {@link SimulationActionProcess} annotation.
-          throw new AssertionError(
-              "simulationActionProcess is null (SimulationActionProcess annotation must" +
-                  " be specified on the method)");
-        }
+        final SimulationActionProcess simulationActionProcess =
+            getSimulationActionProcess(methodAnnotations);
 
         // Action
-        Action actionType = (Action) methodAnnotations.get(Action.class);
-
-        // Technical assertion
-        if (actionType == null) {
-          throw new AssertionError(
-              "actionType is null (Action annotation must be specified on the method)");
-        }
+        final Action actionType = getAction(methodAnnotations);
 
         // Retrieving aimed parameter values
-        List<Object> languages =
+        final List<Object> languages =
             AnnotationUtil.getAnnotatedValues(annotatedParametersValues, Language.class);
         String language = languages.isEmpty() ? null : (String) languages.get(0);
-        List<WAPrimaryKey> sourcePKs =
+        final List<WAPrimaryKey> sourcePKs =
             (List) AnnotationUtil.getAnnotatedValues(annotatedParametersValues, SourcePK.class);
-        List<WAPrimaryKey> targetPKs =
+        final List<WAPrimaryKey> targetPKs =
             (List) AnnotationUtil.getAnnotatedValues(annotatedParametersValues, TargetPK.class);
-        List<Object> sourceObjects =
-            (List) AnnotationUtil.getAnnotatedValues(annotatedParametersValues, SourceObject.class);
+        final List<Object> sourceObjects =
+            AnnotationUtil.getAnnotatedValues(annotatedParametersValues, SourceObject.class);
 
         // Performing verify if necessary
         if ((!sourcePKs.isEmpty() || !sourceObjects.isEmpty()) && !targetPKs.isEmpty()) {
@@ -129,24 +111,22 @@ public class SimulationActionProcessAnnotationInterceptor {
           for (WAPrimaryKey targetPK : targetPKs) {
 
             // Element lister
-            SimulationElementLister elementLister =
-                simulationActionProcess.elementLister().newInstance();
+            SimulationElementLister elementLister = simulationActionProcess.elementLister().newInstance();
             elementLister.setActionType(actionType.value());
             elementLister.setElements(elements);
 
             // Browsing sourcePKs
-            sourcePKs.stream().filter(sourcePK -> ActionType.MOVE != actionType.value() ||
-                !sourcePK.getInstanceId().equals(targetPK.getInstanceId()))
+            sourcePKs.stream()
+                .filter(sourcePK -> ActionType.MOVE != actionType.value() ||
+                    !sourcePK.getInstanceId().equals(targetPK.getInstanceId()))
                 .forEach(sourcePK -> elementLister.listElements(sourcePK, language));
 
             // Browsing sourceObjects
-            for (Object sourceObject : sourceObjects) {
-              elementLister.listElements(sourceObject, language, targetPK);
-            }
+            sourceObjects.forEach(
+                sourceObject -> elementLister.listElements(sourceObject, language, targetPK));
 
             ProcessProvider.getProcessManagement().execute(
-                new SimulationElementConversionProcess(elements, targetPK, actionType.value()),
-                new ProcessExecutionContext(targetPK.getInstanceId()));
+                new SimulationElementConversionProcess(elements, targetPK, actionType.value()), new ProcessExecutionContext(targetPK.getInstanceId()));
           }
 
           // Indicating that a functional check has been performed
@@ -154,31 +134,60 @@ public class SimulationActionProcessAnnotationInterceptor {
               .getCache()
               .put(SIMULATION_PROCESS_PERFORMED, true);
         } else {
-          SilverTrace.warn("Process", "SimulationActionProcessAnnotationInterceptor.intercept()",
-              "intercepted method '" + context.getMethod().getName() +
-                  "', but SourcePK, SourceObject or TargetPK annotations are missing on parameter" +
-                  " specifications...");
+          SilverLogger.getLogger(this)
+              .warn(
+                  "Intercepted method ''{0}'', but SourcePK, SourceObject or TargetPK annotations " +
+                      "are missing on parameter specifications...",
+                  context.getMethod().getName());
         }
 
         // Invoking finally the proxy method initially called
         return proceed(context);
 
       } catch (Exception e) {
-        SilverTrace.error("Process", "SimulationActionProcessAnnotationInterceptor.intercept()",
-            "process.EXCEPTION_FROM_ACTION_PROCESS_SERVICE", e);
+        SilverLogger.getLogger(this)
+            .error("Error in intercepted method: " + context.getMethod().getName(), e);
         throw e;
       } finally {
 
         // Removing the flag indicating that a functional check has been performed (out of the
         // service)
-        CacheServiceProvider.getRequestCacheService()
-            .getCache()
-            .remove(SIMULATION_PROCESS_PERFORMED);
+        CacheServiceProvider.getRequestCacheService().getCache().remove(SIMULATION_PROCESS_PERFORMED);
       }
     }
 
     // Invoking finally the proxy method initially called
     return proceed(context);
+  }
+
+  @NotNull
+  private Action getAction(final Map<Class<Annotation>, Annotation> methodAnnotations) {
+    Action actionType = (Action) methodAnnotations.get(Action.class);
+
+    // Technical assertion
+    if (actionType == null) {
+      throw new AssertionError(
+          "actionType is null (Action annotation must be specified on the method)");
+    }
+    return actionType;
+  }
+
+  @NotNull
+  private SimulationActionProcess getSimulationActionProcess(
+      final Map<Class<Annotation>, Annotation> methodAnnotations) {
+    SimulationActionProcess simulationActionProcess =
+        (SimulationActionProcess) methodAnnotations.get(SimulationActionProcess.class);
+
+    // Technical assertion
+    if (simulationActionProcess == null) {
+      // This verification is not a stupid one. Indeed, the interceptor can be specified
+      // directly via EJB @Interceptors annotation and it can be forgotten to specify the
+      // required {@link SimulationActionProcess} annotation.
+      throw new AssertionError(
+          "simulationActionProcess is null (SimulationActionProcess annotation must" +
+              " be specified on the method)");
+    }
+    return simulationActionProcess;
   }
 
   protected Object proceed(final InvocationContext context) throws Exception {

--- a/core-services/importExport/src/main/java/org/silverpeas/core/importexport/control/GEDImportExport.java
+++ b/core-services/importExport/src/main/java/org/silverpeas/core/importexport/control/GEDImportExport.java
@@ -616,13 +616,8 @@ public abstract class GEDImportExport extends ComponentImportExport {
         NodePK nodePK = new NodePK("unknown", componentId);
         String parentId = NodePK.ROOT_NODE_ID;
         for (String name : path) {
-          NodeDetail existingNode = null;
-          try {
-            existingNode = getNodeService()
+          NodeDetail existingNode = getNodeService()
                 .getDetailByNameAndFatherId(nodePK, name, Integer.parseInt(parentId));
-          } catch (Exception e) {
-            SilverLogger.getLogger(this).warn(e);
-          }
           if (existingNode != null) {
             // topic exists
             parentId = existingNode.getNodePK().getId();

--- a/core-services/workflow/src/main/java/org/silverpeas/core/workflow/engine/WorkflowTools.java
+++ b/core-services/workflow/src/main/java/org/silverpeas/core/workflow/engine/WorkflowTools.java
@@ -2,6 +2,7 @@ package org.silverpeas.core.workflow.engine;
 
 import org.silverpeas.core.contribution.content.form.Field;
 import org.silverpeas.core.contribution.content.form.FormException;
+import org.silverpeas.core.persistence.datasource.OperationContext;
 import org.silverpeas.core.util.ServiceProvider;
 import org.silverpeas.core.util.logging.SilverLogger;
 import org.silverpeas.core.workflow.api.TaskManager;
@@ -31,6 +32,8 @@ import java.util.List;
  * too long period
  */
 class WorkflowTools {
+
+  private static final String ADMIN_ID = "0";
 
   private WorkflowTools() {
   }
@@ -237,6 +240,7 @@ class WorkflowTools {
         Trigger trigger = triggers.next();
         if (trigger != null) {
           try {
+            setUpOperationContext(event);
             ExternalAction externalAction = ServiceProvider.getService(trigger.getHandler());
             externalAction.setProcessInstance(instance);
             externalAction.setEvent(event);
@@ -250,6 +254,15 @@ class WorkflowTools {
         }
       }
     }
+  }
+
+  private static void setUpOperationContext(final GenericEvent event) {
+    String currentUserId = ADMIN_ID;
+    // For a manual action (event)
+    if (event.getUser() != null) {
+      currentUserId = event.getUser().getUserId();
+    }
+    OperationContext.fromUser(org.silverpeas.core.admin.user.model.User.getById(currentUserId));
   }
 
   /**


### PR DESCRIPTION
In SendInKmelia: the creation of the node(s) into which the publication will
be put are now performed into a new transaction so that if the creation fails
it doesn't rollback all the process and once the creation is done, the nodes
are accessed out of the transaction further in the task execution.

Don't forget to merge after https://github.com/Silverpeas/Silverpeas-Components/pull/635