### PR TITLE
Bug #10918

### DIFF
--- a/core-configuration/src/main/config/properties/org/silverpeas/authentication/autDomainLDAP.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/authentication/autDomainLDAP.properties
@@ -44,3 +44,33 @@ autServer0.LDAPUserBaseDN=CN=Users,DC=TSTEXCHANGE
 autServer0.LDAPUserLoginFieldName=sAMAccountName
 # Optional. Set a specific timeout value in milliseconds for the response
 #autServer0.Timeout =
+
+##
+# Optional. If the expiration of password has to be taken into account in Silverpeas
+##
+#
+#autServer0.MustAlertPasswordExpiration=true
+#
+# In that case, two choices. If the two choices are both defined, only the password expiration time
+# is took into account.
+#
+# For any choices, we indicate the format of the date time supported by the LDAP server:
+# - either 'nanoseconds' for a 64-bit value that represents the number of 100-nanosecond intervals
+#   that have elapsed since 12:00 A.M. January 1, 1601 Coordinated Universal Time (UTC).
+# - or 'TimeStamp' for a standard LDAP date time representation according to the pattern
+#   'yyyyyMMddHHmm[ss][fraction of seconds]X'
+#autServer0.LDAPTimeFieldFormat=
+#
+# In the first choice, the LDAP server supports the password expiration time LDAP attribute. In that
+# case indicates here the name of this attribute (if standard: passwordExpirationTime that is in
+# the TimeStamp format).
+#autServer0.LDAPPwdExpirationTimeFieldName=
+#
+# In the second one, the computation of the expiration time is delegated to Silverpeas. For doing,
+# the LDAP server must support the password change time LDAP attribute whose name must be indicated
+# here (if standard: pwdChangedTime that is in the TimeStamp format), and the expiration rules must
+# be defined with the properties PwdExpirationReminderDelay and LDAPPwdMaxAge whose values are
+# expressed in number of days.
+#autServer0.LDAPPwdLastSetFieldName=
+#autServer0.PwdExpirationReminderDelay=
+#autServer0.LDAPPwdMaxAge=

--- a/core-configuration/src/main/config/properties/org/silverpeas/authentication/autDomainMSAD.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/authentication/autDomainMSAD.properties
@@ -48,6 +48,34 @@ autServer0.LDAPUserLoginFieldName=sAMAccountName
 #Connection must be secured if you plan to change passwords
 autServer0.LDAPSecured=false
 autServer0.LDAPSecuredPort=636
-autServer0.LDAPPwdLastSetFieldName=pwdLastSet
-autServer0.LDAPPwdLastSetFieldFormat=nanoseconds
-autServer0.MustAlertPasswordExpiration=false
+
+##
+# Optional. If the expiration of password has to be taken into account in Silverpeas
+##
+#
+#autServer0.MustAlertPasswordExpiration=true
+#
+# In that case, two choices. If the two choices are both defined, only the password expiration time
+# is took into account.
+#
+# For any choices, we indicate the format of the date time supported by the LDAP server:
+# - either 'nanoseconds' for a 64-bit value that represents the number of 100-nanosecond intervals
+#   that have elapsed since 12:00 A.M. January 1, 1601 Coordinated Universal Time (UTC).
+# - or 'TimeStamp' for a standard LDAP date time representation according to the pattern
+#   'yyyyyMMddHHmm[ss][fraction of seconds]X'
+#autServer0.LDAPTimeFieldFormat=nanoseconds
+#
+# In the first choice, the LDAP server supports the password expiration time LDAP attribute. In that
+# case indicates here the name of this attribute (if standard: passwordExpirationTime that is in
+# the TimeStamp format).
+#autServer0.LDAPPwdExpirationTimeFieldName=msDS-UserPasswordExpiryTimeComputed
+#
+# In the second one, the computation of the expiration time is delegated to Silverpeas. For doing,
+# the LDAP server must support the password change time LDAP attribute whose name must be indicated
+# here (if standard: pwdChangedTime that is in the TimeStamp format), and the expiration rules must
+# be defined with the properties PwdExpirationReminderDelay and LDAPPwdMaxAge whose values are
+# expressed in number of days.
+#autServer0.LDAPPwdLastSetFieldName=pwdLastSet
+#autServer0.PwdExpirationReminderDelay=
+#autServer0.LDAPPwdMaxAge=
+

--- a/core-configuration/src/main/config/properties/org/silverpeas/authentication/autDomainOpenDJ.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/authentication/autDomainOpenDJ.properties
@@ -43,7 +43,7 @@ autServer0.LDAPImpl=opends
 autServer0.LDAPAccessLogin=cn=Directory Manager,cn=Root DNs,cn=config
 autServer0.LDAPAccessPasswd=password
 
-autServer0.LDAPUserLoginFieldName=cn
+autServer0.LDAPUserLoginFieldName=uid
 autServer0.LDAPSecured=false
 autServer0.LDAPSecuredPort=636
 
@@ -66,7 +66,7 @@ autServer0.LDAPSecuredPort=636
 # In the first choice, the LDAP server supports the password expiration time LDAP attribute. In that
 # case indicates here the name of this attribute (if standard: passwordExpirationTime that is in
 # the TimeStamp format).
-#autServer0.LDAPPwdExpirationTimeFieldName=passwordExpirationTime
+#autServer0.LDAPPwdExpirationTimeFieldName=ds-pwp-password-expiration-time
 #
 # In the second one, the computation of the expiration time is delegated to Silverpeas. For doing,
 # the LDAP server must support the password change time LDAP attribute whose name must be indicated

--- a/core-configuration/src/main/config/properties/org/silverpeas/authentication/autDomainOpenDJ.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/authentication/autDomainOpenDJ.properties
@@ -43,7 +43,36 @@ autServer0.LDAPImpl=opends
 autServer0.LDAPAccessLogin=cn=Directory Manager,cn=Root DNs,cn=config
 autServer0.LDAPAccessPasswd=password
 
-autServer0.LDAPUserLoginFieldName=uid
+autServer0.LDAPUserLoginFieldName=cn
 autServer0.LDAPSecured=false
 autServer0.LDAPSecuredPort=636
-autServer0.MustAlertPasswordExpiration=false
+
+##
+# Optional. If the expiration of password has to be taken into account in Silverpeas
+##
+#
+#autServer0.MustAlertPasswordExpiration=true
+#
+# In that case, two choices. If the two choices are both defined, only the password expiration time
+# is took into account.
+#
+# For any choices, we indicate the format of the date time supported by the LDAP server:
+# - either 'nanoseconds' for a 64-bit value that represents the number of 100-nanosecond intervals
+#   that have elapsed since 12:00 A.M. January 1, 1601 Coordinated Universal Time (UTC).
+# - or 'TimeStamp' for a standard LDAP date time representation according to the pattern
+#   'yyyyyMMddHHmm[ss][fraction of seconds]X'
+#autServer0.LDAPTimeFieldFormat=TimeStamp
+#
+# In the first choice, the LDAP server supports the password expiration time LDAP attribute. In that
+# case indicates here the name of this attribute (if standard: passwordExpirationTime that is in
+# the TimeStamp format).
+#autServer0.LDAPPwdExpirationTimeFieldName=passwordExpirationTime
+#
+# In the second one, the computation of the expiration time is delegated to Silverpeas. For doing,
+# the LDAP server must support the password change time LDAP attribute whose name must be indicated
+# here (if standard: pwdChangedTime that is in the TimeStamp format), and the expiration rules must
+# be defined with the properties PwdExpirationReminderDelay and LDAPPwdMaxAge whose values are
+# expressed in number of days.
+#autServer0.LDAPPwdLastSetFieldName=pwdChangedTime
+#autServer0.PwdExpirationReminderDelay=
+#autServer0.LDAPPwdMaxAge=

