### PR TITLE
Bug #11118: removing AliasFileServer servlet which was supplying wrongly the documents.

### DIFF
--- a/core-library/src/main/java/org/silverpeas/core/contribution/attachment/model/SimpleDocument.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/attachment/model/SimpleDocument.java
@@ -27,9 +27,9 @@ import org.silverpeas.core.admin.service.OrganizationControllerProvider;
 import org.silverpeas.core.admin.user.model.SilverpeasRole;
 import org.silverpeas.core.admin.user.model.User;
 import org.silverpeas.core.contribution.attachment.WebdavServiceProvider;
-import org.silverpeas.core.i18n.I18NHelper;
 import org.silverpeas.core.persistence.jcr.JcrDataConverter;
 import org.silverpeas.core.persistence.jdbc.DBUtil;
+import org.silverpeas.core.security.Securable;
 import org.silverpeas.core.security.authorization.AccessControlContext;
 import org.silverpeas.core.security.authorization.AccessControlOperation;
 import org.silverpeas.core.security.authorization.SimpleDocumentAccessControl;
@@ -62,7 +62,7 @@ import static org.silverpeas.core.i18n.I18NHelper.defaultLanguage;
  *
  * @author ehugonnet
  */
-public class SimpleDocument implements Serializable {
+public class SimpleDocument implements Serializable, Securable {
 
   private static final long serialVersionUID = 8778738762037114180L;
   private static final SettingBundle settings =
@@ -707,19 +707,6 @@ public class SimpleDocument implements Serializable {
     return onlineUrl;
   }
 
-  public String getAliasURL() {
-    String aliasUrl =
-        FileServerUtils.getAliasURL(getPk().getInstanceId(), getFilename(), getPk().getId());
-    if (I18NHelper.isI18nContentActivated && !I18NHelper.isDefaultLanguage(getLanguage())) {
-      aliasUrl += "&lang=" + getLanguage();
-    }
-    String extension = FileRepositoryManager.getFileExtension(getFilename());
-    if ("exe".equalsIgnoreCase(extension) || "pdf".equalsIgnoreCase(extension)) {
-      aliasUrl += "&logicalName=" + URLEncoder.encodePathParamValue(getFilename());
-    }
-    return aliasUrl;
-  }
-
   public String getWebdavUrl() {
     StringBuilder url = new StringBuilder(CAPACITY);
     String webAppContext = URLUtil.getApplicationURL();
@@ -829,6 +816,7 @@ public class SimpleDocument implements Serializable {
    * @param user a user in Silverpeas.
    * @return true if the user can access this document, false otherwise.
    */
+  @Override
   public boolean canBeAccessedBy(final User user) {
     return SimpleDocumentAccessControl.get().isUserAuthorized(user.getId(), this);
   }
@@ -838,6 +826,7 @@ public class SimpleDocument implements Serializable {
    * @param user a user in Silverpeas.
    * @return true if the user can access this document, false otherwise.
    */
+  @Override
   public boolean canBeModifiedBy(final User user) {
     return SimpleDocumentAccessControl.get().isUserAuthorized(user.getId(), this,
         AccessControlContext.init().onOperationsOf(AccessControlOperation.modification));

--- a/core-library/src/main/java/org/silverpeas/core/contribution/publication/dao/PublicationCriteria.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/publication/dao/PublicationCriteria.java
@@ -48,16 +48,18 @@ public class PublicationCriteria {
 
   public enum QUERY_ORDER_BY {
 
-    BEGIN_VISIBILITY_DATE_ASC("pubBeginDate", true), BEGIN_VISIBILITY_DATE_DESC("pubBeginDate", false),
-    LAST_UPDATE_DATE_ASC("pubUpdateDate", true), LAST_UPDATE_DATE_DESC("pubUpdateDate", false),
-    CREATION_DATE_ASC("pubId", true), CREATION_DATE_DESC("pubId", false);
+    BEGIN_VISIBILITY_DATE_ASC("maxBeginOrUpdateDate", true, true), BEGIN_VISIBILITY_DATE_DESC("maxBeginOrUpdateDate", false, true),
+    LAST_UPDATE_DATE_ASC("pubUpdateDate", true, false), LAST_UPDATE_DATE_DESC("pubUpdateDate", false, false),
+    CREATION_DATE_ASC("pubId", true, false), CREATION_DATE_DESC("pubId", false, false);
 
     private final String propertyName;
     private final boolean asc;
+    private final boolean complex;
 
-    QUERY_ORDER_BY(final String propertyName, final boolean asc) {
+    QUERY_ORDER_BY(final String propertyName, final boolean asc, final boolean complex) {
       this.propertyName = propertyName;
       this.asc = asc;
+      this.complex = complex;
     }
 
     public String getPropertyName() {
@@ -66,6 +68,10 @@ public class PublicationCriteria {
 
     public boolean isAsc() {
       return asc;
+    }
+
+    public boolean isComplex() {
+      return complex;
     }
   }
 
@@ -240,7 +246,7 @@ public class PublicationCriteria {
    * @return itself.
    */
   public PublicationCriteria orderByDescendingBeginDate() {
-    return orderBy(BEGIN_VISIBILITY_DATE_DESC).orderByDescendingLastUpdateDate();
+    return orderBy(BEGIN_VISIBILITY_DATE_DESC, CREATION_DATE_DESC);
   }
 
   /**

--- a/core-library/src/main/java/org/silverpeas/core/security/authorization/PublicationAccessController.java
+++ b/core-library/src/main/java/org/silverpeas/core/security/authorization/PublicationAccessController.java
@@ -292,7 +292,8 @@ public class PublicationAccessController extends AbstractAccessController<Public
         for (final Location location : locations) {
           final Set<SilverpeasRole> nodeUserRoles = nodeAccessController.getUserRoles(userId, location, context);
           if (nodeAccessController.isUserAuthorized(nodeUserRoles)) {
-            userRoles.addAll(nodeUserRoles);
+            // In case of alias, only user role is taken into account
+            userRoles.add(SilverpeasRole.user);
             break;
           }
         }

--- a/core-library/src/test/java/org/silverpeas/core/contribution/attachment/model/SimpleDocumentTest.java
+++ b/core-library/src/test/java/org/silverpeas/core/contribution/attachment/model/SimpleDocumentTest.java
@@ -353,28 +353,6 @@ public class SimpleDocumentTest {
   }
 
   /**
-   * Test of getAliasURL method, of class SimpleDocument.
-   */
-  @Test
-  public void testGetAliasURL() {
-    SimpleDocument instance = new SimpleDocument();
-    instance.setAttachment(new SimpleAttachment());
-    instance.setFilename("myFile.odt");
-    String id = UUID.randomUUID().toString();
-    SimpleDocumentPK pk = new SimpleDocumentPK(id, instanceId);
-    instance.setPK(pk);
-    String expResult =
-        "/silverpeas/AliasFileServer/myFile.odt?ComponentId=kmelia36&AttachmentId=" + id;
-    String result = instance.getAliasURL();
-    assertThat(result, is(expResult));
-    instance.setLanguage("en");
-    expResult = "/silverpeas/AliasFileServer/myFile.odt?ComponentId=kmelia36&AttachmentId=" + id +
-        "&lang=en";
-    result = instance.getAliasURL();
-    assertThat(result, is(expResult));
-  }
-
-  /**
    * Test of getWebdavUrl method, of class SimpleDocument.
    */
   @Test

--- a/core-library/src/test/java/org/silverpeas/core/security/authorization/TestPublicationAccessController.java
+++ b/core-library/src/test/java/org/silverpeas/core/security/authorization/TestPublicationAccessController.java
@@ -1052,7 +1052,7 @@ public class TestPublicationAccessController {
         .verifyCallOfPublicationBmGetDetailAndGetAllAliases()
         .verifyCallOfNodeAccessControllerGetUserRoles()
         .verifyCallOfPublicationBmGetMainLocation();
-    assertIsUserAuthorized(true);
+    assertIsUserAuthorized(false);
 
     // User has USER role on component
     testContext.clear();

--- a/core-war/src/main/webapp/attachment/jsp/publicVersions.jsp
+++ b/core-war/src/main/webapp/attachment/jsp/publicVersions.jsp
@@ -54,6 +54,7 @@
 <%@ page import="org.silverpeas.core.util.ResourceLocator" %>
 <%@ page import="org.silverpeas.core.util.LocalizationBundle" %>
 <%@ page import="org.silverpeas.core.util.SettingBundle" %>
+<%@ page import="javax.ws.rs.core.UriBuilder" %>
 
 <%
   GraphicElementFactory gef =
@@ -78,12 +79,12 @@
 
   SimpleDocument document = (SimpleDocument) request.getAttribute("Document");
   List<SimpleDocument> vVersions = (List<SimpleDocument>) request.getAttribute("Versions");
-  boolean fromAlias = StringUtil.getBooleanValue((String) request.getAttribute("Alias"));
 
   String componentId = document.getPk().getInstanceId();
   String id = document.getPk().getId();
   boolean spinfireViewerEnable = attachmentSettings.getBoolean("SpinfireViewerEnable", false);
   String contentLanguage = (String) request.getAttribute("ContentLanguage");
+  boolean fromAlias = (boolean) request.getAttribute("fromAlias");
 %>
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
@@ -98,9 +99,13 @@
   <view:browseBar extraInformations="${requestScope.Document.title}" clickable="false"/>
 
   <%
-    ArrayPane arrayPane = gef.getArrayPane("List",
-        "ViewAllVersions?DocId=" + id + "&Alias=null&ComponentId=" + componentId, request,
-        session);// declare an array
+    final String arrayUrl = UriBuilder.fromPath("ViewAllVersions")
+        .queryParam("DocId", id)
+        .queryParam("ComponentId", componentId)
+        .queryParam("fromAlias", fromAlias)
+        .queryParam("Language", contentLanguage)
+        .build().toString();
+    ArrayPane arrayPane = gef.getArrayPane("List", arrayUrl, request, session);
 
 // header of the array
     ArrayColumn arrayColumn_version = arrayPane.addArrayColumn(messages.getString("version"));
@@ -127,9 +132,6 @@
 
       arrayLine = arrayPane.addArrayLine(); // set a new line
       String url = URLUtil.getApplicationURL() + publicVersion.getAttachmentURL();
-      if (fromAlias) {
-        url = publicVersion.getAliasURL();
-      }
 
       String spinFire = "";
       if (publicVersion.isContentSpinfire() && spinfireViewerEnable &&

--- a/core-web/src/main/java/org/silverpeas/core/web/attachment/tag/SimpleDocumentContextualMenu.java
+++ b/core-web/src/main/java/org/silverpeas/core/web/attachment/tag/SimpleDocumentContextualMenu.java
@@ -39,8 +39,7 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 
 import static org.silverpeas.core.admin.service.AdministrationServiceProvider.getAdminService;
-import static org.silverpeas.core.contribution.attachment.util.AttachmentSettings
-    .isDisplayableAsContentForComponentInstanceId;
+import static org.silverpeas.core.contribution.attachment.util.AttachmentSettings.isDisplayableAsContentForComponentInstanceId;
 import static org.silverpeas.core.util.StringUtil.NEWLINE;
 
 /**
@@ -53,6 +52,7 @@ public class SimpleDocumentContextualMenu extends TagSupport {
   private boolean useXMLForm;
   private boolean useWebDAV;
   private boolean showMenuNotif;
+  private boolean fromAlias;
 
   private static final String TEMPLATE = "oMenu%s.getItem(%s).cfg.setProperty(\"disabled\", %s);";
 
@@ -76,6 +76,10 @@ public class SimpleDocumentContextualMenu extends TagSupport {
     this.showMenuNotif = showMenuNotif;
   }
 
+  public void setFromAlias(final boolean fromAlias) {
+    this.fromAlias = fromAlias;
+  }
+
   @Override
   public int doStartTag() throws JspException {
     try {
@@ -85,7 +89,7 @@ public class SimpleDocumentContextualMenu extends TagSupport {
       LocalizationBundle messages = ResourceLocator.getLocalizationBundle(
           "org.silverpeas.util.attachment.multilang.attachment", favoriteLanguage);
       UserDetail user = mainSessionController.getCurrentUserDetail();
-      if (attachment.canBeModifiedBy(user)) {
+      if (!fromAlias && attachment.canBeModifiedBy(user)) {
         pageContext.getOut().print(
             prepareActions(attachment, useXMLForm, useWebDAV, user,
                 favoriteLanguage, messages, showMenuNotif));
@@ -120,7 +124,7 @@ public class SimpleDocumentContextualMenu extends TagSupport {
 
   String prepareActions(SimpleDocument attachment, boolean useXMLForm, boolean useWebDAV,
       UserDetail user, final String userLanguage, LocalizationBundle resources,
-      boolean showMenuNotif) throws UnsupportedEncodingException {
+      boolean showMenuNotif) {
     String userId = user.getId();
     String attachmentId = String.valueOf(attachment.getOldSilverpeasId());
     boolean webDavOK = useWebDAV && attachment.isOpenOfficeCompatible();

--- a/core-web/src/main/resources/META-INF/contextMenu.tld
+++ b/core-web/src/main/resources/META-INF/contextMenu.tld
@@ -69,5 +69,12 @@
       <rtexprvalue>true</rtexprvalue>
       <type>java.lang.Boolean</type>
     </attribute>
+    <attribute>
+      <description>To indicate if it is used from an alias.</description>
+      <name>fromAlias</name>
+      <required>true</required>
+      <rtexprvalue>true</rtexprvalue>
+      <type>java.lang.Boolean</type>
+    </attribute>
   </tag>
 </taglib>


### PR DESCRIPTION
The computing of alias URL has been deleted and attachment URL is now always provided, the document displayed as an alias or not.

Fixing also a problem on an other subject. The lastest publication displayed on Silverpeas's homepage (and the homepage of the GED too). Now the ordering is taking into account rightly the visibility period against the update date of publications.

Linked to PR https://github.com/Silverpeas/Silverpeas-Components/pull/674