### PR TITLE
Bug #7598: making template documents compatible with viewer and previewer.

### DIFF
--- a/core-configuration/src/main/config/properties/org/silverpeas/converter/openoffice.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/converter/openoffice.properties
@@ -31,3 +31,15 @@ openoffice.home =
 # if the waiting time is longer than this timeout and an OfficeException will be thrown. By default,
 # the timeout is set at 30000ms. Here we set it at a double time for complex document.
 openoffice.taskTimeout = 60000
+# The extensions of office documents compatible with the openoffice converter, separated by comma or semi colons.
+# If empty, the default compatible documents are defined by MimeTypes.OPEN_OFFICE_MIME_TYPES.
+# If the list is prefixed by "(+)" then the mime types behind the given extensions are added to the default one (cf. just above)
+# If filled with "deactivated", then no document is compatible.
+# IMPORTANT: extensions MUST be specified with a point prefix: ".odp" for example.
+# -> Example, limit compatible mime-types to those corresponding to: .docx;.dotx;.odp;.otp
+# -> Another example, adding to default compatible mime-types those corresponding to: (+).docx;.dotx;.odp;.otp
+# Mime-type detection can be be improved significantly by specifying file paths instead of file extensions.
+# By this way, if the file exists the mime-type is guessed directly from the file instead of a
+# predefined mime-type mapping (mime_types.properties).
+# -> Example, limit compatible mime-types to those corresponding to paths: /home/silverpeas/files/file.odp;/home/silverpeas/files/file.otp
+openoffice.compatible.document.extensions = (+).docm,.dotm,.xlam,.xlsb,.xlsm,.xltm,.potm,.ppam,.ppsm,.pptm

--- a/core-configuration/src/main/config/properties/org/silverpeas/util/attachment/mime_types.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/util/attachment/mime_types.properties
@@ -40,6 +40,7 @@ hqx			application/mac-binhex40
 cpt			application/mac-compactpro
 #			application/macwriteii
 doc			application/msword
+dot			application/msword
 #			application/news-message-id
 #			application/news-transmission
 class			application/octet-stream
@@ -55,6 +56,7 @@ ai			application/postscript
 eps			application/postscript
 ps			application/postscript
 ppt			application/powerpoint
+pot			application/powerpoint
 #			application/remote-printing
 #			application/slate
 #			application/wita
@@ -172,6 +174,7 @@ wmls			text/vnd.wap.wmlscript
 wmlsc			application/vnd.wap.wmlscriptc
 wbmp			image/vnd.wap.wbmp
 xls			application/x-msexcel
+xlt			application/x-msexcel
 abs		audio/x-mpeg
 aim		application/x-aim
 art		image/x-jg

--- a/core-library/src/main/java/org/silverpeas/core/contribution/converter/DocumentFormatConverterProvider.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/converter/DocumentFormatConverterProvider.java
@@ -48,14 +48,6 @@ public class DocumentFormatConverterProvider {
   }
 
   /**
-   * Gets an instance of the ToPDFConverter interface.
-   * @return a ToPDFConverter instance.
-   */
-  public static ToPDFConverter getToPDFConverter() {
-    return ServiceProvider.getService(ToPDFConverter.class);
-  }
-
-  /**
    * Gets an instance of the ToHTMLConverter interface.
    * @return a ToHTMLConverter instance.
    */

--- a/core-library/src/main/java/org/silverpeas/core/contribution/converter/ToPDFConverter.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/converter/ToPDFConverter.java
@@ -32,4 +32,10 @@ package org.silverpeas.core.contribution.converter;
  */
 public interface ToPDFConverter extends DocumentFormatConversion {
 
+  /**
+   * Is the specified document in the format on which the converter works?
+   * @param fileName the fileName or path to check its format is supported.
+   * @return true if the format of the document is supported by this converter, false otherwise.
+   */
+  boolean isDocumentSupported(final String fileName);
 }

--- a/core-library/src/main/java/org/silverpeas/core/contribution/converter/openoffice/OpenOfficeService.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/converter/openoffice/OpenOfficeService.java
@@ -27,12 +27,13 @@ package org.silverpeas.core.contribution.converter.openoffice;
 import org.jodconverter.office.LocalOfficeManager;
 import org.jodconverter.office.OfficeManager;
 import org.silverpeas.core.initialization.Initialization;
-import org.silverpeas.core.util.ResourceLocator;
 import org.silverpeas.core.util.SettingBundle;
 import org.silverpeas.core.util.StringUtil;
 
 import javax.inject.Singleton;
 import java.util.stream.Stream;
