### PR TITLE
Bug #10513: Adding API in order to enhance the management of HTML content (WYSIWYG) for mail sending. Each image provider can now apply their own rules about image resizing or about supplying of image file content.

### DIFF
--- a/core-library/src/main/java/org/silverpeas/core/contribution/attachment/SimpleDocumentUrlAccordingToHtmlSizeDirectiveTranslator.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/attachment/SimpleDocumentUrlAccordingToHtmlSizeDirectiveTranslator.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2000 - 2019 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.contribution.attachment;
+
+import org.silverpeas.core.contribution.content.wysiwyg.service.directive.ImageUrlAccordingToHtmlSizeDirective;
+
+import javax.inject.Singleton;
+
+import static org.silverpeas.core.util.StringUtil.defaultStringIfNotDefined;
+
+/**
+ * @author silveryocha
+ */
+@Singleton
+public class SimpleDocumentUrlAccordingToHtmlSizeDirectiveTranslator
+    implements ImageUrlAccordingToHtmlSizeDirective.SrcTranslator {
+
+  @Override
+  public boolean isCompliantUrl(final String url) {
+    return defaultStringIfNotDefined(url).contains("/attachmentId/");
+  }
+
+  @Override
+  public String translateUrl(final String url, final String width, final String height) {
+    // Computing the new src URL
+    // at first, removing the size from the URL
+    String  newUrl = url.replaceFirst("(?i)/size/[0-9 x]+", "");
+    // then guessing the new src URL
+    StringBuilder sizeUrlPart = new StringBuilder().append(width).append("x").append(height);
+    if (sizeUrlPart.length() > 1) {
+      sizeUrlPart.insert(0, "/size/");
+      newUrl = newUrl.replaceFirst("/name/", sizeUrlPart + "/name/");
+    }
+    return newUrl;
+  }
+}

--- a/core-library/src/main/java/org/silverpeas/core/contribution/attachment/SimpleDocumentUrlToDataSourceScanner.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/attachment/SimpleDocumentUrlToDataSourceScanner.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2000 - 2019 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.contribution.attachment;
+
+import org.silverpeas.core.contribution.content.LinkUrlDataSource;
+import org.silverpeas.core.contribution.content.LinkUrlDataSourceScanner;
+import org.silverpeas.core.io.file.SilverpeasFile;
+import org.silverpeas.core.io.file.SilverpeasFileProvider;
+
+import javax.activation.FileDataSource;
+import javax.inject.Singleton;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import static org.silverpeas.core.util.StringDataExtractor.RegexpPatternDirective.regexps;
+import static org.silverpeas.core.util.StringDataExtractor.from;
+
+/**
+ * @author silveryocha
+ */
+@Singleton
+public class SimpleDocumentUrlToDataSourceScanner implements LinkUrlDataSourceScanner {
+
+  private static final List<Pattern> ATTACHMENT_LINK_PATTERNS = Arrays
+      .asList(Pattern.compile("(?i)=\"([^\"]*/attachmentId/[a-z\\-0-9]+/[^\"]+)"),
+          Pattern.compile("(?i)=\"([^\"]*/File/[a-z\\-0-9]+[^\"]*)"));
+
+  @Override
+  public List<LinkUrlDataSource> scanHtml(final String htmlContent) {
+    final List<LinkUrlDataSource> result = new ArrayList<>();
+    from(htmlContent).withDirectives(regexps(ATTACHMENT_LINK_PATTERNS, 1)).extract().forEach(l -> {
+      final SilverpeasFile attachmentFile = SilverpeasFileProvider.getFile(l);
+      if (attachmentFile.exists()) {
+        result.add(new LinkUrlDataSource(l, () -> new FileDataSource(attachmentFile)));
+      }
+    });
+    return result;
+  }
+}

--- a/core-library/src/main/java/org/silverpeas/core/contribution/content/LinkUrlDataSource.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/content/LinkUrlDataSource.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2000 - 2019 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.contribution.content;
+
+import org.silverpeas.core.util.MemoizedSupplier;
+
+import javax.activation.DataSource;
+import java.util.Objects;
+import java.util.function.Supplier;
+
+/**
+ * @author silveryocha
+ */
+public class LinkUrlDataSource {
+  private final String linkUrl;
+  private final Supplier<DataSource> dataSource;
+
+  public LinkUrlDataSource(final String linkUrl, final Supplier<DataSource> dataSource) {
+    this.linkUrl = linkUrl;
+    this.dataSource = dataSource instanceof MemoizedSupplier
+        ? dataSource
+        : new MemoizedSupplier<>(dataSource);
+  }
+
+  /**
+   * Gets the link url.
+   * @return a string.
+   */
+  public String getLinkUrl() {
+    return linkUrl;
+  }
+
+  /**
+   * Gets the related datasource of link url.
+   * @return the initialized {@link DataSource} instance.
+   */
+  public DataSource getDataSource() {
+    return dataSource.get();
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final LinkUrlDataSource that = (LinkUrlDataSource) o;
+    return Objects.equals(linkUrl, that.linkUrl);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(linkUrl);
+  }
+}

