### PR TITLE
Bug #11139

### DIFF
--- a/core-configuration/src/main/config/properties/org/silverpeas/chat/settings/chat.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/chat/settings/chat.properties
@@ -10,12 +10,29 @@ chat.enable = false
 # If empty, then the video/audio chat is disabled.
 chat.servers.ice =
 
-# the URL of the BOSH service through which the chat client communicates with the XMPP server.
-chat.xmpp.httpBindUrl =
+# The URL (schema + hostname or IP address + port) of the XMPP server which which the Silverpeas
+# Chat client can communicate through the Web. It must be set for the chat to be enabled.
+# All others XMPP services' URL is computed from this property.
+# The value of this property will be use also used to set correctly the security settings of
+# Silverpeas in order to authorize the connexions with the remote XMPP service from the web browser.
+chat.servers.xmpp =
 
-# The URL of the REST service through which Silverpeas creates users and their relationships in
-# the XMPP server.
-chat.xmpp.restUrl =
+# The URL at which the XMPP server is listening for HTTP file transfers between users. Usually, this
+# property doesn't need to be set as it is discovered by the chat client when negotiating with the
+# XMPP server. Nevertheless, it has to be explicitly set if the XMPP server is behind a proxy or the
+# HTTP file transfer service is listening at a port different that the XMPP server one. This
+# property is mainly used to set correctly the security settings of Silverpeas in order to let the
+# user's web browser to upload files to the XMPP server.
+chat.xmpp.httpUpload =
+
+# The relative URL's path of the BOSH service through which the chat client communicates with the
+# XMPP server. The URL will be computed from the chat.servers.xmpp property and this property below.
+chat.xmpp.httpBind =
+
+# The relative URL's path of the REST service through which Silverpeas creates users and their
+# relationships in the XMPP server. The URL will be computed from the chat.servers.xmpp property
+# and this property below.
+chat.xmpp.rest =
 
 # The authentication token used to access the REST service of the XMPP server.
 chat.xmpp.restKey =

--- a/core-services/chat/src/main/java/org/silverpeas/core/chat/ChatInitialization.java
+++ b/core-services/chat/src/main/java/org/silverpeas/core/chat/ChatInitialization.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2000 - 2019 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception. You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.chat;
+
+import org.silverpeas.core.chat.servers.ChatServer;
+import org.silverpeas.core.initialization.Initialization;
+import org.silverpeas.core.util.security.SecuritySettings;
+
+/**
+ * Initializes the resources required by the Chat to work correctly.
+ * @author mmoquillon
+ */
+public class ChatInitialization implements Initialization {
+
+  @Override
+  public void init() throws Exception {
+    final ChatSettings chatSettings = ChatServer.getChatSettings();
+    if (chatSettings.isChatEnabled()) {
+      final SecuritySettings.Registration registration = SecuritySettings.registration();
+      final String xmppService = chatSettings.getChatServerUrl();
+      if (!xmppService.isEmpty()) {
+        registration.registerDefaultSourceInCSP(xmppService);
+        registration.registerDomainInCORS(xmppService);
+      }
+      final String fileTransferService = chatSettings.getFileTransferServiceUrl();
+      if (!fileTransferService.equals(xmppService)) {
+        registration.registerDefaultSourceInCSP(fileTransferService);
+        registration.registerDomainInCORS(fileTransferService);
+      }
+    }
+  }
+}
+  

