### PR TITLE
Bug #11267: fixing new cases of combined characters to normalize into single characters before saving data into JCR.

### DIFF
--- a/core-library/src/main/java/org/silverpeas/core/contribution/attachment/AttachmentService.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/attachment/AttachmentService.java
@@ -154,7 +154,11 @@ public interface AttachmentService extends DocumentIndexing {
 
   /**
    * Create file attached to an object who is identified by the foreignId.
-   *
+   * <p>
+   * The filename returned by {@link SimpleDocument#getFilename()} is normalized in order to get
+   * only single character encoding and no more combined characters. The normalized filename is
+   * set to given document.
+   * </p>
    * @param document the document to be created.
    * @param content the binary content of the document.
    * @return the stored document.
@@ -165,7 +169,11 @@ public interface AttachmentService extends DocumentIndexing {
 
   /**
    * Create file attached to an object who is identified by the foreignId.
-   *
+   * <p>
+   * The filename returned by {@link SimpleDocument#getFilename()} is normalized in order to get
+   * only single character encoding and no more combined characters. The normalized filename is
+   * set to given document.
+   * </p>
    * @param document the document to be created.
    * @param content the binary content of the document.
    * @param indexIt true if the document is to be indexed - false otherwhise.
@@ -175,7 +183,11 @@ public interface AttachmentService extends DocumentIndexing {
 
   /**
    * Create file attached to an object who is identified by the foreignId.
-   *
+   * <p>
+   * The filename returned by {@link SimpleDocument#getFilename()} is normalized in order to get
+   * only single character encoding and no more combined characters. The normalized filename is
+   * set to given document.
+   * </p>
    * @param document the document to be created.
    * @param content the binary content of the document.
    * @param indexIt true if the document is to be indexed - false otherwise.
@@ -188,7 +200,11 @@ public interface AttachmentService extends DocumentIndexing {
 
   /**
    * Create file attached to an object who is identified by the foreignId.
-   *
+   * <p>
+   * The filename returned by {@link SimpleDocument#getFilename()} is normalized in order to get
+   * only single character encoding and no more combined characters. The normalized filename is
+   * set to given document.
+   * </p>
    * @param document the document to be created.
    * @param content the binary content of the document.
    * @return the stored document.
@@ -199,7 +215,11 @@ public interface AttachmentService extends DocumentIndexing {
 
   /**
    * Create file attached to an object who is identified by the foreignId.
-   *
+   * <p>
+   * The filename returned by {@link SimpleDocument#getFilename()} is normalized in order to get
+   * only single character encoding and no more combined characters. The normalized filename is
+   * set to given document.
+   * </p>
    * @param document the document to be created.
    * @param content the binary content of the document.
    * @param indexIt true if the document is to be indexed, false otherwhise.
@@ -209,7 +229,11 @@ public interface AttachmentService extends DocumentIndexing {
 
   /**
    * Create file attached to an object who is identified by the foreignId.
-   *
+   * <p>
+   * The filename returned by {@link SimpleDocument#getFilename()} is normalized in order to get
+   * only single character encoding and no more combined characters. The normalized filename is
+   * set to given document.
+   * </p>
    * @param document the document to be created.
    * @param content the binary content of the document.
    * @param indexIt true if the document is to be indexed, false otherwhise.
@@ -339,7 +363,11 @@ public interface AttachmentService extends DocumentIndexing {
 
   /**
    * To update the document : status, metadata but not its content.
-   *
+   * <p>
+   * The filename returned by {@link SimpleDocument#getFilename()} is normalized in order to get
+   * only single character encoding and no more combined characters. The normalized filename is
+   * set to given document.
+   * </p>
    * @param document
    * @param indexIt
    * @param invokeCallback
@@ -348,7 +376,11 @@ public interface AttachmentService extends DocumentIndexing {
 
   /**
    * To update a document content by updating or adding some content.
-   *
+   * <p>
+   * The filename returned by {@link SimpleDocument#getFilename()} is normalized in order to get
+   * only single character encoding and no more combined characters. The normalized filename is
+   * set to given document.
+   * </p>
    * @param document
    * @param content
    * @param indexIt
@@ -359,7 +391,11 @@ public interface AttachmentService extends DocumentIndexing {
 
   /**
    * To update a document content by updating or adding some content.
-   *
+   * <p>
+   * The filename returned by {@link SimpleDocument#getFilename()} is normalized in order to get
+   * only single character encoding and no more combined characters. The normalized filename is
+   * set to given document.
+   * </p>
    * @param document
    * @param content
    * @param indexIt

--- a/core-library/src/main/java/org/silverpeas/core/contribution/attachment/SimpleDocumentService.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/attachment/SimpleDocumentService.java
@@ -83,6 +83,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.silverpeas.core.persistence.jcr.JcrRepositoryConnector.openSystemSession;
+import static org.silverpeas.core.util.StringUtil.normalize;
 
 /**
  * @author ehugonnet
@@ -272,6 +273,7 @@ public class SimpleDocumentService
   @Override
   public SimpleDocument createAttachment(@SourceObject @TargetPK SimpleDocument document,
       InputStream content, boolean indexIt, boolean notify) {
+    normalizeFileName(document);
     try (JcrSession session = openSystemSession()) {
       SimpleDocumentPK docPk = repository.createDocument(session, document);
       session.save();
@@ -391,6 +393,7 @@ public class SimpleDocumentService
   @Override
   public void updateAttachment(@SourceObject @TargetPK SimpleDocument document, boolean indexIt,
       boolean notify) {
+    normalizeFileName(document);
     try (JcrSession session = openSystemSession()) {
       SimpleDocument oldAttachment =
           repository.findDocumentById(session, document.getPk(), document.getLanguage());
@@ -425,6 +428,7 @@ public class SimpleDocumentService
   @Override
   public void updateAttachment(@SourceObject @TargetPK SimpleDocument document, InputStream in,
       boolean indexIt, boolean notify) {
+    normalizeFileName(document);
     try (JcrSession session = openSystemSession()) {
       String owner = document.getEditedBy();
       if (!StringUtil.isDefined(owner)) {
@@ -1092,5 +1096,15 @@ public class SimpleDocumentService
   @Override
   public void delete(final String componentInstanceId) {
     deleteAllAttachments(componentInstanceId);
+  }
+
+  /**
+   * Normalizes the fileName returned by {@link SimpleDocument#getFilename()} and sets the
+   * normalized result by using {@link SimpleDocument#setFilename(String)} method of given document.
+   * @param document the document which the filename MUST be normalized.
+   */
+  private void normalizeFileName(final SimpleDocument document) {
+    final String normalizedFileName = normalize(document.getFilename());
+    document.setFilename(normalizedFileName);
   }
 }

