### PR TITLE
Bug #10993

### DIFF
--- a/core-api/src/main/java/org/silverpeas/core/persistence/jdbc/sql/setters/SqlBigDecimalParamSetter.java
+++ b/core-api/src/main/java/org/silverpeas/core/persistence/jdbc/sql/setters/SqlBigDecimalParamSetter.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2000 - 2019 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception. You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.persistence.jdbc.sql.setters;
+
+import java.math.BigDecimal;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Setter of SQL parameters of type {@link BigDecimal}.
+ * @author mmoquillon
+ */
+public class SqlBigDecimalParamSetter implements SqlTypedParameterSetter {
+
+  @Override
+  public List<Class<?>> getSupportedTypes() {
+    return Collections.singletonList(BigDecimal.class);
+  }
+
+  @Override
+  public void setParameter(final PreparedStatement statement, final int idx, final Object value)
+      throws SQLException {
+    statement.setBigDecimal(idx, (BigDecimal) value);
+  }
+}
+  

--- a/core-api/src/main/java/org/silverpeas/core/persistence/jdbc/sql/setters/SqlBigIntegerParamSetter.java
+++ b/core-api/src/main/java/org/silverpeas/core/persistence/jdbc/sql/setters/SqlBigIntegerParamSetter.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2000 - 2019 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception. You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.persistence.jdbc.sql.setters;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Setter of SQL parameters of type {@link BigInteger}.
+ * @author mmoquillon
+ */
+public class SqlBigIntegerParamSetter implements SqlTypedParameterSetter {
+
+  @Override
+  public List<Class<?>> getSupportedTypes() {
+    return Collections.singletonList(BigInteger.class);
+  }
+
+  @Override
+  public void setParameter(final PreparedStatement statement, final int idx, final Object value)
+      throws SQLException {
+    statement.setBigDecimal(idx, new BigDecimal((BigInteger) value));
+  }
+}
+  

--- a/core-api/src/main/java/org/silverpeas/core/persistence/jdbc/sql/setters/SqlBinaryParamSetter.java
+++ b/core-api/src/main/java/org/silverpeas/core/persistence/jdbc/sql/setters/SqlBinaryParamSetter.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2000 - 2019 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception. You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.persistence.jdbc.sql.setters;
+
+import java.sql.Blob;
+import java.sql.Clob;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * A setter of SQL parameters of type binaries. The binary types it supports are {@link Byte},
+ * {@link Clob} and {@link Blob}.
+ * @author mmoquillon
+ */
+public class SqlBinaryParamSetter implements SqlTypedParameterSetter {
+
+  @Override
+  public List<Class<?>> getSupportedTypes() {
+    return Arrays.asList(Byte.class, Blob.class, Clob.class);
+  }
+
+  @Override
+  public void setParameter(final PreparedStatement statement, final int idx, final Object value)
+      throws SQLException {
+    if (value instanceof Byte) {
+      statement.setByte(idx, (Byte) value);
+    } else if (value instanceof Blob) {
+      statement.setBlob(idx, (Blob) value);
+    } else if (value instanceof Clob) {
+      statement.setClob(idx, (Clob) value);
+    } else {
+      throw new IllegalArgumentException("Type not supported: " + value.getClass());
+    }
+  }
+}
+  

--- a/core-api/src/main/java/org/silverpeas/core/persistence/jdbc/sql/setters/SqlBooleanParamSetter.java
+++ b/core-api/src/main/java/org/silverpeas/core/persistence/jdbc/sql/setters/SqlBooleanParamSetter.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2000 - 2019 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception. You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.persistence.jdbc.sql.setters;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A setter of SQL parameters of type {@link Boolean}.
+ * @author mmoquillon
+ */
+public class SqlBooleanParamSetter implements SqlTypedParameterSetter {
+
+  @Override
+  public List<Class<?>> getSupportedTypes() {
+    return Collections.singletonList(Boolean.class);
+  }
+
+  @Override
+  public void setParameter(final PreparedStatement statement, final int idx, final Object value)
+      throws SQLException {
+    statement.setBoolean(idx, (Boolean) value);
+  }
+}
+  