+
+import static org.silverpeas.core.util.ResourceLocator.getSettingBundle;
 
 /**
  * The OpenOffice service gives access to an open office process.
@@ -41,8 +42,7 @@ import java.util.stream.Stream;
 @Singleton
 public class OpenOfficeService implements Initialization {
 
-  private static final SettingBundle settings = ResourceLocator.getSettingBundle(
-      "org.silverpeas.converter.openoffice");
+  private static final SettingBundle settings = getSettingBundle("org.silverpeas.converter.openoffice");
   private static final String OPENOFFICE_PORT = "openoffice.port";
   private static final String OPENOFFICE_HOME = "openoffice.home";
   private static final String OPENOFFICE_TASK_TIMEOUT = "openoffice.taskTimeout";
@@ -58,12 +58,12 @@ public class OpenOfficeService implements Initialization {
         .map(String::trim)
         .mapToInt(Integer::parseInt)
         .toArray();
-    LocalOfficeManager.Builder builder = LocalOfficeManager.builder().portNumbers(portNumbers)
+    LocalOfficeManager.Builder builder = LocalOfficeManager.builder()
+        .portNumbers(portNumbers)
         .taskQueueTimeout(taskTimeout);
     if (StringUtil.isDefined(home)) {
       builder = builder.officeHome(home);
     }
-
     officeManager = builder.install().build();
     officeManager.start();
   }

--- a/core-library/src/main/java/org/silverpeas/core/contribution/converter/openoffice/OpenOfficeToPDFConverter.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/converter/openoffice/OpenOfficeToPDFConverter.java
@@ -23,16 +23,19 @@
  */
 package org.silverpeas.core.contribution.converter.openoffice;
 
-import static org.silverpeas.core.contribution.converter.DocumentFormat.pdf;
-
-import java.io.File;
+import org.silverpeas.core.contribution.converter.DocumentFormat;
+import org.silverpeas.core.contribution.converter.ToPDFConverter;
+import org.silverpeas.core.util.MimeTypes.MimeTypeRegistry;
+import org.silverpeas.core.util.SettingBundle;
 
 import javax.inject.Named;
 import javax.inject.Singleton;
+import java.io.File;
 
