### PR TITLE
Bug #10857

### DIFF
--- a/core-api/src/main/java/org/silverpeas/core/notification/user/NotificationContext.java
+++ b/core-api/src/main/java/org/silverpeas/core/notification/user/NotificationContext.java
@@ -19,9 +19,21 @@ public class NotificationContext extends HashMap<String, Object> {
 
   /**
    * The predefined key in the context mapped with the unique identifier of a Silverpeas component
-   * instance.
+   * instance. This key is used to identify the component instance for which a user notification
+   * has to be sent. It is used further in the user selection to filter the users that can access
+   * the component instance.
    */
   public static final String COMPONENT_ID = "componentId";
+
+  /**
+   * The predefined key in the context mapped with the unique identifier of a resource in
+   * Silverpeas. The mapped resource identifier should be a concat of the type and of the
+   * true identifier of the resource. Such a resource can be for example a node within which some
+   * contributions are put. If the resource is managed by a given component instance,
+   * then the key {@link NotificationContext#COMPONENT_ID} must be defined. This key is
+   * used in the user selection to filter the users that can access the specified resource.
+   */
+  public static final String RESOURCE_ID = "resourceId";
 
   /**
    * The predefined key in the context mapped with the unique identifier of a contribution in
@@ -57,6 +69,10 @@ public class NotificationContext extends HashMap<String, Object> {
 
   public String getComponentId() {
     return get(COMPONENT_ID);
+  }
+
+  public String getResourceId() {
+    return get(RESOURCE_ID);
   }
 
   public String getNodeId() {

--- a/core-library/src/test/java/org/silverpeas/core/process/io/file/TestFileHandler.java
+++ b/core-library/src/test/java/org/silverpeas/core/process/io/file/TestFileHandler.java
@@ -52,6 +52,7 @@ import static org.apache.commons.io.IOUtils.*;
 import static org.awaitility.Awaitility.await;
 import static org.awaitility.Awaitility.with;
 import static org.awaitility.Duration.ONE_SECOND;
+import static org.awaitility.Duration.TWO_SECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
@@ -1361,19 +1362,17 @@ public class TestFileHandler extends AbstractHandledFileTest {
 
     inOneSecondDo(() -> writeStringToFile(file1, "toto", Charsets.UTF_8));
     assertThat(fileHandler.isFileNewer(BASE_PATH_TEST, real1, file2), is(true));
-
-    await().atMost(ONE_SECOND).untilAsserted(() -> {
+    
+    await().atMost(TWO_SECONDS).untilAsserted(() -> {
       final Date date = new Date();
       assertThat(fileHandler.isFileNewer(BASE_PATH_TEST, real1, date), is(false));
 
       final long time = System.currentTimeMillis();
       assertThat(fileHandler.isFileNewer(BASE_PATH_TEST, real1, time), is(false));
 
-      await().atMost(ONE_SECOND).untilAsserted(() -> {
-        writeStringToFile(file1, "titi", Charsets.UTF_8);
-        assertThat(fileHandler.isFileNewer(BASE_PATH_TEST, real1, date), is(true));
-        assertThat(fileHandler.isFileNewer(BASE_PATH_TEST, real1, time), is(true));
-      });
+      inOneSecondDo(() -> writeStringToFile(file1, "titi", Charsets.UTF_8));
+      assertThat(fileHandler.isFileNewer(BASE_PATH_TEST, real1, date), is(true));
+      assertThat(fileHandler.isFileNewer(BASE_PATH_TEST, real1, time), is(true));
     });
 
   }
@@ -1415,18 +1414,16 @@ public class TestFileHandler extends AbstractHandledFileTest {
     inOneSecondDo(() -> writeStringToFile(file1, "toto", Charsets.UTF_8));
     assertThat(fileHandler.isFileOlder(BASE_PATH_TEST, real1, file2), is(false));
 
-    await().atMost(ONE_SECOND).untilAsserted(() -> {
+    await().atMost(TWO_SECONDS).untilAsserted(() -> {
       final Date date = new Date();
       assertThat(fileHandler.isFileOlder(BASE_PATH_TEST, real1, date), is(true));
 
       final long time = System.currentTimeMillis();
       assertThat(fileHandler.isFileOlder(BASE_PATH_TEST, real1, time), is(true));
 
-      await().atMost(ONE_SECOND).untilAsserted(() -> {
-        writeStringToFile(file1, "titi", Charsets.UTF_8);
-        assertThat(fileHandler.isFileOlder(BASE_PATH_TEST, real1, date), is(false));
-        assertThat(fileHandler.isFileOlder(BASE_PATH_TEST, real1, time), is(false));
-      });
+      inOneSecondDo(() -> writeStringToFile(file1, "titi", Charsets.UTF_8));
+      assertThat(fileHandler.isFileOlder(BASE_PATH_TEST, real1, date), is(false));
+      assertThat(fileHandler.isFileOlder(BASE_PATH_TEST, real1, time), is(false));
     });
   }
 

--- a/core-war/src/main/java/org/silverpeas/web/notificationuser/servlets/UserNotificationRequestRouter.java
+++ b/core-war/src/main/java/org/silverpeas/web/notificationuser/servlets/UserNotificationRequestRouter.java
@@ -49,6 +49,7 @@ public class UserNotificationRequestRouter
   private static final String MAIN_FUNCTION = "Main";
   private static final String SENDING_FUNCTION = "SendNotif";
   private static final String RELEASE_FUNCTION = "ClearNotif";
+  private static final String RESOURCE_ID = "resourceId";
 
   @Override
   public UserNotificationSessionController createComponentSessionController(
@@ -86,6 +87,8 @@ public class UserNotificationRequestRouter
           request.setAttribute(RECIPIENT_USERS, nuSC.getUsersFrom(recipientUsers));
           request.setAttribute(RECIPIENT_GROUPS, nuSC.getGroupsFrom(recipientGroups));
         }
+        request.setAttribute(NotificationContext.COMPONENT_ID, context.getComponentId());
+        request.setAttribute(NotificationContext.RESOURCE_ID, context.getResourceId());
         final String param = request.getParameter(RECIPIENT_EDITION_PARAM);
         final boolean areRecipientsEditable;
         if (StringUtil.isDefined(param)) {
@@ -93,7 +96,6 @@ public class UserNotificationRequestRouter
         } else {
           areRecipientsEditable = true;
         }
-        request.setAttribute(NotificationContext.COMPONENT_ID, context.getComponentId());
         request.setAttribute(RECIPIENT_EDITION_PARAM, areRecipientsEditable);
         destination = "/userNotification/jsp/notificationSender.jsp";
       } else if (SENDING_FUNCTION.equals(function)) {

--- a/core-war/src/main/java/org/silverpeas/web/selection/control/SelectionPeasWrapperSessionController.java
+++ b/core-war/src/main/java/org/silverpeas/web/selection/control/SelectionPeasWrapperSessionController.java
@@ -23,7 +23,10 @@
  */
 package org.silverpeas.web.selection.control;
 
+import org.silverpeas.core.admin.domain.model.Domain;
 import org.silverpeas.core.admin.service.OrganizationControllerProvider;
+import org.silverpeas.core.admin.user.model.Group;
+import org.silverpeas.core.admin.user.model.UserDetail;
 import org.silverpeas.core.util.StringUtil;
 import org.silverpeas.core.util.URLUtil;
 import org.silverpeas.core.web.mvc.controller.AbstractComponentSessionController;
@@ -31,9 +34,6 @@ import org.silverpeas.core.web.mvc.controller.ComponentContext;
 import org.silverpeas.core.web.mvc.controller.MainSessionController;
 import org.silverpeas.core.web.selection.Selection;
 import org.silverpeas.core.web.selection.SelectionUsersGroups;
-import org.silverpeas.core.admin.domain.model.Domain;
-import org.silverpeas.core.admin.user.model.Group;
-import org.silverpeas.core.admin.user.model.UserDetail;
 
 import java.util.List;
 import java.util.StringTokenizer;
@@ -47,6 +47,7 @@ public class SelectionPeasWrapperSessionController extends AbstractComponentSess
   private static final int USER_GROUP = 2;
 
   private String domainIdFilter = "";
+  private String resourceIdFilter = "";
   private String[] selectedUserIds;
   private String[] selectedGroupIds;
   private int selectable = SelectionUsersGroups.USER;
@@ -200,6 +201,26 @@ public class SelectionPeasWrapperSessionController extends AbstractComponentSess
   }
 
   /**
+   * Gets the identifier of a resource in a given application instance on which the user selection
+   * must be filtered.
+   * @return an identifier of the resource as string, empty if none. It is a concat of the resource
+   * type and of the resource identifier.
+   */
+  public String getResourceIdFilter() {
+    return resourceIdFilter;
+  }
+
+  /**
+   * Sets the identifier of a resource in a given application instance in order to filter user
+   * selection on it.
+   * @param resourceIdFilter the identifier of the resource as string. It should be a concat of the
+   * resource type and of the resource identifier.
+   */
+  public void setResourceIdFilter(final String resourceIdFilter) {
+    this.resourceIdFilter = StringUtil.defaultStringIfNotDefined(resourceIdFilter);
+  }
+
+  /**
    * Init the user panel.
    */
   public String initSelectionPeas(boolean multiple, String instanceId, List<String> roles,
@@ -242,6 +263,11 @@ public class SelectionPeasWrapperSessionController extends AbstractComponentSess
     if (StringUtil.isDefined(getDomainIdFilter()) &&
         !Domain.MIXED_DOMAIN_ID.equals(getDomainIdFilter())) {
       sug.setDomainId(getDomainIdFilter());
+      sel.setExtraParams(sug);
+    }
+
+    if (StringUtil.isDefined(getResourceIdFilter())) {
+      sug.setObjectId(getResourceIdFilter());
       sel.setExtraParams(sug);
     }
 

--- a/core-war/src/main/java/org/silverpeas/web/selection/servlets/SelectionPeasWrapper.java
+++ b/core-war/src/main/java/org/silverpeas/web/selection/servlets/SelectionPeasWrapper.java
@@ -90,6 +90,7 @@ public class SelectionPeasWrapper extends
 
     controller.setSelectable(request.getParameter("selectable"));
     controller.setDomainIdFilter(request.getParameter("domainIdFilter"));
+    controller.setResourceIdFilter(request.getParameter("resourceIdFilter"));
 
     if (controller.isGroupSelectable()) {
       if (selectionMultiple) {

--- a/core-war/src/main/webapp/WEB-INF/tags/silverpeas/util/selectUsersAndGroups.tag
+++ b/core-war/src/main/webapp/WEB-INF/tags/silverpeas/util/selectUsersAndGroups.tag
@@ -83,6 +83,9 @@
 <%@ attribute name="componentIdFilter" required="false" type="java.lang.String"
               description="The component instance id to filter on" %>
 
+<%@ attribute name="resourceIdFilter" required="false" type="java.lang.String"
+              description="The resource id to filter on. It is a concat of the resource type and of the resource identifier. The component id has to be set if set to non null value" %>
+
 <%@ attribute name="id" required="false" type="java.lang.String"
               description="CSS id" %>
 
@@ -207,6 +210,7 @@
       hideDeactivatedState : ${hideDeactivatedState},
       domainIdFilter : domainFilter,
       componentIdFilter : '${componentIdFilter}',
+      resourceIdFilter : '${resourceIdFilter}',
       roleFilter : roleFilter,
       groupFilter : groupFilter,
       initialQuery : '${silfn:escapeJs(initialQuery)}',

--- a/core-war/src/main/webapp/selection/jsp/userpanel.jsp
+++ b/core-war/src/main/webapp/selection/jsp/userpanel.jsp
@@ -103,7 +103,7 @@
 <fmt:message key="selection.searchUsers" var="defaultUserSearchText"/>
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" id="ng-app" ng-app="silverpeas.userSelector">
+<html xmlns="http://www.w3.org/1999/xhtml" id="ng-app" ng-app="silverpeas.userSelector" xml:lang="${sessionScope['SilverSessionController'].favoriteLanguage}">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <view:looknfeel />
@@ -231,7 +231,7 @@
             <input type="hidden" name="UserOrGroupSelection" value="true"/>
             <input id="group-selection" type="hidden" name="GroupSelection" value=""/>
             <input id="user-selection" type="hidden" name="UserSelection" value=""/>
-            <br clear="all"/>
+            <br />
             <div id="validate" class="sp_buttonPane">
               <fmt:message var="selectLabel" key="GML.validate"/>
               <fmt:message var="cancelLabel" key="GML.cancel"/>

--- a/core-war/src/main/webapp/userNotification/jsp/notificationSender.jsp
+++ b/core-war/src/main/webapp/userNotification/jsp/notificationSender.jsp
@@ -44,11 +44,11 @@
 <c:set var="groups" value="${requestScope.recipientGroups}"/>
 <c:set var="recipientsEditable" value="${requestScope.recipientEdition}"/>
 <c:set var="componentId" value="${requestScope.componentId}"/>
-<c:set var="contributionId" value="${requestScope.contributionId}"/>
+<c:set var="resourceId" value="${requestScope.resourceId}"/>
 <c:set var="subject" value="${requestScope.title}"/>
 
-<c:set var="requiredReceiversErrorMessage"><fmt:message key="GML.thefield"/> <b><fmt:message key="addressees"/></b> <fmt:message key="GML.isRequired"/></c:set>
-<c:set var="requiredSubjectErrorMessage"><fmt:message key="GML.thefield"/> <b><fmt:message key="GML.notification.subject"/></b> <fmt:message key="GML.isRequired"/></c:set>
+<c:set var="requiredReceiversErrorMessage"><fmt:message key="GML.thefield"/> <strong><fmt:message key="addressees"/></strong> <fmt:message key="GML.isRequired"/></c:set>
+<c:set var="requiredSubjectErrorMessage"><fmt:message key="GML.thefield"/> <strong><fmt:message key="GML.notification.subject"/></strong> <fmt:message key="GML.isRequired"/></c:set>
 <view:link href="/util/styleSheets/fieldset.css"/>
 <view:includePlugin name="wysiwyg"/>
 <view:loadScript src="/util/javaScript/checkForm.js"/>
@@ -106,6 +106,7 @@
           <viewTags:selectUsersAndGroups id="messager"
                                          selectionType="USER_GROUP"
                                          componentIdFilter="${componentId}"
+                                         resourceIdFilter="${resourceId}"
                                          multiple="true"
                                          mandatory="${recipientsEditable}"
                                          userManualNotificationUserReceiverLimit="${recipientsEditable}"

--- a/core-war/src/main/webapp/util/javaScript/angularjs/services/silverpeas-profile.js
+++ b/core-war/src/main/webapp/util/javaScript/angularjs/services/silverpeas-profile.js
@@ -50,9 +50,11 @@
 
         var User = function() {
           this.relationships = function() {
+            var params = $.extend({}, defaultParameters);
+            params.instance = context.component;
             return adapter.find({
               url : this.contactsUri,
-              criteria : adapter.criteria(arguments[0], defaultParameters)
+              criteria : adapter.criteria(arguments[0], params)
             });
           };
         };
@@ -191,10 +193,10 @@
  * Provider of the User angularjs service for plain old javascript code.
  * @type {User}
  */
-var User = angular.injector(['ng', 'silverpeas', 'silverpeas.adapters', 'silverpeas.services']).get('User');
+window.User = angular.injector(['ng', 'silverpeas', 'silverpeas.adapters', 'silverpeas.services']).get('User');
 
 /**
  * Fetcher of the UserGroup angularjs service for plain old javascript code.
  * @type {UserGroup}
  */
-var UserGroup = angular.injector(['ng', 'silverpeas', 'silverpeas.adapters', 'silverpeas.services']).get('UserGroup');
+window.UserGroup = angular.injector(['ng', 'silverpeas', 'silverpeas.adapters', 'silverpeas.services']).get('UserGroup');

--- a/core-war/src/main/webapp/util/javaScript/silverpeas-user-group-list.js
+++ b/core-war/src/main/webapp/util/javaScript/silverpeas-user-group-list.js
@@ -73,6 +73,7 @@
       this.options = extendsObject({
         hideDeactivatedState : false,
         domainIdFilter : '',
+        resourceIdFilter : '',
         componentIdFilter : ''
       }, options);
       if (typeof params === 'undefined') {
@@ -85,16 +86,19 @@
             params.userStatesToExclude = ['DEACTIVATED'];
           }
           if (this.options.domainIdFilter) {
-            params.domain = this.options.domainIdFilter
+            params.domain = this.options.domainIdFilter;
           }
           if (this.options.componentIdFilter) {
-            params.component = this.options.componentIdFilter
+            params.component = this.options.componentIdFilter;
+          }
+          if (this.options.resourceIdFilter) {
+            params.resource = this.options.resourceIdFilter;
           }
           if (this.options.roleFilter) {
-            params.roles = this.options.roleFilter.join(',')
+            params.roles = this.options.roleFilter.join(',');
           }
           if (this.options.groupFilter) {
-            params.group = this.options.groupFilter
+            params.group = this.options.groupFilter;
           }
         }
       }
@@ -424,6 +428,7 @@
       hideDeactivatedState : true,
       domainIdFilter : '',
       componentIdFilter : '',
+      resourceIdFilter : '',
       groupFilter : '',
       roleFilter : [],
       selectOnTabulationKeyDown : true,
@@ -492,6 +497,9 @@
       }
       if (typeof filterOptions.domainIdFilter !== 'undefined') {
         this.options.domainIdFilter = filterOptions.domainIdFilter;
+      }
+      if (typeof filterOptions.resourceIdFilter !== 'undefined') {
+        this.options.resourceIdFilter = filterOptions.resourceIdFilter;
       }
       if (typeof filterOptions.componentIdFilter !== 'undefined') {
         this.options.componentIdFilter = filterOptions.componentIdFilter;
@@ -753,6 +761,7 @@
     this.options = extendsObject({
       hideDeactivatedState : true,
       domainIdFilter : '',
+      resourceIdFilter : '',
       userPanelId : '',
       initUserPanelUserIdParamName : '',
       initUserPanelGroupIdParamName : '',
@@ -979,6 +988,7 @@
     var params = {
       "formName" : instance.context.userPanelFormName,
       "domainIdFilter" : instance.options.domainIdFilter,
+      "resourceIdFilter" : instance.options.resourceIdFilter,
       "instanceId" : instance.options.componentIdFilter,
       "showDeactivated" : !instance.options.hideDeactivatedState
     };

--- a/core-war/src/main/webapp/util/javaScript/silverpeas-userZoom.js
+++ b/core-war/src/main/webapp/util/javaScript/silverpeas-userZoom.js
@@ -37,7 +37,7 @@
    * - a flag indicating if the plugin is initialized.
    *
    * At initialization, the plugin loads the profile of the user in the current WEB session and
-   * enrichs it with additional functions related to its contacts and to its invitations sent to
+   * enriches it with additional functions related to its contacts and to its invitations sent to
    * others users.
    */
   $.userZoom = {
@@ -53,9 +53,9 @@
       this.currentTooltip = null;
       this.target = null;
     },
-    set: function(target, tooltip) {
+    set: function(target, aTooltip) {
       this.clear();
-      this.currentTooltip = tooltip;
+      this.currentTooltip = aTooltip;
       this.target = target;
     },
     initialize: function() {
@@ -66,7 +66,7 @@
           return aUser.relationships().then(function(contacts) {
             for (var i = 0; i < contacts.length; i++) {
               var contact = contacts[i];
-              if (me.id == contact.id) {
+              if (me.id === contact.id) {
                 return true;
               }
             }
@@ -78,7 +78,7 @@
           return self.currentUser.myInvitationsPromise.then(function(invitations) {
             for (var i = 0; i < invitations.length; i++) {
               var invitation = invitations[i];
-              if (invitation.receiverId == aUser.id || invitation.senderId == aUser.id) {
+              if (invitation.receiverId.toString() === aUser.id || invitation.senderId.toString() === aUser.id) {
                 return invitation;
               }
             }
@@ -213,31 +213,31 @@
   /**
    * Adjusts the position of the given tooltip associated to the specified target.
    */
-  function __adjustingPositions(tooltip, target) {
+  function __adjustingPositions(aTooltip, target) {
     var picto = $('.userzoom-infoConnection img', target);
     var tooltipEdgeXOffset = __getCachedArrowCss("right") + picto.width();
     var tooltipEdgeYOffset = __getCachedArrowCss("height");
-    tooltip.position({
+    aTooltip.position({
       of : target,
       at : 'right-' + tooltipEdgeXOffset + ' bottom+' + tooltipEdgeYOffset,
       my : 'left top',
       collision : 'flip'
     });
-    var targetPosition = target.offset(), tooltipPosition = tooltip.offset();
+    var targetPosition = target.offset(), tooltipPosition = aTooltip.offset();
     var position = (targetPosition.top > tooltipPosition.top ? 'above' : 'below');
     var isTooltipArrowOnRight = targetPosition.left > tooltipPosition.left;
     var toolTipClass = position + (isTooltipArrowOnRight ? ' right' : ' left');
     if (isTooltipArrowOnRight) {
       var paddingAndMarginLeftOffset = Number(target.css('padding-left').replace(/[^0-9]/g, '')) +
           Number(target.css('margin-left').replace(/[^0-9]/g, ''));
-      tooltip.position({
+      aTooltip.position({
         of : target,
         at : 'left bottom+' + tooltipEdgeYOffset,
         my : 'right+' + (tooltipEdgeXOffset + paddingAndMarginLeftOffset) + ' top',
         collision : 'flip'
       });
     }
-    tooltip.addClass(toolTipClass);
+    aTooltip.addClass(toolTipClass);
   }
 
   /**

--- a/core-web/src/main/java/org/silverpeas/core/web/selection/SelectionUsersGroups.java
+++ b/core-web/src/main/java/org/silverpeas/core/web/selection/SelectionUsersGroups.java
@@ -39,20 +39,24 @@ public class SelectionUsersGroups {
   static OrganizationController organizationController =  OrganizationControllerProvider
       .getOrganisationController();
 
-  public final static int USER = 0;
-  public final static int GROUP = 1;
+  public static final int USER = 0;
+  public static final int GROUP = 1;
 
-  String domainId = null;
-  String componentId = null;
-  String objectId = null;
-  List<String> profileIds = null;
-  List<String> profileNames = null;
+  private String domainId = null;
+  private String componentId = null;
+  private String objectId = null;
+  private List<String> profileIds = null;
+  private List<String> profileNames = null;
 
   public String getJoinedProfileNames() {
     if (profileNames != null && !profileNames.isEmpty()) {
       return String.join(",", profileNames);
     }
     return null;
+  }
+
+  public List<String> getProfileIds() {
+    return this.profileIds;
   }
 
   public void setProfileNames(List<String> profileNames) {
@@ -100,9 +104,9 @@ public class SelectionUsersGroups {
     this.domainId = domainId;
   }
 
-  static public String[] getDistinctUserIds(String[] selectedUsers,
+  public static String[] getDistinctUserIds(String[] selectedUsers,
       String[] selectedGroups) {
-    HashSet<String> usersSet = new HashSet<String>();
+    HashSet<String> usersSet = new HashSet<>();
     if (selectedUsers != null && selectedUsers.length > 0) {
       Collections.addAll(usersSet, selectedUsers);
     }
@@ -117,11 +121,11 @@ public class SelectionUsersGroups {
     return usersSet.toArray(new String[usersSet.size()]);
   }
 
-  static public UserDetail[] getUserDetails(String[] userIds) {
+  public static UserDetail[] getUserDetails(String[] userIds) {
     return organizationController.getUserDetails(userIds);
   }
 
-  static public Group[] getGroups(String[] groupIds) {
+  public static Group[] getGroups(String[] groupIds) {
     if (groupIds != null && groupIds.length > 0) {
       Group[] result = new Group[groupIds.length];
       for (int g = 0; g < groupIds.length; g++) {
@@ -132,7 +136,7 @@ public class SelectionUsersGroups {
     return new Group[0];
   }
 
-  static public String[] getUserIds(UserDetail[] users) {
+  public static String[] getUserIds(UserDetail[] users) {
     if (users == null) {
       return new String[0];
     }
@@ -143,7 +147,7 @@ public class SelectionUsersGroups {
     return result;
   }
 
-  static public String[] getGroupIds(Group[] groups) {
+  public static String[] getGroupIds(Group[] groups) {
     if (groups == null) {
       return new String[0];
     }

--- a/core-web/src/main/java/org/silverpeas/core/webapi/profile/UserProfileResource.java
+++ b/core-web/src/main/java/org/silverpeas/core/webapi/profile/UserProfileResource.java
@@ -326,7 +326,7 @@ public class UserProfileResource extends RESTWebService {
   @Path("{userId}/contacts")
   @Produces(MediaType.APPLICATION_JSON)
   public Response getUserContacts(@PathParam("userId") String userId,
-      @QueryParam("application") String instanceId,
+      @QueryParam("instance") String instanceId,
       @QueryParam("roles") String roles,
       @QueryParam("resource") String resource,
       @QueryParam("name") String name,
@@ -424,7 +424,7 @@ public class UserProfileResource extends RESTWebService {
 
   private String[] getContactIds(String userId) {
     try {
-      int myId = Integer.valueOf(userId);
+      int myId = Integer.parseInt(userId);
       List<RelationShip> relationShips = relationShipService.getAllMyRelationShips(myId);
       String[] userIds = new String[relationShips.size()];
       for (int i = 0; i < relationShips.size(); i++) {


### PR DESCRIPTION
In the user notification transverse module, the receivers that can be selected
can be now filtered also by the resource they can access and for which the
notification is sent. Such resource can be for example a node that is a generic
way to represent a category or a topic to categorize the contributions.

Replace Thread.sleep by Awaitility in MassiveAsynchronousNotificationIT

Don't forget to merge after https://github.com/Silverpeas/Silverpeas-Components/pull/658