--- a/core-configuration/src/main/config/properties/org/silverpeas/authentication/multilang/authentication.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/authentication/multilang/authentication.properties
@@ -53,6 +53,7 @@ authentication.logon.Error_SsoOnUnexistantUserAccount =Votre compte utilisateur 
 authentication.logon.Error_UserAccountBlocked = Votre compte est bloqu\u00e9<br/>Veuillez contacter un administrateur
 authentication.logon.Error_UserAccountDeactivated = Votre compte est d\u00e9sactiv\u00e9
 authentication.logon.Error_PwdMustBeChangedOnFirstLogin = Votre mot de passe doit \u00eatre modifi\u00e9 lors de votre premi\u00e8re connexion
+authentication.logon.Error_PwdExpired=Votre mot de passe a expir\u00e9. Veuillez le renouveller.
 authentication.logon.Error_PwdAndEmailMustBeChangedOnFirstLogin = Votre mot de passe doit \u00eatre modifi\u00e9 lors de votre premi\u00e8re connexion. Votre adresse \u00e9lectronique est \u00e9galement requise.
 authentication.logon.Error_UserTosRefused = Vous devez accepter pour acc\u00e9der \u00e0 l'application
 authentication.logon.Error_UserTosTimeout =Le temps imparti pour accepter a \u00e9t\u00e9 d\u00e9pass\u00e9 (10 minutes)

--- a/core-configuration/src/main/config/properties/org/silverpeas/authentication/multilang/authentication_de.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/authentication/multilang/authentication_de.properties
@@ -53,6 +53,7 @@ authentication.logon.Error_SsoOnUnexistantUserAccount =Your user account is not 
 authentication.logon.Error_UserAccountBlocked = Your account is blocked<br/>Please contact an administrator
 authentication.logon.Error_UserAccountDeactivated = Your account is deactivated
 authentication.logon.Error_PwdMustBeChangedOnFirstLogin = You must change your password on your first login
+authentication.logon.Error_PwdExpired=Dein Passwort ist abgelaufen. Bitte erneuern Sie es.
 authentication.logon.Error_PwdAndEmailMustBeChangedOnFirstLogin = You must change your password and fill your email on your first login
 authentication.logon.Error_UserTosRefused =Sie m\u00fcssen akzeptieren, um auf die Anwendung zuzugreifen
 authentication.logon.Error_UserTosTimeout =Die Frist f\u00fcr die Annahme \u00fcberschritten wurde (10 Minuten)

--- a/core-configuration/src/main/config/properties/org/silverpeas/authentication/multilang/authentication_en.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/authentication/multilang/authentication_en.properties
@@ -53,6 +53,7 @@ authentication.logon.Error_SsoOnUnexistantUserAccount =Your user account is not 
 authentication.logon.Error_UserAccountBlocked = Your account is blocked<br/>Please contact an administrator
 authentication.logon.Error_UserAccountDeactivated = Your account is deactivated
 authentication.logon.Error_PwdMustBeChangedOnFirstLogin = You must change your password on your first login
+authentication.logon.Error_PwdExpired=Your password has expired. Please renew it.
 authentication.logon.Error_PwdAndEmailMustBeChangedOnFirstLogin = You must change your password and fill your email on your first login
 authentication.logon.Error_UserTosRefused =You must accept to access the application
 authentication.logon.Error_UserTosTimeout =The time limit for acceptance has been exceeded (10 minutes)

--- a/core-configuration/src/main/config/properties/org/silverpeas/authentication/multilang/authentication_fr.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/authentication/multilang/authentication_fr.properties
@@ -53,6 +53,7 @@ authentication.logon.Error_SsoOnUnexistantUserAccount =Votre compte utilisateur 
 authentication.logon.Error_UserAccountBlocked = Votre compte est bloqu\u00e9<br/>Veuillez contacter un administrateur
 authentication.logon.Error_UserAccountDeactivated = Votre compte est d\u00e9sactiv\u00e9
 authentication.logon.Error_PwdMustBeChangedOnFirstLogin = Votre mot de passe doit \u00eatre modifi\u00e9 lors de votre premi\u00e8re connexion
+authentication.logon.Error_PwdExpired=Votre mot de passe a expir\u00e9. Veuillez le renouveller.
 authentication.logon.Error_PwdAndEmailMustBeChangedOnFirstLogin = Votre mot de passe doit \u00eatre modifi\u00e9 lors de votre premi\u00e8re connexion. Votre adresse \u00e9lectronique est \u00e9galement requise.
 authentication.logon.Error_UserTosRefused =Vous devez accepter pour acc\u00e9der \u00e0 l'application
 authentication.logon.Error_UserTosTimeout =Le temps imparti pour accepter a \u00e9t\u00e9 d\u00e9pass\u00e9 (10 minutes)

--- a/core-library/src/main/java/org/silverpeas/core/admin/domain/driver/ldapdriver/LDAPDriver.java
+++ b/core-library/src/main/java/org/silverpeas/core/admin/domain/driver/ldapdriver/LDAPDriver.java
@@ -33,7 +33,6 @@ import org.silverpeas.core.admin.service.AdminException;
 import org.silverpeas.core.admin.user.model.GroupDetail;
 import org.silverpeas.core.admin.user.model.UserDetail;
 import org.silverpeas.core.admin.user.model.UserFull;
-import org.silverpeas.core.exception.SilverpeasException;
 import org.silverpeas.core.security.authentication.exception.AuthenticationBadCredentialException;
 import org.silverpeas.core.util.SettingBundle;
 import org.silverpeas.core.util.StringUtil;