-import org.silverpeas.core.contribution.converter.DocumentFormat;
-import org.silverpeas.core.contribution.converter.ToPDFConverter;
-import org.silverpeas.core.util.file.FileUtil;
+import static org.silverpeas.core.contribution.converter.DocumentFormat.pdf;
+import static org.silverpeas.core.util.MimeTypes.OPEN_OFFICE_MIME_TYPES;
+import static org.silverpeas.core.util.ResourceLocator.getSettingBundle;
+import static org.silverpeas.core.util.file.FileUtil.getMimeType;
 
 /**
  * Implementation of the ToPDFConverter interface by using the OpenOffice API to perform its job.
@@ -42,6 +45,12 @@ import org.silverpeas.core.util.file.FileUtil;
 @Named("toPDFConverter")
 public class OpenOfficeToPDFConverter extends OpenOfficeConverter implements ToPDFConverter {
 
+  private final SettingBundle settings = getSettingBundle("org.silverpeas.converter.openoffice");
+
+  private MimeTypeRegistry compatibleDocumentMimeTypes = new MimeTypeRegistry(
+      () -> settings.getString("openoffice.compatible.document.extensions", ""),
+      OPEN_OFFICE_MIME_TYPES);
+
   @Override
   public DocumentFormat[] getSupportedFormats() {
     return new DocumentFormat[] { pdf };
@@ -49,6 +58,12 @@ public class OpenOfficeToPDFConverter extends OpenOfficeConverter implements ToP
 
   @Override
   public boolean isDocumentSupported(final File document) {
-    return FileUtil.isOpenOfficeCompatible(document.getName());
+    return isDocumentSupported(document.getPath());
+  }
+
+  @Override
+  public boolean isDocumentSupported(final String fileName) {
+    final String mimeType = getMimeType(fileName);
+    return compatibleDocumentMimeTypes.contains(mimeType);
   }
 }

--- a/core-library/src/test/java/org/silverpeas/core/util/MimeTypeRegistryTest.java
+++ b/core-library/src/test/java/org/silverpeas/core/util/MimeTypeRegistryTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (C) 2000 - 2020 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.util;
+
+import org.junit.jupiter.api.Test;
+import org.silverpeas.core.test.extention.EnableSilverTestEnv;
+import org.silverpeas.core.util.MimeTypes.MimeTypeRegistry;
+
+import java.text.MessageFormat;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.is;
+import static org.silverpeas.core.util.MimeTypes.MimeTypeRegistry.ADDITIONAL_PREFIX_CLAUSE;
+
+/**
+ * @author silveryocha
+ */
+@EnableSilverTestEnv
+class MimeTypeRegistryTest {
+
+  private static final Pair<String, String> DEFAULT_MIME_TYPE = Pair.of(".def", "default-mime-type");
+  private static final Pair<String, String> A_MIME_TYPE = Pair.of(".amt", "a-mime-type");
+  private static final Pair<String, String> ANOTHER_MIME_TYPE = Pair.of(".anmt", "another-mime-type");
+  private static final String UNKNOWN_MIME_TYPE = "application/octet-stream";
+  private final Set<String> DEFAULTS = CollectionUtil.asSet(DEFAULT_MIME_TYPE.getSecond());
+
+  @Test
+  void defaultMimeTypes() {
+    final MimeTypeRegistry documentMimeTypes = new MimeTypeRegistry(() -> "", DEFAULTS);
+    assertThat(mimeTypeIsIn(documentMimeTypes, DEFAULT_MIME_TYPE), is(true));
+    assertThat(mimeTypeIsIn(documentMimeTypes, A_MIME_TYPE), is(false));
+  }
+
+  @Test
+  void noMimeType() {
+    final MimeTypeRegistry documentMimeTypes = new MimeTypeRegistry(() -> "deactivated", DEFAULTS);
+    assertThat(mimeTypeIsIn(documentMimeTypes, DEFAULT_MIME_TYPE), is(false));
+    assertThat(mimeTypeIsIn(documentMimeTypes, A_MIME_TYPE), is(false));
+  }
+
+  @Test
+  void supplierMimeTime() {
+    // semi colons separator
+    final Mutable<String> list = Mutable.of(extList("{0};{1}", A_MIME_TYPE, ANOTHER_MIME_TYPE));
+    final MimeTypeRegistry documentMimeTypes = new MimeTypeRegistry(list::get, DEFAULTS);
+    assertThat(mimeTypeIsIn(documentMimeTypes, DEFAULT_MIME_TYPE), is(false));
+    assertThat(mimeTypeIsIn(documentMimeTypes, A_MIME_TYPE), is(true));
+    assertThat(mimeTypeIsIn(documentMimeTypes, ANOTHER_MIME_TYPE), is(true));
+    // comma separator
+    list.set(extList("{0},{1}", A_MIME_TYPE, ANOTHER_MIME_TYPE));
+    assertThat(mimeTypeIsIn(documentMimeTypes, DEFAULT_MIME_TYPE), is(false));
+    assertThat(mimeTypeIsIn(documentMimeTypes, A_MIME_TYPE), is(true));
+    assertThat(mimeTypeIsIn(documentMimeTypes, ANOTHER_MIME_TYPE), is(true));
+    // mixed separator
+    list.set(extList("   .a ,, ;   ; ;,, ,.b;.c    ;,.d  "));
+    assertThat(mimeTypeIsIn(documentMimeTypes, DEFAULT_MIME_TYPE), is(false));
+    assertThat(documentMimeTypes.currentMimeTypes, containsInAnyOrder("a", "b", "c", "d"));
+    // space separator (so not a right separator)
+    list.set(extList("{0} {1}", A_MIME_TYPE, ANOTHER_MIME_TYPE));
+    assertThat(mimeTypeIsIn(documentMimeTypes, DEFAULT_MIME_TYPE), is(false));
+    assertThat(mimeTypeIsIn(documentMimeTypes, A_MIME_TYPE), is(false));
+    assertThat(mimeTypeIsIn(documentMimeTypes, ANOTHER_MIME_TYPE), is(true));
+  }
+
+  @Test
+  void supplierMimeTimeAndDefaults() {
+    // semi colons separator
+    final Mutable<String> list = Mutable.of(extList(ADDITIONAL_PREFIX_CLAUSE + "{0};{1}", A_MIME_TYPE, ANOTHER_MIME_TYPE));
+    final MimeTypeRegistry documentMimeTypes = new MimeTypeRegistry(list::get, DEFAULTS);
+    assertThat(mimeTypeIsIn(documentMimeTypes, DEFAULT_MIME_TYPE), is(true));
+    assertThat(mimeTypeIsIn(documentMimeTypes, A_MIME_TYPE), is(true));
+    assertThat(mimeTypeIsIn(documentMimeTypes, ANOTHER_MIME_TYPE), is(true));
+    // comma separator
+    list.set(extList(ADDITIONAL_PREFIX_CLAUSE + "{0},{1}", A_MIME_TYPE, ANOTHER_MIME_TYPE));
+    assertThat(mimeTypeIsIn(documentMimeTypes, DEFAULT_MIME_TYPE), is(true));
+    assertThat(mimeTypeIsIn(documentMimeTypes, A_MIME_TYPE), is(true));
+    assertThat(mimeTypeIsIn(documentMimeTypes, ANOTHER_MIME_TYPE), is(true));
+    // mixed separator
+    list.set(extList(ADDITIONAL_PREFIX_CLAUSE + "   .a ,, ;   ; ;,, ,.b;.c    ;,.d  "));
+    assertThat(mimeTypeIsIn(documentMimeTypes, DEFAULT_MIME_TYPE), is(true));
+    assertThat(documentMimeTypes.currentMimeTypes, containsInAnyOrder(DEFAULT_MIME_TYPE.getSecond(), "a", "b", "c", "d"));
+    // mixed separator again
+    list.set(extList(" " + ADDITIONAL_PREFIX_CLAUSE + "   .a ,, ;   ; ;,," + ADDITIONAL_PREFIX_CLAUSE + " ,.b;.c    ;,.d  "));
+    assertThat(mimeTypeIsIn(documentMimeTypes, DEFAULT_MIME_TYPE), is(true));
+    assertThat(documentMimeTypes.currentMimeTypes, containsInAnyOrder(DEFAULT_MIME_TYPE.getSecond(), UNKNOWN_MIME_TYPE, "a", "b", "c", "d"));
+    // mixed separator again (starts not with the additional clause)
+    list.set(extList(" ," + ADDITIONAL_PREFIX_CLAUSE + " ;  .a ,, ;   ; ;,, ,.b;.c    ;,.d  "));
+    assertThat(mimeTypeIsIn(documentMimeTypes, DEFAULT_MIME_TYPE), is(false));
+    assertThat(documentMimeTypes.currentMimeTypes, containsInAnyOrder(UNKNOWN_MIME_TYPE, "a", "b", "c", "d"));
+    // space separator (so not a right separator)
+    list.set(extList(ADDITIONAL_PREFIX_CLAUSE + "{0} {1}", A_MIME_TYPE, ANOTHER_MIME_TYPE));
+    assertThat(mimeTypeIsIn(documentMimeTypes, DEFAULT_MIME_TYPE), is(true));
+    assertThat(mimeTypeIsIn(documentMimeTypes, A_MIME_TYPE), is(false));
+    assertThat(mimeTypeIsIn(documentMimeTypes, ANOTHER_MIME_TYPE), is(true));
+  }
+
+  @SafeVarargs
+  private final String extList(final String template, final Pair<String, String>... extensions) {
+    return MessageFormat.format(template, Stream.of(extensions).map(Pair::getFirst).map(String::toUpperCase).toArray());
+  }
+
+  private boolean mimeTypeIsIn(final MimeTypeRegistry documentMimeTypes,
+      final Pair<String, String> defaultMimeType) {
+    return documentMimeTypes.contains(defaultMimeType.getSecond());
+  }
+}

