### PR TITLE
Feature #9796: taking in charge the links included into WYSIWYG content in order to be handled by SilverpeasWindow link monitor (by applying sp-permalink or sp-link CSS classes on link HTML elements).

### DIFF
--- a/core-library/src/main/java/org/silverpeas/core/contribution/content/form/displayers/WysiwygFCKFieldDisplayer.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/content/form/displayers/WysiwygFCKFieldDisplayer.java
@@ -180,8 +180,8 @@ public class WysiwygFCKFieldDisplayer extends AbstractFieldDisplayer<TextField> 
     final WysiwygContentTransformer wysiwygContentTransformer =
         WysiwygContentTransformer.on(code)
             .modifyImageUrlAccordingToHtmlSizeDirective()
-            .resolveVariablesDirective();
-
+            .resolveVariablesDirective()
+            .applySilverpeasLinkCssDirective();
     out.println(wysiwygContentTransformer.transform());
   }
 

--- a/core-library/src/main/java/org/silverpeas/core/contribution/content/wysiwyg/service/WysiwygContentRenderer.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/content/wysiwyg/service/WysiwygContentRenderer.java
@@ -47,6 +47,7 @@ public class WysiwygContentRenderer extends AbstractContributionRenderer<Wysiwyg
         .on(getContent().getData())
         .modifyImageUrlAccordingToHtmlSizeDirective()
         .resolveVariablesDirective()
+        .applySilverpeasLinkCssDirective()
         .transform();
   }
 

--- a/core-library/src/main/java/org/silverpeas/core/contribution/content/wysiwyg/service/WysiwygContentTransformer.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/content/wysiwyg/service/WysiwygContentTransformer.java
@@ -24,8 +24,9 @@
 package org.silverpeas.core.contribution.content.wysiwyg.service;
 
 import org.silverpeas.core.SilverpeasException;
-import org.silverpeas.core.contribution.content.wysiwyg.service.directive.VariablesReplacementDirective;
 import org.silverpeas.core.contribution.content.wysiwyg.service.directive.ImageUrlAccordingToHtmlSizeDirective;
+import org.silverpeas.core.contribution.content.wysiwyg.service.directive.SilverpeasLinkCssApplierDirective;
+import org.silverpeas.core.contribution.content.wysiwyg.service.directive.VariablesReplacementDirective;
 import org.silverpeas.core.contribution.content.wysiwyg.service.process.MailContentProcess;
 
 import java.util.ArrayList;
@@ -76,6 +77,15 @@ public class WysiwygContentTransformer {
   }
 
   /**
+   * Applies the sp-permalink or sp-link css classes to links HTML elements.
+   * @return the instance of the current {@link WysiwygContentTransformer}.
+   */
+  public WysiwygContentTransformer applySilverpeasLinkCssDirective() {
+    directives.add(new SilverpeasLinkCssApplierDirective());
+    return this;
+  }
+
+  /**
    * Default method in order to apply all the transformation directives and recover immediately the
    * result as string.
    * @return the transformed wysiwyg content.
@@ -107,6 +117,8 @@ public class WysiwygContentTransformer {
    * @throws SilverpeasException on technical error.
    */
   public MailContentProcess.MailResult toMailContent() throws SilverpeasException {
-    return modifyImageUrlAccordingToHtmlSizeDirective().transform(new MailContentProcess());
+    return modifyImageUrlAccordingToHtmlSizeDirective()
+        .resolveVariablesDirective()
+        .transform(new MailContentProcess());
   }
 }