--- a/core-web/src/main/java/org/silverpeas/core/webapi/attachment/SimpleDocumentResourceCreator.java
+++ b/core-web/src/main/java/org/silverpeas/core/webapi/attachment/SimpleDocumentResourceCreator.java
@@ -94,8 +94,8 @@ public class SimpleDocumentResourceCreator extends AbstractSimpleDocumentResourc
     try {
 
       // Create the attachment
-      String normalizedFileName = StringUtil.normalize(filename);
-      SimpleDocumentEntity entity = createSimpleDocument(uploadData, normalizedFileName);
+      final String normalizedFileName = StringUtil.normalize(filename);
+      final SimpleDocumentEntity entity = createSimpleDocument(uploadData, normalizedFileName);
 
       if (AJAX_IFRAME_TRANSPORT.equals(uploadData.getXRequestedWith())) {
 
@@ -175,7 +175,7 @@ public class SimpleDocumentResourceCreator extends AbstractSimpleDocumentResourc
                   new ResourceReference(uploadData.getForeignId(), getComponentId()), lang);
           publicDocument = uploadData.getVersionType() == DocumentVersion.TYPE_PUBLIC_VERSION;
           needCreation = document == null;
-          if (document == null) {
+          if (needCreation) {
             document = new HistorisedDocument(pk, uploadData.getForeignId(), 0, userId,
                 new SimpleAttachment(uploadedFilename, lang, title, description,
                     uploadData.getRequestFile().getSize(), FileUtil.getMimeType(tempFile.getPath()),


### PR DESCRIPTION
- trying to fix a new case of combined character encoding in filename of file uploaded from apple computers (workflow case). The normalization of the filename (which consists to encode all each combined character into a single character) is now applied into creation and modification features provided by simple document service API.
- fixing case of import engine
- fixing SonarQube feedback