--- a/core-library/src/test/resources/org/silverpeas/util/attachment/mime_types.properties
+++ b/core-library/src/test/resources/org/silverpeas/util/attachment/mime_types.properties
@@ -22,121 +22,121 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 # Registered mime-types
-bz2  application/x-bzip
-tar.bz2 application/x-bzip
-tbz2  application/x-bzip
-tb2 application/x-bzip
-tar.gz application/x-gzip
-tgz application/x-gzip
+bz2=application/x-bzip
+tar.bz2=application/x-bzip
+tbz2=application/x-bzip
+tb2=application/x-bzip
+tar.gz=application/x-gzip
+tgz=application/x-gzip
 
-3d	application/xview3d-3d
+3d=application/xview3d-3d
 #			application/activemessage
 #			application/andrew-inset
 #			application/applefile
 #			application/atomicmail
 #			application/dca-rft
 #			application/dec-dx
-hqx			application/mac-binhex40
-cpt			application/mac-compactpro
+hqx=application/mac-binhex40
+cpt=application/mac-compactpro
 #			application/macwriteii
-doc			application/msword
+doc=application/msword
 #			application/news-message-id
 #			application/news-transmission
-class			application/octet-stream
-bin			application/octet-stream
-dms		 	application/octet-stream
-lha		 	application/octet-stream
-lzh			application/octet-stream
-exe		 	application/octet-stream
-jsp			application/jsp
-oda			application/oda
-pdf			application/pdf
-ai			application/postscript
-eps			application/postscript
-ps			application/postscript
-ppt			application/powerpoint
+class=application/octet-stream
+bin=application/octet-stream
+dms=application/octet-stream
+lha=application/octet-stream
+lzh=application/octet-stream
+exe=application/octet-stream
+jsp=application/jsp
+oda=application/oda
+pdf=application/pdf
+ai=application/postscript
+eps=application/postscript
+ps=application/postscript
+ppt=application/powerpoint
 #			application/remote-printing
 #			application/slate
 #			application/wita
 #			application/wordperfect5.1