--- a/core-library/src/main/java/org/silverpeas/core/contribution/content/LinkUrlDataSourceScanner.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/content/LinkUrlDataSourceScanner.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2000 - 2019 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.contribution.content;
+
+import org.silverpeas.core.util.ServiceProvider;
+import org.silverpeas.core.util.StringDataExtractor.RegexpPatternDirective;
+
+import javax.activation.DataSource;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * An implementation of this interface provides a list of {@link RegexpPatternDirective} to extract
+ * link urls from an html content represented as a {@link String} and it provides also the
+ * {@link DataSource} initialization according to an extracted link.
+ * @author silveryocha
+ */
+public interface LinkUrlDataSourceScanner {
+
+  static List<LinkUrlDataSourceScanner> getAll() {
+    final List<LinkUrlDataSourceScanner> asList = ServiceProvider.getAllServices(LinkUrlDataSourceScanner.class)
+        .stream()
+        .sorted(Comparator.comparing(o -> o.getClass().getSimpleName()))
+        .collect(Collectors.toList());
+    return Collections.unmodifiableList(asList);
+  }
+
+  /**
+   * Scans the given html content to extract the link url and provide related {@link DataSource}.
+   * @param htmlContent the HTML content to scan.
+   * @return list of {@link LinkUrlDataSource}.
+   */
+  List<LinkUrlDataSource> scanHtml(final String htmlContent);
+}

--- a/core-library/src/test/java/org/silverpeas/core/contribution/content/wysiwyg/service/WysiwygContentTransformerTest.java
+++ b/core-library/src/test/java/org/silverpeas/core/contribution/content/wysiwyg/service/WysiwygContentTransformerTest.java
@@ -29,30 +29,44 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.silverpeas.core.contribution.attachment.AttachmentService;
+import org.silverpeas.core.contribution.attachment.SimpleDocumentUrlAccordingToHtmlSizeDirectiveTranslator;
+import org.silverpeas.core.contribution.attachment.SimpleDocumentUrlToDataSourceScanner;
 import org.silverpeas.core.contribution.attachment.model.SimpleDocument;
 import org.silverpeas.core.contribution.attachment.model.SimpleDocumentPK;
+import org.silverpeas.core.contribution.content.LinkUrlDataSource;
+import org.silverpeas.core.contribution.content.LinkUrlDataSourceScanner;
+import org.silverpeas.core.contribution.content.wysiwyg.service.directive.ImageUrlAccordingToHtmlSizeDirective;
 import org.silverpeas.core.contribution.content.wysiwyg.service.process.MailContentProcess;
 import org.silverpeas.core.io.file.AttachmentUrlLinkProcessor;
 import org.silverpeas.core.io.file.SilverpeasFileProcessor;
 import org.silverpeas.core.io.file.SilverpeasFileProvider;
 import org.silverpeas.core.test.TestBeanContainer;
 import org.silverpeas.core.test.extention.EnableSilverTestEnv;
+import org.silverpeas.core.test.extention.TestManagedBean;
 import org.silverpeas.core.util.URLUtil;
 import org.silverpeas.core.util.file.FileUtil;
 
+import javax.activation.FileDataSource;
+import javax.inject.Singleton;
 import javax.servlet.http.HttpServletRequest;
 import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Pattern;
 