--- a/core-services/chat/src/main/java/org/silverpeas/core/chat/ChatSettings.java
+++ b/core-services/chat/src/main/java/org/silverpeas/core/chat/ChatSettings.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (C) 2000 - 2019 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception. You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.chat;
+
+import org.silverpeas.core.util.ResourceLocator;
+import org.silverpeas.core.util.SettingBundle;
+import org.silverpeas.core.util.StringUtil;
+
+/**
+ * Setting properties of the chat service. It loads the
+ * <code>SILVERPEAS_HOME/properties/org/silverpeas/chat/settings/chat.properties</code> and provides
+ * all the settings required by the Silverpeas Chat to work correctly.
+ * @author mmoquillon
+ */
+public class ChatSettings {
+
+  private final SettingBundle settings =
+      ResourceLocator.getSettingBundle("org.silverpeas.chat.settings.chat");
+  private final String xmppBaseUrl;
+
+  /**
+   * Constructs a new object wrapping all the settings on the Silverpeas chat service.
+   */
+  public ChatSettings() {
+    final String xmppServerUrl = settings.getString("chat.servers.xmpp", "").trim();
+    if (xmppServerUrl.endsWith("/")) {
+      xmppBaseUrl = xmppServerUrl.substring(0, xmppServerUrl.length() - 1);
+    } else {
+      xmppBaseUrl = xmppServerUrl;
+    }
+  }
+
+  /**
+   * Gets the URL at which the chat server is listening.
+   * @return the chat server's URL.
+   */
+  public String getChatServerUrl() {
+    return xmppBaseUrl;
+  }
+
+  /**
+   * Gets the fully qualified hostname or the IP address of the ICE server listening for audio/video
+   * communications.
+   * @return the hostname or the IP address of the ICE server.
+   */
+  public String getICEServer() {
+    return settings.getString("chat.servers.ice", "");
+  }
+
+  /**
+   * Gets the fully qualified URL of the REST API of the XMPP server with which Silverpeas can use
+   * to create and to remove XMPP users accounts.
+   * @return the URL of the REST API published by the remote XMPP server.
+   */
+  public String getRestApiUrl() {
+    final String rest = settings.getString("chat.xmpp.rest", "").trim();
+    if (!rest.isEmpty()) {
+      if (rest.startsWith("/")) {
+        return xmppBaseUrl + rest;
+      } else {
+        return xmppBaseUrl + "/" + rest;
+      }
+    }
+    return "";
+  }
+
+  /**
+   * Gets the fully qualified URL of the BOSH service of the XMPP server which wich Silverpeas can
+   * use to establish XMPP communications through the web.
+   * @return the URL of the BOSH service provided by the remote XMPP server.
+   */
+  public String getBOSHServiceUrl() {
+    final String bosh = settings.getString("chat.xmpp.httpBind", "").trim();
+    if (!bosh.isEmpty()) {
+      if (bosh.startsWith("/")) {
+        return xmppBaseUrl + bosh;
+      } else {
+        return xmppBaseUrl + "/" + bosh;
+      }
+    }
+    return "";
+  }
+
+  /**
+   * Gets the base URL of the HTTP file transfer service of the XMPP server.
+   * @return the URL of the file transfer service used by the XMPP server to transfer files between
+   * users.
+   */
+  public String getFileTransferServiceUrl() {
+    return settings.getString("chat.xmpp.httpUpload", xmppBaseUrl).trim();
+  }
+
+  /**
+   * Gets the authorization token to use when communicating the REST API of the XMPP server.
+   * @return the authorization token of the XMPP server's REST API.
+   */
+  public String getRestApiAuthToken() {
+    return settings.getString("chat.xmpp.restKey", "");
+  }
+
+  /**
+   * Gets the XMPP domain mapped with the specified Silverpeas domain. If the given domain isn't
+   * mapped with any XMPP domain, then returns the default XMPP domain (provided by the property
+   * <code>chat.xmpp.domain.0</code> in the chat settings).
+   * @param silverpeasDomainId the unique identifier of a domain in Silverpeas. Can be null or
+   * empty in that case the default XMPP domain is returned.
+   * @return the XMPP domain mapped with the specified Silverpeas domain or the default XMPP
+   * domain if set in the chat settings. If no XMPP domain is set in the chat settings, then
+   * returns an empty string.
+   */
+  public String getMappedXmppDomain(final String silverpeasDomainId) {
+    String xmppDomain;
+    if (StringUtil.isDefined(silverpeasDomainId)) {
+      xmppDomain = settings.getString("chat.xmpp.domain." + silverpeasDomainId, "");
+      if (xmppDomain.isEmpty()) {
+        xmppDomain =settings.getString("chat.xmpp.domain.0", "");
+      }
+    } else {
+      xmppDomain =settings.getString("chat.xmpp.domain.0", "");
+    }
+    return xmppDomain;
+  }
+
+  public boolean isChatEnabled() {
+    boolean enabled = settings.getBoolean("chat.enable");
+    final String rest = settings.getString("chat.xmpp.rest", "");
+    final String bosh = settings.getString("chat.xmpp.httpBind", "");
+    return enabled && !rest.isEmpty() && !bosh.isEmpty();
+  }
+}
+  

--- a/core-services/chat/src/main/java/org/silverpeas/core/chat/ChatUser.java
+++ b/core-services/chat/src/main/java/org/silverpeas/core/chat/ChatUser.java
@@ -29,7 +29,6 @@ import org.silverpeas.core.admin.user.model.User;
 import org.silverpeas.core.admin.user.model.UserDetail;
 import org.silverpeas.core.chat.servers.ChatServer;
 import org.silverpeas.core.personalization.UserPreferences;