-bcpio			application/x-bcpio
-vcd			application/x-cdlink
-Z			application/x-compress
-cpio			application/x-cpio
-csh			application/x-csh
-dcr			application/x-director
-dir			application/x-director
-dxr			application/x-director
-dvi			application/x-dvi
-gtar  application/x-gtar
-gz  application/x-gzip
-hdf			application/x-hdf
-cgi			application/x-httpd-cgi
-skp			application/x-koan
-skd			application/x-koan
-skt			application/x-koan
-skm			application/x-koan
-latex			application/x-latex
-mif			application/x-mif
-nc			application/x-netcdf
-cdf			application/x-netcdf
-sh			application/x-sh
-shar			application/x-shar
-sit			application/x-stuffit
-sv4cpio			application/x-sv4cpio
-sv4crc			application/x-sv4crc
-tar			application/x-tar
-tcl			application/x-tcl
-tex			application/x-tex
-texinfo			application/x-texinfo
-texi			application/x-texinfo
-t			application/x-troff
-tr			application/x-troff
-roff			application/x-troff
-man			application/x-troff-man
-me			application/x-troff-me
-ms			application/x-troff-ms
-ustar			application/x-ustar
-src			application/x-wais-source
-xml			text/xml
-ent			text/xml
-cat			text/xml
-sty			text/xml
-dtd			text/dtd
-xsl			text/xsl
-jsp			application/jsp
-zip			application/zip
-au			audio/basic
-snd			audio/basic
-mpga			audio/mpeg
-mp2			audio/mpeg
-aif			audio/x-aiff
-aiff			audio/x-aiff
-aifc			audio/x-aiff
-ram			audio/x-pn-realaudio
-rpm			audio/x-pn-realaudio-plugin
-ra			audio/x-realaudio
-wav			audio/x-wav
-pdb			chemical/x-pdb
-xyz			chemical/x-pdb
-gif			image/gif
-ief			image/ief
-jpeg			image/jpeg
-jpg			image/jpeg
-jpe			image/jpeg
-png			image/png
-tiff			image/tiff
-tif			image/tiff
-bmp			image/bmp
-ras			image/x-cmu-raster
-pnm			image/x-portable-anymap
-pbm			image/x-portable-bitmap
-pgm			image/x-portable-graymap
-ppm			image/x-portable-pixmap
-rgb			image/x-rgb
-xbm			image/x-xbitmap
-xpm			image/x-xpixmap
-xwd			image/x-xwindowdump
+bcpio=application/x-bcpio
+vcd=application/x-cdlink
+Z=application/x-compress
+cpio=application/x-cpio
+csh=application/x-csh
+dcr=application/x-director
+dir=application/x-director
+dxr=application/x-director
+dvi=application/x-dvi
+gtar=application/x-gtar
+gz=application/x-gzip
+hdf=application/x-hdf
+cgi=application/x-httpd-cgi
+skp=application/x-koan
+skd=application/x-koan
+skt=application/x-koan
+skm=application/x-koan
+latex=application/x-latex
+mif=application/x-mif
+nc=application/x-netcdf
+cdf=application/x-netcdf
+sh=application/x-sh
+shar=application/x-shar
+sit=application/x-stuffit
+sv4cpio=application/x-sv4cpio
+sv4crc=application/x-sv4crc
+tar=application/x-tar
+tcl=application/x-tcl
+tex=application/x-tex
+texinfo=application/x-texinfo
+texi=application/x-texinfo
+t=application/x-troff
+tr=application/x-troff
+roff=application/x-troff
+man=application/x-troff-man
+me=application/x-troff-me
+ms=application/x-troff-ms
+ustar=application/x-ustar
+src=application/x-wais-source
+xml=text/xml
+ent=text/xml
+cat=text/xml
+sty=text/xml
+dtd=text/dtd
+xsl=text/xsl
+jsp=application/jsp
+zip=application/zip
+au=audio/basic
+snd=audio/basic
+mpga=audio/mpeg
+mp2=audio/mpeg
+aif=audio/x-aiff
+aiff=audio/x-aiff
+aifc=audio/x-aiff
+ram=audio/x-pn-realaudio
+rpm=audio/x-pn-realaudio-plugin
+ra=audio/x-realaudio
+wav=audio/x-wav
+pdb=chemical/x-pdb
+xyz=chemical/x-pdb
+gif=image/gif
+ief=image/ief
+jpeg=image/jpeg
+jpg=image/jpeg
+jpe=image/jpeg
+png=image/png
+tiff=image/tiff
+tif=image/tiff
+bmp=image/bmp
+ras=image/x-cmu-raster
+pnm=image/x-portable-anymap
+pbm=image/x-portable-bitmap
+pgm=image/x-portable-graymap
+ppm=image/x-portable-pixmap
+rgb=image/x-rgb
+xbm=image/x-xbitmap
+xpm=image/x-xpixmap
+xwd=image/x-xwindowdump
 #			message/external-body
 #			message/news
 #			message/partial