+import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.silverpeas.core.util.StringDataExtractor.RegexpPatternDirective.regexp;
+import static org.silverpeas.core.util.StringDataExtractor.from;
+import static org.silverpeas.core.util.StringUtil.defaultStringIfNotDefined;
 
 @EnableSilverTestEnv
 public class WysiwygContentTransformerTest {
@@ -67,9 +81,24 @@ public class WysiwygContentTransformerTest {
 
   private static final String ODT_ATTACHMENT_ID = "72f56ba9-b089-40c4-b16c-255e93658259";
 
+  @TestManagedBean
+  private MailContentProcess.WysiwygCkeditorMediaLinkUrlToDataSourceScanner ckScanner;
+
+  @TestManagedBean
+  private SimpleDocumentUrlToDataSourceScanner attScanner;
+
+  @TestManagedBean
+  private SimpleDocumentUrlAccordingToHtmlSizeDirectiveTranslator attSrcTranslator;
+
+  @TestManagedBean
+  private GalleryLinkUrlDataSourceScanner4Test gallScanner;
+
+  @TestManagedBean
+  private GalleryImageUrlAccordingToHtmlSizeDirectiveTranslator4Test gallTranslator;
+
   @SuppressWarnings("unchecked")
   @BeforeEach
-  public void setup() throws Exception {
+  void setup() throws Exception {
     originalOdt = new File(getClass().getResource("/" + ODT_NAME).getPath());
     assertThat(originalOdt.exists(), is(true));
     originalImage = new File(getClass().getResource("/" + IMAGE_NAME).getPath());
@@ -124,7 +153,7 @@ public class WysiwygContentTransformerTest {
 
   @SuppressWarnings("unchecked")
   @AfterEach
-  public void destroy() throws Exception {
+  void destroy() throws Exception {
     FileUtils.deleteQuietly(originalImageWithResize100x.getParentFile());
     FileUtils.deleteQuietly(originalImageWithResize100x100.getParentFile());
 
@@ -135,7 +164,7 @@ public class WysiwygContentTransformerTest {
   }
 
   @Test
-  public void toMailContent() throws Exception {
+  void toMailContent() throws Exception {
     WysiwygContentTransformer transformer = WysiwygContentTransformer
         .on(getContentOfDocumentNamed("wysiwygWithSeveralTypesOfLink.txt"));
 
@@ -147,7 +176,7 @@ public class WysiwygContentTransformerTest {
   }
 
   @Test
-  public void manageImageResizing() throws Exception {
+  void manageImageResizing() throws Exception {
     WysiwygContentTransformer transformer =
         WysiwygContentTransformer.on(getContentOfDocumentNamed("wysiwygWithSeveralImages.txt"));
 
@@ -175,6 +204,39 @@ public class WysiwygContentTransformerTest {
       return new File(documentLocation.toURI());
     } catch (URISyntaxException e) {
       return null;
+    }
+  }
+
+  @Singleton
+  public static class GalleryLinkUrlDataSourceScanner4Test implements LinkUrlDataSourceScanner {
+
+    private static final Pattern GALLERY_CONTENT_LINK_PATTERN = Pattern.compile("(?i)=\"([^\"]*/GalleryInWysiwyg/[^\"]+)");
+
+    @Override
+    public List<LinkUrlDataSource> scanHtml(final String htmlContent) {
+      final List<LinkUrlDataSource> result = new ArrayList<>();
+      from(htmlContent).withDirectives(singletonList(regexp(GALLERY_CONTENT_LINK_PATTERN, 1))).extract().forEach(l -> {
+        final File imageFile = mock(File.class);
+        when(imageFile.exists()).thenReturn(true);
+        when(imageFile.getPath()).thenReturn("image.jpg");
+        result.add(new LinkUrlDataSource(l, () -> new FileDataSource(imageFile)));
+      });
+      return result;
+    }
+  }
+
+  @Singleton
+  public static class GalleryImageUrlAccordingToHtmlSizeDirectiveTranslator4Test
+      implements ImageUrlAccordingToHtmlSizeDirective.SrcTranslator {
+
+    @Override
+    public boolean isCompliantUrl(final String url) {
+      return defaultStringIfNotDefined(url).contains("/GalleryInWysiwyg/");
+    }
+
+    @Override
+    public String translateUrl(final String url, final String width, final String height) {
+      return url + "&amp;Size=TEST";
     }
   }
 }

--- a/core-library/src/test/resources/org/silverpeas/core/contribution/content/wysiwyg/service/wysiwygWithSeveralImagesTransformedForImageResizingResult.txt
+++ b/core-library/src/test/resources/org/silverpeas/core/contribution/content/wysiwyg/service/wysiwygWithSeveralImagesTransformedForImageResizingResult.txt
@@ -8,7 +8,7 @@
 
 <p>Photot&egrave;que :</p>
 
-<p><img alt="" border="0" src="/silverpeas/GalleryInWysiwyg/dummy?ImageId=187&amp;ComponentId=gallery4&amp;UseOriginal=false" /></p>
+<p><img alt="" border="0" src="/silverpeas/GalleryInWysiwyg/dummy?ImageId=187&amp;ComponentId=gallery4&amp;UseOriginal=false&amp;Size=TEST" /></p>
 
 <p>Upload image :</p>
 

--- a/core-library/src/test/resources/org/silverpeas/core/contribution/content/wysiwyg/service/wysiwygWithSeveralTypesOfLinkTransformedForMailSendingResult.txt
+++ b/core-library/src/test/resources/org/silverpeas/core/contribution/content/wysiwyg/service/wysiwygWithSeveralTypesOfLinkTransformedForMailSendingResult.txt
@@ -4,25 +4,25 @@
 
 <p><strong>Gras</strong></p>
 
-<p><strong><img alt="kiss" height="23" src="cid:link-content-0" title="kiss" width="23" /></strong></p>
+<p><strong><img alt="kiss" height="23" src="cid:mail-content-attachment-5" title="kiss" width="23" /></strong></p>
 
 <p>Photot&egrave;que :</p>
 
-<p><img alt="" border="0" src="cid:link-content-1" /></p>
+<p><img alt="" border="0" src="cid:mail-content-attachment-0" /></p>
 
 <p>Upload image :</p>
 
-<p><img alt="" src="cid:attachment-content-2" style="width: 100px; height: 100px;" /></p>
+<p><img alt="" src="cid:mail-content-attachment-1" style="width: 100px; height: 100px;" /></p>
 
-<p><img alt="" src="cid:attachment-content-3" style="width: 100px; height: 100px;" /></p>
+<p><img alt="" src="cid:mail-content-attachment-2" style="width: 100px; height: 100px;" /></p>
 
-<p><img alt="" src="cid:attachment-content-5" style="width: 100px; height: 100px;" /></p>
+<p><img alt="" src="cid:mail-content-attachment-4" style="width: 100px; height: 100px;" /></p>
 
 <p><img alt="" src="/silverpeas/File_bad_link/d07411cc-19af-49f8-af57-16fc9fabf318-bis" style="width: 100px; height: 100px;" /></p>
 
-<p><a href="cid:attachment-content-4">/silverpeas/attached_file/componentId/infoLetter175/attachmentId/d07411cc-19af-49f8-af57-16fc9fabf318/lang/fr/size/100x100/name/Aikido16.jpg</a></p>
+<p><a href="cid:mail-content-attachment-3">/silverpeas/attached_file/componentId/infoLetter175/attachmentId/d07411cc-19af-49f8-af57-16fc9fabf318/lang/fr/size/100x100/name/Aikido16.jpg</a></p>
 
-<p><a href="cid:attachment-content-3">/silverpeas/attached_file/componentId/infoLetter175/attachmentId/d07411cc-19af-49f8-af57-16fc9fabf318/lang/fr/size/100x/name/Aikido16.jpg</a></p>
+<p><a href="cid:mail-content-attachment-2">/silverpeas/attached_file/componentId/infoLetter175/attachmentId/d07411cc-19af-49f8-af57-16fc9fabf318/lang/fr/size/100x/name/Aikido16.jpg</a></p>
 
 <p><a href="https://www.toto.fr/silverpeas/attached_file/componentId/infoLetter175/attachmentId/72f56ba9-b089-40c4-b16c-255e93658259-bis/lang/fr/name/2-2_Formation_Developpeur-Partie-2.pdf">/silverpeas/attached_file/componentId/infoLetter175/attachmentId/72f56ba9-b089-40c4-b16c-255e93658259/lang/fr/name/2-2_Formation_Developpeur-Partie-2.pdf</a></p>
 

--- a/core-library/src/test/resources/org/silverpeas/core/contribution/content/wysiwyg/service/wysiwygWithSeveralTypesOfLinkTransformedForMailSendingResultWithImageResizePreProcessing.txt
+++ b/core-library/src/test/resources/org/silverpeas/core/contribution/content/wysiwyg/service/wysiwygWithSeveralTypesOfLinkTransformedForMailSendingResultWithImageResizePreProcessing.txt
@@ -4,25 +4,25 @@
 
 <p><strong>Gras</strong></p>
 
-<p><strong><img alt="kiss" height="23" src="cid:link-content-0" title="kiss" width="23" /></strong></p>
+<p><strong><img alt="kiss" height="23" src="cid:mail-content-attachment-4" title="kiss" width="23" /></strong></p>
 
 <p>Photot&egrave;que :</p>
 
-<p><img alt="" border="0" src="cid:link-content-1" /></p>
+<p><img alt="" border="0" src="cid:mail-content-attachment-0" /></p>
 
 <p>Upload image :</p>
 
-<p><img alt="" src="cid:attachment-content-2" style="width: 100px; height: 100px;" /></p>
+<p><img alt="" src="cid:mail-content-attachment-1" style="width: 100px; height: 100px;" /></p>
 
-<p><img alt="" src="cid:attachment-content-2" style="width: 100px; height: 100px;" /></p>
+<p><img alt="" src="cid:mail-content-attachment-1" style="width: 100px; height: 100px;" /></p>
 
-<p><img alt="" src="cid:attachment-content-4" style="width: 100px; height: 100px;" /></p>
+<p><img alt="" src="cid:mail-content-attachment-3" style="width: 100px; height: 100px;" /></p>
 
 <p><img alt="" src="/silverpeas/File_bad_link/d07411cc-19af-49f8-af57-16fc9fabf318-bis" style="width: 100px; height: 100px;" /></p>
 
-<p><a href="cid:attachment-content-2">/silverpeas/attached_file/componentId/infoLetter175/attachmentId/d07411cc-19af-49f8-af57-16fc9fabf318/lang/fr/size/100x100/name/Aikido16.jpg</a></p>
+<p><a href="cid:mail-content-attachment-1">/silverpeas/attached_file/componentId/infoLetter175/attachmentId/d07411cc-19af-49f8-af57-16fc9fabf318/lang/fr/size/100x100/name/Aikido16.jpg</a></p>
 
-<p><a href="cid:attachment-content-3">/silverpeas/attached_file/componentId/infoLetter175/attachmentId/d07411cc-19af-49f8-af57-16fc9fabf318/lang/fr/size/100x/name/Aikido16.jpg</a></p>
+<p><a href="cid:mail-content-attachment-2">/silverpeas/attached_file/componentId/infoLetter175/attachmentId/d07411cc-19af-49f8-af57-16fc9fabf318/lang/fr/size/100x/name/Aikido16.jpg</a></p>
 
 <p><a href="https://www.toto.fr/silverpeas/attached_file/componentId/infoLetter175/attachmentId/72f56ba9-b089-40c4-b16c-255e93658259-bis/lang/fr/name/2-2_Formation_Developpeur-Partie-2.pdf">/silverpeas/attached_file/componentId/infoLetter175/attachmentId/72f56ba9-b089-40c4-b16c-255e93658259/lang/fr/name/2-2_Formation_Developpeur-Partie-2.pdf</a></p>
 

--- a/core-test/src/main/java/org/silverpeas/core/test/extention/SilverTestEnv.java
+++ b/core-test/src/main/java/org/silverpeas/core/test/extention/SilverTestEnv.java
@@ -398,8 +398,11 @@ public class SilverTestEnv implements TestInstancePostProcessor, ParameterResolv
         all.add(bean);
         when(TestBeanContainer.getMockedBeanContainer()
             .getAllBeansByType(type, qualifiers)).thenReturn(all);
-        when(TestBeanContainer.getMockedBeanContainer().getBeanByType(type, qualifiers)).thenThrow(
-            new AmbiguousResolutionException("A bean of type " + type + " already exist!"));
+        if (existing.size() == 1) {
+          when(TestBeanContainer.getMockedBeanContainer().getBeanByType(type, qualifiers))
+              .thenThrow(
+                  new AmbiguousResolutionException("A bean of type " + type + " already exist!"));
+        }
       }
     } else {
       when(TestBeanContainer.getMockedBeanContainer().getBeanByType(type, qualifiers)).thenReturn(


### PR DESCRIPTION
- adding SrcTranslator API to ImageUrlAccordingToHtmlSizeDirective implementation which permits to different image providers to translate an URL without size directive to an URL having one according to width and height extracted from HTML content
- adding scanner API which permits to different image providers to supply for each detected image URL from an HTML content a javax.activation.DataSource instance. It is especially useful when transforming WYSIWYG content to send it through a mail
- adding attachment SrcTranslator implementation
- adding attachment LinkUrlDataSourceScanner implementation
- fixing a little problem about injection engine of unit test environment

Linked to PR https://github.com/Silverpeas/Silverpeas-Components/pull/645