### PR TITLE
Feature #10766 Online Editing: support of MSProject files

### DIFF
--- a/core-configuration/src/main/config/properties/org/silverpeas/util/attachment/mime_types.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/util/attachment/mime_types.properties
@@ -223,6 +223,8 @@ docm	application/vnd.ms-word.document.macroEnabled.12
 docx	application/vnd.openxmlformats-officedocument.wordprocessingml.document
 dotm	application/vnd.ms-word.template.macroEnabled.12
 dotx	application/vnd.openxmlformats-officedocument.wordprocessingml.template
+mpp application/vnd.ms-project
+mpt application/vnd.ms-project
 potm	application/vnd.ms-powerpoint.template.macroEnabled.12
 potx	application/vnd.openxmlformats-officedocument.presentationml.template
 ppam	application/vnd.ms-powerpoint.addin.macroEnabled.12

--- a/core-library/src/main/java/org/silverpeas/core/util/MimeTypes.java
+++ b/core-library/src/main/java/org/silverpeas/core/util/MimeTypes.java
@@ -112,10 +112,13 @@ public interface MimeTypes {
   String MIME_TYPE_OO_IMAGE = "application/vnd.oasis.opendocument.image";
   // Extension .odm (Document principal)
   String MIME_TYPE_OO_MASTER = "application/vnd.oasis.opendocument.text-master";
-  Set<String> MS_OFFICE_MIME_TYPES = new HashSet<String>(Arrays
-      .asList(
-          new String[]{WORD_MIME_TYPE, EXCEL_MIME_TYPE1, EXCEL_MIME_TYPE2, POWERPOINT_MIME_TYPE1,
-            POWERPOINT_MIME_TYPE2}));
+
+  //Extension .mpp
+  String MSPROJECT_MIME_TYPE = "application/vnd.ms-project";
+
+  //Extension .mpt
+  String MSPROJECT_TEMPLATE_MIME_TYPE = "application/vnd.ms-project";
+
   Set<String> OPEN_OFFICE_MIME_TYPES = new HashSet<String>(Arrays.asList(
       new String[]{WORD_MIME_TYPE, WORD_2007_MIME_TYPE, WORD_2007_TEMPLATE_MIME_TYPE,
         EXCEL_MIME_TYPE1, EXCEL_MIME_TYPE2, EXCEL_2007_MIME_TYPE, EXCEL_2007_TEMPLATE_MIME_TYPE,

--- a/core-library/src/main/java/org/silverpeas/core/util/file/FileUtil.java
+++ b/core-library/src/main/java/org/silverpeas/core/util/file/FileUtil.java
@@ -241,7 +241,7 @@ public class FileUtil implements MimeTypes {
   }
 
   static boolean isMsOfficeExtension(final String mimeType) {
-    return mimeType.startsWith(WORD_2007_EXTENSION) || mimeType.startsWith(EXCEL_2007_EXTENSION)
+    return mimeType.startsWith(WORD_2007_EXTENSION) || mimeType.startsWith(MSPROJECT_MIME_TYPE) || mimeType.startsWith(MSPROJECT_TEMPLATE_MIME_TYPE) || mimeType.startsWith(EXCEL_2007_EXTENSION)
         || mimeType.startsWith(POWERPOINT_2007_EXTENSION);
   }
 


### PR DESCRIPTION
Les fichiers .mpp et .mpt peuvent maintenant être modifiés en ligne.
A noter que la déclaration MS_OFFICE_MIME_TYPES a été supprimée car elle n'était plus utilisée.

Nécessite la mise  à jour sur le poste client de l'exécutable onlineEditing.exe