--- a/core-library/src/main/java/org/silverpeas/core/contribution/content/wysiwyg/service/directive/SilverpeasLinkCssApplierDirective.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/content/wysiwyg/service/directive/SilverpeasLinkCssApplierDirective.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2000 - 2019 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.silverpeas.core.contribution.content.wysiwyg.service.directive;
+
+import net.htmlparser.jericho.Element;
+import net.htmlparser.jericho.HTMLElementName;
+import net.htmlparser.jericho.Source;
+import net.htmlparser.jericho.StartTag;
+import org.silverpeas.core.contribution.content.wysiwyg.service.WysiwygContentTransformerDirective;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.silverpeas.core.util.StringUtil.defaultStringIfNotDefined;
+import static org.silverpeas.core.util.StringUtil.isNotDefined;
+import static org.silverpeas.core.util.URLUtil.getApplicationURL;
+import static org.silverpeas.core.util.URLUtil.isPermalink;
+
+/**
+ * Applies sp-permalink or sp-link CSS classes to links.
+ * @author silveryocha
+ */
+public class SilverpeasLinkCssApplierDirective implements WysiwygContentTransformerDirective {
+
+  @Override
+  public String execute(final String wysiwygContent) {
+    final String wysiwygToTransform = wysiwygContent != null ? wysiwygContent : "";
+    final Source source = new Source(wysiwygToTransform);
+    final List<Element> linkElements = source.getAllElements(HTMLElementName.A);
+    final Map<String, String> replacements = new HashMap<>();
+    for (final Element currentLink : linkElements) {
+      final StartTag linkStartTag = currentLink.getStartTag();
+      if (isCompliantTarget(linkStartTag)) {
+        final String href = defaultStringIfNotDefined(currentLink.getAttributeValue("href"));
+        if (isPermalink(href)) {
+          apply(linkStartTag, "sp-permalink", replacements);
+        } else if (href.contains(getApplicationURL())) {
+          apply(linkStartTag, "sp-link", replacements);
+        }
+      }
+    }
+
+    String transformedWysiwygContent = wysiwygToTransform;
+    for (Map.Entry<String, String> replacement : replacements.entrySet()) {
+      transformedWysiwygContent = transformedWysiwygContent.replace(replacement.getKey(),
+          replacement.getValue());
+    }
+
+    // Returning the transformed WYSIWYG.
+    return transformedWysiwygContent;
+  }
+
+  private void apply(final StartTag linkStartTag, final String cssClass, final Map<String, String> replacements) {
+    final String linkStartTagAsString = linkStartTag.toString();
+    if (replacements.containsKey(linkStartTagAsString)) {
+      return;
+    }
+    final String currentCssClasses = linkStartTag.getAttributeValue("class");
+    final String newLinkStartTagAsString;
+    if (currentCssClasses == null) {
+      newLinkStartTagAsString = linkStartTagAsString
+          .replaceFirst("([ \t\r\n]*)>$", " class=\"" + cssClass + "\"$1>");
+    } else {
+      final String cleanedCssClasses = currentCssClasses.replaceAll("[ ]*(sp-permalink|sp-link)", "").trim();
+      final String cssClassToAdd = cleanedCssClasses.isEmpty() ? cssClass : (" " + cssClass);
+      final String newCssClasses = cleanedCssClasses + cssClassToAdd;
+      newLinkStartTagAsString = linkStartTagAsString.replaceAll(
+          "(class[ \t\r\n]*=[ \t\r\n]*([\"'])[ \t\r\n]*)" + currentCssClasses +
+              "([ \t\r\n]*([\"']))", "$1" + newCssClasses + "$2");
+    }
+    replacements.put(linkStartTagAsString, newLinkStartTagAsString);
+  }
+
+  private boolean isCompliantTarget(final StartTag linkStartTag) {
+    return isNotDefined(linkStartTag.getAttributeValue("target"));
+  }
+}

--- a/core-library/src/test/java/org/silverpeas/core/contribution/content/wysiwyg/service/WysiwygContentTransformerTest.java
+++ b/core-library/src/test/java/org/silverpeas/core/contribution/content/wysiwyg/service/WysiwygContentTransformerTest.java
@@ -37,6 +37,7 @@ import org.silverpeas.core.contribution.content.LinkUrlDataSource;
 import org.silverpeas.core.contribution.content.LinkUrlDataSourceScanner;
 import org.silverpeas.core.contribution.content.wysiwyg.service.directive.ImageUrlAccordingToHtmlSizeDirective;
 import org.silverpeas.core.contribution.content.wysiwyg.service.process.MailContentProcess;
+import org.silverpeas.core.html.PermalinkRegistry;
 import org.silverpeas.core.io.file.AttachmentUrlLinkProcessor;
 import org.silverpeas.core.io.file.SilverpeasFileProcessor;
 import org.silverpeas.core.io.file.SilverpeasFileProvider;
