### PR TITLE
[quickinfo-optims] Increasing performances around the statistic services.

### DIFF
--- a/core-configuration/src/main/config/properties/org/silverpeas/util/viewGenerator/settings/BigAndAngular.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/util/viewGenerator/settings/BigAndAngular.properties
@@ -143,6 +143,8 @@ ticker.linkOnItem = true
 ticker.items.description = false
 # Delay (in seconds) between each quiet request to server
 ticker.autocheck.delay = 60
+# Display limit, 0 or less = no limit
+ticker.display.limit = 10
 # The pause (in milliseconds) on a news item before being replaced
 ticker.plugin.pauseOnItems = 5000
 # Animation type - current options are 'reveal' or 'fade'

--- a/core-library/src/main/java/org/silverpeas/core/admin/quota/service/QuotaService.java
+++ b/core-library/src/main/java/org/silverpeas/core/admin/quota/service/QuotaService.java
@@ -79,8 +79,12 @@ public interface QuotaService<T extends QuotaKey> {
 
   /**
    * Verifies if the quota is full or not enough from a given quota key.
-   * If full then a quota full exception is throwed.
-   * If not enough then a quota not enough exception is throwed.
+   * <p>
+   * Be aware of that the quota count will be loaded and computed each time this signature is
+   * called.
+   * </p>
+   * If full then a quota full exception is thrown
+   * If not enough then a quota not enough exception is thrown.
    * @param key the key
    * @return the quota used by the verify treatment
    * @throws QuotaException on error
@@ -90,14 +94,52 @@ public interface QuotaService<T extends QuotaKey> {
   /**
    * Verifies if the quota is full or not enough from a given quota key and adding a counting
    * offset.
-   * If full then a quota full exception is throwed.
-   * If not enough then a quota not enough exception is throwed.
+   * <p>
+   * Be aware of that the quota count will be loaded and computed each time this signature is
+   * called.
+   * </p>
+   * If full then a quota full exception is throw.
+   * If not enough then a quota not enough exception is throw.
    * @param key the key
-   * @param countingOffset a counting offiset
+   * @param countingOffset a counting offset
    * @return the quota used by the verify treatment
    * @throws QuotaException on error
    */
   Quota verify(T key, AbstractQuotaCountingOffset countingOffset) throws QuotaException;
+
+  /**
+   * Verifies if the given loaded and computed quota.
+   * <p>
+   * Be aware of that the quota count is not again computed by this service. When this signature
+   * is called, it means that the {@link Quota} instance has been already loaded and there is no
+   * need to perform again the counting.
+   * </p>
+   * If full then a quota full exception is thrown
+   * If not enough then a quota not enough exception is thrown.
+   * @param key the key
+   * @param quota a loaded quota
+   * @return the quota used by the verify treatment
+   * @throws QuotaException on error
+   */
+  Quota verify(T key, Quota quota) throws QuotaException;
+
+  /**
+   * Verifies if the given loaded and computed quota by adding a counting offset.
+   * <p>
+   * Be aware of that the quota count is not again computed by this service. When this signature
+   * is called, it means that the {@link Quota} instance has been already loaded and there is no
+   * need to perform again the counting.
+   * </p>
+   * If full then a quota full exception is thrown.
+   * If not enough then a quota not enough exception is thrown.
+   * @param key the key
+   * @param quota a loaded quota
+   * @param countingOffset a counting offset
+   * @throws QuotaException on error
+   * @return a copied quota from the given one containing the count with the offset used by
+   * the verify treatment
+   */
+  Quota verify(T key, Quota quota, AbstractQuotaCountingOffset countingOffset) throws QuotaException;
 
   /**
    * Removes quietly the quota of the resource from a given quota key.

--- a/core-library/src/main/java/org/silverpeas/core/admin/space/quota/process/check/DataStorageQuotaProcessCheck.java
+++ b/core-library/src/main/java/org/silverpeas/core/admin/space/quota/process/check/DataStorageQuotaProcessCheck.java
@@ -24,7 +24,6 @@
 package org.silverpeas.core.admin.space.quota.process.check;
 
 import org.silverpeas.core.admin.component.model.SilverpeasComponentInstance;
-import org.silverpeas.core.admin.quota.constant.QuotaLoad;
 import org.silverpeas.core.admin.quota.exception.QuotaException;
 import org.silverpeas.core.admin.service.OrganizationController;
 import org.silverpeas.core.admin.space.SpaceInst;
@@ -88,7 +87,7 @@ public class DataStorageQuotaProcessCheck extends AbstractFileProcessCheck {
       for (final SpaceInst space : identifyHandledSpaces(processExecutionContext, fileHandler)) {
         try {
           SpaceServiceProvider.getDataStorageSpaceQuotaService()
-              .verify(DataStorageSpaceQuotaKey.from(space),
+              .verify(DataStorageSpaceQuotaKey.from(space), space.getDataStorageQuota(),
                   SpaceDataStorageQuotaCountingOffset.from(space, fileHandler));
         } catch (final QuotaException quotaException) {
           SilverLogger.getLogger(this).silent(quotaException);
@@ -134,7 +133,7 @@ public class DataStorageQuotaProcessCheck extends AbstractFileProcessCheck {
     final List<SpaceInst> handledSpaces = new ArrayList<>();
     for (final String spaceId : spaceIds) {
       SpaceInst handledSpace = organizationController.getSpaceInstById(spaceId);
-      if (!QuotaLoad.UNLIMITED.equals(handledSpace.getDataStorageQuota().getLoad())) {
+      if (handledSpace.getDataStorageQuota().isNotUnlimitedLoad()) {
         handledSpaces.add(handledSpace);
       }
     }

--- a/core-services/silverstatistics/src/main/java/org/silverpeas/core/silverstatistics/access/service/StatisticService.java
+++ b/core-services/silverstatistics/src/main/java/org/silverpeas/core/silverstatistics/access/service/StatisticService.java
@@ -26,6 +26,7 @@ package org.silverpeas.core.silverstatistics.access.service;
 import org.silverpeas.core.ResourceReference;
 import org.silverpeas.core.WAPrimaryKey;
 import org.silverpeas.core.admin.PaginationPage;
+import org.silverpeas.core.contribution.model.Contribution;
 import org.silverpeas.core.contribution.model.SilverpeasContent;
 import org.silverpeas.core.silverstatistics.access.model.HistoryByUser;
 import org.silverpeas.core.silverstatistics.access.model.HistoryCriteria.QUERY_ORDER_BY;
@@ -36,6 +37,7 @@ import org.silverpeas.core.util.SilverpeasList;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
+import java.util.stream.Stream;
 
 /**
  * contract interface to manage silverpeas statistics
@@ -135,5 +137,13 @@ public interface StatisticService {
   Collection<HistoryObjectDetail> getLastHistoryOfObjectsForUser(String userId,
       int actionType, String objectType, int nbObjects);
 
-  boolean isRead(SilverpeasContent content, String userId);
+  /**
+   * Filters the given contributions in order to keep only those read by the user represented by
+   * the given identifier.
+   * @param contributions the contributions to filter.
+   * @param userId the identifier of the user to verify.
+   * @param <T> the type of contribution.
+   * @return a stream of read <T>
+   */
+  <T extends Contribution> Stream<T> filterRead(Collection<T> contributions, String userId);
 }