--- a/core-api/src/main/java/org/silverpeas/core/persistence/jdbc/sql/setters/SqlDateParamSetter.java
+++ b/core-api/src/main/java/org/silverpeas/core/persistence/jdbc/sql/setters/SqlDateParamSetter.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2000 - 2019 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception. You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.persistence.jdbc.sql.setters;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+
+/**
+ * A setter of SQL parameters of type date that includes java.sql.{@link java.sql.Date},
+ * {@link java.util.Date} and {@link LocalDate}.
+ * @author mmoquillon
+ */
+public class SqlDateParamSetter extends SqlTemporalParamSetter {
+
+  @Override
+  public List<Class<?>> getSupportedTypes() {
+    return Arrays.asList(java.sql.Date.class, Date.class, LocalDate.class);
+  }
+
+  @Override
+  public void setParameter(final PreparedStatement statement, final int idx, final Object value)
+      throws SQLException {
+    if (value instanceof java.sql.Date) {
+      statement.setDate(idx, (java.sql.Date) value);
+    } else if (isADate(value)) {
+      statement.setDate(idx,
+          new java.sql.Date(toInstant(value).toEpochMilli()));
+    } else {
+      throwTypeNotSupported(value.getClass());
+    }
+  }
+
+  private boolean isADate(final Object parameter) {
+    return parameter instanceof Date || parameter instanceof LocalDate;
+  }
+}
+  

--- a/core-api/src/main/java/org/silverpeas/core/persistence/jdbc/sql/setters/SqlDateTimeParamSetter.java
+++ b/core-api/src/main/java/org/silverpeas/core/persistence/jdbc/sql/setters/SqlDateTimeParamSetter.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2000 - 2019 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception. You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.persistence.jdbc.sql.setters;
+
+import org.silverpeas.core.date.DateTime;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * A setter of SQL parameters of type datetime that includes the following types {@link DateTime},
+ * {@link Instant}, {@link java.time.LocalDate}, {@link OffsetDateTime} and {@link ZonedDateTime}.
+ * @author mmoquillon
+ */
+class SqlDateTimeParamSetter extends SqlTemporalParamSetter {
+
+  @Override
+  public List<Class<?>> getSupportedTypes() {
+    return Arrays.asList(Timestamp.class, DateTime.class, Instant.class, LocalDateTime.class,
+        OffsetDateTime.class, ZonedDateTime.class);
+  }
+
+  @Override
+  public void setParameter(final PreparedStatement statement, final int idx, final Object value)
+      throws SQLException {
+    if (value instanceof Timestamp) {
+      statement.setTimestamp(idx, (Timestamp) value);
+    } else if (isADateTime(value)) {
+      statement.setTimestamp(idx, new Timestamp(toInstant(value).toEpochMilli()));
+    } else {
+      throwTypeNotSupported(value.getClass());
+    }
+  }
+
+  private boolean isADateTime(final Object parameter) {
+    if (parameter instanceof DateTime) {
+      return true;
+    }
+    if (parameter instanceof Instant) {
+      return true;
+    }
+    if (parameter instanceof LocalDateTime) {
+      return true;
+    }
+    if (parameter instanceof OffsetDateTime) {
+      return true;
+    }
+    return parameter instanceof ZonedDateTime;
+  }
+}
+  

--- a/core-api/src/main/java/org/silverpeas/core/persistence/jdbc/sql/setters/SqlEnumParamSetter.java
+++ b/core-api/src/main/java/org/silverpeas/core/persistence/jdbc/sql/setters/SqlEnumParamSetter.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2000 - 2019 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception. You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.persistence.jdbc.sql.setters;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A setter of SQL parameters of type {@link Enum}. It is the internal name of the enum instance
+ * that is set.
+ * @author mmoquillon
+ */
+public class SqlEnumParamSetter implements SqlTypedParameterSetter {
+
+  @Override
+  public List<Class<?>> getSupportedTypes() {
+    return Collections.singletonList(Enum.class);
+  }
+
+  @Override
+  public void setParameter(final PreparedStatement statement, final int idx, final Object value)
+      throws SQLException {
+    statement.setString(idx, ((Enum) value).name());
+  }
+}
+  

--- a/core-api/src/main/java/org/silverpeas/core/persistence/jdbc/sql/setters/SqlIntegerParamSetter.java
+++ b/core-api/src/main/java/org/silverpeas/core/persistence/jdbc/sql/setters/SqlIntegerParamSetter.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2000 - 2019 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception. You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.persistence.jdbc.sql.setters;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * The setter of SQL parameters of type {@link Integer}.
+ * @author mmoquillon
+ */
+public class SqlIntegerParamSetter implements SqlTypedParameterSetter {
+  @Override
+  public List<Class<?>> getSupportedTypes() {
+    return Collections.singletonList(Integer.class);
+  }
+
+  @Override
+  public void setParameter(final PreparedStatement statement, final int idx, final Object value)
+      throws SQLException {
+      statement.setInt(idx, (Integer) value);
+  }
+}
+  