@@ -95,6 +96,9 @@ public class WysiwygContentTransformerTest {
 
   @TestManagedBean
   private GalleryImageUrlAccordingToHtmlSizeDirectiveTranslator4Test gallTranslator;
+
+  @TestManagedBean
+  private PermalinkRegistry permalinkRegistry;
 
   @SuppressWarnings("unchecked")
   @BeforeEach
@@ -184,6 +188,17 @@ public class WysiwygContentTransformerTest {
 
     assertThat(result, is(getContentOfDocumentNamed(
         "wysiwygWithSeveralImagesTransformedForImageResizingResult.txt")));
+  }
+
+  @Test
+  public void applyingSilverpeasLinkCss() throws Exception {
+    WysiwygContentTransformer transformer =
+        WysiwygContentTransformer.on(getContentOfDocumentNamed("wysiwygWithSeveralTypesOfLink.txt"));
+
+    String result = transformer.applySilverpeasLinkCssDirective().transform();
+
+    assertThat(result, is(getContentOfDocumentNamed(
+        "wysiwygWithSeveralTypesOfLinkTransformedForCssLinkApplierResult.txt")));
   }
 
   /*

--- a/core-library/src/test/resources/org/silverpeas/core/contribution/content/wysiwyg/service/wysiwygWithSeveralTypesOfLink.txt
+++ b/core-library/src/test/resources/org/silverpeas/core/contribution/content/wysiwyg/service/wysiwygWithSeveralTypesOfLink.txt
@@ -29,3 +29,30 @@
 <p><a href="/silverpeas/attached_file/componentId/infoLetter175/attachmentId/72f56ba9-b089-40c4-b16c-255e93658259/lang/fr/name/2-2_Formation_Developpeur-Partie-2.pdf">/silverpeas/attached_file/componentId/infoLetter175/attachmentId/72f56ba9-b089-40c4-b16c-255e93658259/lang/fr/name/2-2_Formation_Developpeur-Partie-2.pdf</a></p>
 
 <p><a href="/silverpeas/attached_file/componentId/infoLetter175/attachmentId_bad_link/72f56ba9-b089-40c4-b16c-255e93658259/lang/fr/name/2-2_Formation_Developpeur-Partie-2.pdf">/silverpeas/attached_file/componentId/infoLetter175/attachmentId/72f56ba9-b089-40c4-b16c-255e93658259/lang/fr/name/2-2_Formation_Developpeur-Partie-2.pdf</a></p>
+
+<p><a href="/silverpeas/Publication/345" >  A publication!!  </a></p>
+
+<p><a href="/silverpeas/Publication/346"
+ >  An other publication!!  </a></p>
+
+<p><a class="" href="/silverpeas/Publication/346">  Publication 346  </a></p>
+
+<p><a class="" href="/silverpeas/Publication/346">  Publication 346  </a></p>
+
+<p><a class=' ' href="/silverpeas/Publication/346">  Publication 346  </a></p>
+
+<p><a class="sp-link" href="/silverpeas/Publication/346">  Publication 346  </a></p>
+
+<p><a class=" sp-permalink " href="/silverpeas/Publication/346">  Publication 346  </a></p>
+
+<p><a class="toto" href="/silverpeas/Publication/346">  Publication 346  </a></p>
+
+<p><a class="sp-permalink toto" href="/silverpeas/Publication/346">  Publication 346  </a></p>
+
+<p><a class
+  =
+  "toto sp-link" href="/silverpeas/Publication/346?x=1&amp;y=2" >  Publication 346  </a></p>
+
+<p><a class="toto" href="/silverpeas/Publication/346" target="_blank">  Publication 346  </a></p>
+
+<p><a class="toto" href="/silverpeas/Publication/346" target="_self">  Publication 346  </a></p>

--- a/core-library/src/test/resources/org/silverpeas/core/contribution/content/wysiwyg/service/wysiwygWithSeveralTypesOfLinkTransformedForCssLinkApplierResult.txt
+++ b/core-library/src/test/resources/org/silverpeas/core/contribution/content/wysiwyg/service/wysiwygWithSeveralTypesOfLinkTransformedForCssLinkApplierResult.txt
@@ -1,0 +1,58 @@
+<p>Un contenu complexe pour une <span style="color:#FFFFE0;"><span style="background-color: rgb(255, 0, 0);">campagne</span></span> simple.</p>
+
+<p><u>Soulign&eacute;</u></p>
+
+<p><strong>Gras</strong></p>
+
+<p><strong><img alt="kiss" height="23" src="/silverpeas/wysiwyg/jsp/ckeditor/plugins/smiley/images/kiss.png" title="kiss" width="23" /></strong></p>
+
+<p>Photot&egrave;que :</p>
+
+<p><img alt="" border="0" src="/silverpeas/GalleryInWysiwyg/dummy?ImageId=187&amp;ComponentId=gallery4&amp;UseOriginal=false" /></p>
+
+<p>Upload image :</p>
+
+<p><img alt="" src="/silverpeas/attached_file/componentId/infoLetter175/attachmentId/d07411cc-19af-49f8-af57-16fc9fabf318/lang/fr/name/Aikido16.jpg" style="width: 100px; height: 100px;" /></p>
+
+<p><img alt="" src="/silverpeas/attached_file/componentId/infoLetter175/attachmentId/d07411cc-19af-49f8-af57-16fc9fabf318/lang/fr/size/100x/name/Aikido16.jpg" style="width: 100px; height: 100px;" /></p>
+
+<p><img alt="" src="http://www.toto.fr/silverpeas/File/d07411cc-19af-49f8-af57-16fc9fabf318-bis" style="width: 100px; height: 100px;" /></p>
+
+<p><img alt="" src="/silverpeas/File_bad_link/d07411cc-19af-49f8-af57-16fc9fabf318-bis" style="width: 100px; height: 100px;" /></p>
+
+<p><a href="/silverpeas/attached_file/componentId/infoLetter175/attachmentId/d07411cc-19af-49f8-af57-16fc9fabf318/lang/fr/size/100x100/name/Aikido16.jpg" class="sp-link">/silverpeas/attached_file/componentId/infoLetter175/attachmentId/d07411cc-19af-49f8-af57-16fc9fabf318/lang/fr/size/100x100/name/Aikido16.jpg</a></p>
+
+<p><a href="/silverpeas/attached_file/componentId/infoLetter175/attachmentId/d07411cc-19af-49f8-af57-16fc9fabf318/lang/fr/size/100x/name/Aikido16.jpg" class="sp-link">/silverpeas/attached_file/componentId/infoLetter175/attachmentId/d07411cc-19af-49f8-af57-16fc9fabf318/lang/fr/size/100x/name/Aikido16.jpg</a></p>
+
+<p><a href="https://www.toto.fr/silverpeas/attached_file/componentId/infoLetter175/attachmentId/72f56ba9-b089-40c4-b16c-255e93658259-bis/lang/fr/name/2-2_Formation_Developpeur-Partie-2.pdf" class="sp-link">/silverpeas/attached_file/componentId/infoLetter175/attachmentId/72f56ba9-b089-40c4-b16c-255e93658259/lang/fr/name/2-2_Formation_Developpeur-Partie-2.pdf</a></p>
+
+<p><a href="/silverpeas/attached_file/componentId/infoLetter175/attachmentId/72f56ba9-b089-40c4-b16c-255e93658259/lang/fr/name/2-2_Formation_Developpeur-Partie-2.pdf" class="sp-link">/silverpeas/attached_file/componentId/infoLetter175/attachmentId/72f56ba9-b089-40c4-b16c-255e93658259/lang/fr/name/2-2_Formation_Developpeur-Partie-2.pdf</a></p>
+
+<p><a href="/silverpeas/attached_file/componentId/infoLetter175/attachmentId_bad_link/72f56ba9-b089-40c4-b16c-255e93658259/lang/fr/name/2-2_Formation_Developpeur-Partie-2.pdf" class="sp-link">/silverpeas/attached_file/componentId/infoLetter175/attachmentId/72f56ba9-b089-40c4-b16c-255e93658259/lang/fr/name/2-2_Formation_Developpeur-Partie-2.pdf</a></p>
+
+<p><a href="/silverpeas/Publication/345" class="sp-permalink" >  A publication!!  </a></p>
+
+<p><a href="/silverpeas/Publication/346" class="sp-permalink"
+ >  An other publication!!  </a></p>
+
+<p><a class="sp-permalink" href="/silverpeas/Publication/346">  Publication 346  </a></p>
+
+<p><a class="sp-permalink" href="/silverpeas/Publication/346">  Publication 346  </a></p>
+
+<p><a class='sp-permalink' href="/silverpeas/Publication/346">  Publication 346  </a></p>
+
+<p><a class="sp-permalink" href="/silverpeas/Publication/346">  Publication 346  </a></p>
+
+<p><a class="sp-permalink" href="/silverpeas/Publication/346">  Publication 346  </a></p>
+
+<p><a class="toto sp-permalink" href="/silverpeas/Publication/346">  Publication 346  </a></p>
+
+<p><a class="toto sp-permalink" href="/silverpeas/Publication/346">  Publication 346  </a></p>
+
+<p><a class
+  =
+  "toto sp-permalink" href="/silverpeas/Publication/346?x=1&amp;y=2" >  Publication 346  </a></p>
+
+<p><a class="toto" href="/silverpeas/Publication/346" target="_blank">  Publication 346  </a></p>
+
+<p><a class="toto" href="/silverpeas/Publication/346" target="_self">  Publication 346  </a></p>

--- a/core-library/src/test/resources/org/silverpeas/core/contribution/content/wysiwyg/service/wysiwygWithSeveralTypesOfLinkTransformedForMailSendingResult.txt
+++ b/core-library/src/test/resources/org/silverpeas/core/contribution/content/wysiwyg/service/wysiwygWithSeveralTypesOfLinkTransformedForMailSendingResult.txt
@@ -29,3 +29,30 @@
 <p><a href="/silverpeas/attached_file/componentId/infoLetter175/attachmentId/72f56ba9-b089-40c4-b16c-255e93658259/lang/fr/name/2-2_Formation_Developpeur-Partie-2.pdf">/silverpeas/attached_file/componentId/infoLetter175/attachmentId/72f56ba9-b089-40c4-b16c-255e93658259/lang/fr/name/2-2_Formation_Developpeur-Partie-2.pdf</a></p>
 
 <p><a href="/silverpeas/attached_file/componentId/infoLetter175/attachmentId_bad_link/72f56ba9-b089-40c4-b16c-255e93658259/lang/fr/name/2-2_Formation_Developpeur-Partie-2.pdf">/silverpeas/attached_file/componentId/infoLetter175/attachmentId/72f56ba9-b089-40c4-b16c-255e93658259/lang/fr/name/2-2_Formation_Developpeur-Partie-2.pdf</a></p>
+
+<p><a href="/silverpeas/Publication/345" >  A publication!!  </a></p>
+
+<p><a href="/silverpeas/Publication/346"
+ >  An other publication!!  </a></p>
+
+<p><a class="" href="/silverpeas/Publication/346">  Publication 346  </a></p>
+
+<p><a class="" href="/silverpeas/Publication/346">  Publication 346  </a></p>
+
+<p><a class=' ' href="/silverpeas/Publication/346">  Publication 346  </a></p>
+
+<p><a class="sp-link" href="/silverpeas/Publication/346">  Publication 346  </a></p>
+
+<p><a class=" sp-permalink " href="/silverpeas/Publication/346">  Publication 346  </a></p>
+
+<p><a class="toto" href="/silverpeas/Publication/346">  Publication 346  </a></p>
+
+<p><a class="sp-permalink toto" href="/silverpeas/Publication/346">  Publication 346  </a></p>
+
+<p><a class
+  =
+  "toto sp-link" href="/silverpeas/Publication/346?x=1&amp;y=2" >  Publication 346  </a></p>
+
+<p><a class="toto" href="/silverpeas/Publication/346" target="_blank">  Publication 346  </a></p>
+
+<p><a class="toto" href="/silverpeas/Publication/346" target="_self">  Publication 346  </a></p>

--- a/core-library/src/test/resources/org/silverpeas/core/contribution/content/wysiwyg/service/wysiwygWithSeveralTypesOfLinkTransformedForMailSendingResultWithImageResizePreProcessing.txt
+++ b/core-library/src/test/resources/org/silverpeas/core/contribution/content/wysiwyg/service/wysiwygWithSeveralTypesOfLinkTransformedForMailSendingResultWithImageResizePreProcessing.txt
@@ -29,3 +29,30 @@
 <p><a href="/silverpeas/attached_file/componentId/infoLetter175/attachmentId/72f56ba9-b089-40c4-b16c-255e93658259/lang/fr/name/2-2_Formation_Developpeur-Partie-2.pdf">/silverpeas/attached_file/componentId/infoLetter175/attachmentId/72f56ba9-b089-40c4-b16c-255e93658259/lang/fr/name/2-2_Formation_Developpeur-Partie-2.pdf</a></p>
 
 <p><a href="/silverpeas/attached_file/componentId/infoLetter175/attachmentId_bad_link/72f56ba9-b089-40c4-b16c-255e93658259/lang/fr/name/2-2_Formation_Developpeur-Partie-2.pdf">/silverpeas/attached_file/componentId/infoLetter175/attachmentId/72f56ba9-b089-40c4-b16c-255e93658259/lang/fr/name/2-2_Formation_Developpeur-Partie-2.pdf</a></p>
+
+<p><a href="/silverpeas/Publication/345" >  A publication!!  </a></p>
+
+<p><a href="/silverpeas/Publication/346"
+ >  An other publication!!  </a></p>
+
+<p><a class="" href="/silverpeas/Publication/346">  Publication 346  </a></p>
+
+<p><a class="" href="/silverpeas/Publication/346">  Publication 346  </a></p>
+
+<p><a class=' ' href="/silverpeas/Publication/346">  Publication 346  </a></p>
+
+<p><a class="sp-link" href="/silverpeas/Publication/346">  Publication 346  </a></p>
+
+<p><a class=" sp-permalink " href="/silverpeas/Publication/346">  Publication 346  </a></p>
+
+<p><a class="toto" href="/silverpeas/Publication/346">  Publication 346  </a></p>
+
+<p><a class="sp-permalink toto" href="/silverpeas/Publication/346">  Publication 346  </a></p>
+
+<p><a class
+  =
+  "toto sp-link" href="/silverpeas/Publication/346?x=1&amp;y=2" >  Publication 346  </a></p>
+
+<p><a class="toto" href="/silverpeas/Publication/346" target="_blank">  Publication 346  </a></p>
+
+<p><a class="toto" href="/silverpeas/Publication/346" target="_self">  Publication 346  </a></p>

--- a/core-war/src/main/java/org/silverpeas/web/servlets/GoToFile.java
+++ b/core-war/src/main/java/org/silverpeas/web/servlets/GoToFile.java
@@ -23,15 +23,15 @@
  */
 package org.silverpeas.web.servlets;
 
-import org.silverpeas.core.web.util.servlet.GoTo;
-import org.silverpeas.core.util.URLUtil;
-import org.silverpeas.core.admin.user.model.UserDetail;
 import org.apache.commons.codec.CharEncoding;
+import org.silverpeas.core.admin.user.model.UserDetail;
 import org.silverpeas.core.contribution.attachment.AttachmentServiceProvider;
 import org.silverpeas.core.contribution.attachment.model.SimpleDocument;
 import org.silverpeas.core.contribution.attachment.model.SimpleDocumentPK;
-import org.silverpeas.core.web.util.ClientBrowserUtil;
 import org.silverpeas.core.util.StringUtil;
+import org.silverpeas.core.util.URLUtil;
+import org.silverpeas.core.web.util.ClientBrowserUtil;
+import org.silverpeas.core.web.util.servlet.GoTo;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -53,15 +53,12 @@ public class GoToFile extends GoTo {
     String componentId = attachment.getInstanceId();
     String foreignId = attachment.getForeignId();
 
-    if (isUserLogin(req)) {
-      // Has the user access rights
-      if (attachment.canBeAccessedBy(UserDetail.getCurrentRequester())) {
-        res.setCharacterEncoding(CharEncoding.UTF_8);
-        res.setContentType("text/html; charset=utf-8");
-        String fileName = ClientBrowserUtil.rfc2047EncodeFilename(req, attachment.getFilename());
-        res.setHeader("Content-Disposition", "inline; filename=\"" + fileName + "\"");
-        return URLUtil.getFullApplicationURL(req) + encodeFilename(attachment.getAttachmentURL());
-      }
+    if (isUserLogin(req) && attachment.canBeAccessedBy(UserDetail.getCurrentRequester())) {
+      res.setCharacterEncoding(CharEncoding.UTF_8);
+      res.setContentType(attachment.getContentType() + "; charset=utf-8");
+      String fileName = ClientBrowserUtil.rfc2047EncodeFilename(req, attachment.getFilename());
+      res.setHeader("Content-Disposition", "inline; filename=\"" + fileName + "\"");
+      return URLUtil.getFullApplicationURL(req) + encodeFilename(attachment.getAttachmentURL());
     }
 
     if (StringUtil.isDefined(req.getParameter("ComponentId"))) {


### PR DESCRIPTION
Fixing the WYSIWYG variables which were not resolved into context of InfoLetter sending.

Linked to PR https://github.com/Silverpeas/Silverpeas-Looks/pull/37