-import org.silverpeas.core.util.SettingBundle;
 
 import java.util.Date;
 
@@ -116,12 +115,8 @@ public class ChatUser extends UserDetail {
    * @return the chat domain of the user.
    */
   public String getChatDomain() {
-    SettingBundle settings = ChatServer.getChatSettings();
-    String domain = settings.getString("chat.xmpp.domain." + getDomainId(), "");
-    if (domain.isEmpty()) {
-      domain = settings.getString("chat.xmpp.domain.0");
-    }
-    return domain;
+    ChatSettings settings = ChatServer.getChatSettings();
+    return settings.getMappedXmppDomain(getDomainId());
   }
 
   @Override

--- a/core-services/chat/src/main/java/org/silverpeas/core/chat/servers/ChatServer.java
+++ b/core-services/chat/src/main/java/org/silverpeas/core/chat/servers/ChatServer.java
@@ -25,9 +25,7 @@ package org.silverpeas.core.chat.servers;
 
 import org.silverpeas.core.admin.user.model.User;
 import org.silverpeas.core.chat.ChatServerException;
-import org.silverpeas.core.util.ResourceLocator;
-import org.silverpeas.core.util.SettingBundle;
-import org.silverpeas.core.util.StringUtil;
+import org.silverpeas.core.chat.ChatSettings;
 
 /**
  * This interface represents a Chat server. An implementation of this interface has to implement
@@ -44,8 +42,8 @@ public interface ChatServer {
    * all the required parameters to communicate correctly with the remote chat server.
    * @return a bundle of settings on the chat service.
    */
-  static SettingBundle getChatSettings() {
-    return ResourceLocator.getSettingBundle("org.silverpeas.chat.settings.chat");
+  static ChatSettings getChatSettings() {
+    return new ChatSettings();
   }
 
   /**
@@ -57,9 +55,7 @@ public interface ChatServer {
    * Silverpeas configuration. False otherwise.
    */
   static boolean isEnabled() {
-    return getChatSettings().getBoolean("chat.enable", false) &&
-        StringUtil.isDefined(getChatSettings().getString("chat.xmpp.httpBindUrl", null)) &&
-        StringUtil.isDefined(getChatSettings().getString("chat.xmpp.restUrl", null));
+    return getChatSettings().isChatEnabled();
   }
 
   /**

--- a/core-services/chat/src/main/java/org/silverpeas/core/chat/servers/EJabberdServer.java
+++ b/core-services/chat/src/main/java/org/silverpeas/core/chat/servers/EJabberdServer.java
@@ -25,9 +25,9 @@ package org.silverpeas.core.chat.servers;
 
 import org.silverpeas.core.admin.user.model.User;
 import org.silverpeas.core.chat.ChatServerException;
+import org.silverpeas.core.chat.ChatSettings;
 import org.silverpeas.core.chat.ChatUser;
 import org.silverpeas.core.util.JSONCodec.JSONObject;
-import org.silverpeas.core.util.SettingBundle;
 import org.silverpeas.core.util.logging.SilverLogger;
 
 import javax.ws.rs.core.Response;
@@ -63,9 +63,9 @@ public class EJabberdServer implements ChatServer {
    * Constructs a new instance.
    */
   public EJabberdServer() {
-    SettingBundle settings = ChatServer.getChatSettings();
-    this.url = settings.getString("chat.xmpp.restUrl");
-    String key = settings.getString("chat.xmpp.restKey");
+    ChatSettings settings = ChatServer.getChatSettings();
+    this.url = settings.getRestApiUrl();
+    String key = settings.getRestApiAuthToken();
     this.requester = new HttpRequester("Bearer " + key);
   }
 

--- a/core-services/chat/src/main/java/org/silverpeas/core/chat/servers/OpenfireServer.java
+++ b/core-services/chat/src/main/java/org/silverpeas/core/chat/servers/OpenfireServer.java
@@ -26,8 +26,8 @@ package org.silverpeas.core.chat.servers;
 import org.silverpeas.core.SilverpeasExceptionMessages;
 import org.silverpeas.core.admin.user.model.User;
 import org.silverpeas.core.chat.ChatServerException;
+import org.silverpeas.core.chat.ChatSettings;
 import org.silverpeas.core.chat.ChatUser;
-import org.silverpeas.core.util.SettingBundle;
 import org.silverpeas.core.util.StringUtil;
 import org.silverpeas.core.util.logging.SilverLogger;
 
@@ -60,9 +60,9 @@ public class OpenfireServer implements ChatServer {
   private final HttpRequester theRequester;
 
   public OpenfireServer() {
-    SettingBundle settings = ChatServer.getChatSettings();
-    this.url = settings.getString("chat.xmpp.restUrl") + "/users";
-    String key = settings.getString("chat.xmpp.restKey");
+    ChatSettings settings = ChatServer.getChatSettings();
+    this.url = settings.getRestApiUrl() + "/users";
+    String key = settings.getRestApiAuthToken();
     this.theRequester = new HttpRequester(key);
   }
 

--- a/core-war/src/main/java/org/silverpeas/web/token/SessionSynchronizerTokenValidator.java
+++ b/core-war/src/main/java/org/silverpeas/web/token/SessionSynchronizerTokenValidator.java
@@ -30,7 +30,7 @@ import org.silverpeas.core.util.ResourceLocator;
 import org.silverpeas.core.util.StringUtil;
 import org.silverpeas.core.util.logging.SilverLogger;
 import org.silverpeas.core.web.token.SynchronizerTokenService;
-import org.silverpeas.core.web.util.security.SecuritySettings;
+import org.silverpeas.core.util.security.SecuritySettings;
 import org.silverpeas.core.webapi.base.UserPrivilegeValidation;
 
 import javax.inject.Inject;

--- a/core-war/src/main/webapp/WEB-INF/tags/silverpeas/chat/silverChatInitialization.tag
+++ b/core-war/src/main/webapp/WEB-INF/tags/silverpeas/chat/silverChatInitialization.tag
@@ -34,13 +34,13 @@
 <c:set var="chatUser" value="<%=ChatUser.getCurrentRequester()%>"/>
 <jsp:useBean id="chatUser" type="org.silverpeas.core.chat.ChatUser"/>
 <c:set var="chatSettings" value="<%=ChatServer.getChatSettings()%>"/>
-<jsp:useBean id="chatSettings" type="org.silverpeas.core.util.SettingBundle"/>
+<jsp:useBean id="chatSettings" type="org.silverpeas.core.chat.ChatSettings"/>
 <c:set var="chatBundle" value="<%=ChatLocalizationProvider.getLocalizationBundle(
           User.getCurrentRequester().getUserPreferences().getLanguage())%>"/>
 <jsp:useBean id="chatBundle" type="org.silverpeas.core.util.LocalizationBundle"/>
 
-<c:set var="chatUrl" value="${chatSettings.getString('chat.xmpp.httpBindUrl', '')}"/>
-<c:set var="chatIceServer" value="${chatSettings.getString('chat.servers.ice', '')}"/>
+<c:set var="chatUrl" value="${chatSettings.BOSHServiceUrl}"/>
+<c:set var="chatIceServer" value="${chatSettings.ICEServer}"/>
 
 <script type="text/javascript">
   (function() {

--- a/core-war/src/main/webapp/WEB-INF/tags/silverpeas/util/displayExternalFullIframe.tag
+++ b/core-war/src/main/webapp/WEB-INF/tags/silverpeas/util/displayExternalFullIframe.tag
@@ -23,7 +23,7 @@
   --%>
 
 <%@ tag language="java" pageEncoding="UTF-8" %>
-<%@ tag import="org.silverpeas.core.web.util.security.SecuritySettings" %>
+<%@ tag import="org.silverpeas.core.util.security.SecuritySettings" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn" %>

--- a/core-web/src/main/java/org/silverpeas/core/web/filter/WebCORSFilter.java
+++ b/core-web/src/main/java/org/silverpeas/core/web/filter/WebCORSFilter.java
@@ -23,12 +23,10 @@
  */
 package org.silverpeas.core.web.filter;
 
-import org.silverpeas.core.util.ResourceLocator;
-import org.silverpeas.core.util.SettingBundle;
 import org.silverpeas.core.util.StringUtil;
 import org.silverpeas.core.util.URLUtil;
 import org.silverpeas.core.web.util.HttpMethod;
-import org.silverpeas.core.web.util.security.SecuritySettings;
+import org.silverpeas.core.util.security.SecuritySettings;
 import org.silverpeas.core.webapi.base.UserPrivilegeValidation;
 
 import javax.servlet.Filter;

--- a/core-web/src/main/java/org/silverpeas/core/web/mvc/route/ComponentRequestRouter.java
+++ b/core-web/src/main/java/org/silverpeas/core/web/mvc/route/ComponentRequestRouter.java
@@ -53,7 +53,7 @@ import org.silverpeas.core.web.mvc.util.WysiwygRouting;
 import org.silverpeas.core.web.mvc.webcomponent.SilverpeasAuthenticatedHttpServlet;
 import org.silverpeas.core.web.token.SynchronizerTokenService;
 import org.silverpeas.core.web.util.SilverpeasTransverseWebErrorUtil;
-import org.silverpeas.core.web.util.security.SecuritySettings;
+import org.silverpeas.core.util.security.SecuritySettings;
 import org.silverpeas.core.web.util.viewgenerator.html.GraphicElementFactory;
 
 import javax.inject.Inject;

--- a/core-web/src/main/java/org/silverpeas/core/web/token/SynchronizerTokenService.java
+++ b/core-web/src/main/java/org/silverpeas/core/web/token/SynchronizerTokenService.java
@@ -36,7 +36,7 @@ import org.silverpeas.core.security.token.synchronizer.SynchronizerToken;
 import org.silverpeas.core.util.ServiceProvider;
 import org.silverpeas.core.util.StringUtil;
 import org.silverpeas.core.util.logging.SilverLogger;
-import org.silverpeas.core.web.util.security.SecuritySettings;
+import org.silverpeas.core.util.security.SecuritySettings;
 import org.silverpeas.core.webapi.base.UserPrivilegeValidation;
 
 import javax.inject.Singleton;

--- a/core-web/src/main/java/org/silverpeas/core/web/util/viewgenerator/html/JavascriptPluginInclusion.java
+++ b/core-web/src/main/java/org/silverpeas/core/web/util/viewgenerator/html/JavascriptPluginInclusion.java
@@ -45,7 +45,7 @@ import org.silverpeas.core.util.StringUtil;
 import org.silverpeas.core.util.URLUtil;
 import org.silverpeas.core.web.look.LayoutConfiguration;
 import org.silverpeas.core.web.look.LookHelper;
-import org.silverpeas.core.web.util.security.SecuritySettings;
+import org.silverpeas.core.util.security.SecuritySettings;
 import org.silverpeas.core.web.util.viewgenerator.html.operationpanes.OperationsOfCreationAreaTag;
 import org.silverpeas.core.web.util.viewgenerator.html.pdc.BaseClassificationPdCTag;
 

--- a/core-web/src/main/java/org/silverpeas/core/web/util/viewgenerator/html/override/ATag.java
+++ b/core-web/src/main/java/org/silverpeas/core/web/util/viewgenerator/html/override/ATag.java
@@ -26,7 +26,7 @@ package org.silverpeas.core.web.util.viewgenerator.html.override;
 import org.apache.ecs.xhtml.a;
 import org.silverpeas.core.security.token.Token;
 import org.silverpeas.core.util.StringUtil;
-import org.silverpeas.core.web.util.security.SecuritySettings;
+import org.silverpeas.core.util.security.SecuritySettings;
 import org.silverpeas.core.web.token.SynchronizerTokenService;
 
 import javax.servlet.http.HttpServletRequest;

--- a/core-web/src/main/java/org/silverpeas/core/web/util/viewgenerator/html/override/FormTag.java
+++ b/core-web/src/main/java/org/silverpeas/core/web/util/viewgenerator/html/override/FormTag.java
@@ -28,7 +28,7 @@ import org.apache.ecs.xhtml.input;
 import org.silverpeas.core.security.token.Token;
 import org.silverpeas.core.util.Charsets;
 import org.silverpeas.core.util.StringUtil;
-import org.silverpeas.core.web.util.security.SecuritySettings;
+import org.silverpeas.core.util.security.SecuritySettings;
 import org.silverpeas.core.web.token.SynchronizerTokenService;
 
 import javax.servlet.http.HttpServletRequest;


### PR DESCRIPTION
The configuration properties of the Silverpeas Chat client are now wrapped in
the ChatSettings class.
Some properties in the chat.properties configuration file are renamed whereas
another ones are added:
- chat.servers.xmpp to indicate the base URL of the XMPP server
- chat.xmpp.httpUpload to indicate the base URL of the HTTP file transfer
  service of the XMPP server when this one is listening at another URL than the
  one indicated by chat.servers.xmpp property.

A new class is introduced: ChatInitialization. It's goal is to set the security
settings of Silverpeas with the URL(s) of the services published by the XMPP
server. For doing, the SecuritySettings provides now a Registration object
whose aim is to allow any external components in Silverpeas to register some
URLs as to be security valid.