### PR TITLE
Bug #11135

### DIFF
--- a/core-library/src/main/java/org/silverpeas/core/admin/service/Admin.java
+++ b/core-library/src/main/java/org/silverpeas/core/admin/service/Admin.java
@@ -5236,7 +5236,7 @@ class Admin implements Administration {
       final UserSearchCriteriaForDAO criteria) throws AdminException {
     String[] theGroupIds = searchCriteria.getCriterionOnGroupIds();
     if (theGroupIds == UserDetailsSearchCriteria.ANY_GROUPS) {
-      criteria.and().onGroupIds(SearchCriteria.ANY);
+      criteria.and().onGroupIds(SearchCriteria.Constants.ANY);
     } else {
       Set<String> groupIds = new HashSet<>();
       for (String aGroupId : theGroupIds) {

--- a/core-library/src/main/java/org/silverpeas/core/admin/user/GroupManager.java
+++ b/core-library/src/main/java/org/silverpeas/core/admin/user/GroupManager.java
@@ -153,7 +153,8 @@ public class GroupManager {
       UserSearchCriteriaForDAO criteriaOnUsers = factory.getUserSearchCriteriaDAO();
       return userDao.getUserCountByCriteria(connection, criteriaOnUsers.
           onDomainIds(domainId).
-          onGroupIds(groupIds.toArray(new String[groupIds.size()])));
+          onGroupIds(groupIds.toArray(new String[0])).
+          onUserStatesToExclude(UserState.REMOVED));
     } catch (SQLException e) {
       throw new AdminException(e.getMessage(), e);
     } finally {

--- a/core-library/src/main/java/org/silverpeas/core/admin/user/UserManager.java
+++ b/core-library/src/main/java/org/silverpeas/core/admin/user/UserManager.java
@@ -142,7 +142,8 @@ public class UserManager {
       AdminException {
     try (Connection connection = DBUtil.openConnection()) {
       return userDAO.getUserCountByCriteria(connection,
-          UserSearchCriteriaForDAO.newCriteria().onDomainIds(domainId));
+          UserSearchCriteriaForDAO.newCriteria().onDomainIds(domainId)
+              .onUserStatesToExclude(UserState.REMOVED));
     } catch (Exception e) {
       throw new AdminException(failureOnGetting("user count in domain", domainId), e);
     }
@@ -155,7 +156,8 @@ public class UserManager {
    */
   public int getUserCount() throws AdminException {
     try (Connection connection = DBUtil.openConnection()) {
-      return userDAO.getUserCountByCriteria(connection, UserSearchCriteriaForDAO.newCriteria());
+      return userDAO.getUserCountByCriteria(connection, UserSearchCriteriaForDAO.newCriteria()
+          .onUserStatesToExclude(UserState.REMOVED));
     } catch (Exception e) {
       throw new AdminException(failureOnGetting("total user count", ""), e);
     }
@@ -174,7 +176,7 @@ public class UserManager {
     }
     try (Connection connection = DBUtil.openConnection()) {
       List<UserDetail> users = userDAO.getUsersInGroups(connection, groupIds);
-      return users.toArray(new UserDetail[users.size()]);
+      return users.toArray(new UserDetail[0]);
     } catch (Exception e) {
       throw new AdminException(failureOnGetting("users in groups", String.join(", ", groupIds)), e);
     }

--- a/core-library/src/main/java/org/silverpeas/core/admin/user/dao/GroupSearchCriteriaForDAO.java
+++ b/core-library/src/main/java/org/silverpeas/core/admin/user/dao/GroupSearchCriteriaForDAO.java
@@ -56,10 +56,20 @@ public class GroupSearchCriteriaForDAO implements SearchCriteria {
     tables.add("st_group");
   }
 
+  /**
+   * Constructs new criteria on the user groups to search in the data source.
+   * @return new search criteria for DAOs.
+   */
   public static GroupSearchCriteriaForDAO newCriteria() {
     return newCriteriaFrom(new GroupsSearchCriteria());
   }
 
+  /**
+   * Constructs new criteria on the user groups to search in the data source from the specified
+   * criteria on the groups' properties.
+   * @param criteria criteria on the groups' properties the search must satisfy.
+   * @return new search criteria for DAOs.
+   */
   public static GroupSearchCriteriaForDAO newCriteriaFrom(final GroupsSearchCriteria criteria) {
     return new GroupSearchCriteriaForDAO(criteria);
   }
@@ -91,7 +101,7 @@ public class GroupSearchCriteriaForDAO implements SearchCriteria {
 
   @Override
   public GroupSearchCriteriaForDAO onGroupIds(String... groupIds) {
-    if (groupIds != ANY) {
+    if (groupIds != Constants.ANY) {
       this.criteria.onGroupIds(groupIds);
     }
     return this;
@@ -128,7 +138,7 @@ public class GroupSearchCriteriaForDAO implements SearchCriteria {
 
   @Override
   public SearchCriteria onUserIds(String... userIds) {
-    if (userIds != ANY) {
+    if (userIds != Constants.ANY) {
       tables.add("st_group_user_rel");
       this.userIds = Arrays.copyOf(userIds, userIds.length);
     }

--- a/core-library/src/main/java/org/silverpeas/core/admin/user/dao/UserSearchCriteriaForDAO.java
+++ b/core-library/src/main/java/org/silverpeas/core/admin/user/dao/UserSearchCriteriaForDAO.java
@@ -30,7 +30,6 @@ import org.silverpeas.core.admin.user.model.SearchCriteria;
 import org.silverpeas.core.admin.user.model.UserDetailsSearchCriteria;
 import org.silverpeas.core.persistence.jdbc.sql.JdbcSqlQuery;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -42,7 +41,7 @@ import static org.silverpeas.core.util.StringUtil.isDefined;
 
 /**
  * An implementation of the search criteria for user details stored in a SQL data source and used by
- * the DAOs. By default, the criterion are linked together by a conjonction operator. Nevertheless,
+ * the DAOs. By default, the criteria are linked together by a conjunction operator. Nevertheless,
  * you can explicitly specify it by using the UserSearchCriteriaForDAO#and() method.
  */
 public class UserSearchCriteriaForDAO implements SearchCriteria {
@@ -58,12 +57,27 @@ public class UserSearchCriteriaForDAO implements SearchCriteria {
     tables.add(ST_USER);
   }
 
+  /**
+   * Constructs new criteria on the users to search in the data source. Automatically, all the
+   * deleted users are always excluded from the search scope, but not the removed users (the users
+   * that in a deletion awaiting). To exclude the removed users, simply pass the state
+   * {@link UserState#REMOVED} in the
+   * {@link UserSearchCriteriaForDAO#onUserStatesToExclude(UserState...)} method invocation.
+   * @return new search criteria for DAOs.
+   */
   public static UserSearchCriteriaForDAO newCriteria() {
-    final UserSearchCriteriaForDAO newCriteria = newCriteriaFrom(new UserDetailsSearchCriteria());
-    newCriteria.onUserStatesToExclude(UserState.REMOVED);
-    return newCriteria;
+    return newCriteriaFrom(new UserDetailsSearchCriteria());
   }
 
+  /**
+   * Constructs new criteria on the users to search in the data source from the specified criteria
+   * on the users' properties. Automatically, all the deleted users are always excluded from the
+   * search scope, but not the removed users (the users that in a deletion awaiting). To exclude the
+   * removed users, simply indicate the state {@link UserState#REMOVED} as to be excluded either in
+   * the specified criteria or in the
+   * {@link UserSearchCriteriaForDAO#onUserStatesToExclude(UserState...)} method invocation.
+   * @return new search criteria for DAOs.
+   */
   public static UserSearchCriteriaForDAO newCriteriaFrom(final UserDetailsSearchCriteria criteria) {
     return new UserSearchCriteriaForDAO(criteria);
   }
@@ -116,7 +130,7 @@ public class UserSearchCriteriaForDAO implements SearchCriteria {
 
   @Override
   public UserSearchCriteriaForDAO onGroupIds(String... groupIds) {
-    if (groupIds != ANY) {
+    if (groupIds != Constants.ANY) {
       tables.add("st_group_user_rel");
       criteria.onGroupIds(groupIds);
     }
@@ -140,7 +154,7 @@ public class UserSearchCriteriaForDAO implements SearchCriteria {
 
   @Override
   public UserSearchCriteriaForDAO onUserIds(String... userIds) {
-    if (userIds != ANY) {
+    if (userIds != Constants.ANY) {
       criteria.onUserIds(userIds);
     }
     return this;
@@ -148,7 +162,7 @@ public class UserSearchCriteriaForDAO implements SearchCriteria {
 
   @Override
   public SearchCriteria onUserSpecificIds(final String... userSpecificIds) {
-    if (userSpecificIds != ANY) {
+    if (userSpecificIds != Constants.ANY) {
       criteria.onUserSpecificIds(userSpecificIds);
     }
     return this;

--- a/core-library/src/main/java/org/silverpeas/core/admin/user/model/SearchCriteria.java
+++ b/core-library/src/main/java/org/silverpeas/core/admin/user/model/SearchCriteria.java
@@ -33,15 +33,21 @@ import org.silverpeas.core.admin.user.constant.UserState;
  */
 public interface SearchCriteria {
 
-  /**
-   * The whatever value to be used as criterion value if you don't care of a given criterion.
-   */
-  String[] ANY = null;
+  class Constants {
+
+    private Constants() {
+    }
+
+    /**
+     * The whatever value to be used as criterion value if you don't care of a given criterion.
+     */
+    public static final String[] ANY = null;
+  }
 
   /**
-   * Appends a criteria conjonction.
+   * Appends a criteria conjunction.
    *
-   * @return the criteria enriched with a conjonction. The conjonction will be applied with the last
+   * @return the criteria enriched with a conjunction. The conjunction will be applied with the last
    * added criterion and the next one.
    */
   SearchCriteria and();
@@ -71,7 +77,7 @@ public interface SearchCriteria {
   /**
    * Appends a criterion on the user domain for which the search must be constrained to. The
    * properties of the resources to fetch have to satisfy this criterion.
-   *
+   * This criterion replaces any previous criterion on the user domains.
    * @param domainIds the unique identifier of the user domain.
    * @return the criteria enriched with a criterion on the user domain.
    */
@@ -80,7 +86,7 @@ public interface SearchCriteria {
   /**
    * Appends a criterion on the user groups for which the search must be constrained to. The
    * properties of the resources to fetch have to satisfy this criterion.
-   *
+   * This criterion replaces any previous criterion on the user groups.
    * @param groupIds the unique identifiers of the groups.
    * @return the criteria enriched with a criterion on the user groups.
    */
@@ -89,7 +95,7 @@ public interface SearchCriteria {
   /**
    * Appends a criterion on the user access level for which the search must be constrained to. The
    * properties of the resources to fetch have to satisfy this criterion.
-   *
+   * This criterion replaces any previous criterion on the user access levels.
    * @param accessLevels the access levels aimed.
    * @return the criteria enriched with a criterion on the user access level.
    */
@@ -107,7 +113,7 @@ public interface SearchCriteria {
   /**
    * Appends a criterion on the user roles for which the search must be constrained to. The
    * properties of the resources to fetch have to satisfy this criterion.
-   *
+   * This criterion replaces any previous criterion on the user roles.
    * @param roleNames the name of the user roles on which the criterion has to be built.
    * @return the criteria enriched with a criterion on the role names.
    */
@@ -116,34 +122,36 @@ public interface SearchCriteria {
   /**
    * Appends a criteria on the user profiles for which the search must be constrained to. The
    * properties of the resources to fetch have to satisfy this criterion.
-   *
+   * This criterion replaces any previous criterion on the user profiles.
    * @param userIds the user identifiers.
    * @return the criteria enriched with a criterion on the user identifiers.
    */
   SearchCriteria onUserIds(String... userIds);
 
   /**
-   * Appends a criteria on the user profiles for which the search must be constrained to. The
+   * Appends a criterion on the user profiles for which the search must be constrained to. The
    * properties of the resources to fetch have to satisfy this criterion.
    * <p>
    * One, and only one, domain id will be mandatory!
    * </p>
+   * This criterion replaces any previous criterion on the user profiles.
    * @param userSpecificIds the user specific identifiers.
    * @return the criteria enriched with a criterion on the user identifiers.
    */
   SearchCriteria onUserSpecificIds(String... userSpecificIds);
 
   /**
-   * Appends a criteria on the user states that must exclude users from the result. The
-   * properties of the resources to fetch have to satisfy this criterion.
-   *
+   * Appends a criterion on the user states to be excluded in the search of users. The
+   * properties of the resources to fetch have to satisfy this criterion. By default, the deleted
+   * users are always excluded but not the removed users. Latter have to be explicitly excluded.
+   * This criterion replaces any previous criterion on the user states.
    * @param userStates the user states that exclude users from the result.
    * @return the criteria enriched with a criterion on the user states.
    */
   SearchCriteria onUserStatesToExclude(UserState... userStates);
 
   /**
-   * Appends a criteria on a resources pagination. The pagination is a mechanism to distribute the
+   * Appends a criterion on a resources pagination. The pagination is a mechanism to distribute the
    * resources to fetch in one or more pages of same size and to navigate among theses different
    * available pages.
    * Yet, this criterion is about the page of resources to fetch.
@@ -153,9 +161,9 @@ public interface SearchCriteria {
   SearchCriteria onPagination(final PaginationPage page);
 
   /**
-   * Appends a criteria disjonction.
+   * Appends a criteria disjunction.
    *
-   * @return the criteria enriched with a disjonction. The disjonction will be applied with the last
+   * @return the criteria enriched with a disjunction. The disjunction will be applied with the last
    * added criterion and the next one.
    */
   SearchCriteria or();
@@ -163,7 +171,7 @@ public interface SearchCriteria {
   /**
    * Is this criteria empty?
    *
-   * @return true if this criteria has no criterion, false otherwise.
+   * @return true if this object has no any criteria, false otherwise.
    */
   boolean isEmpty();
 }

--- a/core-library/src/main/java/org/silverpeas/core/admin/user/model/UserDetail.java
+++ b/core-library/src/main/java/org/silverpeas/core/admin/user/model/UserDetail.java
@@ -539,7 +539,7 @@ public class UserDetail implements User {
 
   @Override
   public boolean isActivatedState() {
-    return !isAnonymous() && !isDeletedState() && !isDeactivatedState();
+    return !isAnonymous() && !isDeletedState() && !isRemovedState() && !isDeactivatedState();
   }
 
   @Override

--- a/core-library/src/main/java/org/silverpeas/core/admin/user/model/UserDetailsSearchCriteria.java
+++ b/core-library/src/main/java/org/silverpeas/core/admin/user/model/UserDetailsSearchCriteria.java
@@ -41,7 +41,7 @@ import static org.silverpeas.core.util.StringUtil.isDefined;
  */
 public class UserDetailsSearchCriteria implements SearchCriteria {
 
-  public static final String[] ANY_GROUPS = ANY;
+  public static final String[] ANY_GROUPS = Constants.ANY;
   private static final String USER_ACCESS_LEVELS = "userAccessLevels";
   private static final String USER_STATES_TO_EXCLUDE = "userStatesToExclude";
 

--- a/core-library/src/main/java/org/silverpeas/core/security/authorization/ComponentAccessController.java
+++ b/core-library/src/main/java/org/silverpeas/core/security/authorization/ComponentAccessController.java
@@ -131,7 +131,7 @@ public class ComponentAccessController extends AbstractAccessController<String>
       return;
     }
     if (Administration.Constants.ADMIN_COMPONENT_ID.equals(componentId)) {
-      if (User.getById(userId).isAccessAdmin()) {
+      if (user.isAccessAdmin()) {
         userRoles.add(SilverpeasRole.admin);
       }
       return;

--- a/core-war/src/main/webapp/selection/jsp/userpanel.jsp
+++ b/core-war/src/main/webapp/selection/jsp/userpanel.jsp
@@ -42,6 +42,7 @@
 <view:setBundle basename="org.silverpeas.notificationManager.multilang.notificationManagerBundle" var="notificationBundle" />
 
 <view:setConstant var="DEACTIVATED_USER_STATE" constant="org.silverpeas.core.admin.user.constant.UserState.DEACTIVATED"/>
+<view:setConstant var="REMOVED_USER_STATE"     constant="org.silverpeas.core.admin.user.constant.UserState.REMOVED"/>
 <fmt:message var="DEACTIVATED_SHORT_LABEL" key="GML.user.account.state.DEACTIVATED.short"/>
 <c:set var="DEACTIVATED_SHORT_LABEL" value="${fn:toLowerCase(DEACTIVATED_SHORT_LABEL)}"/>
 
@@ -316,7 +317,9 @@
             }
             if (typeof params === 'object') {
               if (context.hidingDeactivatedState) {
-                params.userStatesToExclude = ['${DEACTIVATED_USER_STATE}'];
+                params.userStatesToExclude = ['${DEACTIVATED_USER_STATE}', '${REMOVED_USER_STATE}'];
+              } else {
+                params.userStatesToExclude = ['${REMOVED_USER_STATE}'];
               }
             }
             return params;

--- a/core-war/src/main/webapp/subscription/jsp/subscriptionpanel.jsp
+++ b/core-war/src/main/webapp/subscription/jsp/subscriptionpanel.jsp
@@ -232,7 +232,8 @@
         if (userIds.length > 0) {
           termination = termination.then(function() {
             return User.get({
-              id : userIds
+              id : userIds,
+              includeRemoved: true
             }).then(function(users) {
               $(users).each(function(index, user) {
                 context.users[user.id] = user;

--- a/core-war/src/main/webapp/util/javaScript/silverpeas-user-group-list.js
+++ b/core-war/src/main/webapp/util/javaScript/silverpeas-user-group-list.js
@@ -83,8 +83,9 @@
       if (typeof _params === 'object') {
         if (!_params.id && !_params.ids) {
           _params.withChildren = true;
+          _params.userStatesToExclude = [];
           if (this.options.hideDeactivatedState) {
-            _params.userStatesToExclude = ['DEACTIVATED'];
+            _params.userStatesToExclude.push('DEACTIVATED');
           }
           if (this.options.domainIdFilter) {
             _params.domain = this.options.domainIdFilter;

--- a/core-web/src/main/java/org/silverpeas/core/webapi/admin/scim/ScimUserAdminService.java
+++ b/core-web/src/main/java/org/silverpeas/core/webapi/admin/scim/ScimUserAdminService.java
@@ -166,8 +166,9 @@ public class ScimUserAdminService extends AbstractScimAdminService implements Pr
     logger().debug(() -> "finding user by filter " + filter);
     validateDomainExists();
     try {
-      final UserProfilesSearchCriteriaBuilder criteriaBuilder = UserProfilesSearchCriteriaBuilder
-          .aSearchCriteria().withDomainIds(new String[]{scimRequestContext.getDomainId()});
+      final UserProfilesSearchCriteriaBuilder criteriaBuilder =
+          UserProfilesSearchCriteriaBuilder.aSearchCriteria()
+              .withDomainIds(scimRequestContext.getDomainId());
 
       final int startIndex = pageRequest.getStartIndex() != null ? pageRequest.getStartIndex() : 0;
       final int itemPerPage = pageRequest.getCount() != null ? pageRequest.getCount() : 10;

--- a/core-web/src/main/java/org/silverpeas/core/webapi/profile/UserProfilesSearchCriteriaBuilder.java
+++ b/core-web/src/main/java/org/silverpeas/core/webapi/profile/UserProfilesSearchCriteriaBuilder.java
@@ -24,10 +24,12 @@
 package org.silverpeas.core.webapi.profile;
 
 import org.silverpeas.core.admin.PaginationPage;
-import org.silverpeas.core.admin.user.model.UserDetailsSearchCriteria;
 import org.silverpeas.core.admin.user.constant.UserAccessLevel;
 import org.silverpeas.core.admin.user.constant.UserState;
+import org.silverpeas.core.admin.user.model.UserDetailsSearchCriteria;
 import org.silverpeas.core.util.ArrayUtil;
+
+import java.util.Arrays;
 
 import static org.silverpeas.core.util.StringUtil.isDefined;
 
@@ -37,11 +39,22 @@ import static org.silverpeas.core.util.StringUtil.isDefined;
 public class UserProfilesSearchCriteriaBuilder {
 
   private UserDetailsSearchCriteria searchCriteria;
+  private boolean includeRemoved = false;
 
+  /**
+   * Constructs a new builder of criteria for searching user profiles.
+   * @return a {@link UserProfilesSearchCriteriaBuilder} instance.
+   */
   public static UserProfilesSearchCriteriaBuilder aSearchCriteria() {
     return new UserProfilesSearchCriteriaBuilder();
   }
 
+  /**
+   * The users to find should satisfy the specified name. The wildcard character '*' is supported
+   * to mean any characters.
+   * @param name the name of a user. It can be the firstname or the lastname of the users to search.
+   * @return itself.
+   */
   public UserProfilesSearchCriteriaBuilder withName(String name) {
     if (isDefined(name)) {
       String filterByName = name.replaceAll("\\*", "%");
@@ -50,6 +63,11 @@ public class UserProfilesSearchCriteriaBuilder {
     return this;
   }
 
+  /**
+   * The users to find have an access right on the specified component instance.
+   * @param instanceId the unique identifier of a component instance.
+   * @return
+   */
   public UserProfilesSearchCriteriaBuilder withComponentInstanceId(String instanceId) {
     if (isDefined(instanceId)) {
       searchCriteria.onComponentInstanceId(instanceId);
@@ -57,6 +75,13 @@ public class UserProfilesSearchCriteriaBuilder {
     return this;
   }
 
+  /**
+   * The users to find have an access right on the specified resource. The component instance should
+   * be set with the method {@link UserProfilesSearchCriteriaBuilder#withComponentInstanceId(String)}
+   * in order to refer exactly the resource.
+   * @param resourceId the unique identifier of a resource in a given component instance.
+   * @return itself.
+   */
   public UserProfilesSearchCriteriaBuilder withResourceId(String resourceId) {
     if (isDefined(resourceId)) {
       searchCriteria.onResourceId(resourceId);
@@ -64,14 +89,24 @@ public class UserProfilesSearchCriteriaBuilder {
     return this;
   }
 
-  public UserProfilesSearchCriteriaBuilder withRoles(String[] roleIds) {
+  /**
+   * The users to find have to play at least one of the specified roles.
+   * @param roleIds one or more identifiers of roles.
+   * @return itself.
+   */
+  public UserProfilesSearchCriteriaBuilder withRoles(String... roleIds) {
     if (roleIds != null && roleIds.length > 0) {
       searchCriteria.onRoleNames(roleIds);
     }
     return this;
   }
 
-  public UserProfilesSearchCriteriaBuilder withGroupIds(String[] groupIds) {
+  /**
+   * The users to find have to be at least in one of the specified user groups.
+   * @param groupIds one or more unique identifiers of user groups.
+   * @return itself.
+   */
+  public UserProfilesSearchCriteriaBuilder withGroupIds(String... groupIds) {
     if(ArrayUtil.isNotEmpty(groupIds)) {
       if (ArrayUtil.contains(groupIds, UserProfileResource.QUERY_ALL_GROUPS)) {
         searchCriteria.onGroupIds(UserDetailsSearchCriteria.ANY_GROUPS);
@@ -82,45 +117,103 @@ public class UserProfilesSearchCriteriaBuilder {
     return this;
   }
 
-  public UserProfilesSearchCriteriaBuilder withDomainIds(String[] domainIds) {
+  /**
+   * The users to find have to be at least in one of the specified user directory domains.
+   * @param domainIds one or more unique identifiers of domains.
+   * @return itself.
+   */
+  public UserProfilesSearchCriteriaBuilder withDomainIds(String... domainIds) {
     searchCriteria.onDomainIds(domainIds);
     return this;
   }
 
-  public UserProfilesSearchCriteriaBuilder withAccessLevels(UserAccessLevel[] accessLevels) {
+  /**
+   * The users to find must have at least one of the specified access levels
+   * @param accessLevels one or more access levels.
+   * @return itself.
+   */
+  public UserProfilesSearchCriteriaBuilder withAccessLevels(UserAccessLevel... accessLevels) {
     if (accessLevels != null && accessLevels.length > 0) {
       searchCriteria.onAccessLevels(accessLevels);
     }
     return this;
   }
 
-  public UserProfilesSearchCriteriaBuilder withUserIds(String[] userIds) {
+  /**
+   * The users to find are those with the specified unique identifiers of users.
+   * @param userIds one ore more unique identifiers of users;
+   * @return itself.
+   */
+  public UserProfilesSearchCriteriaBuilder withUserIds(String... userIds) {
     if (userIds != null && userIds.length > 0) {
       searchCriteria.onUserIds(userIds);
     }
     return this;
   }
 
-  public UserProfilesSearchCriteriaBuilder withUserSpecificIds(String[] userSpecificIds) {
+  /**
+   * The users to find are those with the specified domain specific identifiers of users.
+   * @param userSpecificIds one ore more domain specific identifiers of users;
+   * @return itself.
+   */
+  public UserProfilesSearchCriteriaBuilder withUserSpecificIds(String... userSpecificIds) {
     if (userSpecificIds != null && userSpecificIds.length > 0) {
       searchCriteria.onUserSpecificIds(userSpecificIds);
     }
     return this;
   }
 
-  public UserProfilesSearchCriteriaBuilder withUserStatesToExclude(UserState[] userStates) {
+  /**
+   * Excludes from the search scope the users with the specified states. The deleted
+   * users are always excluded as to be expected. Be cautious, by default the removed users are here
+   * also excluded but they can be included explicitly by invoking the method
+   * {@link UserProfilesSearchCriteriaBuilder#includeAlsoRemovedUsers()}.
+   * @param userStates the states the users to find must not have.
+   * @return itself.
+   */
+  public UserProfilesSearchCriteriaBuilder withUserStatesToExclude(UserState... userStates) {
     if (userStates != null && userStates.length > 0) {
       searchCriteria.onUserStatesToExclude(userStates);
     }
     return this;
   }
 
+  /**
+   * Includes also among the users to find those they are removed.
+   * @return itself.
+   */
+  public UserProfilesSearchCriteriaBuilder includeAlsoRemovedUsers() {
+    this.includeRemoved = true;
+    return this;
+  }
+
+  /**
+   * The search results are paginated and only the specified page should be returned from the
+   * search results.
+   * @param page the page corresponding to a paginated search results.
+   * @return itself.
+   */
   public UserProfilesSearchCriteriaBuilder withPaginationPage(final PaginationPage page) {
     searchCriteria.onPagination(page);
     return this;
   }
 
+  /**
+   * Builds the criteria according to the build properties that have been set.
+   * @return a {@link UserDetailsSearchCriteria} instance.
+   */
   public UserDetailsSearchCriteria build() {
+    if (!includeRemoved) {
+      UserState[] allExcludedStates;
+      if (searchCriteria.isCriterionOnUserStatesToExcludeSet()) {
+        UserState[] excludedStates = searchCriteria.getCriterionOnUserStatesToExclude();
+        allExcludedStates = Arrays.copyOf(excludedStates, excludedStates.length + 1);
+        allExcludedStates[excludedStates.length] = UserState.REMOVED;
+      } else {
+        allExcludedStates = new UserState[] {UserState.REMOVED};
+      }
+      searchCriteria.onUserStatesToExclude(allExcludedStates);
+    }
     return searchCriteria;
   }
 


### PR DESCRIPTION
Now, by default, the search of users by criteria doesn't exclude the removed
ones. A removed user is a user that is a deletion awaiting; its account isn't
then deleted and it can be restored later with the right access profiles.
It is then now required to explicitly exclude the removed users in the search.
By doing so, no more errors are thrown when we are looking for users with among
them some whose account in Silverpeas is removed; this is the case with the
user subscriptions for example.

Don't forget to merge also PR https://github.com/Silverpeas/Silverpeas-Components/pull/675