### PR TITLE
Bug #11426: implementing the feed of events from personal calendars.

### DIFF
--- a/core-api/src/main/java/org/silverpeas/core/util/StringUtil.java
+++ b/core-api/src/main/java/org/silverpeas/core/util/StringUtil.java
@@ -37,6 +37,7 @@ import java.util.regex.Pattern;
 
 public class StringUtil extends StringUtils {
 
+  public static final String EMPTY = StringUtils.EMPTY;
   public static final String NEWLINE = System.getProperty("line.separator");
 
   private static final String PATTERN_START = "{";
@@ -146,7 +147,6 @@ public class StringUtil extends StringUtils {
     return StringUtils.defaultString((isDefined(string) ? string : null), defaultString);
   }
 
-  @SuppressWarnings("ResultOfMethodCallIgnored")
   public static boolean isInteger(String value) {
     try {
       Integer.parseInt(value);
@@ -166,7 +166,6 @@ public class StringUtil extends StringUtils {
     return integer;
   }
 
-  @SuppressWarnings("ResultOfMethodCallIgnored")
   public static boolean isLong(String value) {
     try {
       Long.parseLong(value);
@@ -178,17 +177,16 @@ public class StringUtil extends StringUtils {
 
   public static float asFloat(String value) {
     if (StringUtil.isFloat(value)) {
-      return Float.valueOf(value);
+      return Float.parseFloat(value);
     } else if (value != null) {
       String charge = value.replace(',', '.');
       if (StringUtil.isFloat(charge)) {
-        return Float.valueOf(charge);
+        return Float.parseFloat(charge);
       }
     }
     return 0f;
   }
 
-  @SuppressWarnings("ResultOfMethodCallIgnored")
   public static boolean isFloat(String value) {
     try {
       Float.parseFloat(value);
@@ -203,7 +201,7 @@ public class StringUtil extends StringUtils {
    * @return a String with all quotes replaced by spaces
    */
   public static String escapeQuote(String text) {
-    return text.replaceAll("'", " ");
+    return text.replace("'", " ");
   }
 
   /**

--- a/core-library/src/main/java/org/silverpeas/core/calendar/notification/AttendeeNotificationBuilder.java
+++ b/core-library/src/main/java/org/silverpeas/core/calendar/notification/AttendeeNotificationBuilder.java
@@ -23,6 +23,7 @@
  */
 package org.silverpeas.core.calendar.notification;
 
+import org.silverpeas.core.admin.component.model.PersonalComponentInstance;
 import org.silverpeas.core.admin.user.model.User;
 import org.silverpeas.core.calendar.Attendee;
 import org.silverpeas.core.calendar.CalendarComponent;
@@ -63,7 +64,7 @@ import static org.silverpeas.core.util.DateUtil.getHourOutputFormat;
  * default one.
  * @author mmoquillon
  */
-class AttendeeNotificationBuilder extends AbstractCalendarEventUserNotificationBuilder
+class AttendeeNotificationBuilder extends AbstractCalendarEventUserNotificationBuilder<Contribution>
     implements RemoveSenderRecipientBehavior {
 
   private NotifAction notifCause;
@@ -78,7 +79,6 @@ class AttendeeNotificationBuilder extends AbstractCalendarEventUserNotificationB
    * @param calendarComponent the calendar component concerned by the notification.
    * @param action the action that was performed onto the event.
    */
-  @SuppressWarnings("unchecked")
   AttendeeNotificationBuilder(final Contribution calendarComponent, final NotifAction action) {
     super(calendarComponent, null);
     this.notifCause = action;
@@ -255,5 +255,14 @@ class AttendeeNotificationBuilder extends AbstractCalendarEventUserNotificationB
               getHourOutputFormat(language).getPattern())) + " (" +
           calendarComponent.getCalendar().getZoneId() + ")";
     }
+  }
+
+  @Override
+  protected boolean isUserCanBeNotified(final String userId) {
+    if (PersonalComponentInstance.from(getComponentInstanceId()).isPresent()) {
+      // It is the case of attendee of an event on a personal calendar
+      return true;
+    }
+    return super.isUserCanBeNotified(userId);
   }
 }

--- a/core-library/src/main/java/org/silverpeas/core/calendar/notification/CalendarEventUserNotificationReminder.java
+++ b/core-library/src/main/java/org/silverpeas/core/calendar/notification/CalendarEventUserNotificationReminder.java
@@ -25,6 +25,7 @@
 package org.silverpeas.core.calendar.notification;
 
 import org.silverpeas.core.SilverpeasRuntimeException;
+import org.silverpeas.core.admin.component.model.PersonalComponentInstance;
 import org.silverpeas.core.calendar.CalendarEvent;
 import org.silverpeas.core.calendar.CalendarEventOccurrence;
 import org.silverpeas.core.contribution.model.Contribution;
@@ -121,6 +122,15 @@ public class CalendarEventUserNotificationReminder implements BackgroundReminder
         final SilverpeasTemplate template) {
       super.performTemplateData(localizedContribution, template);
       template.setAttribute("contributionType_" + CalendarEvent.TYPE, true);
+    }
+
+    @Override
+    protected boolean isUserCanBeNotified(final String userId) {
+      if (PersonalComponentInstance.from(getComponentInstanceId()).isPresent()) {
+        // It is the case of reminder on an event on a personal calendar
+        return true;
+      }
+      return super.isUserCanBeNotified(userId);
     }
   }
 }

--- a/core-library/src/main/java/org/silverpeas/core/socialnetwork/provider/SocialEventProvider.java
+++ b/core-library/src/main/java/org/silverpeas/core/socialnetwork/provider/SocialEventProvider.java
@@ -42,8 +42,7 @@ public interface SocialEventProvider extends SocialInformationProvider {
       Date begin, Date end);
 
   List<SocialInformation> getLastSocialInformationsListOfMyContacts(String myId,
-      List<String> myContactsIds,
-      Date begin, Date end);
+      List<String> myContactsIds, Date begin, Date end);
 
   List<SocialInformation> getMyLastSocialInformationsList(String myId, Date begin, Date end);
 }

--- a/core-war/pom.xml
+++ b/core-war/pom.xml
@@ -246,4 +246,31 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>integration-test</id>
+      <activation>
+        <property>
+          <name>context</name>
+          <value>ci</value>
+        </property>
+      </activation>
+      <build>
+        <testResources>
+          <testResource>
+            <directory>src/integration-test/resources</directory>
+            <filtering>true</filtering>
+            <includes>
+              <include>**/*.properties</include>
+            </includes>
+          </testResource>
+          <testResource>
+            <directory>src/test/resources</directory>
+            <filtering>false</filtering>
+          </testResource>
+        </testResources>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/core-war/src/integration-test/java/org/silverpeas/web/test/WarBuilder4WarCore.java
+++ b/core-war/src/integration-test/java/org/silverpeas/web/test/WarBuilder4WarCore.java
@@ -57,6 +57,7 @@ public class WarBuilder4WarCore extends WarBuilder<WarBuilder4WarCore> {
   public static <T> WarBuilder4WarCore onWarForTestClass(Class<T> test) {
     WarBuilder4WarCore warBuilder = new WarBuilder4WarCore(test);
     warBuilder.addMavenDependencies("javax.jcr:jcr");
+    warBuilder.addMavenDependenciesWithPersistence("org.silverpeas.core:silverpeas-core-api");
     warBuilder.addMavenDependenciesWithPersistence("org.silverpeas.core:silverpeas-core");
     warBuilder.addMavenDependenciesWithPersistence("org.silverpeas.core.services:silverpeas-core-pdc");
     warBuilder.addMavenDependenciesWithPersistence("org.silverpeas.core:silverpeas-core-web");
@@ -71,6 +72,7 @@ public class WarBuilder4WarCore extends WarBuilder<WarBuilder4WarCore> {
     warBuilder.addMavenDependencies("org.silverpeas.core.services:silverpeas-core-sharing");
     warBuilder.addMavenDependencies("org.silverpeas.core.services:silverpeas-core-chat");
     warBuilder.addMavenDependencies("org.silverpeas.core.services:silverpeas-core-workflow");
+    warBuilder.addAsResource("maven.properties");
     return warBuilder;
   }
 

--- a/core-war/src/integration-test/java/org/silverpeas/web/usercalendar/socialnetwork/DefaultUserCalendarEventOccurrenceSocialProviderIT.java
+++ b/core-war/src/integration-test/java/org/silverpeas/web/usercalendar/socialnetwork/DefaultUserCalendarEventOccurrenceSocialProviderIT.java
@@ -1,0 +1,391 @@
+/*
+ * Copyright (C) 2000 - 2020 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.silverpeas.web.usercalendar.socialnetwork;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.silverpeas.core.admin.component.PersonalComponentRegistry;
+import org.silverpeas.core.admin.component.WAComponentRegistry;
+import org.silverpeas.core.cache.service.CacheServiceProvider;
+import org.silverpeas.core.personalization.UserMenuDisplay;
+import org.silverpeas.core.personalization.UserPreferences;
+import org.silverpeas.core.personalization.service.DefaultPersonalizationService;
+import org.silverpeas.core.socialnetwork.model.SocialInformation;
+import org.silverpeas.core.socialnetwork.model.SocialInformationType;
+import org.silverpeas.core.socialnetwork.provider.SocialEventProvider;
+import org.silverpeas.core.socialnetwork.provider.SocialMediaCommentProvider;
+import org.silverpeas.core.socialnetwork.provider.SocialMediaProvider;
+import org.silverpeas.core.socialnetwork.provider.SocialNewsCommentProvider;
+import org.silverpeas.core.test.rule.DbSetupRule;
+import org.silverpeas.core.test.rule.MavenTargetDirectoryRule;
+import org.silverpeas.core.util.DateUtil;
+import org.silverpeas.core.util.lang.SystemWrapper;
+import org.silverpeas.web.test.WarBuilder4WarCore;
+
+import javax.annotation.Priority;
+import javax.enterprise.inject.Alternative;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.io.File;
+import java.text.ParseException;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static java.util.Collections.singletonList;
+import static javax.interceptor.Interceptor.Priority.APPLICATION;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * @author silveryocha
+ */
+@RunWith(Arquillian.class)
+public class DefaultUserCalendarEventOccurrenceSocialProviderIT {
+
+  private static final String TABLE_CREATION_SCRIPT =
+      "/org/silverpeas/web/usercalendar/socialnetwork/create-database.sql";
+  private static final String DATASET_SCRIPT =
+      "/org/silverpeas/web/usercalendar/socialnetwork/calendar-dataset.sql";
+
+  private static final String RDV_1_TITLE = "RDV1";
+  private static final String RDV_3_TITLE = "RDV3";
+  private static final String RDV_4_TITLE = "RDV4";
+
+  private static final String DEFAULT_END_DATE = "2011/07/31";
+  private static final String BEGIN_DATE_1 = "2011/07/01";
+  private static final String BEGIN_DATE_9 = "2011/07/09";
+  private static final String BEGIN_DATE_10 = "2011/07/10";
+  public static final String USER_1 = "1";
+  public static final String USER_2 = "2";
+
+  @Inject
+  private SocialEventProvider socialEventsInterface;
+
+  @Rule
+  public MavenTargetDirectoryRule mavenTargetDirectoryRule = new MavenTargetDirectoryRule(this);
+
+  @Rule
+  public DbSetupRule dbSetupRule = DbSetupRule
+      .createTablesFrom(TABLE_CREATION_SCRIPT)
+      .loadInitialDataSetFrom(DATASET_SCRIPT);
+
+  @Deployment
+  public static Archive<?> createTestArchive() {
+    return WarBuilder4WarCore
+        .onWarForTestClass(DefaultUserCalendarEventOccurrenceSocialProviderIT.class)
+        .addPackages(false, "org.silverpeas.web.usercalendar")
+        .addPackages(true, "org.silverpeas.web.usercalendar.notification")
+        .addPackages(true, "org.silverpeas.web.usercalendar.services")
+        .testFocusedOn(war -> war
+            .addPackages(true, "org.silverpeas.web.usercalendar.socialnetwork")
+            .addAsResource("org/silverpeas/web/usercalendar/socialnetwork"))
+        .build();
+  }
+
+  @Before
+  public void setup() throws Exception {
+    final File silverpeasHome = mavenTargetDirectoryRule.getResourceTestDirFile();
+    SystemWrapper.get().getenv().put("SILVERPEAS_HOME", silverpeasHome.getPath());
+    WAComponentRegistry.get().init();
+    PersonalComponentRegistry.get().init();
+    CacheServiceProvider.clearAllThreadCaches();
+  }
+
+  /*
+   * Test of getSocialInformationsList.
+   * This test is a migration of testing of JournalDAO.getNextEventsForUser signature which will
+   * be soon removed.
+   */
+  @Test
+  public void testGetSocialInformationsList() throws ParseException {
+    setNowForTest(DateUtil.parse("2011/07/07"));
+
+    Date begin = DateUtil.parse(BEGIN_DATE_1);
+    final Date end = DateUtil.parse(DEFAULT_END_DATE);
+
+    List<SocialInformation> list = socialEventsInterface
+        .getSocialInformationsList(USER_1, null, begin, end);
+
+    assertThat(list, notNullValue());
+    assertThat(toTitles(list), contains(RDV_1_TITLE, RDV_4_TITLE, RDV_3_TITLE));
+    assertThat(toSocialTypes(list).filter(SocialInformationType.EVENT::equals).count(), is(3L));
+    assertCountOfMine(list, 3L);
+
+    begin = DateUtil.parse(BEGIN_DATE_9);
+    list = socialEventsInterface.getSocialInformationsList(USER_1, null, begin, end);
+    assertThat(list, notNullValue());
+    // Order by day and time  event 3et 3 have the same day but the hour of event3 before Event2
+    assertThat(toTitles(list), contains(RDV_4_TITLE, RDV_3_TITLE));
+    assertThat(toSocialTypes(list).filter(SocialInformationType.EVENT::equals).count(), is(2L));
+    assertCountOfMine(list, 2L);
+
+    begin = DateUtil.parse(BEGIN_DATE_10);
+    list = socialEventsInterface.getSocialInformationsList(USER_1, null, begin, end);
+    assertThat(list, notNullValue());
+    assertThat(list, empty());
+  }
+
+  /*
+   * Test of getSocialInformationListOfMyContacts.
+   * This test is a migration of testing of JournalDAO.getNextEventsForMyContacts signature which
+   * will be soon removed.
+   */
+  @Test
+  public void testGetNextEventsForMyContacts() throws ParseException {
+    setNowForTest(DateUtil.parse("2011/07/07"));
+
+    final List<String> myContactIds = singletonList(USER_1);
+
+    Date begin = DateUtil.parse(BEGIN_DATE_1);
+    final Date end = DateUtil.parse(DEFAULT_END_DATE);
+
+    List<SocialInformation> list = socialEventsInterface
+        .getSocialInformationListOfMyContacts(USER_2, myContactIds, begin, end);
+
+    assertThat(list, notNullValue());
+    assertThat(toTitles(list), contains(RDV_1_TITLE, RDV_4_TITLE, RDV_3_TITLE));
+    assertThat(toSocialTypes(list).filter(SocialInformationType.EVENT::equals).count(), is(3L));
+    assertCountOfMine(list, 0L);
+
+    begin = DateUtil.parse(BEGIN_DATE_9);
+    list = socialEventsInterface
+        .getSocialInformationListOfMyContacts(USER_2, myContactIds, begin, end);
+    assertThat(list, notNullValue());
+    // Order by day and time  event 3et 3 have the same day but the hour of event3 befor Event2
+    assertThat(toTitles(list), contains(RDV_4_TITLE, RDV_3_TITLE));
+    assertThat(toSocialTypes(list).filter(SocialInformationType.EVENT::equals).count(), is(2L));
+    assertCountOfMine(list, 0L);
+
+    begin = DateUtil.parse(BEGIN_DATE_10);
+    list = socialEventsInterface
+        .getSocialInformationListOfMyContacts(USER_2, myContactIds, begin, end);
+    assertThat(list, notNullValue());
+    assertThat(list, empty());
+  }
+
+  /*
+   * Test of getLastSocialInformationsListOfMyContacts.
+   * This test is a migration of testing of JournalDAO.getLastEventsForMyContacts signature which
+   * will be soon removed.
+   */
+  @Test
+  public void testGetLastEventsForMyContacts() throws ParseException {
+    setNowForTest(DateUtil.parse("2012/07/07"));
+
+    final List<String> myContactIds = singletonList(USER_1);
+
+    Date begin = DateUtil.parse(BEGIN_DATE_1);
+    final Date end = DateUtil.parse(DEFAULT_END_DATE);
+
+    List<SocialInformation> list = socialEventsInterface
+        .getLastSocialInformationsListOfMyContacts(USER_2, myContactIds, begin, end);
+
+    //order S3,S2,S1
+    assertThat(list, notNullValue());
+    assertThat(toTitles(list), contains(RDV_3_TITLE, RDV_4_TITLE, RDV_1_TITLE));
+    assertThat(toSocialTypes(list).filter(SocialInformationType.LASTEVENT::equals).count(), is(3L));
+    assertCountOfMine(list, 0L);
+
+    //test limit
+    begin = DateUtil.parse(BEGIN_DATE_9);
+    list = socialEventsInterface
+        .getLastSocialInformationsListOfMyContacts(USER_2, myContactIds, begin, end);
+    assertThat(list, notNullValue());
+    // Order by day and time  event 3et 3 have the same day but the hour of event3 before Event2
+    assertThat(toTitles(list), contains(RDV_3_TITLE, RDV_4_TITLE));
+    assertThat(toSocialTypes(list).filter(SocialInformationType.LASTEVENT::equals).count(), is(2L));
+    assertCountOfMine(list, 0L);
+
+    begin = DateUtil.parse(BEGIN_DATE_10);
+    list = socialEventsInterface
+        .getLastSocialInformationsListOfMyContacts(USER_2, myContactIds, begin, end);
+    assertThat(list, notNullValue());
+    assertThat(list, empty());
+  }
+
+  /*
+   * Test of getMyLastSocialInformationsList.
+   * This test is a migration of testing of JournalDAO.getMyLastEvents signature which
+   * will be soon removed.
+   */
+  @Test
+  public void testGetMyLastEvents() throws ParseException {
+    setNowForTest(DateUtil.parse("2012/07/07"));
+
+    Date begin = DateUtil.parse(BEGIN_DATE_1);
+    final Date end = DateUtil.parse(DEFAULT_END_DATE);
+
+    List<SocialInformation> list = socialEventsInterface
+        .getMyLastSocialInformationsList(USER_1, begin, end);
+
+    //order S3,S2,S1
+    assertThat(list, notNullValue());
+    assertThat(toTitles(list), contains(RDV_3_TITLE, RDV_4_TITLE, RDV_1_TITLE));
+    assertThat(toSocialTypes(list).filter(SocialInformationType.LASTEVENT::equals).count(), is(3L));
+    assertCountOfMine(list, 3L);
+
+    //test limit
+    begin = DateUtil.parse(BEGIN_DATE_9);
+    list = socialEventsInterface.getMyLastSocialInformationsList(USER_1, begin, end);
+    assertThat(list, notNullValue());
+    // Order by day and time  event 3et 3 have the same day but the hour of event3 before Event2
+    assertThat(toTitles(list), contains(RDV_3_TITLE, RDV_4_TITLE));
+    assertThat(toSocialTypes(list).filter(SocialInformationType.LASTEVENT::equals).count(), is(2L));
+    assertCountOfMine(list, 2L);
+
+    begin = DateUtil.parse(BEGIN_DATE_10);
+    list = socialEventsInterface.getMyLastSocialInformationsList(USER_1, begin, end);
+    assertThat(list, notNullValue());
+    assertThat(list, empty());
+  }
+
+  private List<String> toTitles(final List<SocialInformation> list) {
+    return list.stream().map(SocialInformation::getTitle).collect(Collectors.toList());
+  }
+
+  private Stream<SocialInformationType> toSocialTypes(final List<SocialInformation> list) {
+    return list.stream().map(SocialInformation::getType).map(SocialInformationType::valueOf);
+  }
+
+  private void setNowForTest(final Date now) {
+    ((StubbedUserCalendarEventOccurrenceSocialProvider) socialEventsInterface).setNow(now);
+  }
+
+  /**
+   * Update information is here hacked and the real meaning of this information is:
+   * <ul>
+   *   <li>true = mine</li>
+   *   <li>false = to an other user</li>
+   * </ul>
+   * @param list the list to verify.
+   * @param expectedCount the expected count.
+   */
+  private void assertCountOfMine(final List<SocialInformation> list, final long expectedCount) {
+    assertThat(list.stream().filter(SocialInformation::isUpdated).count(), is(expectedCount));
+  }
+
+  @Singleton
+  @Alternative
+  @Priority(APPLICATION + 100)
+  public static class StubbedUserCalendarEventOccurrenceSocialProvider
+      extends DefaultUserCalendarEventOccurrenceSocialProvider {
+
+    private Date now = null;
+
+    public void setNow(final Date now) {
+      this.now = now;
+    }
+
+    @Override
+    protected Date getLegacyNow() {
+      return now;
+    }
+  }
+
+  /**
+   * An implementation is needed
+   */
+  @Singleton
+  @Alternative
+  @Priority(APPLICATION + 100)
+  public static class StubbedSocialMediaCommentProvider implements SocialMediaCommentProvider {
+    @Override
+    public List<SocialInformation> getSocialInformationList(final String userId, final Date begin,
+        final Date end) {
+      return null;
+    }
+
+    @Override
+    public List<SocialInformation> getSocialInformationListOfMyContacts(final String myId,
+        final List<String> myContactsIds, final Date begin, final Date end) {
+      return null;
+    }
+  }
+
+  /**
+   * An implementation is needed
+   */
+  @Singleton
+  @Alternative
+  @Priority(APPLICATION + 100)
+  public static class StubbedSocialMediaProvider implements SocialMediaProvider {
+
+    @Override
+    public List<SocialInformation> getSocialInformationList(final String userId, final Date begin,
+        final Date end) {
+      return null;
+    }
+
+    @Override
+    public List<SocialInformation> getSocialInformationListOfMyContacts(final String myId,
+        final List<String> myContactsIds, final Date begin, final Date end) {
+      return null;
+    }
+  }
+
+  /**
+   * An implementation is needed
+   */
+  @Singleton
+  @Alternative
+  @Priority(APPLICATION + 100)
+  public static class StubbedSocialNewsCommentProvider implements SocialNewsCommentProvider {
+    @Override
+    public List<SocialInformation> getSocialInformationList(final String userId, final Date begin,
+        final Date end) {
+      return null;
+    }
+
+    @Override
+    public List<SocialInformation> getSocialInformationListOfMyContacts(final String myId,
+        final List<String> myContactsIds, final Date begin, final Date end) {
+      return null;
+    }
+  }
+
+  /**
+   * After some trouble without understanding why
+   * {@link org.silverpeas.core.personalization.UserPreferences} cannot be queried, the
+   * personalization service is stubbed.
+   */
+  @Singleton
+  @Alternative
+  @Priority(APPLICATION + 100)
+  public static class StubbedPersonalizationService extends DefaultPersonalizationService {
+
+    @Override
+    public UserPreferences getUserSettings(final String userId) {
+      return new UserPreferences("fr", ZoneId.of("Europe/Paris"), "", "",
+          false, false, false, UserMenuDisplay.DEFAULT);
+    }
+  }
+}

--- a/core-war/src/integration-test/resources/META-INF/services/test-org.silverpeas.core.util.logging.SilverLoggerFactory
+++ b/core-war/src/integration-test/resources/META-INF/services/test-org.silverpeas.core.util.logging.SilverLoggerFactory
@@ -1,0 +1,1 @@
+org.silverpeas.core.util.logging.sys.SysLoggerFactory

--- a/core-war/src/integration-test/resources/maven.properties
+++ b/core-war/src/integration-test/resources/maven.properties
@@ -1,0 +1,31 @@
+#
+# Copyright (C) 2000 - 2019 Silverpeas
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# As a special exception to the terms and conditions of version 3.0 of
+# the GPL, you may redistribute this Program in connection with Free/Libre
+# Open Source Software ("FLOSS") applications as described in Silverpeas's
+# FLOSS exception.  You should have recieved a copy of the text describing
+# the FLOSS exception, and it is also available here:
+# "http://www.silverpeas.org/docs/core/legal/floss_exception.html"
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# To change this template, choose Tools | Templates
+# and open the template in the editor.
+
+build.dir=${project.build.directory}/temp
+silverpeas.version=${project.version}
+project.build.directory=${project.build.directory}
+test-resources.directory=${project.build.directory}/test-classes
+wildfly.home=${wildfly.home}

--- a/core-war/src/integration-test/resources/org/silverpeas/web/usercalendar/socialnetwork/calendar-dataset.sql
+++ b/core-war/src/integration-test/resources/org/silverpeas/web/usercalendar/socialnetwork/calendar-dataset.sql
@@ -1,0 +1,42 @@
+-- Admin data (users and the access level definition) required by the Silverpeas Calendar Engine to work
+INSERT INTO st_accesslevel (id, name) VALUES
+  ('U', 'User'),
+  ('A', 'Administrator');
+
+INSERT INTO st_user
+  (id, domainId, specificId, firstName, lastName, login, accessLevel, state, stateSaveDate, notifManualReceiverLimit)
+VALUES
+  (0, 0, '0', NULL, 'Administrateur', 'SilverAdmin', 'A', 'VALID', '2012-01-01 00:00:00.000', 0),
+  (1, 0, '1', 'Toto', 'Chez-les-Papoos', 'toto', 'U', 'VALID', '2012-01-01 00:00:00.000', 0),
+  (2, 0, '2', 'Gustave', 'Eiffel', 'gustave', 'U', 'VALID', '2012-01-01 00:00:00.000', 0);
+
+INSERT INTO Personalization
+  (id, languages, zoneId, look, personalwspace, thesaurusstatus)
+VALUES
+  ('1', 'fr', 'Europe/Paris', 'Initial', '', 0),
+  ('2', 'fr', 'Europe/Paris', 'Initial', '', 0);
+
+
+-- Some Calendars
+INSERT INTO sb_cal_calendar
+  (id, instanceId, title, zoneid, createDate, createdBy, lastUpdateDate, lastUpdatedBy, version)
+VALUES
+  ('CAL_ID_1', 'userCalendar1_PCI', 'Calendar User 1', 'UTC', '2010-07-28T16:50:00Z', '1', '2010-07-28T16:50:00Z', '1', 0),
+  ('CAL_ID_2', 'userCalendar2_PCI', 'Calendar User 2', 'UTC', '2010-07-28T16:50:00Z', '2', '2010-07-28T16:55:00Z', '2', 1);
+
+-- Some events
+INSERT INTO sb_cal_components
+  (id, calendarId, startDate, endDate, inDays, title, description, priority, createDate, createdBy, lastUpdateDate, lastUpdatedBy, version)
+VALUES
+  ('ID_CMP_1', 'CAL_ID_1', '2011-07-08T12:00:00Z', '2011-07-08T13:00:00Z', FALSE, 'RDV1', 'bla blab', 0, '2011-07-01T16:50:00Z', '1', '2011-07-01T16:50:00Z', '1', 0),
+  ('ID_CMP_2', 'CAL_ID_2', '2011-07-08T12:00:00Z', '2011-07-08T13:00:00Z', FALSE, 'RDV1', 'bla blab', 0, '2011-07-01T16:50:00Z', '2', '2011-07-01T16:50:00Z', '2', 0),
+  ('ID_CMP_3', 'CAL_ID_1', '2011-07-09T13:00:00Z', '2011-07-09T14:00:00Z', FALSE, 'RDV3', 'bla2 blab2', 1, '2011-07-01T16:50:00Z', '1', '2011-07-01T16:50:00Z', '1', 0),
+  ('ID_CMP_4', 'CAL_ID_1', '2011-07-09T07:00:00Z', '2011-07-09T08:00:00Z', FALSE, 'RDV4', 'bla4 blab4', 0, '2011-07-01T16:50:00Z', '1', '2011-07-01T16:50:00Z', '1', 0);
+
+INSERT INTO sb_cal_event
+  (id, componentId, visibility, recurrenceId)
+VALUES
+  ('ID_E_1', 'ID_CMP_1', 'PRIVATE', NULL),
+  ('ID_E_2', 'ID_CMP_2', 'PRIVATE', NULL),
+  ('ID_E_3', 'ID_CMP_3', 'PUBLIC', NULL),
+  ('ID_E_4', 'ID_CMP_4', 'PUBLIC', NULL);

--- a/core-war/src/integration-test/resources/org/silverpeas/web/usercalendar/socialnetwork/create-database.sql
+++ b/core-war/src/integration-test/resources/org/silverpeas/web/usercalendar/socialnetwork/create-database.sql
@@ -1,0 +1,205 @@
+-- System required tables
+
+CREATE TABLE IF NOT EXISTS ST_Space
+(
+  id                    int PRIMARY KEY NOT NULL,
+  domainFatherId        int,
+  name                  varchar(100)  NOT NULL,
+  description           varchar(400),
+  createdBy             int,
+  firstPageType         int NOT NULL,
+  firstPageExtraParam   varchar(400),
+  orderNum              int DEFAULT (0) NOT NULL,
+  createTime            varchar(20),
+  updateTime            varchar(20),
+  removeTime            varchar(20),
+  spaceStatus           char(1),
+  updatedBy             int,
+  removedBy             int,
+  lang                  char(2),
+  isInheritanceBlocked  int default(0) NOT NULL,
+  look                  varchar(50),
+  displaySpaceFirst     smallint,
+  isPersonal            smallint
+);
+
+CREATE TABLE IF NOT EXISTS SB_ContentManager_Instance
+(
+  instanceId    int NOT NULL ,
+  componentId   varchar(100) NOT NULL ,
+  containerType varchar(100) NOT NULL ,
+  contentType   varchar(100) NOT NULL
+);
+
+CREATE TABLE ST_Token (
+  id int8 NOT NULL ,
+  tokenType varchar(50) NOT NULL ,
+  resourceId varchar(50) NOT NULL ,
+  token varchar(50) NOT NULL ,
+  saveCount int NOT NULL ,
+  saveDate timestamp NOT NULL,
+  CONSTRAINT const_st_token_pk PRIMARY KEY (id)
+);
+
+-- User
+
+CREATE TABLE IF NOT EXISTS ST_AccessLevel
+(
+  id   CHAR(1)      NOT NULL,
+  name VARCHAR(100) NOT NULL,
+  CONSTRAINT PK_AccessLevel PRIMARY KEY (id),
+  CONSTRAINT UN_AccessLevel_1 UNIQUE (name)
+);
+
+CREATE TABLE IF NOT EXISTS ST_User (
+  id                            INT                  NOT NULL,
+  domainId                      INT                  NOT NULL,
+  specificId                    VARCHAR(500)         NOT NULL,
+  firstName                     VARCHAR(100),
+  lastName                      VARCHAR(100)         NOT NULL,
+  email                         VARCHAR(100),
+  login                         VARCHAR(50)          NOT NULL,
+  loginMail                     VARCHAR(100),
+  accessLevel                   CHAR(1) DEFAULT 'U'  NOT NULL,
+  loginquestion                 VARCHAR(200),
+  loginanswer                   VARCHAR(200),
+  creationDate                  TIMESTAMP,
+  saveDate                      TIMESTAMP,
+  version                       INT DEFAULT 0        NOT NULL,
+  tosAcceptanceDate             TIMESTAMP,
+  lastLoginDate                 TIMESTAMP,
+  nbSuccessfulLoginAttempts     INT DEFAULT 0        NOT NULL,
+  lastLoginCredentialUpdateDate TIMESTAMP,
+  expirationDate                TIMESTAMP,
+  state                         VARCHAR(30)          NOT NULL,
+  stateSaveDate                 TIMESTAMP            NOT NULL,
+  notifManualReceiverLimit      INT,
+  CONSTRAINT PK_User PRIMARY KEY (id),
+  CONSTRAINT UN_User_1 UNIQUE (specificId, domainId),
+  CONSTRAINT UN_User_2 UNIQUE (login, domainId),
+  CONSTRAINT FK_User_1 FOREIGN KEY (accessLevel) REFERENCES ST_AccessLevel (id)
+);
+
+CREATE TABLE IF NOT EXISTS Personalization (
+  id                  varchar(100) PRIMARY KEY NOT NULL,
+  languages           varchar(100) NULL,
+  zoneId              varchar(100) NULL,
+  look                varchar(50)  NULL,
+  personalWSpace      varchar(50)  NULL,
+  thesaurusStatus     int          NOT NULL,
+  dragAndDropStatus   int          DEFAULT 1,
+  webdavEditingStatus int          DEFAULT 0,
+  menuDisplay         varchar(50)  DEFAULT 'DEFAULT'
+);
+
+-- Calendar API
+
+CREATE TABLE IF NOT EXISTS SB_Cal_Calendar (
+  id             VARCHAR(40)   NOT NULL,
+  instanceId     VARCHAR(30)   NOT NULL,
+  title          VARCHAR(255)  NOT NULL,
+  zoneId         VARCHAR(40)   NOT NULL,
+  externalUrl    VARCHAR(250),
+  synchroDate    TIMESTAMP,
+  createDate     TIMESTAMP     NOT NULL,
+  createdBy      VARCHAR(40)   NOT NULL,
+  lastUpdateDate TIMESTAMP     NOT NULL,
+  lastUpdatedBy  VARCHAR(40)   NOT NULL,
+  version        INT8          NOT NULL,
+  CONSTRAINT PK_CALENDAR PRIMARY KEY (id)
+);
+
+CREATE TABLE IF NOT EXISTS SB_Cal_Recurrence (
+  id                   VARCHAR(40)  NOT NULL,
+  recur_periodInterval INT          NOT NULL,
+  recur_periodUnit     VARCHAR(5)   NOT NULL,
+  recur_count          INT,
+  recur_endDate        TIMESTAMP,
+  CONSTRAINT PK_RECURRENCE PRIMARY KEY (id)
+);
+
+CREATE TABLE IF NOT EXISTS SB_Cal_Recurrence_DayOfWeek (
+  recurrenceId    VARCHAR(40) NOT NULL,
+  recur_nth       INT         NOT NULL,
+  recur_dayOfWeek INT         NOT NULL,
+  CONSTRAINT FK_Recurrence_DayOfWeek FOREIGN KEY (recurrenceId) REFERENCES SB_Cal_Recurrence(id)
+);
+
+CREATE TABLE IF NOT EXISTS SB_Cal_Recurrence_Exception (
+  recurrenceId        VARCHAR(40) NOT NULL,
+  recur_exceptionDate TIMESTAMP   NOT NULL,
+  CONSTRAINT FK_Recurrence_Exception FOREIGN KEY (recurrenceId) REFERENCES SB_Cal_Recurrence(id)
+);
+
+CREATE TABLE IF NOT EXISTS SB_Cal_Components (
+  id             VARCHAR(40)   NOT NULL,
+  calendarId     VARCHAR(40)   NOT NULL,
+  startDate      TIMESTAMP     NOT NULL,
+  endDate        TIMESTAMP     NOT NULL,
+  inDays         BOOLEAN       NOT NULL,
+  title          VARCHAR(255)  NOT NULL,
+  description    VARCHAR(2000) NOT NULL,
+  location       VARCHAR(255)  NULL,
+  attributes     VARCHAR(40)   NULL,
+  priority       INT           NOT NULL,
+  sequence       INT8          NOT NULL DEFAULT 0,
+  createDate     TIMESTAMP     NOT NULL,
+  createdBy      VARCHAR(40)   NOT NULL,
+  lastUpdateDate TIMESTAMP     NOT NULL,
+  lastUpdatedBy  VARCHAR(40)   NOT NULL,
+  version        INT8          NOT NULL,
+  CONSTRAINT PK_CalComponent PRIMARY KEY (id),
+  CONSTRAINT FK_Calendar     FOREIGN KEY (calendarId) REFERENCES SB_Cal_Calendar(id)
+);
+
+CREATE TABLE IF NOT EXISTS SB_Cal_Event (
+  id             VARCHAR(40)   NOT NULL,
+  externalId     VARCHAR(255)  NULL,
+  synchroDate    TIMESTAMP,
+  componentId    VARCHAR(40)   NOT NULL,
+  visibility     VARCHAR(50)   NOT NULL,
+  recurrenceId   VARCHAR(40)   NULL,
+  CONSTRAINT PK_Event            PRIMARY KEY (id),
+  CONSTRAINT FK_Event_Component  FOREIGN KEY (componentId)  REFERENCES SB_Cal_Components(id),
+  CONSTRAINT FK_Event_Recurrence FOREIGN KEY (recurrenceId) REFERENCES SB_Cal_Recurrence(id)
+);
+
+CREATE TABLE IF NOT EXISTS SB_Cal_Occurrences (
+  id             VARCHAR(60)   NOT NULL,
+  eventId        VARCHAR(40)   NOT NULL,
+  componentId    VARCHAR(40)   NOT NULL,
+  CONSTRAINT PK_Occurrence           PRIMARY KEY (id),
+  CONSTRAINT FK_Occurrence_Event     FOREIGN KEY (eventId)     REFERENCES SB_Cal_Event,
+  CONSTRAINT FK_Occurrence_Component FOREIGN KEY (componentId) REFERENCES SB_Cal_Components(id)
+);
+
+CREATE TABLE IF NOT EXISTS SB_Cal_Attributes (
+  id         VARCHAR(40)  NOT NULL,
+  name       VARCHAR(255) NOT NULL,
+  value      VARCHAR(255) NOT NULL,
+  CONSTRAINT PK_Attributes PRIMARY KEY (id, name)
+);
+
+CREATE TABLE IF NOT EXISTS SB_Cal_Categories (
+  id       VARCHAR(40)  NOT NULL,
+  category VARCHAR(255) NOT NULL,
+  CONSTRAINT Pk_Categories PRIMARY KEY (id, category)
+);
+
+CREATE TABLE IF NOT EXISTS SB_Cal_Attendees (
+  id                VARCHAR(40) NOT NULL,
+  attendeeId        VARCHAR(40) NOT NULL,
+  componentId       VARCHAR(40) NOT NULL,
+  type              INT         NOT NULL,
+  participation     VARCHAR(12) NOT NULL DEFAULT 'AWAITING',
+  presence          VARCHAR(12) NOT NULL DEFAULT 'REQUIRED',
+  delegate          VARCHAR(40) NULL,
+  createDate        TIMESTAMP   NOT NULL,
+  createdBy         VARCHAR(40) NOT NULL,
+  lastUpdateDate    TIMESTAMP   NOT NULL,
+  lastUpdatedBy     VARCHAR(40) NOT NULL,
+  version           INT8        NOT NULL,
+  CONSTRAINT PK_Attendee           PRIMARY KEY (id),
+  CONSTRAINT FK_Attendee_Component FOREIGN KEY (componentId) REFERENCES SB_Cal_Components(id),
+  CONSTRAINT FK_Delegate           FOREIGN KEY (delegate) REFERENCES SB_Cal_Attendees(id)
+);

--- a/core-war/src/integration-test/resources/xmlcomponents/personals/userCalendar.xml
+++ b/core-war/src/integration-test/resources/xmlcomponents/personals/userCalendar.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright (C) 2000 - 2019 Silverpeas
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as
+  ~ published by the Free Software Foundation, either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ As a special exception to the terms and conditions of version 3.0 of
+  ~ the GPL, you may redistribute this Program in connection with Free/Libre
+  ~ Open Source Software ("FLOSS") applications as described in Silverpeas's
+  ~ FLOSS exception. You should have received a copy of the text describing
+  ~ the FLOSS exception, and it is also available here:
+  ~ "http://www.silverpeas.org/docs/core/legal/floss_exception.html"
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+<PersonalComponent xmlns="http://silverpeas.org/xml/ns/component"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://silverpeas.org/xml/ns/component http://www.silverpeas.org/xsd/component.xsd">
+  <name>userCalendar</name>
+  <label>
+    <message lang="fr">Mes agendas</message>
+    <message lang="en">My diaries</message>
+    <message lang="de">My diaries</message>
+  </label>
+  <description>
+    <message lang="fr">Vos agendas personnels.</message>
+    <message lang="en">Your personal diaries.</message>
+    <message lang="de">Your personal diaries.</message>
+  </description>
+  <visible>true</visible>
+</PersonalComponent>

--- a/core-war/src/main/java/org/silverpeas/web/usercalendar/services/UserCalendarWebManager.java
+++ b/core-war/src/main/java/org/silverpeas/web/usercalendar/services/UserCalendarWebManager.java
@@ -50,10 +50,9 @@ public class UserCalendarWebManager extends CalendarWebManager {
 
   @Override
   public List<CalendarEventOccurrence> getEventOccurrencesOf(final LocalDate startDate,
-      final LocalDate endDate, final List<Calendar> calendars) {
+      final LocalDate endDate, final List<Calendar> calendars, final User currentRequester) {
     List<CalendarEventOccurrence> result =
-        super.getEventOccurrencesOf(startDate, endDate, calendars);
-    final User currentRequester = User.getCurrentRequester();
+        super.getEventOccurrencesOf(startDate, endDate, calendars, currentRequester);
     calendars.stream().filter(c -> c.isMainPersonalOf(currentRequester)).forEach(p -> {
       // Add occurrence participation of user
       final List<CalendarEventOccurrence> participationOccurrences =

--- a/core-war/src/main/java/org/silverpeas/web/usercalendar/socialnetwork/DefaultUserCalendarEventOccurrenceSocialProvider.java
+++ b/core-war/src/main/java/org/silverpeas/web/usercalendar/socialnetwork/DefaultUserCalendarEventOccurrenceSocialProvider.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright (C) 2000 - 2020 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.silverpeas.web.usercalendar.socialnetwork;
+
+import org.silverpeas.core.admin.component.model.PersonalComponent;
+import org.silverpeas.core.admin.component.model.PersonalComponentInstance;
+import org.silverpeas.core.admin.user.model.User;
+import org.silverpeas.core.calendar.Calendar;
+import org.silverpeas.core.calendar.CalendarEventOccurrence;
+import org.silverpeas.core.calendar.VisibilityLevel;
+import org.silverpeas.core.socialnetwork.model.SocialInformation;
+import org.silverpeas.core.socialnetwork.model.SocialInformationType;
+import org.silverpeas.core.socialnetwork.provider.SocialEventProvider;
+import org.silverpeas.core.util.DateUtil;
+import org.silverpeas.core.util.StringUtil;
+import org.silverpeas.core.web.calendar.socialnetwork.CalendarEventOccurrenceSocialInformation;
+import org.silverpeas.core.webapi.calendar.CalendarResourceURIs;
+import org.silverpeas.core.webapi.calendar.CalendarWebManager;
+import org.silverpeas.web.usercalendar.UserCalendarSettings;
+
+import javax.annotation.Priority;
+import javax.enterprise.inject.Alternative;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static java.time.OffsetDateTime.ofInstant;
+import static java.time.ZoneId.systemDefault;
+import static java.util.Collections.singleton;
+import static java.util.stream.Stream.empty;
+import static javax.interceptor.Interceptor.Priority.APPLICATION;
+import static org.silverpeas.core.admin.component.model.PersonalComponentInstance.from;
+import static org.silverpeas.core.util.StringUtil.isDefined;
+
+/**
+ * For now, this implementation is alternative to
+ * {@link org.silverpeas.core.personalorganizer.socialnetwork.SocialEvent} one.
+ * <p>
+ * Indeed, {@link org.silverpeas.core.personalorganizer.socialnetwork.SocialEvent} implementation
+ * will be soon deleted. But, while waiting for that to happen, it is kept intact.
+ * </p>
+ * @author silveryocha
+ */
+@Singleton
+@Alternative
+@Priority(APPLICATION + 10)
+public class DefaultUserCalendarEventOccurrenceSocialProvider implements SocialEventProvider {
+
+  private static final String USER_CALENDAR_COMPONENT_NAME = UserCalendarSettings.COMPONENT_NAME;
+  private static final String NEXT_EVENT_TYPE = SocialInformationType.EVENT.toString();
+  private static final String LAST_EVENT_TYPE = SocialInformationType.LASTEVENT.toString();
+
+  private final Comparator<SocialInformation> comparatorByDateAsc = Comparator
+      .comparing(SocialInformation::getDate);
+
+  private final Comparator<SocialInformation> comparatorByDateDesc = comparatorByDateAsc.reversed();
+
+  @Inject
+  private CalendarResourceURIs uri;
+
+  protected DefaultUserCalendarEventOccurrenceSocialProvider() {
+  }
+
+  @Override
+  public List<SocialInformation> getSocialInformationsList(String userId, String classification,
+      Date begin, Date end) {
+    return streamData(userId, singleton(userId), classification, begin, end, true)
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public List<SocialInformation> getSocialInformationList(final String userId, final Date begin,
+      final Date end) {
+    return getSocialInformationsList(userId, StringUtil.EMPTY, begin, end);
+  }
+
+  @Override
+  public List<SocialInformation> getSocialInformationListOfMyContacts(String userId,
+      List<String> myContactsIds, Date begin, Date end) {
+    return streamData(userId, myContactsIds, StringUtil.EMPTY, begin, end, true)
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public List<SocialInformation> getLastSocialInformationsListOfMyContacts(String userId,
+      List<String> myContactsIds, Date begin, Date end) {
+    return streamData(userId, myContactsIds, StringUtil.EMPTY, begin, end, false)
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public List<SocialInformation> getMyLastSocialInformationsList(String userId, Date begin,
+      Date end) {
+    return streamData(userId, singleton(userId), StringUtil.EMPTY, begin, end, false)
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Centralization of the getting of data.
+   * @param requesterId the identifier of the user processing the request.
+   * @param aimedUserIds the user identifiers for which the occurrences MUST be be searched for.
+   * @param visibilityFilter an optional visibility filter.
+   * @param begin the start date of the time window to request.
+   * @param end the end date of the time window to request.
+   * @param getNext true means that the next occurrences from now and into the time window are
+   * requested, otherwise it the last occurrences into the time windows needed.
+   * @return a stream of {@link SocialInformation}.
+   */
+  private Stream<CalendarEventOccurrenceSocialInformation> streamData(String requesterId,
+      final Collection<String> aimedUserIds, String visibilityFilter, Date begin, Date end,
+      boolean getNext) {
+    final Optional<PersonalComponent> userCalendarComponent = PersonalComponent
+        .getByName(USER_CALENDAR_COMPONENT_NAME);
+    if (!userCalendarComponent.isPresent()) {
+      return empty();
+    }
+    final CalendarWebManager calendarWebManager = getCalendarWebManager();
+    final User requester = User.getById(requesterId);
+    final ZoneId userZoneId = requester.getUserPreferences().getZoneId();
+    final Date legacyNow = getLegacyNow();
+    final OffsetDateTime now = ofInstant(legacyNow.toInstant(), systemDefault());
+    final LocalDate startDate = toUserLocalDate(begin, userZoneId);
+    final LocalDate endDate = toUserLocalDate(end, userZoneId).plusDays(1);
+    final List<PersonalComponentInstance> componentIds = aimedUserIds.stream()
+        .map(User::getById)
+        .filter(Objects::nonNull)
+        .map(u -> from(u, userCalendarComponent.get()))
+        .collect(Collectors.toList());
+    if (componentIds.isEmpty()) {
+      return empty();
+    }
+    Stream<CalendarEventOccurrenceSocialInformation> streamResult = componentIds.stream()
+        .flatMap(i -> {
+          final List<Calendar> userCalendars = calendarWebManager.getCalendarsHandledBy(i.getId());
+          if (userCalendars.isEmpty()) {
+            return empty();
+          }
+          final User userOwner = i.getUser();
+          final List<CalendarEventOccurrence> occurrences = calendarWebManager
+              .getEventOccurrencesOf(startDate, endDate, userCalendars, userOwner);
+          return asSocialInformationList(occurrences, now, requesterId, userZoneId, userOwner.getId());
+        });
+    if (getNext) {
+      streamResult = streamResult.filter(i -> NEXT_EVENT_TYPE.equals(i.getType()));
+    } else {
+      streamResult = streamResult.filter(i -> LAST_EVENT_TYPE.equals(i.getType()));
+    }
+    if (isDefined(visibilityFilter)) {
+      streamResult = streamResult.filter(onVisibility(visibilityFilter));
+    }
+    if (aimedUserIds.stream().anyMatch(i -> !String.valueOf(i).equals(requesterId))) {
+      // Updated value is hacked. Not super good, but for now, no refactoring at this level.
+      // Here, if true (default value) this data means that the calendar occurrence is a personal
+      // one of requester.
+      final String componentIdOfRequester = from(requester, userCalendarComponent.get()).getId();
+      streamResult = streamResult.map(i -> {
+        final boolean isOneOfRequester = i.getOccurrence().getCalendarEvent().getCalendar()
+            .getComponentInstanceId().equals(componentIdOfRequester);
+        i.setUpdated(isOneOfRequester);
+        return i;
+      });
+    }
+    if (getNext) {
+      streamResult = streamResult.sorted(comparatorByDateAsc);
+    } else {
+      streamResult = streamResult.sorted(comparatorByDateDesc);
+    }
+    return streamResult.map(i -> {
+      if (!i.getIcon().contains("private")) {
+        i.setUrl(uri.ofOccurrencePermalink(i.getOccurrence()).toString());
+      }
+      return i;
+    });
+  }
+
+  private LocalDate toUserLocalDate(final Date begin, final ZoneId userZoneId) {
+    return ofInstant(begin.toInstant(), systemDefault()).atZoneSameInstant(userZoneId).toLocalDate();
+  }
+
+  protected Date getLegacyNow() {
+    return DateUtil.getNow();
+  }
+
+  private Predicate<CalendarEventOccurrenceSocialInformation> onVisibility(final String visibility) {
+    final VisibilityLevel visibilityLevel = VisibilityLevel.valueOf(visibility.toUpperCase());
+    return o -> o.getOccurrence().getVisibilityLevel() == visibilityLevel;
+  }
+
+  private Stream<CalendarEventOccurrenceSocialInformation> asSocialInformationList(
+      final Collection<CalendarEventOccurrence> occurrences, final OffsetDateTime now,
+      final String requesterId, final ZoneId userZoneId, final String userOwnerId) {
+    return occurrences.stream()
+        .map(o -> asSocialInformation(o, now, requesterId, userZoneId, userOwnerId));
+  }
+
+  private CalendarEventOccurrenceSocialInformation asSocialInformation(
+      final CalendarEventOccurrence occurrence, final OffsetDateTime now, final String requesterId,
+      final ZoneId userZoneId, final String userOwnerId) {
+    return new CalendarEventOccurrenceSocialInformation(occurrence, now, requesterId, userZoneId,
+        userOwnerId);
+  }
+
+  private CalendarWebManager getCalendarWebManager() {
+    return CalendarWebManager.get(USER_CALENDAR_COMPONENT_NAME);
+  }
+}

--- a/core-web/src/main/java/org/silverpeas/core/web/calendar/socialnetwork/CalendarEventOccurrenceSocialInformation.java
+++ b/core-web/src/main/java/org/silverpeas/core/web/calendar/socialnetwork/CalendarEventOccurrenceSocialInformation.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (C) 2000 - 2020 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.silverpeas.core.web.calendar.socialnetwork;
+
+import org.silverpeas.core.calendar.CalendarEventOccurrence;
+import org.silverpeas.core.calendar.VisibilityLevel;
+import org.silverpeas.core.date.Period;
+import org.silverpeas.core.socialnetwork.model.AbstractSocialInformation;
+import org.silverpeas.core.socialnetwork.model.SocialInformation;
+import org.silverpeas.core.socialnetwork.model.SocialInformationType;
+import org.silverpeas.core.util.StringUtil;
+
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.Objects;
+
+import static java.time.ZoneOffset.UTC;
+import static org.silverpeas.core.date.TemporalConverter.asLocalDate;
+import static org.silverpeas.core.date.TemporalConverter.asOffsetDateTime;
+
+/**
+ * @author silveryocha
+ */
+public class CalendarEventOccurrenceSocialInformation extends AbstractSocialInformation {
+
+  private final String requesterId;
+  private final ZoneId userZoneId;
+  private final String userOwnerId;
+  private final Period period;
+  private final CalendarEventOccurrence occurrence;
+
+  /**
+   * Creates a {@link SocialInformation} instance corresponding to a
+   * {@link CalendarEventOccurrence} one.
+   * @param occurrence an occurrence.
+   * @param now the now temporal (date and time).
+   * @param requesterId the identifier of the requester.
+   * @param userZoneId a user zone id in order to handle properly dates according to user timezone.
+   * @param userOwnerId the identifier of the user the social information belong to.
+   */
+  public CalendarEventOccurrenceSocialInformation(CalendarEventOccurrence occurrence,
+      final OffsetDateTime now, final String requesterId, final ZoneId userZoneId,
+      final String userOwnerId) {
+    this.requesterId = requesterId;
+    this.userZoneId = userZoneId;
+    this.userOwnerId = userOwnerId;
+    this.occurrence = occurrence;
+    this.period = occurrence.getPeriod();
+    if (period.endsAfter(now.atZoneSameInstant(UTC).toLocalDate().atStartOfDay(UTC))) {
+      setType(SocialInformationType.EVENT.toString());
+    } else {
+      setType(SocialInformationType.LASTEVENT.toString());
+    }
+    setUpdated(true);
+    setUrl(StringUtil.EMPTY);
+  }
+
+  @Override
+  public String getIcon() {
+    // Indeed, isUpdated means here isTheEventOneOfCurrentUser
+    if (!isUpdated()
+        && VisibilityLevel.PRIVATE == occurrence.getVisibilityLevel()
+        && occurrence.getAttendees().stream().noneMatch(a -> a.getId().equals(requesterId))) {
+      return getType() + "_private.gif";
+    }
+    return getType() + "_public.gif";
+  }
+
+  @Override
+  public String getTitle() {
+    return occurrence.getTitle();
+  }
+
+  @Override
+  public String getDescription() {
+    return occurrence.getDescription();
+  }
+
+  @Override
+  public String getAuthor() {
+    return userOwnerId;
+  }
+
+  @Override
+  public Date getDate() {
+    Date startDate = super.getDate();
+    if (startDate == null) {
+      final Instant instant = period.isInDays()
+          ? asLocalDate(period.getStartDate()).atStartOfDay(userZoneId).toInstant()
+          : asOffsetDateTime(period.getStartDate()).atZoneSameInstant(userZoneId).toInstant();
+      startDate = Date.from(instant);
+      setDate(startDate);
+    }
+    return startDate;
+  }
+
+  @Override
+  public int compareTo(SocialInformation socialInfo) {
+    if (SocialInformationType.LASTEVENT.toString().equals(getType())) {
+      // event in the past
+      return getDate().compareTo(socialInfo.getDate()) * -1;
+    }
+    // future event
+    return getDate().compareTo(socialInfo.getDate());
+  }
+
+  public CalendarEventOccurrence getOccurrence() {
+    return occurrence;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final CalendarEventOccurrenceSocialInformation that =
+        (CalendarEventOccurrenceSocialInformation) o;
+    return Objects.equals(userOwnerId, that.userOwnerId) &&
+        Objects.equals(occurrence, that.occurrence);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), userOwnerId, occurrence);
+  }
+}

--- a/core-web/src/main/java/org/silverpeas/core/webapi/calendar/CalendarWebManager.java
+++ b/core-web/src/main/java/org/silverpeas/core/webapi/calendar/CalendarWebManager.java
@@ -635,6 +635,23 @@ public class CalendarWebManager {
    */
   public List<CalendarEventOccurrence> getEventOccurrencesOf(LocalDate startDate, LocalDate endDate,
       List<Calendar> calendars) {
+    return getEventOccurrencesOf(startDate, endDate, calendars, User.getCurrentRequester());
+  }
+
+  /**
+   * Gets the event occurrences associated to a calendar and contained a the time window specified
+   * by the start and end datetimes.<br>
+   * The occurrences are sorted from the lowest to the highest date.
+   * @param startDate the start date of time window.
+   * @param endDate the end date of time window.
+   * @param calendars the calendars the event occurrences belong to.
+   * @return a list of entities of calendar event occurrences.
+   */
+  public List<CalendarEventOccurrence> getEventOccurrencesOf(LocalDate startDate, LocalDate endDate,
+      List<Calendar> calendars, User currentRequester) {
+    if (currentRequester == null) {
+      throw new IllegalArgumentException("Current requester MUST be defined");
+    }
     return calendars.isEmpty() ? emptyList() : Calendar
         .getTimeWindowBetween(startDate, endDate)
         .filter(f -> f.onCalendar(calendars))


### PR DESCRIPTION
The same behavior has been implemented as the one existing until now with old personal calendars.
It means that old events are retrieved when filter is on "All" resources and next events are retrieved when filter is on "Events"...
Don't ask me why.