--- a/core-api/src/main/java/org/silverpeas/core/persistence/jdbc/sql/setters/SqlLongParamSetter.java
+++ b/core-api/src/main/java/org/silverpeas/core/persistence/jdbc/sql/setters/SqlLongParamSetter.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2000 - 2019 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception. You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.persistence.jdbc.sql.setters;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A setter of SQL parameters of type {@link Long}.
+ * @author mmoquillon
+ */
+public class SqlLongParamSetter implements SqlTypedParameterSetter {
+
+  @Override
+  public List<Class<?>> getSupportedTypes() {
+    return Collections.singletonList(Long.class);
+  }
+
+  @Override
+  public void setParameter(final PreparedStatement statement, final int idx, final Object value)
+      throws SQLException {
+    statement.setLong(idx, (Long) value);
+  }
+}
+  

--- a/core-api/src/main/java/org/silverpeas/core/persistence/jdbc/sql/setters/SqlStatementParameterSetter.java
+++ b/core-api/src/main/java/org/silverpeas/core/persistence/jdbc/sql/setters/SqlStatementParameterSetter.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2000 - 2019 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception. You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.persistence.jdbc.sql.setters;
+
+import org.silverpeas.core.util.ServiceProvider;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Singleton;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * A setter of parameters of a {@link PreparedStatement} instance according to the concrete type of
+ * the value with which the parameter has to be set.
+ * @author mmoquillon
+ */
+@Singleton
+public class SqlStatementParameterSetter {
+
+  private Map<Class<?>, SqlTypedParameterSetter> settersByType = new HashMap<>();
+
+  /**
+   * Registers all of the SQL parameter setters available in Silverpeas for later use.
+   */
+  @PostConstruct
+  void registerAll() {
+    Set<SqlTypedParameterSetter> setters =
+        ServiceProvider.getAllServices(SqlTypedParameterSetter.class);
+    for(SqlTypedParameterSetter aSetter : setters) {
+      for (Class<?> type: aSetter.getSupportedTypes()) {
+        settersByType.put(type, aSetter);
+      }
+    }
+  }
+
+  /**
+   * Sets the nth parameter of the specified SQL statement with the given value. The setting is
+   * really done by using the parameter setter that supports the concrete type of the value; that
+   * is to say by the setter that knows how to set a SQL parameter of a given type.
+   * @param statement a {@link PreparedStatement} instance representing the SQL request.
+   * @param idx the index of the parameter in the SQL statement.
+   * @param value the value with which will be set the parameter.
+   * @throws SQLException if an error occurs while setting the parameter.
+   */
+  public void setParameter(final PreparedStatement statement, final int idx, final Object value)
+      throws SQLException {
+    SqlTypedParameterSetter setter = getSetterForType(value.getClass());
+    if (setter != null) {
+      setter.setParameter(statement, idx, value);
+    } else {
+      setObjectIdentifier(statement, idx, value);
+    }
+  }
+
+  private void setObjectIdentifier(final PreparedStatement preparedStatement,
+      final int paramIndex, final Object parameter) throws SQLException {
+    try {
+      Method idGetter = parameter.getClass().getDeclaredMethod("getId");
+      String id = (String) idGetter.invoke(parameter);
+      preparedStatement.setString(paramIndex, id);
+    } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
+      throw new IllegalArgumentException(
+          "SQL parameter type not handled: " + parameter.getClass(), e);
+    }
+  }
+
+  private SqlTypedParameterSetter getSetterForType(final Class<?> type) {
+    SqlTypedParameterSetter setter = settersByType.get(type);
+    if (setter == null) {
+      Class<?> superType = type.getSuperclass();
+      if (superType != null) {
+        setter = getSetterForType(superType);
+      }
+    }
+    return setter;
+  }
+}
+  

--- a/core-api/src/main/java/org/silverpeas/core/persistence/jdbc/sql/setters/SqlTemporalParamSetter.java
+++ b/core-api/src/main/java/org/silverpeas/core/persistence/jdbc/sql/setters/SqlTemporalParamSetter.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2000 - 2019 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception. You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.persistence.jdbc.sql.setters;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.time.Instant;
+
+/**
+ * An abstract setter of SQL parameters of type temporal. It provides common features for more
+ * concrete setter of temporal parameters.
+ * @author mmoquillon
+ */
+public abstract class SqlTemporalParamSetter implements SqlTypedParameterSetter {
+
+  protected Instant toInstant(final Object value) {
+    try {
+      if (value instanceof Instant) {
+        return (Instant) value;
+      }
+      Method toInstant = value.getClass().getMethod("toInstant");
+      return (Instant) toInstant.invoke(value);
+    } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
+      throw new IllegalArgumentException(
+          "Date or date time parameter expected. But is " + value.getClass(), e);
+    }
+  }
+
+  protected void throwTypeNotSupported(final Class<?> type) {
+    throw new IllegalArgumentException("Type not supported: " + type.getName());
+  }
+}
+  

