### PR TITLE
Bug #11039: making the display of PDF attached files (via a permalinkURL) possible without breaking out the Silverpeas's navigation.

### DIFF
--- a/core-war/src/main/webapp/util/javaScript/silverpeas-view.js
+++ b/core-war/src/main/webapp/util/javaScript/silverpeas-view.js
@@ -155,10 +155,7 @@
 
     // Player
     $documentViewer.embedPlayer({
-      url : sp.ajaxRequest(view.viewerUri)
-              .withParam('documentId', view.documentId)
-              .withParam('language', view.language)
-              .getUrl(),
+      url : view.viewerUri,
       width : view.width,
       height : view.height
     });
@@ -202,10 +199,7 @@
 
     // Player
     $documentViewer.embedPlayer({
-      url : sp.ajaxRequest(view.viewerUri)
-              .withParam('documentId', view.documentId)
-              .withParam('language', view.language)
-              .getUrl(),
+      url : view.viewerUri,
       width : view.width,
       height : view.height
     });

--- a/core-web/src/main/java/org/silverpeas/core/webapi/viewer/DocumentViewEntity.java
+++ b/core-web/src/main/java/org/silverpeas/core/webapi/viewer/DocumentViewEntity.java
@@ -94,6 +94,7 @@ public class DocumentViewEntity extends AbstractPreviewEntity<DocumentViewEntity
       }
       viewerUri += "fp";
     }
+    viewerUri += "?documentId=" + documentId + "&language=" + language;
   }
 
   protected DocumentViewEntity() {


### PR DESCRIPTION
The Silverpeas's PDF viewer is now provided instead of the one of the WEB browser.
As it is encapsulated into a safe iframe, there is no more side effect with the iframe of the Silverpeas's layout.