### PR TITLE
Bug #11365: making complex string templates customizable.

### DIFF
--- a/core-api/src/main/java/org/silverpeas/core/template/SilverpeasTemplate.java
+++ b/core-api/src/main/java/org/silverpeas/core/template/SilverpeasTemplate.java
@@ -29,6 +29,18 @@ public interface SilverpeasTemplate {
   String TEMPLATE_ROOT_DIR = "template.root.dir";
   String TEMPLATE_CUSTOM_DIR = "template.customer.dir";
 
+  /**
+   * When the result of string template processing is built from a combination of several
+   * template files, this method MUST be called BEFORE calling {@link #applyFileTemplate(String)}.
+   * <p>
+   * It is in charge of merging the templates given by the product and the one modified by the
+   * customer. By this way, the customer modifies only the necessary templates in case of
+   * customization.
+   * </p>
+   * @return itself.
+   */
+  SilverpeasTemplate mergeRootWithCustom();
+
   void setAttribute(String name, Object value);
 
   String applyFileTemplate(String fileName);

--- a/core-library/src/main/java/org/silverpeas/core/notification/user/delayed/delegate/DelayedNotificationDelegate.java
+++ b/core-library/src/main/java/org/silverpeas/core/notification/user/delayed/delegate/DelayedNotificationDelegate.java
@@ -526,7 +526,9 @@ public class DelayedNotificationDelegate extends AbstractNotification {
    */
   private SilverpeasTemplate getTemplate() {
     if (template == null) {
-      template = SilverpeasTemplateFactory.createSilverpeasTemplateOnCore("notification/delayed");
+      template = SilverpeasTemplateFactory
+          .createSilverpeasTemplateOnCore("notification/delayed")
+          .mergeRootWithCustom();
     }
     return template;
   }


### PR DESCRIPTION
When a String is produced with StringTemplate API from a set of template files (not a single file), the customization was not effective when just a few (not all) of template files were overridden.
The detection of the template file directory (the one of the product or the one of customizations) was not rightly done because the customization needs all template files customized and not just a few.

A modification has been done in order to permits to customize just the needed template files. Now, when a custom folder exists and if it has been requested to StringTemplate API, the template files from product and the customized are merged into a new folder and the template files taken into account from string producing come from this new folder.

The new folder is called "__merged_delete_me_on_template_modification" and is located into the folder of customized template files.
When a customized template is modified, the new folder (if it already exists) MUST be deleted in order that the modifications are taken into account.