--- a/core-api/src/main/java/org/silverpeas/core/persistence/jdbc/sql/setters/SqlTextSetter.java
+++ b/core-api/src/main/java/org/silverpeas/core/persistence/jdbc/sql/setters/SqlTextSetter.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2000 - 2019 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception. You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.persistence.jdbc.sql.setters;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A setter of SQL parameters of type {@link String}.
+ * @author mmoquillon
+ */
+public class SqlTextSetter implements SqlTypedParameterSetter {
+
+  @Override
+  public List<Class<?>> getSupportedTypes() {
+    return Collections.singletonList(String.class);
+  }
+
+  @Override
+  public void setParameter(final PreparedStatement statement, final int idx, final Object value)
+      throws SQLException {
+    statement.setString(idx, (String) value);
+  }
+}
+  

--- a/core-api/src/main/java/org/silverpeas/core/persistence/jdbc/sql/setters/SqlTypedParameterSetter.java
+++ b/core-api/src/main/java/org/silverpeas/core/persistence/jdbc/sql/setters/SqlTypedParameterSetter.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2000 - 2019 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception. You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.persistence.jdbc.sql.setters;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.List;
+
+/**
+ * A setter of typed parameters of a {@link PreparedStatement} instance.
+ * @author mmoquillon
+ */
+public interface SqlTypedParameterSetter {
+
+  /**
+   * Specifies the concrete types of the parameter this setter supports.
+   * @return a list of supported parameter types.
+   */
+  List<Class<?>> getSupportedTypes();
+
+  /**
+   * Sets the nth parameter of the specified prepared statement with the given value.
+   * @param statement the prepared statement.
+   * @param idx the index of the parameter to set in the prepared statement.
+   * @param value the value with which the parameter has to be set.
+   * @throws SQLException if an error occurs while setting the parameter.
+   */
+  void setParameter(final PreparedStatement statement, int idx, final Object value)
+      throws SQLException;
+}

--- a/core-api/src/main/java/org/silverpeas/core/persistence/jdbc/sql/setters/package-info.java
+++ b/core-api/src/main/java/org/silverpeas/core/persistence/jdbc/sql/setters/package-info.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2000 - 2019 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception. You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Contains all the setters of SQL parameters witin a SQL request
+ * (id est a {@link java.sql.PreparedStatement}. Each setter is about the setting of a parameter of
+ * a given type. They are dedicated to be used by the
+ * {@link org.silverpeas.core.persistence.jdbc.sql.JdbcSqlExecutor} objects.
+ * @author mmoquillon
+ */
+package org.silverpeas.core.persistence.jdbc.sql.setters;

--- a/core-web/src/main/java/org/silverpeas/core/web/util/viewgenerator/html/pagination/AbstractPagination.java
+++ b/core-web/src/main/java/org/silverpeas/core/web/util/viewgenerator/html/pagination/AbstractPagination.java
@@ -50,7 +50,7 @@ public abstract class AbstractPagination implements Pagination {
   private int nbPagesAround = -1;
   private LocalizationBundle multilang;
 
-  public AbstractPagination() {
+  protected AbstractPagination() {
   }
 
   static PaginationPage getPaginationPageFrom(final String pageSizeAsString,
@@ -60,10 +60,10 @@ public abstract class AbstractPagination implements Pagination {
     int pageNumber = pagination.getPageNumber();
     int pageSize = pagination.getPageSize();
     if (StringUtil.isInteger(pageSizeAsString)) {
-      pageSize = Integer.valueOf(pageSizeAsString);
+      pageSize = Integer.parseInt(pageSizeAsString);
     }
     if (StringUtil.isInteger(itemIndexAsString)) {
-      pageNumber = (Integer.valueOf(itemIndexAsString) / pageSize) + 1;
+      pageNumber = (Integer.parseInt(itemIndexAsString) / pageSize) + 1;
     }
     return new PaginationPage(pageNumber, pageSize);
   }
@@ -279,16 +279,4 @@ public abstract class AbstractPagination implements Pagination {
     }
     return translation;
   }
-
-  @Override
-  public abstract String print();
-
-  @Override
-  public abstract String printIndex();
-
-  @Override
-  public abstract String printIndex(String text);
-
-  @Override
-  public abstract String printCounter();
 }


### PR DESCRIPTION
Fix the bug 10993

Don't forget to merge also the PR https://github.com/Silverpeas/Silverpeas-Components/pull/664
This is this PR that fixes the bug.

Split the setting of the SQL parameters in a PreparedStatement into several
setter objects, each of them dedicated to set a specific parameter type.
This is to avoid the use of multiple if-conditions and it allow to add more
easily an additional setter without having to modify the implementation of the
JdbcSqlExecutor interface.

Improve the setter of SQL date by taking explicitly into account the type of the
parameter value is of type java.sql.Date.