@@ -146,91 +146,99 @@ xwd			image/x-xwindowdump
 #			multipart/digest
 #			multipart/mixed
 #			multipart/parallel
-html			text/html
-htm			text/html
-txt			text/plain
-rtx			text/richtext
-tsv			text/tab-separated-values
-etx			text/x-setext
-sgml			text/x-sgml
-sgm			text/x-sgml
-mpeg			video/mpeg
-mpg			video/mpeg
-mpe			video/mpeg
-qt			video/quicktime
-mov			video/quicktime
-avi			video/x-msvideo
-movie			video/x-sgi-movie
-ice			x-conference/x-cooltalk
-wrl			x-world/x-vrml
-vrml			x-world/x-vrml
-wml			text/vnd.wap.wml
-wmlc			application/vnd.wap.wmlc
-wmls			text/vnd.wap.wmlscript
-wmlsc			application/vnd.wap.wmlscriptc
-wbmp			image/vnd.wap.wbmp
-xls			application/x-msexcel
-abs		audio/x-mpeg
-aim		application/x-aim
-art		image/x-jg
-asf		video/x-ms-asf
-asx		video/x-ms-asf
-avx		video/x-rad-screenplay
-cer		application/x-x509-ca-cert
-css		text/css
-jar		application/java-archive
-java	text/plain
-jnlp	application/x-java-jnlp-file
-js		text/javascript
-mac		image/x-macpaint
-mp1		audio/x-mpeg
-mp2		audio/x-mpeg
-mp3		audio/x-mpeg
-mp4		video/mp4
-flv		video/flv
-odb		application/vnd.oasis.opendocument.database
-odc		application/vnd.oasis.opendocument.chart
-odf		application/vnd.oasis.opendocument.formula
-odg		application/vnd.oasis.opendocument.graphics
-odi		application/vnd.oasis.opendocument.image
-odm		application/vnd.oasis.opendocument.text-master
-odp		application/vnd.oasis.opendocument.presentation
-ods		application/vnd.oasis.opendocument.spreadsheet
-odt		application/vnd.oasis.opendocument.text
-ogg		application/ogg
-otg		application/vnd.oasis.opendocument.graphics-template
-oth		application/vnd.oasis.opendocument.text-web
-otp		application/vnd.oasis.opendocument.presentation-template
-ots		application/vnd.oasis.opendocument.spreadsheet-template
-ott		application/vnd.oasis.opendocument.text-template
-pic		image/pict
-pict	image/pict
-pls		audio/x-scpls
-psd		image/x-photoshop
-rdf		application/rdf+xml
-rtf		application/rtf
-swf		application/x-shockwave-flash
-xht		application/xhtml+xml
-xhtml	application/xhtml+xml
-xslt	application/xslt+xml
-xul		application/vnd.mozilla.xul+xml
-svg		image/svg+xml
-svgz	image/svg+xml
-vsd		application/x-visio
-docm	application/vnd.ms-word.document.macroEnabled.12
-docx	application/vnd.openxmlformats-officedocument.wordprocessingml.document
-dotm	application/vnd.ms-word.template.macroEnabled.12
-dotx	application/vnd.openxmlformats-officedocument.wordprocessingml.template
-potm	application/vnd.ms-powerpoint.template.macroEnabled.12
-potx	application/vnd.openxmlformats-officedocument.presentationml.template
-ppam	application/vnd.ms-powerpoint.addin.macroEnabled.12
-ppsm	application/vnd.ms-powerpoint.slideshow.macroEnabled.12
-ppsx	application/vnd.openxmlformats-officedocument.presentationml.slideshow
-pptm	application/vnd.ms-powerpoint.presentation.macroEnabled.12
-pptx	application/vnd.openxmlformats-officedocument.presentationml.presentation
-xlam	application/vnd.ms-excel.addin.macroEnabled.12
-xlsb	application/vnd.ms-excel.sheet.binary.macroEnabled.12
-xlsm	application/vnd.ms-excel.sheet.macroEnabled.12
-xlsx	application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
-xltm	application/vnd.ms-excel.template.macroEnabled.12
-xltx	application/vnd.openxmlformats-officedocument.spreadsheetml.template
+html=text/html
+htm=text/html
+txt=text/plain
+rtx=text/richtext
+tsv=text/tab-separated-values
+etx=text/x-setext
+sgml=text/x-sgml
+sgm=text/x-sgml
+mpeg=video/mpeg
+mpg=video/mpeg
+mpe=video/mpeg
+qt=video/quicktime
+mov=video/quicktime
+avi=video/x-msvideo
+movie=video/x-sgi-movie
+ice=x-conference/x-cooltalk
+wrl=x-world/x-vrml
+vrml=x-world/x-vrml
+wml=text/vnd.wap.wml
+wmlc=application/vnd.wap.wmlc
+wmls=text/vnd.wap.wmlscript
+wmlsc=application/vnd.wap.wmlscriptc
+wbmp=image/vnd.wap.wbmp
+xls=application/x-msexcel
+abs=audio/x-mpeg
+aim=application/x-aim
+art=image/x-jg
+asf=video/x-ms-asf
+asx=video/x-ms-asf
+avx=video/x-rad-screenplay
+cer=application/x-x509-ca-cert
+css=text/css
+jar=application/java-archive
+java=text/plain
+jnlp=application/x-java-jnlp-file
+js=text/javascript
+mac=image/x-macpaint
+mp1=audio/x-mpeg
+mp2=audio/x-mpeg
+mp3=audio/x-mpeg
+mp4=video/mp4
+flv=video/flv
+odb=application/vnd.oasis.opendocument.database
+odc=application/vnd.oasis.opendocument.chart
+odf=application/vnd.oasis.opendocument.formula
+odg=application/vnd.oasis.opendocument.graphics
+odi=application/vnd.oasis.opendocument.image
+odm=application/vnd.oasis.opendocument.text-master
+odp=application/vnd.oasis.opendocument.presentation
+ods=application/vnd.oasis.opendocument.spreadsheet
+odt=application/vnd.oasis.opendocument.text
+ogg=application/ogg
+otg=application/vnd.oasis.opendocument.graphics-template
+oth=application/vnd.oasis.opendocument.text-web
+otp=application/vnd.oasis.opendocument.presentation-template
+ots=application/vnd.oasis.opendocument.spreadsheet-template
+ott=application/vnd.oasis.opendocument.text-template
+pic=image/pict
+pict=image/pict
+pls=audio/x-scpls
+psd=image/x-photoshop
+rdf=application/rdf+xml
+rtf=application/rtf
+swf=application/x-shockwave-flash
+xht=application/xhtml+xml
+xhtml=application/xhtml+xml
+xslt=application/xslt+xml
+xul=application/vnd.mozilla.xul+xml
+svg=image/svg+xml
+svgz=image/svg+xml
+vsd=application/x-visio
+docm=application/vnd.ms-word.document.macroEnabled.12
+docx=application/vnd.openxmlformats-officedocument.wordprocessingml.document
+dotm=application/vnd.ms-word.template.macroEnabled.12
+dotx=application/vnd.openxmlformats-officedocument.wordprocessingml.template
+potm=application/vnd.ms-powerpoint.template.macroEnabled.12
+potx=application/vnd.openxmlformats-officedocument.presentationml.template
+ppam=application/vnd.ms-powerpoint.addin.macroEnabled.12
+ppsm=application/vnd.ms-powerpoint.slideshow.macroEnabled.12
+ppsx=application/vnd.openxmlformats-officedocument.presentationml.slideshow
+pptm=application/vnd.ms-powerpoint.presentation.macroEnabled.12
+pptx=application/vnd.openxmlformats-officedocument.presentationml.presentation
+xlam=application/vnd.ms-excel.addin.macroEnabled.12
+xlsb=application/vnd.ms-excel.sheet.binary.macroEnabled.12
+xlsm=application/vnd.ms-excel.sheet.macroEnabled.12
+xlsx=application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
+xltm=application/vnd.ms-excel.template.macroEnabled.12
+xltx=application/vnd.openxmlformats-officedocument.spreadsheetml.template
+#For MimeTypeRegistryTest
+def=default-mime-type
+amt=a-mime-type
+anmt=another-mime-type
+a=a
+b=b
+c=c
+d=d