@@ -223,9 +222,9 @@ public class LDAPDriver extends AbstractDomainDriver {
       LDAPEntry theEntry = getUserLDAPEntry(ld, user.getSpecificId());
 
       if (theEntry == null) {
-        throw new AuthenticationBadCredentialException("LDAPDriver.updateUserFull()",
-            SilverpeasException.ERROR, "admin.EX_USER_NOT_FOUND",
-            "User=" + user.getSpecificId() + ";IdField=" + driverSettings.getUsersIdField());
+        throw new AuthenticationBadCredentialException(
+            "User not found: " + user.getSpecificId() + ";IdField=" +
+                driverSettings.getUsersIdField());
       }
 
       String userFullDN = theEntry.getDN();

--- a/core-library/src/main/java/org/silverpeas/core/admin/domain/driver/ldapdriver/LDAPGroupAllRoot.java
+++ b/core-library/src/main/java/org/silverpeas/core/admin/domain/driver/ldapdriver/LDAPGroupAllRoot.java
@@ -217,6 +217,7 @@ public class LDAPGroupAllRoot extends AbstractLDAPGroup {
           append("PB getting Group's subgroups : ").append(parentId).append("\n");
           SynchroDomainReport.error(LDAPGROUP_ALL_ROOT_GET_CHILD_GROUPS_ENTRY,
               "Erreur lors de la récupération des groupes racine (parentId = " + parentId + ")", e);
+          theEntries = new LDAPEntry[0];
         } else {
           throw e;
         }

--- a/core-library/src/main/java/org/silverpeas/core/security/authentication/Authentication.java
+++ b/core-library/src/main/java/org/silverpeas/core/security/authentication/Authentication.java
@@ -24,11 +24,9 @@
 package org.silverpeas.core.security.authentication;
 
 import org.silverpeas.core.security.authentication.exception.AuthenticationException;
-import org.silverpeas.core.security.authentication.exception
-    .AuthenticationPwdChangeNotAvailException;
+import org.silverpeas.core.security.authentication.exception.AuthenticationPwdChangeNotAvailException;
 import org.silverpeas.core.silvertrace.SilverTrace;
 import org.silverpeas.core.util.SettingBundle;
-import org.silverpeas.core.exception.SilverpeasException;
 
 /**
  * A set of security-related operations about a user authentication.
@@ -198,9 +196,7 @@ public abstract class Authentication {
   protected <T> void doChangePassword(AuthenticationConnection<T> connection,
                                       AuthenticationCredential credential,
                                       String newPassword) throws AuthenticationException {
-    throw new AuthenticationPwdChangeNotAvailException(
-        "AuthenticationServer.changePassword", SilverpeasException.ERROR,
-        "authentication.EX_PASSWD_CHANGE_NOTAVAILABLE");
+    throw new AuthenticationPwdChangeNotAvailException("The password modification isn't available");
   }
 
   /**
@@ -218,9 +214,7 @@ public abstract class Authentication {
    */
   protected <T> void doResetPassword(AuthenticationConnection<T> connection, String login, String newPassword)
       throws AuthenticationException {
-    throw new AuthenticationPwdChangeNotAvailException(
-        "AuthenticationServer.doResetPassword", SilverpeasException.ERROR,
-        "authentication.EX_PASSWD_CHANGE_NOTAVAILABLE");
+    throw new AuthenticationPwdChangeNotAvailException("The password reset isn't available");
   }
 
   private void doSecurityOperation(SecurityOperation op) throws AuthenticationException {

--- a/core-library/src/main/java/org/silverpeas/core/security/authentication/Authentication.java
+++ b/core-library/src/main/java/org/silverpeas/core/security/authentication/Authentication.java
@@ -25,8 +25,8 @@ package org.silverpeas.core.security.authentication;
 
 import org.silverpeas.core.security.authentication.exception.AuthenticationException;
 import org.silverpeas.core.security.authentication.exception.AuthenticationPwdChangeNotAvailException;
-import org.silverpeas.core.silvertrace.SilverTrace;
 import org.silverpeas.core.util.SettingBundle;
+import org.silverpeas.core.util.logging.SilverLogger;
 
 /**
  * A set of security-related operations about a user authentication.
@@ -42,8 +42,6 @@ import org.silverpeas.core.util.SettingBundle;
  * @author mmoquillon
  */
 public abstract class Authentication {
-
-  protected static final String module = "authentication";
 
   protected boolean enabled = true;
 
@@ -155,7 +153,8 @@ public abstract class Authentication {
    * @throws AuthenticationException if no connection can be established with a server of the remote
    * authentication service.
    */
-  abstract protected <T> AuthenticationConnection<T> openConnection() throws AuthenticationException;
+  protected abstract <T> AuthenticationConnection<T> openConnection()
+      throws AuthenticationException;
 
   /**
    * Closes the connection that was previously opened with the server of the remote authentication
@@ -166,7 +165,7 @@ public abstract class Authentication {
    * @throws AuthenticationException if no connection was previously opened or if the connection
    * cannot be closed for any reason.
    */
-  abstract protected <T> void closeConnection(AuthenticationConnection<T> connection)
+  protected abstract <T> void closeConnection(AuthenticationConnection<T> connection)
       throws AuthenticationException;
 
   /**
@@ -177,8 +176,8 @@ public abstract class Authentication {
    * @param <T> the type of the authentication server's connector.
    * @throws AuthenticationException if an error occurs while authenticating the user.
    */
-  abstract protected <T> void doAuthentication(AuthenticationConnection<T> connection,
-                                               AuthenticationCredential credential) throws AuthenticationException;
+  protected abstract <T> void doAuthentication(AuthenticationConnection<T> connection,
+       AuthenticationCredential credential) throws AuthenticationException;
 
   /**
    * Does the password change by using the specified connection with the remote server and with
@@ -194,8 +193,8 @@ public abstract class Authentication {
    * @throws AuthenticationException if an error occurs while changing the user password.
    */
   protected <T> void doChangePassword(AuthenticationConnection<T> connection,
-                                      AuthenticationCredential credential,
-                                      String newPassword) throws AuthenticationException {
+        AuthenticationCredential credential,
+        String newPassword) throws AuthenticationException {
     throw new AuthenticationPwdChangeNotAvailException("The password modification isn't available");
   }
 
@@ -212,8 +211,8 @@ public abstract class Authentication {
    * @param <T> the type of the authentication server's connector.
    * @throws AuthenticationException if an error occurs while resetting the user password.
    */
-  protected <T> void doResetPassword(AuthenticationConnection<T> connection, String login, String newPassword)
-      throws AuthenticationException {
+  protected <T> void doResetPassword(AuthenticationConnection<T> connection, String login,
+      String newPassword) throws AuthenticationException {
     throw new AuthenticationPwdChangeNotAvailException("The password reset isn't available");
   }
 
@@ -230,8 +229,7 @@ public abstract class Authentication {
         }
       } catch (AuthenticationException closeEx) {
         // The exception that could occur in the emergency stop is not interesting.
-        SilverTrace.error(module, "Authentication." + op.getName(),
-            "root.EX_EMERGENCY_CONNECTION_CLOSE_FAILED", "", closeEx);
+        SilverLogger.getLogger(this).error(closeEx);
       }
     }
   }

--- a/core-library/src/main/java/org/silverpeas/core/security/authentication/AuthenticationCAS.java
+++ b/core-library/src/main/java/org/silverpeas/core/security/authentication/AuthenticationCAS.java
@@ -23,19 +23,18 @@
  */
 package org.silverpeas.core.security.authentication;
 
+import org.silverpeas.core.persistence.jdbc.DBUtil;
+import org.silverpeas.core.security.authentication.exception.AuthenticationBadCredentialException;
+import org.silverpeas.core.security.authentication.exception.AuthenticationException;
+import org.silverpeas.core.security.authentication.exception.AuthenticationHostException;
+import org.silverpeas.core.util.SettingBundle;
+
 import java.sql.Connection;
 import java.sql.Driver;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Properties;
-
-import org.silverpeas.core.persistence.jdbc.DBUtil;
-import org.silverpeas.core.util.SettingBundle;
-import org.silverpeas.core.exception.SilverpeasException;
-import org.silverpeas.core.security.authentication.exception.AuthenticationBadCredentialException;
-import org.silverpeas.core.security.authentication.exception.AuthenticationException;
-import org.silverpeas.core.security.authentication.exception.AuthenticationHostException;
 
 public class AuthenticationCAS extends Authentication {
 
@@ -68,25 +67,14 @@ public class AuthenticationCAS extends Authentication {
       info.setProperty("user", jdbcLogin);
       info.setProperty("password", jdbcPasswd);
       driverSQL = (Driver) Class.forName(jdbcDriver).newInstance();
-    } catch (InstantiationException ex) {
-      throw new AuthenticationHostException("AuthenticationCAS.openConnection()",
-          SilverpeasException.ERROR, "root.EX_CANT_INSTANCIATE_DB_DRIVER",
-          "Driver=" + jdbcDriver, ex);
-    } catch (IllegalAccessException ex) {
-      throw new AuthenticationHostException("AuthenticationCAS.openConnection()",
-          SilverpeasException.ERROR, "root.EX_CANT_INSTANCIATE_DB_DRIVER",
-          "Driver=" + jdbcDriver, ex);
-    } catch (ClassNotFoundException ex) {
-      throw new AuthenticationHostException("AuthenticationCAS.openConnection()",
-          SilverpeasException.ERROR, "root.EX_CANT_INSTANCIATE_DB_DRIVER",
-          "Driver=" + jdbcDriver, ex);
+    } catch (InstantiationException|IllegalAccessException|ClassNotFoundException ex) {
+      throw new AuthenticationHostException("Invalid JDBC driver: " + jdbcDriver, ex);
     }
     try {
       Connection connection = driverSQL.connect(jdbcUrl, info);
-      return new AuthenticationConnection<Connection>(connection);
+      return new AuthenticationConnection<>(connection);
     } catch (SQLException ex) {
-      throw new AuthenticationHostException("AuthenticationCAS.openConnection()",
-          SilverpeasException.ERROR, "root.EX_CONNECTION_OPEN_FAILED", "JDBCUrl=" + jdbcUrl, ex);
+      throw new AuthenticationHostException("Cannot connect to database at " + jdbcUrl, ex);
     }
   }
 
@@ -101,13 +89,11 @@ public class AuthenticationCAS extends Authentication {
       rs = stmt.executeQuery();
       if (!rs.next()) {
         throw new AuthenticationBadCredentialException(
-            "AuthenticationCAS.doAuthentication()",
-            SilverpeasException.ERROR, "authentication.EX_USER_NOT_FOUND", "User=" + credential.getLogin());
+            "User not found with login: " + credential.getLogin());
       }
 
     } catch (SQLException ex) {
-      throw new AuthenticationHostException("AuthenticationCAS.doAuthentication()",
-          SilverpeasException.ERROR, "authentication.EX_SQL_ACCESS_ERROR", ex);
+      throw new AuthenticationHostException(ex);
     } finally {
       DBUtil.close(rs, stmt);
     }

--- a/core-library/src/main/java/org/silverpeas/core/security/authentication/AuthenticationCAS.java
+++ b/core-library/src/main/java/org/silverpeas/core/security/authentication/AuthenticationCAS.java
@@ -29,6 +29,8 @@ import org.silverpeas.core.security.authentication.exception.AuthenticationExcep
 import org.silverpeas.core.security.authentication.exception.AuthenticationHostException;
 import org.silverpeas.core.util.SettingBundle;
 
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 import java.sql.Connection;
 import java.sql.Driver;
 import java.sql.PreparedStatement;
@@ -60,14 +62,18 @@ public class AuthenticationCAS extends Authentication {
   }
 
   @Override
+  @SuppressWarnings("unchecked")
   protected AuthenticationConnection<Connection> openConnection() throws AuthenticationException {
     Properties info = new Properties();
-    Driver driverSQL = null;
+    Driver driverSQL;
     try {
       info.setProperty("user", jdbcLogin);
       info.setProperty("password", jdbcPasswd);
-      driverSQL = (Driver) Class.forName(jdbcDriver).newInstance();
-    } catch (InstantiationException|IllegalAccessException|ClassNotFoundException ex) {
+      Constructor<Driver> constructor =
+          ((Class<Driver>) Class.forName(jdbcDriver)).getConstructor();
+      driverSQL = constructor.newInstance();
+    } catch (NoSuchMethodException | InstantiationException | IllegalAccessException |
+        ClassNotFoundException | InvocationTargetException ex) {
       throw new AuthenticationHostException("Invalid JDBC driver: " + jdbcDriver, ex);
     }
     try {

--- a/core-library/src/main/java/org/silverpeas/core/security/authentication/AuthenticationServer.java
+++ b/core-library/src/main/java/org/silverpeas/core/security/authentication/AuthenticationServer.java
@@ -23,15 +23,12 @@
  */
 package org.silverpeas.core.security.authentication;
 
-import org.silverpeas.core.exception.SilverpeasException;
 import org.silverpeas.core.security.authentication.exception.AuthenticationBadCredentialException;
 import org.silverpeas.core.security.authentication.exception.AuthenticationException;
 import org.silverpeas.core.security.authentication.exception.AuthenticationExceptionVisitor;
 import org.silverpeas.core.security.authentication.exception.AuthenticationHostException;
-import org.silverpeas.core.security.authentication.exception
-    .AuthenticationPasswordAboutToExpireException;
-import org.silverpeas.core.security.authentication.exception
-    .AuthenticationPwdChangeNotAvailException;
+import org.silverpeas.core.security.authentication.exception.AuthenticationPasswordAboutToExpireException;
+import org.silverpeas.core.security.authentication.exception.AuthenticationPwdChangeNotAvailException;
 import org.silverpeas.core.security.authentication.exception.AuthenticationPwdNotAvailException;
 import org.silverpeas.core.util.ResourceLocator;
 import org.silverpeas.core.util.SettingBundle;
@@ -140,8 +137,7 @@ public class AuthenticationServer {
   public void changePassword(final AuthenticationCredential credential,
       final String newPassword) throws AuthenticationException {
     if (!passwordChangeAllowed) {
-      throw new AuthenticationPwdChangeNotAvailException("AuthenticationServer.changePassword",
-          SilverpeasException.ERROR, "authentication.EX_PASSWD_CHANGE_NOTAVAILABLE");
+      throw new AuthenticationPwdChangeNotAvailException("The password modification isn't available");
     }
 
     doSecurityOperation(new SecurityOperation(SecurityOperation.P_CHANGE, credential) {
@@ -177,8 +173,7 @@ public class AuthenticationServer {
   public void resetPassword(final String login, final String newPassword) throws
       AuthenticationException {
     if (!passwordChangeAllowed) {
-      throw new AuthenticationPwdChangeNotAvailException("AuthenticationServer.resetPassword",
-          SilverpeasException.ERROR, "authentication.EX_PASSWD_CHANGE_NOTAVAILABLE");
+      throw new AuthenticationPwdChangeNotAvailException("The password reset isn't available");
     }
 
     doSecurityOperation(new SecurityOperation(SecurityOperation.P_RESET,
@@ -192,8 +187,7 @@ public class AuthenticationServer {
 
   private void doSecurityOperation(SecurityOperation op) throws AuthenticationException {
     if (!StringUtil.isDefined(op.getAuthenticationCredential().getLogin())) {
-      throw new AuthenticationException("AuthenticationServer." + op.getName(),
-          SilverpeasException.ERROR, "authentication.EX_LOGIN_EMPTY");
+      throw new AuthenticationException("The login of the user isn't set!");
     }
 
     boolean serverNotFound = true;
@@ -218,12 +212,9 @@ public class AuthenticationServer {
 
     if (serverNotFound) {
       if (lastException == null) {
-        throw new AuthenticationException("AuthenticationServer." + op.getName(),
-            SilverpeasException.ERROR, "authentication.EX_NO_SERVER_AVAILABLE");
+        throw new AuthenticationException("No server definition found");
       } else {
-        throw new AuthenticationException("AuthenticationServer." + op.getName(),
-            SilverpeasException.ERROR, "authentication.EX_AUTHENTICATION_FAILED_LAST_ERROR",
-            lastException);
+        throw lastException;
       }
     }
   }

--- a/core-library/src/main/java/org/silverpeas/core/security/authentication/exception/AuthenticationBadCredentialException.java
+++ b/core-library/src/main/java/org/silverpeas/core/security/authentication/exception/AuthenticationBadCredentialException.java
@@ -29,36 +29,20 @@
 
 package org.silverpeas.core.security.authentication.exception;
 
-/**
- * @author tleroi
- * @version
- */
 public class AuthenticationBadCredentialException extends AuthenticationException {
 
-  private static final long serialVersionUID = -6224596419804291843L;
+  private static final long serialVersionUID = 415496726065000804L;
 
-  /**
-   * -------------------------------------------------------------------------- constructor
-   * constructor
-   */
-  public AuthenticationBadCredentialException(String callingClass,
-      int errorLevel, String message) {
-    super(callingClass, errorLevel, message);
+  public AuthenticationBadCredentialException(final String message, final String... parameters) {
+    super(message, parameters);
   }
 
-  public AuthenticationBadCredentialException(String callingClass,
-      int errorLevel, String message, String extraParams) {
-    super(callingClass, errorLevel, message, extraParams);
+  public AuthenticationBadCredentialException(final String message, final Throwable cause) {
+    super(message, cause);
   }
 
-  public AuthenticationBadCredentialException(String callingClass,
-      int errorLevel, String message, Exception nested) {
-    super(callingClass, errorLevel, message, nested);
-  }
-
-  public AuthenticationBadCredentialException(String callingClass,
-      int errorLevel, String message, String extraParams, Exception nested) {
-    super(callingClass, errorLevel, message, extraParams, nested);
+  public AuthenticationBadCredentialException(final Throwable cause) {
+    super(cause);
   }
 
   @Override

--- a/core-library/src/main/java/org/silverpeas/core/security/authentication/exception/AuthenticationException.java
+++ b/core-library/src/main/java/org/silverpeas/core/security/authentication/exception/AuthenticationException.java
@@ -29,48 +29,30 @@
 
 package org.silverpeas.core.security.authentication.exception;
 
-import org.silverpeas.core.exception.SilverpeasException;
+import org.silverpeas.core.SilverpeasException;
 
 /**
- * @author tleroi
- * @version
+ * Exception thrown when an error occurs while a user is authenticating himself against
+ * Silverpeas.
+ * @author tleroi, mmoquillon
  */
 public class AuthenticationException extends SilverpeasException {
 
-  private static final long serialVersionUID = 8552020923204390308L;
+  private static final long serialVersionUID = -2893207451975784160L;
 
-  /**
-   * -------------------------------------------------------------------------- constructor
-   * constructor
-   */
-  public AuthenticationException(String callingClass, int errorLevel,
-      String message) {
-    super(callingClass, errorLevel, message);
+  public AuthenticationException(final String message, final String... parameters) {
+    super(message, parameters);
   }
 
-  public AuthenticationException(String callingClass, int errorLevel,
-      String message, String extraParams) {
-    super(callingClass, errorLevel, message, extraParams);
+  public AuthenticationException(final String message, final Throwable cause) {
+    super(message, cause);
   }
 
-  public AuthenticationException(String callingClass, int errorLevel,
-      String message, Exception nested) {
-    super(callingClass, errorLevel, message, nested);
-  }
-
-  public AuthenticationException(String callingClass, int errorLevel,
-      String message, String extraParams, Exception nested) {
-    super(callingClass, errorLevel, message, extraParams, nested);
+  public AuthenticationException(final Throwable cause) {
+    super(cause);
   }
 
   public void accept(AuthenticationExceptionVisitor visitor) throws AuthenticationException {
     visitor.visit(this);
-  }
-
-  /**
-   * -------------------------------------------------------------------------- getModule getModule
-   */
-  public String getModule() {
-    return "authentication";
   }
 }

--- a/core-library/src/main/java/org/silverpeas/core/security/authentication/exception/AuthenticationHostException.java
+++ b/core-library/src/main/java/org/silverpeas/core/security/authentication/exception/AuthenticationHostException.java
@@ -29,30 +29,18 @@ package org.silverpeas.core.security.authentication.exception;
  */
 public class AuthenticationHostException extends AuthenticationException {
 
-  private static final long serialVersionUID = 3318090264755986318L;
+  private static final long serialVersionUID = 3690730936110857259L;
 
-  /**
-   * -------------------------------------------------------------------------- constructor
-   * constructor
-   */
-  public AuthenticationHostException(String callingClass, int errorLevel,
-      String message) {
-    super(callingClass, errorLevel, message);
+  public AuthenticationHostException(final String message, final String... parameters) {
+    super(message, parameters);
   }
 
-  public AuthenticationHostException(String callingClass, int errorLevel,
-      String message, String extraParams) {
-    super(callingClass, errorLevel, message, extraParams);
+  public AuthenticationHostException(final String message, final Throwable cause) {
+    super(message, cause);
   }
 
-  public AuthenticationHostException(String callingClass, int errorLevel,
-      String message, Exception nested) {
-    super(callingClass, errorLevel, message, nested);
-  }
-
-  public AuthenticationHostException(String callingClass, int errorLevel,
-      String message, String extraParams, Exception nested) {
-    super(callingClass, errorLevel, message, extraParams, nested);
+  public AuthenticationHostException(final Throwable cause) {
+    super(cause);
   }
 
   @Override

--- a/core-library/src/main/java/org/silverpeas/core/security/authentication/exception/AuthenticationNoMoreUserConnectionAttemptException.java
+++ b/core-library/src/main/java/org/silverpeas/core/security/authentication/exception/AuthenticationNoMoreUserConnectionAttemptException.java
@@ -29,28 +29,21 @@
 
 package org.silverpeas.core.security.authentication.exception;
 
-/**
- *
- */
 public class AuthenticationNoMoreUserConnectionAttemptException extends AuthenticationException {
 
-  public AuthenticationNoMoreUserConnectionAttemptException(String callingClass, int errorLevel,
-      String message) {
-    super(callingClass, errorLevel, message);
+  private static final long serialVersionUID = -3589975136567037191L;
+
+  public AuthenticationNoMoreUserConnectionAttemptException(final String message,
+      final String... parameters) {
+    super(message, parameters);
   }
 
-  public AuthenticationNoMoreUserConnectionAttemptException(String callingClass, int errorLevel,
-      String message, String extraParams) {
-    super(callingClass, errorLevel, message, extraParams);
+  public AuthenticationNoMoreUserConnectionAttemptException(final String message,
+      final Throwable cause) {
+    super(message, cause);
   }
 
-  public AuthenticationNoMoreUserConnectionAttemptException(String callingClass, int errorLevel,
-      String message, Exception nested) {
-    super(callingClass, errorLevel, message, nested);
-  }
-
-  public AuthenticationNoMoreUserConnectionAttemptException(String callingClass, int errorLevel,
-      String message, String extraParams, Exception nested) {
-    super(callingClass, errorLevel, message, extraParams, nested);
+  public AuthenticationNoMoreUserConnectionAttemptException(final Throwable cause) {
+    super(cause);
   }
 }

--- a/core-library/src/main/java/org/silverpeas/core/security/authentication/exception/AuthenticationPasswordAboutToExpireException.java
+++ b/core-library/src/main/java/org/silverpeas/core/security/authentication/exception/AuthenticationPasswordAboutToExpireException.java
@@ -29,36 +29,21 @@
 
 package org.silverpeas.core.security.authentication.exception;
 
-/**
- * @author tleroi
- * @version
- */
 public class AuthenticationPasswordAboutToExpireException extends AuthenticationException {
 
-  private static final long serialVersionUID = -6944881509553671169L;
+  private static final long serialVersionUID = -8442163373117133600L;
 
-  /**
-   * -------------------------------------------------------------------------- constructor
-   * constructor
-   */
-  public AuthenticationPasswordAboutToExpireException(String callingClass,
-      int errorLevel, String message) {
-    super(callingClass, errorLevel, message);
+  public AuthenticationPasswordAboutToExpireException(final String message,
+      final String... parameters) {
+    super(message, parameters);
   }
 
-  public AuthenticationPasswordAboutToExpireException(String callingClass,
-      int errorLevel, String message, String extraParams) {
-    super(callingClass, errorLevel, message, extraParams);
+  public AuthenticationPasswordAboutToExpireException(final String message, final Throwable cause) {
+    super(message, cause);
   }
 
-  public AuthenticationPasswordAboutToExpireException(String callingClass,
-      int errorLevel, String message, Exception nested) {
-    super(callingClass, errorLevel, message, nested);
-  }
-
-  public AuthenticationPasswordAboutToExpireException(String callingClass,
-      int errorLevel, String message, String extraParams, Exception nested) {
-    super(callingClass, errorLevel, message, extraParams, nested);
+  public AuthenticationPasswordAboutToExpireException(final Throwable cause) {
+    super(cause);
   }
 
   @Override

--- a/core-library/src/main/java/org/silverpeas/core/security/authentication/exception/AuthenticationPasswordExpired.java
+++ b/core-library/src/main/java/org/silverpeas/core/security/authentication/exception/AuthenticationPasswordExpired.java
@@ -24,7 +24,18 @@
 package org.silverpeas.core.security.authentication.exception;
 
 public class AuthenticationPasswordExpired extends AuthenticationException {
-  public AuthenticationPasswordExpired(String extraParams) {
-    super(null, ERROR, "authentication.EX_PASSWORD_EXPIRED", extraParams);
+
+  private static final long serialVersionUID = 5100036068286015388L;
+
+  public AuthenticationPasswordExpired(final String message, final String... parameters) {
+    super(message, parameters);
+  }
+
+  public AuthenticationPasswordExpired(final String message, final Throwable cause) {
+    super(message, cause);
+  }
+
+  public AuthenticationPasswordExpired(final Throwable cause) {
+    super(cause);
   }
 }

--- a/core-library/src/main/java/org/silverpeas/core/security/authentication/exception/AuthenticationPasswordMustBeChangedAtNextLogon.java
+++ b/core-library/src/main/java/org/silverpeas/core/security/authentication/exception/AuthenticationPasswordMustBeChangedAtNextLogon.java
@@ -24,7 +24,20 @@
 package org.silverpeas.core.security.authentication.exception;
 
 public class AuthenticationPasswordMustBeChangedAtNextLogon extends AuthenticationException {
-  public AuthenticationPasswordMustBeChangedAtNextLogon(String extraParams) {
-    super(null, ERROR, "authentication.EX_PASSWORD_MUST_BE_CHANGED_AT_NEXT_LOGON", extraParams);
+
+  private static final long serialVersionUID = -4913081751513865879L;
+
+  public AuthenticationPasswordMustBeChangedAtNextLogon(final String message,
+      final String... parameters) {
+    super(message, parameters);
+  }
+
+  public AuthenticationPasswordMustBeChangedAtNextLogon(final String message,
+      final Throwable cause) {
+    super(message, cause);
+  }
+
+  public AuthenticationPasswordMustBeChangedAtNextLogon(final Throwable cause) {
+    super(cause);
   }
 }

--- a/core-library/src/main/java/org/silverpeas/core/security/authentication/exception/AuthenticationPasswordMustBeChangedOnFirstLogin.java
+++ b/core-library/src/main/java/org/silverpeas/core/security/authentication/exception/AuthenticationPasswordMustBeChangedOnFirstLogin.java
@@ -24,7 +24,20 @@
 package org.silverpeas.core.security.authentication.exception;
 
 public class AuthenticationPasswordMustBeChangedOnFirstLogin extends AuthenticationException {
-  public AuthenticationPasswordMustBeChangedOnFirstLogin(String extraParams) {
-    super(null, ERROR, "authentication.EX_PASSWORD_MUST_BE_CHANGED_ON_FIRST_LOGIN", extraParams);
+
+  private static final long serialVersionUID = -9059548758621418900L;
+
+  public AuthenticationPasswordMustBeChangedOnFirstLogin(final String message,
+      final String... parameters) {
+    super(message, parameters);
+  }
+
+  public AuthenticationPasswordMustBeChangedOnFirstLogin(final String message,
+      final Throwable cause) {
+    super(message, cause);
+  }
+
+  public AuthenticationPasswordMustBeChangedOnFirstLogin(final Throwable cause) {
+    super(cause);
   }
 }

--- a/core-library/src/main/java/org/silverpeas/core/security/authentication/exception/AuthenticationPwdChangeNotAvailException.java
+++ b/core-library/src/main/java/org/silverpeas/core/security/authentication/exception/AuthenticationPwdChangeNotAvailException.java
@@ -29,35 +29,21 @@
 
 package org.silverpeas.core.security.authentication.exception;
 
-/**
- * @author Ludovic Bertin
- */
 public class AuthenticationPwdChangeNotAvailException extends AuthenticationException {
 
-  private static final long serialVersionUID = -5828893849246684442L;
+  private static final long serialVersionUID = 216177360526878544L;
 
-  /**
-   * -------------------------------------------------------------------------- constructor
-   * constructor
-   */
-  public AuthenticationPwdChangeNotAvailException(String callingClass,
-      int errorLevel, String message) {
-    super(callingClass, errorLevel, message);
+  public AuthenticationPwdChangeNotAvailException(final String message,
+      final String... parameters) {
+    super(message, parameters);
   }
 
-  public AuthenticationPwdChangeNotAvailException(String callingClass,
-      int errorLevel, String message, String extraParams) {
-    super(callingClass, errorLevel, message, extraParams);
+  public AuthenticationPwdChangeNotAvailException(final String message, final Throwable cause) {
+    super(message, cause);
   }
 
-  public AuthenticationPwdChangeNotAvailException(String callingClass,
-      int errorLevel, String message, Exception nested) {
-    super(callingClass, errorLevel, message, nested);
-  }
-
-  public AuthenticationPwdChangeNotAvailException(String callingClass,
-      int errorLevel, String message, String extraParams, Exception nested) {
-    super(callingClass, errorLevel, message, extraParams, nested);
+  public AuthenticationPwdChangeNotAvailException(final Throwable cause) {
+    super(cause);
   }
 
   @Override

--- a/core-library/src/main/java/org/silverpeas/core/security/authentication/exception/AuthenticationPwdNotAvailException.java
+++ b/core-library/src/main/java/org/silverpeas/core/security/authentication/exception/AuthenticationPwdNotAvailException.java
@@ -29,36 +29,20 @@
 
 package org.silverpeas.core.security.authentication.exception;
 
-/**
- * @author tleroi
- * @version
- */
 public class AuthenticationPwdNotAvailException extends AuthenticationException {
 
-  private static final long serialVersionUID = 3338040913682812355L;
+  private static final long serialVersionUID = -8615348829881392380L;
 
-  /**
-   * -------------------------------------------------------------------------- constructor
-   * constructor
-   */
-  public AuthenticationPwdNotAvailException(String callingClass,
-      int errorLevel, String message) {
-    super(callingClass, errorLevel, message);
+  public AuthenticationPwdNotAvailException(final String message, final String... parameters) {
+    super(message, parameters);
   }
 
-  public AuthenticationPwdNotAvailException(String callingClass,
-      int errorLevel, String message, String extraParams) {
-    super(callingClass, errorLevel, message, extraParams);
+  public AuthenticationPwdNotAvailException(final String message, final Throwable cause) {
+    super(message, cause);
   }
 
-  public AuthenticationPwdNotAvailException(String callingClass,
-      int errorLevel, String message, Exception nested) {
-    super(callingClass, errorLevel, message, nested);
-  }
-
-  public AuthenticationPwdNotAvailException(String callingClass,
-      int errorLevel, String message, String extraParams, Exception nested) {
-    super(callingClass, errorLevel, message, extraParams, nested);
+  public AuthenticationPwdNotAvailException(final Throwable cause) {
+    super(cause);
   }
 
   @Override

--- a/core-library/src/main/java/org/silverpeas/core/security/authentication/exception/AuthenticationUserAccountBlockedException.java
+++ b/core-library/src/main/java/org/silverpeas/core/security/authentication/exception/AuthenticationUserAccountBlockedException.java
@@ -23,28 +23,20 @@
  */
 package org.silverpeas.core.security.authentication.exception;
 
-/**
- *
- */
 public class AuthenticationUserAccountBlockedException extends AuthenticationException {
 
-  public AuthenticationUserAccountBlockedException(String callingClass, int errorLevel,
-      String message) {
-    super(callingClass, errorLevel, message);
+  private static final long serialVersionUID = 6603968149549138503L;
+
+  public AuthenticationUserAccountBlockedException(final String message,
+      final String... parameters) {
+    super(message, parameters);
   }
 
-  public AuthenticationUserAccountBlockedException(String callingClass, int errorLevel,
-      String message, String extraParams) {
-    super(callingClass, errorLevel, message, extraParams);
+  public AuthenticationUserAccountBlockedException(final String message, final Throwable cause) {
+    super(message, cause);
   }
 
-  public AuthenticationUserAccountBlockedException(String callingClass, int errorLevel,
-      String message, Exception nested) {
-    super(callingClass, errorLevel, message, nested);
-  }
-
-  public AuthenticationUserAccountBlockedException(String callingClass, int errorLevel,
-      String message, String extraParams, Exception nested) {
-    super(callingClass, errorLevel, message, extraParams, nested);
+  public AuthenticationUserAccountBlockedException(final Throwable cause) {
+    super(cause);
   }
 }

--- a/core-library/src/main/java/org/silverpeas/core/security/authentication/exception/AuthenticationUserAccountDeactivatedException.java
+++ b/core-library/src/main/java/org/silverpeas/core/security/authentication/exception/AuthenticationUserAccountDeactivatedException.java
@@ -23,28 +23,21 @@
  */
 package org.silverpeas.core.security.authentication.exception;
 
-/**
- *
- */
 public class AuthenticationUserAccountDeactivatedException extends AuthenticationException {
 
-  public AuthenticationUserAccountDeactivatedException(String callingClass, int errorLevel,
-      String message) {
-    super(callingClass, errorLevel, message);
+  private static final long serialVersionUID = -2238547859290425020L;
+
+  public AuthenticationUserAccountDeactivatedException(final String message,
+      final String... parameters) {
+    super(message, parameters);
   }
 
-  public AuthenticationUserAccountDeactivatedException(String callingClass, int errorLevel,
-      String message, String extraParams) {
-    super(callingClass, errorLevel, message, extraParams);
+  public AuthenticationUserAccountDeactivatedException(final String message,
+      final Throwable cause) {
+    super(message, cause);
   }
 
-  public AuthenticationUserAccountDeactivatedException(String callingClass, int errorLevel,
-      String message, Exception nested) {
-    super(callingClass, errorLevel, message, nested);
-  }
-
-  public AuthenticationUserAccountDeactivatedException(String callingClass, int errorLevel,
-      String message, String extraParams, Exception nested) {
-    super(callingClass, errorLevel, message, extraParams, nested);
+  public AuthenticationUserAccountDeactivatedException(final Throwable cause) {
+    super(cause);
   }
 }

--- a/core-library/src/main/java/org/silverpeas/core/security/authentication/exception/AuthenticationUserMustAcceptTermsOfService.java
+++ b/core-library/src/main/java/org/silverpeas/core/security/authentication/exception/AuthenticationUserMustAcceptTermsOfService.java
@@ -24,9 +24,19 @@
 package org.silverpeas.core.security.authentication.exception;
 
 public class AuthenticationUserMustAcceptTermsOfService extends AuthenticationException {
-  private static final long serialVersionUID = 9019312668487778347L;
 
-  public AuthenticationUserMustAcceptTermsOfService() {
-    super(null, WARNING, "authentication.EX_USER_MUST_ACCEPT_TERMS_OF_SERVICE", "");
+  private static final long serialVersionUID = -2474749140822463181L;
+
+  public AuthenticationUserMustAcceptTermsOfService(final String message,
+      final String... parameters) {
+    super(message, parameters);
+  }
+
+  public AuthenticationUserMustAcceptTermsOfService(final String message, final Throwable cause) {
+    super(message, cause);
+  }
+
+  public AuthenticationUserMustAcceptTermsOfService(final Throwable cause) {
+    super(cause);
   }
 }

--- a/core-library/src/main/java/org/silverpeas/core/security/authentication/verifier/UserCanLoginVerifier.java
+++ b/core-library/src/main/java/org/silverpeas/core/security/authentication/verifier/UserCanLoginVerifier.java
@@ -27,13 +27,10 @@ import org.silverpeas.core.admin.domain.model.Domain;
 import org.silverpeas.core.admin.service.AdminException;
 import org.silverpeas.core.admin.service.Administration;
 import org.silverpeas.core.admin.user.model.UserDetail;
-import org.silverpeas.core.exception.SilverpeasException;
 import org.silverpeas.core.security.authentication.exception.AuthenticationBadCredentialException;
 import org.silverpeas.core.security.authentication.exception.AuthenticationException;
-import org.silverpeas.core.security.authentication.exception
-    .AuthenticationUserAccountBlockedException;
-import org.silverpeas.core.security.authentication.exception
-    .AuthenticationUserAccountDeactivatedException;
+import org.silverpeas.core.security.authentication.exception.AuthenticationUserAccountBlockedException;
+import org.silverpeas.core.security.authentication.exception.AuthenticationUserAccountDeactivatedException;
 import org.silverpeas.core.util.StringUtil;
 import org.silverpeas.core.util.logging.SilverLogger;
 
@@ -48,8 +45,6 @@ public class UserCanLoginVerifier extends AbstractAuthenticationVerifier {
   public static final String ERROR_INCORRECT_LOGIN_PWD_DOMAIN = "6";
   public static final String ERROR_USER_ACCOUNT_BLOCKED = "Error_UserAccountBlocked";
   public static final String ERROR_USER_ACCOUNT_DEACTIVATED = "Error_UserAccountDeactivated";
-  public static final String VERIFIER = "UserCanLoginVerifier.verify()";
-  public static final String CANNOT_LOGIN = "authentication.EX_VERIFY_USER_CAN_LOGIN";
 
   /**
    * Default constructor.
@@ -95,19 +90,17 @@ public class UserCanLoginVerifier extends AbstractAuthenticationVerifier {
   public void verify() throws AuthenticationException {
     if(getUser() == null) {
       // Authentication failed
-      throw new AuthenticationBadCredentialException(VERIFIER,
-          SilverpeasException.ERROR, CANNOT_LOGIN);
+      throw new AuthenticationBadCredentialException("No user with such credential");
     } else if (!isUserStateValid()) {
       // For now, if user is not valid (BLOCKED, DEACTIVATED, EXPIRED, REMOVED, DELETED, UNKNOWN)
       // he is considered as BLOCKED.
       if (getUser().isDeactivatedState()) {
-        throw new AuthenticationUserAccountDeactivatedException(VERIFIER,
-            SilverpeasException.ERROR, CANNOT_LOGIN,
-            "Login=" + getUser().getLogin());
+        throw new AuthenticationUserAccountDeactivatedException(
+            "The account of the user with login " + getUser().getLogin() + " is deactivated");
       }
-      throw new AuthenticationUserAccountBlockedException(VERIFIER,
-          SilverpeasException.ERROR, CANNOT_LOGIN,
-          "Login=" + getUser().getLogin());
+      throw new AuthenticationUserAccountBlockedException(
+          "The account of the user with login " + getUser().getLogin() + " is blocked"
+      );
     }
   }
 

--- a/core-library/src/main/java/org/silverpeas/core/security/authentication/verifier/UserCanTryAgainToLoginVerifier.java
+++ b/core-library/src/main/java/org/silverpeas/core/security/authentication/verifier/UserCanTryAgainToLoginVerifier.java
@@ -55,7 +55,7 @@ import java.util.concurrent.ConcurrentHashMap;
 public class UserCanTryAgainToLoginVerifier extends AbstractAuthenticationVerifier {
 
   private static final Map<String, UserCanTryAgainToLoginVerifier> cache =
-      new ConcurrentHashMap<String, UserCanTryAgainToLoginVerifier>();
+      new ConcurrentHashMap<>();
 
   private static boolean isActivated = false;
   private static boolean isCacheCleanerInitialized = false;
@@ -246,7 +246,7 @@ public class UserCanTryAgainToLoginVerifier extends AbstractAuthenticationVerifi
    */
   private class CacheCleanerJob extends Job {
 
-    public final static String JOB_NAME = "AuthenticationUserConnectionAttemptsVerifierCleanerJob";
+    public static final String JOB_NAME = "AuthenticationUserConnectionAttemptsVerifierCleanerJob";
 
     /**
      * Default constructor.

--- a/core-library/src/main/java/org/silverpeas/core/security/authentication/verifier/UserCanTryAgainToLoginVerifier.java
+++ b/core-library/src/main/java/org/silverpeas/core/security/authentication/verifier/UserCanTryAgainToLoginVerifier.java
@@ -26,7 +26,6 @@ package org.silverpeas.core.security.authentication.verifier;
 import org.apache.commons.lang3.time.DateUtils;
 import org.silverpeas.core.admin.service.AdminController;
 import org.silverpeas.core.admin.user.model.UserDetail;
-import org.silverpeas.core.exception.SilverpeasException;
 import org.silverpeas.core.i18n.I18NHelper;
 import org.silverpeas.core.scheduler.Job;
 import org.silverpeas.core.scheduler.JobExecutionContext;
@@ -34,8 +33,7 @@ import org.silverpeas.core.scheduler.SchedulerException;
 import org.silverpeas.core.scheduler.SchedulerProvider;
 import org.silverpeas.core.scheduler.trigger.JobTrigger;
 import org.silverpeas.core.scheduler.trigger.TimeUnit;
-import org.silverpeas.core.security.authentication.exception
-    .AuthenticationNoMoreUserConnectionAttemptException;
+import org.silverpeas.core.security.authentication.exception.AuthenticationNoMoreUserConnectionAttemptException;
 import org.silverpeas.core.util.DateUtil;
 import org.silverpeas.core.util.ServiceProvider;
 import org.silverpeas.core.util.StringUtil;
@@ -163,8 +161,6 @@ public class UserCanTryAgainToLoginVerifier extends AbstractAuthenticationVerifi
         clearCache();
       }
       throw new AuthenticationNoMoreUserConnectionAttemptException(
-          "UserCanTryAgainToLoginVerifier.verify()", SilverpeasException.ERROR,
-          "authentication.EX_VERIFY_USER_CAN_TRY_AGAIN_TO_LOGIN",
           getUser() != null ? "Login=" + getUser().getLogin() : "");
     }
     return this;

--- a/core-library/src/main/java/org/silverpeas/core/security/authentication/verifier/UserMustAcceptTermsOfServiceVerifier.java
+++ b/core-library/src/main/java/org/silverpeas/core/security/authentication/verifier/UserMustAcceptTermsOfServiceVerifier.java
@@ -91,7 +91,8 @@ public class UserMustAcceptTermsOfServiceVerifier extends AbstractAuthentication
     if (isTermsOfServiceAcceptanceDateIsExpired()) {
       // Caching for 10 minutes
       tosToken = applicationCache.add(this, LIVE_10_MINUTES);
-      throw new AuthenticationUserMustAcceptTermsOfService();
+      throw new AuthenticationUserMustAcceptTermsOfService(
+          "The user must accept the terms of service");
     }
     return this;
   }

--- a/core-library/src/main/java/org/silverpeas/core/security/authentication/verifier/UserMustChangePasswordVerifier.java
+++ b/core-library/src/main/java/org/silverpeas/core/security/authentication/verifier/UserMustChangePasswordVerifier.java
@@ -52,8 +52,7 @@ public class UserMustChangePasswordVerifier extends AbstractAuthenticationVerifi
     PASSWORD_CHANGED
   }
 
-  private static Map<String, UserFirstLoginStep> usersFirstLoginStep =
-      new ConcurrentHashMap<String, UserFirstLoginStep>();
+  private static Map<String, UserFirstLoginStep> usersFirstLoginStep = new ConcurrentHashMap<>();
 
   protected static boolean isThatUserMustChangePasswordOnFirstLogin = false;
   protected static boolean isThatUserMustFillEmailAddressOnFirstLogin = false;
@@ -142,8 +141,7 @@ public class UserMustChangePasswordVerifier extends AbstractAuthenticationVerifi
 
     if (proposeToUserToChangePassword()) {
       throw new AuthenticationPasswordAboutToExpireException(
-          "The password has to be changed for the user" + getUser() != null ?
-              "Login=" + getUser().getLogin() : "");
+          "The password has to be changed for the user with login " + getUser().getLogin());
     }
 
     if (mustForceUserToChangePassword()) {

--- a/core-library/src/main/java/org/silverpeas/core/security/authentication/verifier/UserMustChangePasswordVerifier.java
+++ b/core-library/src/main/java/org/silverpeas/core/security/authentication/verifier/UserMustChangePasswordVerifier.java
@@ -23,14 +23,13 @@
  */
 package org.silverpeas.core.security.authentication.verifier;
 
-import org.silverpeas.core.util.StringUtil;
-import org.silverpeas.core.i18n.I18NHelper;
 import org.silverpeas.core.admin.user.model.UserDetail;
-import org.silverpeas.core.exception.SilverpeasException;
+import org.silverpeas.core.i18n.I18NHelper;
 import org.silverpeas.core.security.authentication.exception.AuthenticationException;
 import org.silverpeas.core.security.authentication.exception.AuthenticationPasswordAboutToExpireException;
 import org.silverpeas.core.security.authentication.exception.AuthenticationPasswordExpired;
 import org.silverpeas.core.security.authentication.exception.AuthenticationPasswordMustBeChangedOnFirstLogin;
+import org.silverpeas.core.util.StringUtil;
 
 import javax.servlet.http.HttpServletRequest;
 import java.util.Map;
@@ -143,9 +142,8 @@ public class UserMustChangePasswordVerifier extends AbstractAuthenticationVerifi
 
     if (proposeToUserToChangePassword()) {
       throw new AuthenticationPasswordAboutToExpireException(
-          "UserMustChangePasswordVerifier.verify()", SilverpeasException.ERROR,
-          "authentication.EX_VERIFY_ASKING_USER_CHANGE_PASSWORD",
-          getUser() != null ? "Login=" + getUser().getLogin() : "");
+          "The password has to be changed for the user" + getUser() != null ?
+              "Login=" + getUser().getLogin() : "");
     }
 
     if (mustForceUserToChangePassword()) {


### PR DESCRIPTION
Fix the bug with the date time parsing of a LDAP attribute.
Add a new property for LDAP domains: _LDAPPwdExpirationTimeFieldName_.
This property is valued with the name of the LDAP attribute representing the password expiration date time. When set, Silverpeas will ask the server LDAP the password expiration date time instead of computing it.