--- a/core-war/src/main/java/org/silverpeas/web/jobstartpage/control/JobStartPagePeasSessionController.java
+++ b/core-war/src/main/java/org/silverpeas/web/jobstartpage/control/JobStartPagePeasSessionController.java
@@ -557,6 +557,7 @@ public class JobStartPagePeasSessionController extends AbstractComponentSessionC
       try {
         SpaceServiceProvider.getComponentSpaceQuotaService().initialize(
             ComponentSpaceQuotaKey.from(space), space.getComponentSpaceQuota().getMaxCount());
+        space.clearComponentSpaceQuotaCache();
       } catch (QuotaException qe) {
         throw new QuotaRuntimeException(qe.getMessage(), qe);
       }
@@ -573,6 +574,7 @@ public class JobStartPagePeasSessionController extends AbstractComponentSessionC
       try {
         SpaceServiceProvider.getDataStorageSpaceQuotaService().initialize(
             DataStorageSpaceQuotaKey.from(space), space.getDataStorageQuota().getMaxCount());
+        space.clearDataStorageQuotaCache();
       } catch (QuotaException qe) {
         throw new QuotaRuntimeException(qe.getMessage(), qe);
       }

--- a/core-war/src/main/webapp/WEB-INF/tags/silverpeas/util/displayTicker.tag
+++ b/core-war/src/main/webapp/WEB-INF/tags/silverpeas/util/displayTicker.tag
@@ -76,7 +76,7 @@ var tickerNews = [];
 (function($) {
   function worker() {
     $.ajax({
-      url : webContext + '/services/news/ticker',
+      url : webContext + '/services/news/ticker?limit='+${settings.displayLimit},
       type : "GET",
       dataType : "json",
       cache : false,

--- a/core-war/src/main/webapp/jobStartPagePeas/jsp/startPageInfo.jsp
+++ b/core-war/src/main/webapp/jobStartPagePeas/jsp/startPageInfo.jsp
@@ -370,10 +370,10 @@ out.println(window.printAfter());
 %>
 <view:progressMessage/>
 <div id="pasteOptionsDialog" style="display:none">
-<form name="pasteForm" action="Paste" method="post">
+<form name="pasteForm" action="Paste" method="GET">
 <div id="pasteOptions"></div>
 </form>
-  <form id="spaceForm" action="" method="POST">
+  <form id="spaceForm" action="" method="GET">
     <input id='Translation' name='Translation' type='hidden'/>
     <input id='Id' name='Id' type='hidden'/>
   </form>

--- a/core-war/src/main/webapp/util/javaScript/silverpeas.js
+++ b/core-war/src/main/webapp/util/javaScript/silverpeas.js
@@ -1930,6 +1930,33 @@ if (typeof window.sp === 'undefined') {
         };
       }
     },
+    accListPane : {
+      nextItems : function(url, targetListId) {
+        return sp.ajaxRequest(url).send()
+            .then(function(request) {
+              const $tmpContainer = jQuery('<div>');
+              $tmpContainer.html(request.responseText);
+              const paneSelector = '#' + targetListId + '-pane';
+              const targetListSelector = '#' + targetListId;
+              const actionsPaneSelector = paneSelector + ' .acc-list-pane-actions';
+              const $tmpListContent = jQuery(targetListSelector, $tmpContainer);
+              const $tmpActionContent = jQuery(actionsPaneSelector, $tmpContainer);
+              jQuery(targetListSelector).append($tmpListContent.children());
+              jQuery(actionsPaneSelector).remove();
+              const $pane = jQuery(paneSelector);
+              if ($tmpActionContent.length) {
+                $pane.append($tmpActionContent);
+              }
+            })
+            .then(function() {
+              if (window.spProgressMessage) {
+                window.spProgressMessage.hide();
+              } else if (window.top.spProgressMessage) {
+                window.top.spProgressMessage.hide();
+              }
+            });
+      }
+    },
     arrayPane : {
       ajaxControls : function(containerCssSelector, options) {
         var __refreshFromRequestResponse = function(request) {

--- a/core-web/src/main/java/org/silverpeas/core/web/look/TickerSettings.java
+++ b/core-web/src/main/java/org/silverpeas/core/web/look/TickerSettings.java
@@ -23,11 +23,11 @@
  */
 package org.silverpeas.core.web.look;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import org.silverpeas.core.util.SettingBundle;
 import org.silverpeas.core.util.StringUtil;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class TickerSettings {
 
@@ -36,6 +36,7 @@ public class TickerSettings {
   private boolean linkOnItem = false;
   private int refreshDelay = 60;
   private boolean displayDescription = false;
+  private int displayLimit = 10;
 
   public TickerSettings(SettingBundle settings) {
     for (String key : settings.keySet()) {
@@ -49,6 +50,7 @@ public class TickerSettings {
     linkOnItem = settings.getBoolean("ticker.linkOnItem", false);
     refreshDelay = settings.getInteger("ticker.autocheck.delay", 60);
     displayDescription = settings.getBoolean("ticker.items.description", false);
+    displayLimit = settings.getInteger("ticker.display.limit", 10);
   }
 
   public void setLabel(String label) {
@@ -72,6 +74,10 @@ public class TickerSettings {
 
   public int getRefreshDelay() {
     return refreshDelay;
+  }
+
+  public int getDisplayLimit() {
+    return displayLimit;
   }
 
   public boolean isDescriptionDisplayed() {

--- a/core-web/src/main/java/org/silverpeas/core/web/util/viewgenerator/html/buttonpanes/AbstractButtonPane.java
+++ b/core-web/src/main/java/org/silverpeas/core/web/util/viewgenerator/html/buttonpanes/AbstractButtonPane.java
@@ -23,7 +23,9 @@
  */
 package org.silverpeas.core.web.util.viewgenerator.html.buttonpanes;
 
+import org.silverpeas.core.util.StringUtil;
 import org.silverpeas.core.web.util.viewgenerator.html.buttons.Button;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -35,11 +37,11 @@ import java.util.List;
  */
 public abstract class AbstractButtonPane implements ButtonPane {
 
+  public static final int VERTICAL_PANE = 1;
+  public static final int HORIZONTAL_PANE = 2;
+  private String cssClass = StringUtil.EMPTY;
   private List<Button> buttons = null;
   private String verticalWidth = "50px";
-  public final static int VERTICAL_PANE = 1;
-  public final static int HORIZONTAL_PANE = 2;
-
   private int viewType = HORIZONTAL_PANE;
 
   /**
@@ -47,7 +49,16 @@ public abstract class AbstractButtonPane implements ButtonPane {
    *
    */
   public AbstractButtonPane() {
-    buttons = new ArrayList<Button>();
+    buttons = new ArrayList<>();
+  }
+
+  @Override
+  public void setCssClass(final String cssClass) {
+    this.cssClass = cssClass != null && cssClass.length() > 0 ? " " + cssClass : StringUtil.EMPTY;
+  }
+
+  protected String getCssClass() {
+    return cssClass;
   }
 
   /**
@@ -67,16 +78,6 @@ public abstract class AbstractButtonPane implements ButtonPane {
   @Override
   public void setVerticalPosition() {
     viewType = VERTICAL_PANE;
-  }
-
-  /**
-   * Method declaration
-   * @param width
-   *
-   */
-  @Override
-  public void setVerticalWidth(String width) {
-    verticalWidth = width;
   }
 
   /**
@@ -117,6 +118,16 @@ public abstract class AbstractButtonPane implements ButtonPane {
 
   /**
    * Method declaration
+   * @param width
+   *
+   */
+  @Override
+  public void setVerticalWidth(String width) {
+    verticalWidth = width;
+  }
+
+  /**
+   * Method declaration
    * @return
    *
    */
@@ -128,12 +139,4 @@ public abstract class AbstractButtonPane implements ButtonPane {
    *
    */
   public abstract String verticalPrint();
-
-  /**
-   * Method declaration
-   * @return
-   *
-   */
-  @Override
-  public abstract String print();
 }

--- a/core-web/src/main/java/org/silverpeas/core/web/util/viewgenerator/html/buttonpanes/ButtonPane.java
+++ b/core-web/src/main/java/org/silverpeas/core/web/util/viewgenerator/html/buttonpanes/ButtonPane.java
@@ -35,35 +35,41 @@ import org.silverpeas.core.web.util.viewgenerator.html.buttons.Button;
 public interface ButtonPane extends SimpleGraphicElement {
 
   /**
+   * Sets some CSS classes
+   * @param cssClass CSS classes.
+   */
+  void setCssClass(String cssClass);
+
+  /**
    * Method declaration
    * @param button
    * @see
    */
-  public void addButton(Button button);
+  void addButton(Button button);
 
   /**
    * Method declaration
    * @see
    */
-  public void setVerticalPosition();
+  void setVerticalPosition();
 
   /**
    * Method declaration
    * @param width
    * @see
    */
-  public void setVerticalWidth(String width);
+  void setVerticalWidth(String width);
 
   /**
    * Method declaration
    * @see
    */
-  public void setHorizontalPosition();
+  void setHorizontalPosition();
 
   /**
    * Print the browseBar in an html format.
    * @return The html based line code
    */
-  public String print();
+  String print();
 
 }

--- a/core-web/src/main/java/org/silverpeas/core/web/util/viewgenerator/html/buttonpanes/ButtonPaneTag.java
+++ b/core-web/src/main/java/org/silverpeas/core/web/util/viewgenerator/html/buttonpanes/ButtonPaneTag.java
@@ -23,9 +23,11 @@
  */
 package org.silverpeas.core.web.util.viewgenerator.html.buttonpanes;
 
+import org.apache.ecs.ElementContainer;
+import org.silverpeas.core.util.StringUtil;
 import org.silverpeas.core.web.util.viewgenerator.html.GraphicElementFactory;
 import org.silverpeas.core.web.util.viewgenerator.html.buttons.Button;
-import java.io.IOException;
+
 import javax.servlet.jsp.JspException;
 import javax.servlet.jsp.tagext.TagSupport;
 
@@ -37,16 +39,24 @@ public class ButtonPaneTag extends TagSupport {
   private static final String BUTTON_PANE_ATT = "pageContextButtonPane";
   private static final long serialVersionUID = -3658916991820665360L;
 
+  private String cssClass = StringUtil.EMPTY;
+
+  public void setCssClass(final String cssClass) {
+    this.cssClass = cssClass;
+  }
+
   @Override
   public int doEndTag() throws JspException {
-    final ButtonPane buttonPane = (ButtonPane) pageContext.getAttribute(BUTTON_PANE_ATT);
-    try {
-      pageContext.getOut().println(buttonPane.print());
-    } catch (final IOException e) {
-      throw new JspException("ButtonPane Tag", e);
-    }
-    pageContext.removeAttribute(BUTTON_PANE_ATT);
+    getContent().output(pageContext.getOut());
     return EVAL_PAGE;
+  }
+
+  public ElementContainer getContent() {
+    final ElementContainer elements = new ElementContainer();
+    final ButtonPane buttonPane = (ButtonPane) pageContext.getAttribute(BUTTON_PANE_ATT);
+    elements.addElement(buttonPane.print());
+    pageContext.removeAttribute(BUTTON_PANE_ATT);
+    return elements;
   }
 
   @Override
@@ -82,6 +92,7 @@ public class ButtonPaneTag extends TagSupport {
           getAttribute(
           GraphicElementFactory.GE_FACTORY_SESSION_ATT);
       result = gef.getButtonPane();
+      result.setCssClass(cssClass);
       pageContext.setAttribute(BUTTON_PANE_ATT, result);
     }
     return result;

--- a/core-web/src/main/java/org/silverpeas/core/web/util/viewgenerator/html/buttonpanes/ButtonPaneWA2.java
+++ b/core-web/src/main/java/org/silverpeas/core/web/util/viewgenerator/html/buttonpanes/ButtonPaneWA2.java
@@ -28,9 +28,6 @@
  */
 package org.silverpeas.core.web.util.viewgenerator.html.buttonpanes;
 
-import org.silverpeas.core.web.util.viewgenerator.html.buttons.Button;
-import java.util.List;
-
 /**
  * The default implementation of ArrayPane interface
  * @author squere
@@ -38,63 +35,29 @@ import java.util.List;
  */
 public class ButtonPaneWA2 extends AbstractButtonPane {
 
-  /**
-   * Constructor declaration
-   *
-   */
   public ButtonPaneWA2() {
     super();
   }
 
-  /**
-   * Method declaration
-   * @return
-   *
-   */
   @Override
   public String horizontalPrint() {
-    StringBuilder result = new StringBuilder();
-    List<Button> buttons = getButtons();
-
-    result.append("<div class=\"sp_buttonPane\">");
-
-    if (buttons.size() > 0) {
-      result.append(buttons.get(0).print());
-    }
-    for (int i = 1; i < buttons.size(); i++) {
-      result.append(buttons.get(i).print());
-    }
-  
+    final StringBuilder result = new StringBuilder();
+    result.append("<div class=\"sp_buttonPane").append(getCssClass()).append("\">");
+    getButtons().forEach(b -> result.append(b.print()));
     result.append("</div>");
-
     return result.toString();
   }
 
-  /**
-   * Method declaration
-   * @return
-   *
-   */
   @Override
   public String verticalPrint() {
-    StringBuilder result = new StringBuilder();
-    List<Button> buttons = getButtons();
-    String verticalWidth = getVerticalWidth();
-    result.append(
-        "<div class=\"sp_buttonPane verticalPane\" style=\"width:").append(verticalWidth).
-        append(";\">");
-    for (Button button : buttons) {
-      result.append(button.print());
-    }
+    final StringBuilder result = new StringBuilder();
+    result.append("<div class=\"sp_buttonPane verticalPane").append(getCssClass())
+        .append("\" style=\"width:").append(getVerticalWidth()).append(";\">");
+    getButtons().forEach(b -> result.append(b.print()));
     result.append("</div>");
     return result.toString();
   }
 
-  /**
-   * Method declaration
-   * @return
-   *
-   */
   @Override
   public String print() {
     if (getViewType() == VERTICAL_PANE) {

--- a/core-web/src/main/java/org/silverpeas/core/web/util/viewgenerator/html/layout/BodyPartLayoutTag.java
+++ b/core-web/src/main/java/org/silverpeas/core/web/util/viewgenerator/html/layout/BodyPartLayoutTag.java
@@ -37,11 +37,20 @@ import static org.silverpeas.core.web.util.viewgenerator.html.JavascriptPluginIn
 public class BodyPartLayoutTag extends SilverpeasLayout {
   private static final long serialVersionUID = 7740509977305998444L;
 
+  private String cssClass;
+
+  public void setCssClass(final String cssClass) {
+    this.cssClass = cssClass;
+  }
+
   @Override
   public int doEndTag() throws JspException {
     final body body = new body();
     if (isDefined(getId())) {
       body.setID(getId());
+    }
+    if (isDefined(cssClass)) {
+      body.setClass(cssClass);
     }
     body.addElement(getBodyContent().getString());
     renderAngularJs(body);

--- a/core-web/src/main/java/org/silverpeas/core/web/util/viewgenerator/html/list/AbstractListItemsTag.java
+++ b/core-web/src/main/java/org/silverpeas/core/web/util/viewgenerator/html/list/AbstractListItemsTag.java
@@ -23,37 +23,33 @@
  */
 package org.silverpeas.core.web.util.viewgenerator.html.list;
 
+import org.apache.taglibs.standard.tag.rt.core.ForEachTag;
 import org.silverpeas.core.util.SilverpeasList;
-import org.silverpeas.core.web.util.viewgenerator.html.pagination.Pagination;
 
+import javax.servlet.jsp.JspTagException;
 import java.util.List;
 
 /**
- * Iterate over items.
+ * Centralizing code about iterating over items.
  * <p>If an instance of {@link SilverpeasList} is given, optimizations are offered</p>
- * @author Yohann Chastagnier
+ * @author silveryocha
  */
-public class ListItemsTag extends AbstractListItemsTag {
-  private static final long serialVersionUID = 8166244530238320119L;
+public abstract class AbstractListItemsTag extends ForEachTag {
+  private static final long serialVersionUID = -6470873825192693523L;
 
+  @SuppressWarnings({"unchecked", "rawtypes"})
   @Override
-  protected <T> SilverpeasList<T> optimize(final List<T> list) {
-    final ListPaneTag pane = getListPane();
-    final SilverpeasList<T> silverpeasList = SilverpeasList.wrap(list);
-    if (silverpeasList.isSlice()) {
-      // The list is already paginated
-      return silverpeasList;
+  public void setItems(final Object items) throws JspTagException {
+    if (items instanceof List) {
+      final SilverpeasList optimized = optimize((List) items);
+      getListPane().setNbItems((int) optimized.originalListSize());
+      super.setItems(optimized);
     } else {
-      // Getting (and initializing) the pagination
-      final Pagination pagination = pane.getPagination(list.size());
-      // Computing the paginated list
-      return pagination.getPaginatedListFrom(silverpeasList);
+      super.setItems(items);
     }
   }
 
-  @SuppressWarnings("unchecked")
-  @Override
-  protected ListPaneTag getListPane() {
-    return (ListPaneTag) findAncestorWithClass(this, ListPaneTag.class);
-  }
+  protected abstract <T> SilverpeasList<T> optimize(final List<T> list);
+
+  protected abstract <T extends AbstractListPaneTag> T getListPane();
 }

--- a/core-web/src/main/java/org/silverpeas/core/web/util/viewgenerator/html/list/AbstractListPaneTag.java
+++ b/core-web/src/main/java/org/silverpeas/core/web/util/viewgenerator/html/list/AbstractListPaneTag.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2000 - 2019 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.silverpeas.core.web.util.viewgenerator.html.list;
+
+import javax.servlet.ServletRequest;
+import javax.servlet.http.HttpSession;
+import javax.servlet.jsp.JspException;
+import javax.servlet.jsp.tagext.BodyTagSupport;
+
+/**
+ * Centralization of common code.
+ * @author silveryocha
+ */
+public abstract class AbstractListPaneTag extends BodyTagSupport {
+  private static final long serialVersionUID = -2052000122857193772L;
+  static final int DEFAULT_NB_ITEM_PER_PAGE = 10;
+  private String var;
+  private String routingAddress = null;
+  private int nbItems = 0;
+
+  public String getRoutingAddress() {
+    return routingAddress;
+  }
+
+  public void setRoutingAddress(String routingAddress) {
+    this.routingAddress = routingAddress;
+  }
+  /**
+   * The name of the HttpSession attribute that contains the Pagination.
+   * @param name the name which references the pagination into the session.
+   */
+  public void setVar(final String name) {
+    this.var = name;
+  }
+
+  int getNbItems() {
+    return nbItems;
+  }
+
+  void setNbItems(final int nbItems) {
+    this.nbItems = nbItems;
+  }
+
+  String getVar() {
+    return var;
+  }
+
+  @Override
+  public int doStartTag() throws JspException {
+    nbItems = 0;
+    return super.doStartTag();
+  }
+
+  protected ServletRequest getRequest() {
+    return pageContext.getRequest();
+  }
+
+  protected HttpSession getSession() {
+    return pageContext.getSession();
+  }
+}

--- a/core-web/src/main/java/org/silverpeas/core/web/util/viewgenerator/html/list/AccumulativeListPaneTag.java
+++ b/core-web/src/main/java/org/silverpeas/core/web/util/viewgenerator/html/list/AccumulativeListPaneTag.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright (C) 2000 - 2019 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.silverpeas.core.web.util.viewgenerator.html.list;
+
+import org.apache.ecs.ElementContainer;
+import org.apache.ecs.xhtml.div;
+import org.silverpeas.core.web.util.viewgenerator.html.buttonpanes.ButtonPaneTag;
+import org.silverpeas.core.web.util.viewgenerator.html.buttons.ButtonTag;
+
+import javax.servlet.jsp.JspException;
+import java.io.Serializable;
+
+import static java.lang.String.format;
+import static org.silverpeas.core.util.StringUtil.getBooleanValue;
+import static org.silverpeas.core.web.util.viewgenerator.html.pagination.Pagination.INDEX_PARAMETER_NAME;
+import static org.silverpeas.core.web.util.viewgenerator.html.pagination.Pagination.ITEMS_PER_PAGE_PARAM;
+
+/**
+ * Create a new simple list pane.
+ * @author silveryocha
+ */
+public class AccumulativeListPaneTag extends AbstractListPaneTag {
+  private static final long serialVersionUID = -237212701930752379L;
+  static final String NEXT_PARAMETER_NAME = "AccListNextAction";
+
+  private String targetListId;
+  private String nextActionLabel;
+  private int batchSize = DEFAULT_NB_ITEM_PER_PAGE;
+  private boolean moreItems = false;
+
+  public void setTargetListId(final String targetListId) {
+    this.targetListId = targetListId;
+    setId(targetListId + "-pane");
+  }
+
+  public void setNextActionLabel(final String nextActionLabel) {
+    this.nextActionLabel = nextActionLabel;
+  }
+
+  String getNextActionLabel() {
+    return nextActionLabel;
+  }
+
+  public void setBatchSize(final int batchSize) {
+    this.batchSize = batchSize;
+  }
+
+  void setMoreItems(final boolean moreItems) {
+    this.moreItems = moreItems;
+  }
+
+  @Override
+  public int doStartTag() throws JspException {
+    if (!getBooleanValue(getRequest().getParameter(NEXT_PARAMETER_NAME))) {
+      clearState();
+    }
+    return super.doStartTag();
+  }
+
+  @Override
+  public int doEndTag() throws JspException {
+    final div listPane = new div();
+    listPane.setID(getId());
+    listPane.setClass("acc-list-pane");
+    listPane.addElement(getBodyContent().getString());
+    if (moreItems) {
+      listPane.addElement(getActionPane());
+    }
+    new ElementContainer().addElement(listPane).output(pageContext.getOut());
+    return super.doEndTag();
+  }
+
+  private ElementContainer getActionPane() throws JspException {
+    final State state = getState();
+    final String baseUrl = getRoutingAddress();
+    final StringBuilder url = new StringBuilder(baseUrl);
+    if (baseUrl.indexOf('?') < 0) {
+      url.append("?");
+    } else {
+      url.append("&");
+    }
+    url.append(NEXT_PARAMETER_NAME).append("=true");
+    url.append("&").append(ITEMS_PER_PAGE_PARAM).append("=").append(state.getBatchSize());
+    url.append("&").append(INDEX_PARAMETER_NAME).append("=").append(state.getNextStartIndex());
+    final String nextAction = format("sp.accListPane.nextItems('%s', '%s')", url, targetListId);
+    final ButtonPaneTag buttonPaneTag = new ButtonPaneTag();
+    buttonPaneTag.setPageContext(pageContext);
+    buttonPaneTag.setParent(this);
+    buttonPaneTag.setCssClass("acc-list-pane-actions");
+    final ButtonTag buttonTag = new ButtonTag();
+    buttonTag.setPageContext(pageContext);
+    buttonTag.setParent(buttonPaneTag);
+    buttonTag.setClasses("acc-list-pane-next-action");
+    buttonTag.setLabel(getNextActionLabel());
+    buttonTag.setAction("javascript:" + nextAction);
+    buttonTag.doEndTag();
+    return buttonPaneTag.getContent();
+  }
+
+  State getState() {
+    final String sessionKey = this.getClass().getSimpleName() + getVar();
+    State state = (State) getSession().getAttribute(sessionKey);
+    if (state == null) {
+      state = new State(batchSize);
+      getSession().setAttribute(sessionKey, state);
+    }
+    return state;
+  }
+
+  private void clearState() {
+    final String sessionKey = this.getClass().getSimpleName() + getVar();
+    getSession().removeAttribute(sessionKey);
+  }
+
+  static class State implements Serializable {
+    private static final long serialVersionUID = 2766488468504645179L;
+    private final int batchSize;
+    private int currentListSize = -1;
+    private int currentStartIndex = -1;
+    private int nextStartIndex = -1;
+
+    State(final int batchSize) {
+      this.batchSize = batchSize;
+    }
+
+    int getBatchSize() {
+      return batchSize;
+    }
+
+    int getCurrentListSize() {
+      return currentListSize;
+    }
+
+    void setCurrentListSize(final int currentListSize) {
+      this.currentListSize = currentListSize;
+    }
+
+    int getCurrentStartIndex() {
+      return currentStartIndex;
+    }
+
+    void setCurrentStartIndex(final int previousStartIndex) {
+      this.currentStartIndex = previousStartIndex;
+    }
+
+    int getNextStartIndex() {
+      return nextStartIndex;
+    }
+
+    void setNextStartIndex(final int nextStartIndex) {
+      this.nextStartIndex = nextStartIndex;
+    }
+
+    boolean isFirstDisplay() {
+      return currentListSize == -1;
+    }
+  }
+}

--- a/core-web/src/main/java/org/silverpeas/core/web/util/viewgenerator/html/list/ListPaneTag.java
+++ b/core-web/src/main/java/org/silverpeas/core/web/util/viewgenerator/html/list/ListPaneTag.java
@@ -29,43 +29,26 @@ import org.silverpeas.core.admin.PaginationPage;
 import org.silverpeas.core.web.util.viewgenerator.html.GraphicElementFactory;
 import org.silverpeas.core.web.util.viewgenerator.html.pagination.Pagination;
 
-import javax.servlet.ServletRequest;
-import javax.servlet.http.HttpSession;
 import javax.servlet.jsp.JspException;
-import javax.servlet.jsp.tagext.BodyTagSupport;
+import java.io.Serializable;
 
 import static org.silverpeas.core.util.StringUtil.isDefined;
-import static org.silverpeas.core.web.util.viewgenerator.html.pagination.Pagination
-    .INDEX_PARAMETER_NAME;
-import static org.silverpeas.core.web.util.viewgenerator.html.pagination.Pagination
-    .ITEMS_PER_PAGE_PARAM;
+import static org.silverpeas.core.web.util.viewgenerator.html.pagination.Pagination.INDEX_PARAMETER_NAME;
+import static org.silverpeas.core.web.util.viewgenerator.html.pagination.Pagination.ITEMS_PER_PAGE_PARAM;
 
 /**
  * Create a new ListPane.
  * @author silveryocha
  */
-public class ListPaneTag extends BodyTagSupport {
+public class ListPaneTag extends AbstractListPaneTag {
   private static final long serialVersionUID = 1370094709020971998L;
-  private static final int DEFAULT_NB_ITEM_PER_PAGE = 10;
-  private String var;
-  private String routingAddress = null;
   private int numberLinesPerPage = DEFAULT_NB_ITEM_PER_PAGE;
   private PaginationPage page;
-  private int nbItems = 0;
-
-  public String getRoutingAddress() {
-    return routingAddress;
-  }
-
-  public void setRoutingAddress(String routingAddress) {
-    this.routingAddress = routingAddress;
-  }
 
   @Override
   public int doStartTag() throws JspException {
-    nbItems = 0;
     initNbLinesPerPage();
-    return EVAL_BODY_BUFFERED;
+    return super.doStartTag();
   }
 
   @Override
@@ -96,14 +79,6 @@ public class ListPaneTag extends BodyTagSupport {
     return EVAL_PAGE;
   }
 
-  /**
-   * The name of the HttpSession attribute that contains the Pagination.
-   * @param name the name which references the pagination into the session.
-   */
-  public void setVar(final String name) {
-    this.var = name;
-  }
-
   public void setNumberLinesPerPage(int numberLinesPerPage) {
     this.numberLinesPerPage = numberLinesPerPage;
   }
@@ -118,7 +93,7 @@ public class ListPaneTag extends BodyTagSupport {
    * @return the {@link Pagination} instance.
    */
   Pagination getPagination(final int nbItems) {
-    final String cacheKey = this.getClass().getSimpleName() + "pagination" + this.var;
+    final String cacheKey = this.getClass().getSimpleName() + "pagination" + getVar();
     Pagination pagination = (Pagination) getRequest().getAttribute(cacheKey);
     if (pagination == null) {
       GraphicElementFactory gef = getGraphicElementFactory();
@@ -138,7 +113,7 @@ public class ListPaneTag extends BodyTagSupport {
   private void initNbLinesPerPage() {
     final String nbLines = getRequest().getParameter(ITEMS_PER_PAGE_PARAM);
     if (isDefined(nbLines)) {
-      getState().setMaximumVisibleLine(Integer.valueOf(nbLines));
+      getState().setMaximumVisibleLine(Integer.parseInt(nbLines));
     }
     final String index = getRequest().getParameter(INDEX_PARAMETER_NAME);
     if (isDefined(index)) {
@@ -146,16 +121,8 @@ public class ListPaneTag extends BodyTagSupport {
     }
   }
 
-  int getNbItems() {
-    return nbItems;
-  }
-
-  void setNbItems(final int nbItems) {
-    this.nbItems = nbItems;
-  }
-
   State getState() {
-    final String sessionKey = this.getClass().getSimpleName() + this.var;
+    final String sessionKey = this.getClass().getSimpleName() + getVar();
     State state = (State) getSession().getAttribute(sessionKey);
     if (state == null) {
       state = new State(numberLinesPerPage);
@@ -173,17 +140,10 @@ public class ListPaneTag extends BodyTagSupport {
         .getAttribute(GraphicElementFactory.GE_FACTORY_SESSION_ATT);
   }
 
-  private ServletRequest getRequest() {
-    return pageContext.getRequest();
-  }
-
-  private HttpSession getSession() {
-    return pageContext.getSession();
-  }
-
-  static class State {
+  static class State implements Serializable {
+    private static final long serialVersionUID = 879525429823439845L;
+    private int maximumVisibleLine;
     private int firstVisibleLine = 0;
-    private int maximumVisibleLine = DEFAULT_NB_ITEM_PER_PAGE;
 
     public State(final int maximumVisibleLine) {
       this.maximumVisibleLine = maximumVisibleLine;

--- a/core-web/src/main/java/org/silverpeas/core/web/util/viewgenerator/html/pagination/Pagination.java
+++ b/core-web/src/main/java/org/silverpeas/core/web/util/viewgenerator/html/pagination/Pagination.java
@@ -105,13 +105,12 @@ public interface Pagination extends SimpleGraphicElement {
     return Pair.of(firstIndex, lastIndex);
   }
 
-  @SuppressWarnings("unchecked")
-  default SilverpeasList getPaginatedListFrom(List list) {
-    if (list instanceof SilverpeasList && ((SilverpeasList) list).isSlice()) {
-      return (SilverpeasList) list;
+  default <T> SilverpeasList<T> getPaginatedListFrom(List<T> list) {
+    if (list instanceof SilverpeasList && ((SilverpeasList<T>) list).isSlice()) {
+      return (SilverpeasList<T>) list;
     }
     final Pair<Integer, Integer> indexes = getStartLastIndexes();
-    final List lightList = list.subList(indexes.getLeft(), indexes.getRight());
+    final List<T> lightList = list.subList(indexes.getLeft(), indexes.getRight());
     return PaginationList.from(lightList, list.size());
   }
 

--- a/core-web/src/main/resources/META-INF/viewGenerator.tld
+++ b/core-web/src/main/resources/META-INF/viewGenerator.tld
@@ -772,6 +772,12 @@
     </tag-class>
     <body-content>JSP</body-content>
     <attribute>
+      <name>cssClass</name>
+      <required>false</required>
+      <rtexprvalue>true</rtexprvalue>
+      <type>java.lang.String</type>
+    </attribute>
+    <attribute>
       <description>Indicates if the button are added vertically.</description>
       <name>verticalPosition</name>
       <required>false</required>
@@ -1521,6 +1527,135 @@
     </description>
     <name>listItems</name>
     <tag-class>org.silverpeas.core.web.util.viewgenerator.html.list.ListItemsTag</tag-class>
+    <body-content>JSP</body-content>
+    <attribute>
+      <description>
+        Collection of items to iterate over.
+      </description>
+      <name>items</name>
+      <required>false</required>
+      <rtexprvalue>true</rtexprvalue>
+      <type>java.lang.Object</type>
+      <deferred-value>
+        <type>java.lang.Object</type>
+      </deferred-value>
+    </attribute>
+    <attribute>
+      <description>
+        If items specified:
+        Iteration begins at the item located at the
+        specified index. First item of the collection has
+        index 0.
+        If items not specified:
+        Iteration begins with index set at the value
+        specified.
+      </description>
+      <name>begin</name>
+      <required>false</required>
+      <rtexprvalue>true</rtexprvalue>
+      <type>int</type>
+    </attribute>
+    <attribute>
+      <description>
+        If items specified:
+        Iteration ends at the item located at the
+        specified index (inclusive).
+        If items not specified:
+        Iteration ends when index reaches the value
+        specified.
+      </description>
+      <name>end</name>
+      <required>false</required>
+      <rtexprvalue>true</rtexprvalue>
+      <type>int</type>
+    </attribute>
+    <attribute>
+      <description>
+        Iteration will only process every step items of
+        the collection, starting with the first one.
+      </description>
+      <name>step</name>
+      <required>false</required>
+      <rtexprvalue>true</rtexprvalue>
+      <type>int</type>
+    </attribute>
+    <attribute>
+      <description>
+        Name of the exported scoped variable for the
+        current item of the iteration. This scoped
+        variable has nested visibility. Its type depends
+        on the object of the underlying collection.
+      </description>
+      <name>var</name>
+      <required>false</required>
+      <rtexprvalue>false</rtexprvalue>
+    </attribute>
+    <attribute>
+      <description>
+        Name of the exported scoped variable for the
+        status of the iteration. Object exported is of type
+        javax.servlet.jsp.jstl.core.LoopTagStatus. This scoped variable has nested
+        visibility.
+      </description>
+      <name>varStatus</name>
+      <required>false</required>
+      <rtexprvalue>false</rtexprvalue>
+    </attribute>
+  </tag>
+  <tag>
+    <description>Tag to create an accumulative list pane to display a list of data.</description>
+    <name>accListPane</name>
+    <tag-class>org.silverpeas.core.web.util.viewgenerator.html.list.AccumulativeListPaneTag</tag-class>
+    <body-content>JSP</body-content>
+    <attribute>
+      <description>HTML identifier of the HTML list (UL or OL normally) which is necessary for the
+        line update mechanism. This target list id is used to create automatically the HTML
+        identifier of the accumulative list pane by concatenating '-pane' to the given identifier.
+      </description>
+      <name>targetListId</name>
+      <required>true</required>
+      <rtexprvalue>true</rtexprvalue>
+      <type>java.lang.String</type>
+    </attribute>
+    <attribute>
+      <description>The label of the next action.</description>
+      <name>nextActionLabel</name>
+      <required>true</required>
+      <rtexprvalue>true</rtexprvalue>
+      <type>java.lang.String</type>
+    </attribute>
+    <attribute>
+      <description>Name of the accumulative list pane in the SessionScope</description>
+      <name>var</name>
+      <required>true</required>
+      <rtexprvalue>true</rtexprvalue>
+      <type>java.lang.String</type>
+    </attribute>
+    <attribute>
+      <description>URL to be used to get next lines.</description>
+      <name>routingAddress</name>
+      <required>true</required>
+      <rtexprvalue>true</rtexprvalue>
+      <type>java.lang.String</type>
+    </attribute>
+    <attribute>
+      <description>Defines default number of next lines to retrieve</description>
+      <name>batchSize</name>
+      <required>false</required>
+      <rtexprvalue>true</rtexprvalue>
+      <type>java.lang.Integer</type>
+    </attribute>
+  </tag>
+  <tag>
+    <description>
+      This TAG must be enclosed into a accListPane one.
+      MANDATORY in case of optimized pagination rendering.
+      The basic iteration tag, accepting many different
+      collection types and supporting subsetting and other
+      functionality.
+    </description>
+    <name>accListItems</name>
+    <tag-class>org.silverpeas.core.web.util.viewgenerator.html.list.AccumulativeListItemsTag</tag-class>
     <body-content>JSP</body-content>
     <attribute>
       <description>
@@ -2527,6 +2662,12 @@
     <body-content>JSP</body-content>
     <attribute>
       <name>id</name>
+      <required>false</required>
+      <rtexprvalue>true</rtexprvalue>
+      <type>java.lang.String</type>
+    </attribute>
+    <attribute>
+      <name>cssClass</name>
       <required>false</required>
       <rtexprvalue>true</rtexprvalue>
       <type>java.lang.String</type>

--- a/core-web/src/test-awaiting/resources/com/stratelia/webactiv/util/viewGenerator/settings/BigAndAngular.properties
+++ b/core-web/src/test-awaiting/resources/com/stratelia/webactiv/util/viewGenerator/settings/BigAndAngular.properties
@@ -141,6 +141,8 @@ ticker.label = default
 ticker.linkOnItem = true
 # Delay (in seconds) between each quiet request to server
 ticker.autocheck.delay = 60
+# Display limit, 0 or less = no limit
+ticker.display.limit = 10
 # The pause (in milliseconds) on a news item before being replaced
 ticker.plugin.pauseOnItems = 5000
 # Animation type - current options are 'reveal' or 'fade'

--- a/core-web/src/test-awaiting/resources/org/silverpeas/util/viewGenerator/settings/BigAndAngular.properties
+++ b/core-web/src/test-awaiting/resources/org/silverpeas/util/viewGenerator/settings/BigAndAngular.properties
@@ -141,6 +141,8 @@ ticker.label = default
 ticker.linkOnItem = true
 # Delay (in seconds) between each quiet request to server
 ticker.autocheck.delay = 60
+# Display limit, 0 or less = no limit
+ticker.display.limit = 10
 # The pause (in milliseconds) on a news item before being replaced
 ticker.plugin.pauseOnItems = 5000
 # Animation type - current options are 'reveal' or 'fade'


### PR DESCRIPTION
To get the number of access by contribution for a batch of contributions, services of statistics can now query the database by a single query for all contributions instead of performing a query per contribution.

Adding also a new parameter ticker.display.limit (from look properties) which permits to limit the number of news raquested by the ticker.

Adding a new TAG in order to manage accumulative lists.
A little refactoring about list pane has been done in order to centralize common codes between the two kind of list.

Optimizing the computing of Quota by increasing performances on file walking and refactoring a little quota services.