### PR TITLE
Bug #8896

### DIFF
--- a/core-library/src/main/java/org/silverpeas/core/subscription/AbstractProfiledResourceSubscriptionListener.java
+++ b/core-library/src/main/java/org/silverpeas/core/subscription/AbstractProfiledResourceSubscriptionListener.java
@@ -31,7 +31,8 @@ import javax.inject.Inject;
 import java.io.Serializable;
 
 /**
- * Abstract listener of deletion events to remove all subscriptions on the deleted resource.
+ * Abstract listener of events to remove all the subscriptions on a deleted resource or on a
+ * resource for which the subscription feature is disabled.
  * It does really the unsubscription and delegates the getting of the subscription resource to the
  * concrete implementors.
  * @author mmoquillon
@@ -49,7 +50,18 @@ public abstract class AbstractProfiledResourceSubscriptionListener<R extends Ser
     subscriptionService.unsubscribeByResource(resource);
   }
 
+  @Override
+  public void onUpdate(final T event) throws Exception {
+    final R object = event.getTransition().getAfter();
+    final boolean isEnabled = isSubscriptionEnabled(object);
+    if (!isEnabled) {
+      final SubscriptionResource resource = getSubscriptionResource(object);
+      subscriptionService.unsubscribeByResource(resource);
+    }
+  }
+
   protected abstract SubscriptionResource getSubscriptionResource(final R resource);
 
+  protected abstract boolean isSubscriptionEnabled(final R resource);
 }
   

--- a/core-library/src/main/java/org/silverpeas/core/subscription/ResourceSubscriptionService.java
+++ b/core-library/src/main/java/org/silverpeas/core/subscription/ResourceSubscriptionService.java
@@ -34,6 +34,23 @@ import org.silverpeas.core.subscription.util.SubscriptionSubscriberList;
 public interface ResourceSubscriptionService {
 
   /**
+   * Some predefined constants to use by Silverpeas components to support identical behaviours.
+   */
+  class Constants {
+
+    private Constants() {
+    }
+
+    /**
+     * Configuration parameter to enable or not the subscription on the resource on which the
+     * parameter is applied. Usually it is used in some component instances' configuration. Any
+     * change in the value of this parameter is listened by the subscription transverse service to
+     * update all the actual subscriptions on the concerned resource.
+     */
+    public static final String SUBSCRIPTION_PARAMETER = "useSubscription";
+  }
+
+  /**
    * Gets all subscribers registered on a component.<br>
    * This service does not look at resources handled by the component but just explicit component
    * subscriptions.

--- a/core-library/src/main/java/org/silverpeas/core/subscription/SubscriptionComponentInstEventListener.java
+++ b/core-library/src/main/java/org/silverpeas/core/subscription/SubscriptionComponentInstEventListener.java
@@ -25,14 +25,17 @@
 package org.silverpeas.core.subscription;
 
 import org.silverpeas.core.admin.component.model.ComponentInst;
+import org.silverpeas.core.admin.component.model.Parameter;
 import org.silverpeas.core.admin.component.notification.ComponentInstanceEvent;
 import org.silverpeas.core.subscription.service.ComponentSubscriptionResource;
+import org.silverpeas.core.util.StringUtil;
 
 import javax.inject.Singleton;
 
 /**
- * Listener of the events on the deletion of a component instance to delete all the subscriptions
- * on that component instance (and hence on its resources).
+ * Listener of the events on the deletion or on an update of a component instance. If the component
+ * instance is deleted or if the subscription on the component instance is disabled, then remove all
+ * the subscriptions on that component instance (and hence on its resources).
  * @author mmoquillon
  */
 @Singleton
@@ -42,6 +45,13 @@ public class SubscriptionComponentInstEventListener
   @Override
   protected SubscriptionResource getSubscriptionResource(final ComponentInst resource) {
     return ComponentSubscriptionResource.from(resource.getId());
+  }
+
+  @Override
+  protected boolean isSubscriptionEnabled(final ComponentInst resource) {
+    final Parameter parameter =
+        resource.getParameter(ResourceSubscriptionService.Constants.SUBSCRIPTION_PARAMETER);
+    return parameter == null || StringUtil.getBooleanValue(parameter.getValue());
   }
 }
   

--- a/core-library/src/main/java/org/silverpeas/core/subscription/SubscriptionNodeEventListener.java
+++ b/core-library/src/main/java/org/silverpeas/core/subscription/SubscriptionNodeEventListener.java
@@ -43,5 +43,10 @@ public class SubscriptionNodeEventListener
   protected SubscriptionResource getSubscriptionResource(final NodeDetail resource) {
     return NodeSubscriptionResource.from(resource.getNodePK());
   }
+
+  @Override
+  protected boolean isSubscriptionEnabled(final NodeDetail resource) {
+    return true;
+  }
 }
   


### PR DESCRIPTION
The subscription service listens now the events about the update of a component
instance in order to know if there is a parameter about the subscription
activation if it is enabled or not. In the case the parameter is disabled, all
the subscriptions on that component instance are removed.

Don't forget to merge also https://github.com/Silverpeas/Silverpeas-Components/pull/669