--- a/core-services/viewer/src/main/java/org/silverpeas/core/viewer/service/DefaultPreviewService.java
+++ b/core-services/viewer/src/main/java/org/silverpeas/core/viewer/service/DefaultPreviewService.java
@@ -24,7 +24,7 @@
 package org.silverpeas.core.viewer.service;
 
 import org.silverpeas.core.contribution.converter.DocumentFormat;
-import org.silverpeas.core.contribution.converter.DocumentFormatConverterProvider;
+import org.silverpeas.core.contribution.converter.ToPDFConverter;
 import org.silverpeas.core.contribution.converter.option.SinglePageSelection;
 import org.silverpeas.core.io.media.image.ImageTool;
 import org.silverpeas.core.io.media.image.ImageToolDirective;
@@ -59,14 +59,9 @@ public class DefaultPreviewService extends AbstractViewerService implements Prev
 
   // Extension of pdf document file
   private static final Set<String> imageMimeTypePreviewable = new HashSet<>();
-  static {
-    for (final String imageExtension : new String[] { BMP_IMAGE_EXTENSION, GIF_IMAGE_EXTENSION,
-        JPG_IMAGE_EXTENSION, PCD_IMAGE_EXTENSION, PNG_IMAGE_EXTENSION, TGA_IMAGE_EXTENSION,
-        TIF_IMAGE_EXTENSION }) {
-      imageMimeTypePreviewable.add(FileUtil.getMimeType("file." + imageExtension));
-    }
-    imageMimeTypePreviewable.remove(MimeTypes.DEFAULT_MIME_TYPE);
-  }
+
+  @Inject
+  private ToPDFConverter toPDFConverter;
 
   @Inject
   private ImageTool imageTool;
@@ -77,11 +72,11 @@ public class DefaultPreviewService extends AbstractViewerService implements Prev
    */
   @Override
   public boolean isPreviewable(final File file) {
-    final String fileName = file.getPath();
+    final String filePath = file.getPath();
     if (imageTool.isActivated() && file.exists()) {
-      final String mimeType = FileUtil.getMimeType(fileName);
-      return imageMimeTypePreviewable.contains(mimeType) || FileUtil.isPdf(fileName) ||
-          FileUtil.isOpenOfficeCompatible(fileName) || PLAIN_TEXT_MIME_TYPE.equals(mimeType);
+      final String mimeType = FileUtil.getMimeType(filePath);
+      return imageMimeTypePreviewable.contains(mimeType) || FileUtil.isPdf(filePath) ||
+          toPDFConverter.isDocumentSupported(filePath) || PLAIN_TEXT_MIME_TYPE.equals(mimeType);
     }
     return false;
   }
@@ -107,7 +102,7 @@ public class DefaultPreviewService extends AbstractViewerService implements Prev
         // If the document is an Open Office one
         // 1 - converting it into PDF document
         // 2 - converting the previous result into PNG image
-        if (FileUtil.isOpenOfficeCompatible(viewerContext.getOriginalSourceFile().getName())) {
+        if (toPDFConverter.isDocumentSupported(viewerContext.getOriginalSourceFile().getPath())) {
           final File pdfFile = toPdf(viewerContext.getOriginalSourceFile(),
               generateTmpFile(viewerContext, PDF_DOCUMENT_EXTENSION));
           resultFile = toImage(pdfFile, changeFileExtension(pdfFile, PNG_IMAGE_EXTENSION));
@@ -152,8 +147,7 @@ public class DefaultPreviewService extends AbstractViewerService implements Prev
    * @return
    */
   private File toPdf(final File source, final File destination) {
-    DocumentFormatConverterProvider.getToPDFConverter()
-        .convert(source, destination, DocumentFormat.pdf, new SinglePageSelection(1));
+    toPDFConverter.convert(source, destination, DocumentFormat.pdf, new SinglePageSelection(1));
     return destination;
   }
 
@@ -179,5 +173,14 @@ public class DefaultPreviewService extends AbstractViewerService implements Prev
       deleteQuietly(source);
     }
     return destination;
+  }
+
+  static {
+    for (final String imageExtension : new String[] { BMP_IMAGE_EXTENSION, GIF_IMAGE_EXTENSION,
+        JPG_IMAGE_EXTENSION, PCD_IMAGE_EXTENSION, PNG_IMAGE_EXTENSION, TGA_IMAGE_EXTENSION,
+        TIF_IMAGE_EXTENSION }) {
+      imageMimeTypePreviewable.add(FileUtil.getMimeType("file." + imageExtension));
+    }
+    imageMimeTypePreviewable.remove(MimeTypes.DEFAULT_MIME_TYPE);
   }
 }


### PR DESCRIPTION
- adding a new mechanism of mime-type registry which can be used by several services. Each service using it is able to define its own mime-type registry. Here, the office document to PDF converter defines now its own registry of handled mime-types and the converter itself is able to indicates to other services (as viewer or previewer ones) if a file is supported or not
- making that the viewer and previewer services depends to the office document to PDF converter in order to verify if a file is supported or not
- taking into account template office documents by default