### PR TITLE
Trying to improve the sorting possibilities by taking care about existing manual sorting, the settings which permits to display the attachments of resource from the youngest to the oldest or the contrary and the fact that a manual sorting could result to the initial sorting.

### DIFF
--- a/core-configuration/src/main/config/properties/org/silverpeas/util/attachment/Attachment.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/util/attachment/Attachment.properties
@@ -89,6 +89,16 @@ deconnectedMode=true
 # 1 to get list of documents from the oldest add to the youngest one.
 # -1 to get list of documents from the youngest add to the oldest one.
 # If nothing is filled, '1' is automatically chosen.
+#
+# If an attachment order has been manually set by a user to a list of attachment, then this parameter
+# indicates if a new attachment is added at top or at end of this list.
+#
+# LIMIT CASE: in the case where the attachments is listed from oldest to youngest (attachment.list.order = 1)
+# and the sort of an attachment list is manually sorted, if the default list sort is set again in order to
+# list attachment from youngest to oldest, then a new attachment added to this list is yet added
+# at end of list instead top. But after that, if a manual sort is again performed on this list,
+# a new attachment is again rightly added.
+#
 attachment.list.order = -1
 
 # Turn on this parameter to use online editing based on custom protocol (instead of Java app)

--- a/core-library/src/integration-test/java/org/silverpeas/core/contribution/attachment/HistorisedAttachmentServiceIT.java
+++ b/core-library/src/integration-test/java/org/silverpeas/core/contribution/attachment/HistorisedAttachmentServiceIT.java
@@ -26,7 +26,6 @@ package org.silverpeas.core.contribution.attachment;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.CharEncoding;
-import org.apache.jackrabbit.commons.cnd.ParseException;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.Archive;
@@ -61,7 +60,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.URISyntaxException;
-import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
@@ -98,7 +96,7 @@ public class HistorisedAttachmentServiceIT extends JcrIntegrationIT {
   }
 
   @Before
-  public void loadJcr() throws RepositoryException, IOException {
+  public void loadJcr() throws Exception {
     SchedulerInitializer.get().init(SchedulerInitializer.SchedulerType.VOLATILE);
     try (JcrSession session = openSystemSession()) {
       if (!session.getRootNode().hasNode(instanceId)) {
@@ -468,79 +466,196 @@ public class HistorisedAttachmentServiceIT extends JcrIntegrationIT {
   }
 
   /**
-   * Test of reorderAttachments method, of class AttachmentService.
-   *
-   * @throws LoginException
-   * @throws RepositoryException
-   * @throws IOException
+   * Test of reorderAttachments and createAttachment methods, of class AttachmentService.
    */
   @Test
-  public void testReorderAttachments() throws RepositoryException,
-      IOException {
+  public void testReorderAttachmentsAndCreateAttachment() {
     ResourceReference foreignKey = new ResourceReference("node36", instanceId);
-    try (JcrSession session = openSystemSession()) {
-      Date creationDate = RandomGenerator.getRandomCalendar().getTime();
-      SimpleDocumentPK emptyId = new SimpleDocumentPK("-1", instanceId);
-      String foreignId = foreignKey.getId();
-      SimpleDocument document1 = new HistorisedDocument(emptyId, foreignId, 10,
-          new SimpleAttachment("test.odp", "fr", "Mon document de test 1",
-          "Ceci est un document de test", "Ceci est un test".getBytes(Charsets.UTF_8).length,
-          MimeTypes.MIME_TYPE_OO_PRESENTATION, "10", creationDate, "5"));
-      InputStream content = new ByteArrayInputStream("Ceci est un test".getBytes(Charsets.UTF_8));
-      SimpleDocumentPK id = instance.createAttachment(document1, content).getPk();
-      document1 = instance.searchDocumentById(id, "fr");
+    Date creationDate = RandomGenerator.getRandomCalendar().getTime();
+    SimpleDocumentPK emptyId = new SimpleDocumentPK("-1", instanceId);
+    String foreignId = foreignKey.getId();
+    SimpleDocument document1 = new HistorisedDocument(emptyId, foreignId, 10,
+        new SimpleAttachment("test.odp", "fr", "Mon document de test 1",
+        "Ceci est un document de test", "Ceci est un test".getBytes(Charsets.UTF_8).length,
+        MimeTypes.MIME_TYPE_OO_PRESENTATION, "10", creationDate, "5"));
+    InputStream content = new ByteArrayInputStream("Ceci est un test".getBytes(Charsets.UTF_8));
+    SimpleDocumentPK id = instance.createAttachment(document1, content).getPk();
+    document1 = instance.searchDocumentById(id, "fr");
 
-      emptyId = new SimpleDocumentPK("-1", instanceId);
-      SimpleDocument document2 = new HistorisedDocument(emptyId, foreignId, 5,
-          new SimpleAttachment("test.odp", "fr", "Mon document de test 2",
-          "Ceci est un document de test", "Ceci est un test".getBytes(Charsets.UTF_8).length,
-          MimeTypes.MIME_TYPE_OO_PRESENTATION, "10", creationDate, "5"));
-      content = new ByteArrayInputStream("Ceci est un test".getBytes(Charsets.UTF_8));
-      id = instance.createAttachment(document2, content).getPk();
-      document2  = instance.searchDocumentById(id, "fr");
+    emptyId = new SimpleDocumentPK("-1", instanceId);
+    SimpleDocument document2 = new HistorisedDocument(emptyId, foreignId, 5,
+        new SimpleAttachment("test.odp", "fr", "Mon document de test 2",
+        "Ceci est un document de test", "Ceci est un test".getBytes(Charsets.UTF_8).length,
+        MimeTypes.MIME_TYPE_OO_PRESENTATION, "10", creationDate, "5"));
+    content = new ByteArrayInputStream("Ceci est un test".getBytes(Charsets.UTF_8));
+    id = instance.createAttachment(document2, content).getPk();
+    document2  = instance.searchDocumentById(id, "fr");
 
-      emptyId = new SimpleDocumentPK("-1", instanceId);
-      SimpleDocument document3 = new HistorisedDocument(emptyId, foreignId, 100,
-          new SimpleAttachment("test.odp", "fr", "Mon document de test 3",
-          "Ceci est un document de test", "Ceci est un test".getBytes(Charsets.UTF_8).length,
-          MimeTypes.MIME_TYPE_OO_PRESENTATION, "10", creationDate, "5"));
-      content = new ByteArrayInputStream("Ceci est un test".getBytes(Charsets.UTF_8));
-      id = instance.createAttachment(document3, content).getPk();
-      document3 = instance.searchDocumentById(id, "fr");
+    emptyId = new SimpleDocumentPK("-1", instanceId);
+    SimpleDocument document3 = new HistorisedDocument(emptyId, foreignId, 100,
+        new SimpleAttachment("test.odp", "fr", "Mon document de test 3",
+        "Ceci est un document de test", "Ceci est un test".getBytes(Charsets.UTF_8).length,
+        MimeTypes.MIME_TYPE_OO_PRESENTATION, "10", creationDate, "5"));
+    content = new ByteArrayInputStream("Ceci est un test".getBytes(Charsets.UTF_8));
+    id = instance.createAttachment(document3, content).getPk();
+    document3 = instance.searchDocumentById(id, "fr");
 
-      emptyId = new SimpleDocumentPK("-1", instanceId);
-      foreignId = "node49";
-      SimpleDocument document4 = new HistorisedDocument(emptyId, foreignId, 0,
-          new SimpleAttachment("test.docx", "en", "My test document 4",
-          "This is a test document", "This is a test".getBytes(Charsets.UTF_8).length,
-          MimeTypes.WORD_2007_MIME_TYPE, "0", creationDate, "18"));
-      content = new ByteArrayInputStream("This is a test".getBytes(Charsets.UTF_8));
-      id = instance.createAttachment(document4, content).getPk();
-      document4 = instance.searchDocumentById(id, "en");
+    emptyId = new SimpleDocumentPK("-1", instanceId);
+    SimpleDocument document4 = new HistorisedDocument(emptyId, "node49", 0,
+        new SimpleAttachment("test.docx", "en", "My test document 4",
+        "This is a test document", "This is a test".getBytes(Charsets.UTF_8).length,
+        MimeTypes.WORD_2007_MIME_TYPE, "0", creationDate, "18"));
+    content = new ByteArrayInputStream("This is a test".getBytes(Charsets.UTF_8));
+    id = instance.createAttachment(document4, content).getPk();
+    document4 = instance.searchDocumentById(id, "en");
 
-      session.save();
-      List<SimpleDocument> result =
-          instance.listDocumentsByForeignKey(foreignKey, "fr");
-      assertThat(result, is(notNullValue()));
-      assertThat(result, hasSize(3));
-      assertThat(result.get(0), SimpleDocumentMatcher.matches(document2));
-      assertThat(result.get(1), SimpleDocumentMatcher.matches(document1));
-      assertThat(result.get(2), SimpleDocumentMatcher.matches(document3));
-      List<SimpleDocumentPK> reorderedList = new ArrayList<>(3);
-      reorderedList.add(document1.getPk());
-      reorderedList.add(document2.getPk());
-      reorderedList.add(document3.getPk());
-      instance.reorderAttachments(reorderedList);
-      result = instance.listDocumentsByForeignKey(foreignKey, "fr");
-      assertThat(result, is(notNullValue()));
-      assertThat(result, hasSize(3));
-      document1.setOrder(5);
-      document2.setOrder(10);
-      document3.setOrder(15);
-      assertThat(result.get(0), SimpleDocumentMatcher.matches(document1));
-      assertThat(result.get(1), SimpleDocumentMatcher.matches(document2));
-      assertThat(result.get(2), SimpleDocumentMatcher.matches(document3));
-    }
+    List<SimpleDocument> result =
+        instance.listDocumentsByForeignKey(foreignKey, "fr");
+    assertThat(result, is(notNullValue()));
+    assertThat(result, hasSize(3));
+    assertThat(result.get(0), SimpleDocumentMatcher.matches(document2));
+    assertThat(result.get(1), SimpleDocumentMatcher.matches(document1));
+    assertThat(result.get(2), SimpleDocumentMatcher.matches(document3));
+    // manual sorting
+    List<SimpleDocumentPK> reorderedList = new ArrayList<>(3);
+    reorderedList.add(document1.getPk());
+    reorderedList.add(document2.getPk());
+    reorderedList.add(document3.getPk());
+    instance.reorderAttachments(reorderedList);
+    result = instance.listDocumentsByForeignKey(foreignKey, "fr");
+    assertThat(result, is(notNullValue()));
+    assertThat(result, hasSize(3));
+    document1.setOrder(1);
+    document2.setOrder(2);
+    document3.setOrder(3);
+    assertThat(result.get(0), SimpleDocumentMatcher.matches(document1));
+    assertThat(result.get(1), SimpleDocumentMatcher.matches(document2));
+    assertThat(result.get(2), SimpleDocumentMatcher.matches(document3));
+    // Create new document
+    emptyId = new SimpleDocumentPK("-1", instanceId);
+    SimpleDocument document5 = new HistorisedDocument(emptyId, foreignId, 0,
+        new SimpleAttachment("test.odp", "fr", "Mon document de test 5",
+            "Ceci est un document de test", "Ceci est un test".getBytes(Charsets.UTF_8).length,
+            MimeTypes.MIME_TYPE_OO_PRESENTATION, "10", creationDate, "5"));
+    content = new ByteArrayInputStream("Ceci est un test".getBytes(Charsets.UTF_8));
+    id = instance.createAttachment(document5, content).getPk();
+    document5 = instance.searchDocumentById(id, "fr");
+    assertThat(document5.getOrder(), is(4));
+    // Getting default sorting according to UI
+    reorderedList = new ArrayList<>(3);
+    reorderedList.add(document2.getPk());
+    reorderedList.add(document1.getPk());
+    reorderedList.add(document3.getPk());
+    reorderedList.add(document5.getPk());
+    instance.reorderAttachments(reorderedList);
+    result = instance.listDocumentsByForeignKey(foreignKey, "fr");
+    assertThat(result, is(notNullValue()));
+    assertThat(result, hasSize(4));
+    document2.setOrder(1);
+    document1.setOrder(2);
+    document3.setOrder(3);
+    document5.setOrder(4);
+    assertThat(result.get(0), SimpleDocumentMatcher.matches(document2));
+    assertThat(result.get(1), SimpleDocumentMatcher.matches(document1));
+    assertThat(result.get(2), SimpleDocumentMatcher.matches(document3));
+    assertThat(result.get(3), SimpleDocumentMatcher.matches(document5));
+  }
+
+  /**
+   * Test of reorderAttachments and createAttachment methods, of class AttachmentService.
+   */
+  @Test
+  public void testReorderAttachmentsAndCreateAttachmentWhenSortedFromYoungestToOldestOnUI() {
+    attachmentSettings.put("attachment.list.order", "-1");
+    ResourceReference foreignKey = new ResourceReference("node36", instanceId);
+    Date creationDate = RandomGenerator.getRandomCalendar().getTime();
+    SimpleDocumentPK emptyId = new SimpleDocumentPK("-1", instanceId);
+    String foreignId = foreignKey.getId();
+    SimpleDocument document1 = new HistorisedDocument(emptyId, foreignId, 5,
+        new SimpleAttachment("test.odp", "fr", "Mon document de test 1",
+        "Ceci est un document de test", "Ceci est un test".getBytes(Charsets.UTF_8).length,
+        MimeTypes.MIME_TYPE_OO_PRESENTATION, "10", creationDate, "5"));
+    InputStream content = new ByteArrayInputStream("Ceci est un test".getBytes(Charsets.UTF_8));
+    SimpleDocumentPK id = instance.createAttachment(document1, content).getPk();
+    document1 = instance.searchDocumentById(id, "fr");
+
+    emptyId = new SimpleDocumentPK("-1", instanceId);
+    SimpleDocument document2 = new HistorisedDocument(emptyId, foreignId, 50,
+        new SimpleAttachment("test.odp", "fr", "Mon document de test 2",
+        "Ceci est un document de test", "Ceci est un test".getBytes(Charsets.UTF_8).length,
+        MimeTypes.MIME_TYPE_OO_PRESENTATION, "10", creationDate, "5"));
+    content = new ByteArrayInputStream("Ceci est un test".getBytes(Charsets.UTF_8));
+    id = instance.createAttachment(document2, content).getPk();
+    document2  = instance.searchDocumentById(id, "fr");
+
+    emptyId = new SimpleDocumentPK("-1", instanceId);
+    SimpleDocument document3 = new HistorisedDocument(emptyId, foreignId, 100,
+        new SimpleAttachment("test.odp", "fr", "Mon document de test 3",
+        "Ceci est un document de test", "Ceci est un test".getBytes(Charsets.UTF_8).length,
+        MimeTypes.MIME_TYPE_OO_PRESENTATION, "10", creationDate, "5"));
+    content = new ByteArrayInputStream("Ceci est un test".getBytes(Charsets.UTF_8));
+    id = instance.createAttachment(document3, content).getPk();
+    document3 = instance.searchDocumentById(id, "fr");
+
+    emptyId = new SimpleDocumentPK("-1", instanceId);
+    SimpleDocument document4 = new HistorisedDocument(emptyId, "node49", 0,
+        new SimpleAttachment("test.docx", "en", "My test document 4",
+        "This is a test document", "This is a test".getBytes(Charsets.UTF_8).length,
+        MimeTypes.WORD_2007_MIME_TYPE, "0", creationDate, "18"));
+    content = new ByteArrayInputStream("This is a test".getBytes(Charsets.UTF_8));
+    id = instance.createAttachment(document4, content).getPk();
+    document4 = instance.searchDocumentById(id, "en");
+
+    List<SimpleDocument> result =
+        instance.listDocumentsByForeignKey(foreignKey, "fr");
+    assertThat(result, is(notNullValue()));
+    assertThat(result, hasSize(3));
+    assertThat(result.get(0), SimpleDocumentMatcher.matches(document3));
+    assertThat(result.get(1), SimpleDocumentMatcher.matches(document2));
+    assertThat(result.get(2), SimpleDocumentMatcher.matches(document1));
+    // manual sorting
+    List<SimpleDocumentPK> reorderedList = new ArrayList<>(3);
+    reorderedList.add(document3.getPk());
+    reorderedList.add(document1.getPk());
+    reorderedList.add(document2.getPk());
+    instance.reorderAttachments(reorderedList);
+    result = instance.listDocumentsByForeignKey(foreignKey, "fr");
+    assertThat(result, is(notNullValue()));
+    assertThat(result, hasSize(3));
+    document3.setOrder(200000);
+    document1.setOrder(200001);
+    document2.setOrder(200002);
+    assertThat(result.get(0), SimpleDocumentMatcher.matches(document3));
+    assertThat(result.get(1), SimpleDocumentMatcher.matches(document1));
+    assertThat(result.get(2), SimpleDocumentMatcher.matches(document2));
+    // Create new document
+    emptyId = new SimpleDocumentPK("-1", instanceId);
+    SimpleDocument document5 = new HistorisedDocument(emptyId, foreignId, 0,
+        new SimpleAttachment("test.odp", "fr", "Mon document de test 5",
+            "Ceci est un document de test", "Ceci est un test".getBytes(Charsets.UTF_8).length,
+            MimeTypes.MIME_TYPE_OO_PRESENTATION, "10", creationDate, "5"));
+    content = new ByteArrayInputStream("Ceci est un test".getBytes(Charsets.UTF_8));
+    id = instance.createAttachment(document5, content).getPk();
+    document5 = instance.searchDocumentById(id, "fr");
+    assertThat(document5.getOrder(), is(199999));
+    // Getting default sorting according to UI
+    reorderedList = new ArrayList<>(4);
+    reorderedList.add(document5.getPk());
+    reorderedList.add(document3.getPk());
+    reorderedList.add(document2.getPk());
+    reorderedList.add(document1.getPk());
+    instance.reorderAttachments(reorderedList);
+    result = instance.listDocumentsByForeignKey(foreignKey, "fr");
+    assertThat(result, is(notNullValue()));
+    assertThat(result, hasSize(4));
+    document5.setOrder(4);
+    document3.setOrder(3);
+    document2.setOrder(2);
+    document1.setOrder(1);
+    assertThat(result.get(0), SimpleDocumentMatcher.matches(document5));
+    assertThat(result.get(1), SimpleDocumentMatcher.matches(document3));
+    assertThat(result.get(2), SimpleDocumentMatcher.matches(document2));
+    assertThat(result.get(3), SimpleDocumentMatcher.matches(document1));
   }
 
   /**

--- a/core-library/src/integration-test/java/org/silverpeas/core/test/jcr/JcrIntegrationIT.java
+++ b/core-library/src/integration-test/java/org/silverpeas/core/test/jcr/JcrIntegrationIT.java
@@ -23,11 +23,14 @@
  */
 package org.silverpeas.core.test.jcr;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.ExpectedException;
 import org.silverpeas.core.contribution.attachment.process.SimpleDocumentDummyHandledFileConverter;
 import org.silverpeas.core.contribution.attachment.repository.JcrContext;
+import org.silverpeas.core.contribution.attachment.util.AttachmentSettings;
+import org.silverpeas.core.test.extention.SettingBundleStub;
 import org.silverpeas.core.test.rule.DbSetupRule;
 import org.silverpeas.core.test.rule.MavenTargetDirectoryRule;
 import org.silverpeas.core.util.ServiceProvider;
@@ -41,8 +44,13 @@ public abstract class JcrIntegrationIT {
       "org/silverpeas/core/admin/create_space_components_database.sql";
   public static final String DATASET_SCRIPT =
       "org/silverpeas/core/admin/test-spaces_and_components-dataset.sql";
-
+  protected SettingBundleStub attachmentSettings;
   public MavenTargetDirectoryRule mavenTargetDirectory = new MavenTargetDirectoryRule(this);
+
+  @Rule
+  public DbSetupRule dbSetupRule = DbSetupRule.createTablesFrom("/" + DATABASE_CREATION_SCRIPT)
+      .loadInitialDataSetFrom("/" + DATASET_SCRIPT);
+
   private ExpectedException expectedException = ExpectedException.none();
   private JcrContext jcrContext = new JcrContext();
 
@@ -61,13 +69,15 @@ public abstract class JcrIntegrationIT {
     return jcrContext;
   }
 
-  @Rule
-  public DbSetupRule dbSetupRule = DbSetupRule.createTablesFrom("/" + DATABASE_CREATION_SCRIPT)
-      .loadInitialDataSetFrom("/" + DATASET_SCRIPT);
-
   @Before
   public void setup() throws Exception {
     ServiceProvider.getService(SimpleDocumentDummyHandledFileConverter.class).init();
+    attachmentSettings = new SettingBundleStub(AttachmentSettings.class, "settings");
+    attachmentSettings.beforeEach(null);
   }
 
+  @After
+  public void clean() throws Exception {
+    attachmentSettings.afterEach(null);
+  }
 }

--- a/core-library/src/main/java/org/silverpeas/core/contribution/attachment/SimpleDocumentService.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/attachment/SimpleDocumentService.java
@@ -1062,7 +1062,7 @@ public class SimpleDocumentService
   @Override
   public void switchAllowingDownloadForReaders(final SimpleDocumentPK pk, final boolean allowing) {
     SimpleDocument document = searchDocumentById(pk, null);
-    final Boolean documentUpdateRequired;
+    final boolean documentUpdateRequired;
     if (allowing) {
       documentUpdateRequired =
           document.addRolesForWhichDownloadIsAllowed(SilverpeasRole.READER_ROLES);

--- a/core-library/src/main/java/org/silverpeas/core/contribution/attachment/model/Attachments.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/attachment/model/Attachments.java
@@ -23,7 +23,6 @@
  */
 package org.silverpeas.core.contribution.attachment.model;
 
-import org.silverpeas.core.ResourceReference;
 import org.silverpeas.core.admin.user.model.User;
 import org.silverpeas.core.contribution.model.Contribution;
 import org.silverpeas.core.contribution.model.ContributionIdentifier;
@@ -39,7 +38,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import static org.silverpeas.core.contribution.attachment.AttachmentServiceProvider.getAttachmentService;
 import static org.silverpeas.core.contribution.attachment.util.AttachmentSettings.listFromYoungestToOldestAdd;
 
 /**
@@ -112,10 +110,7 @@ public class Attachments {
     if (CollectionUtil.isNotEmpty(this.uploadedFiles)) {
       List<UploadedFile> files = new ArrayList<>(this.uploadedFiles);
       final ContributionIdentifier contributionId = contribution.getContributionId();
-      if (listFromYoungestToOldestAdd() && !getAttachmentService().
-          listDocumentsByForeignKeyAndType(new ResourceReference(contributionId.getLocalId(),
-              contributionId.getComponentInstanceId()), DocumentType.attachment, null)
-          .isManuallySorted()) {
+      if (listFromYoungestToOldestAdd()) {
         Collections.reverse(files);
       }
       for (UploadedFile uploadedFile : files) {

--- a/core-library/src/main/java/org/silverpeas/core/contribution/attachment/repository/DocumentRepository.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/attachment/repository/DocumentRepository.java
@@ -41,6 +41,7 @@ import org.silverpeas.core.persistence.jcr.JcrSession;
 import org.silverpeas.core.persistence.jcr.util.NodeIterable;
 import org.silverpeas.core.persistence.jcr.util.PropertyIterable;
 import org.silverpeas.core.util.DateUtil;
+import org.silverpeas.core.util.Pair;
 import org.silverpeas.core.util.StringUtil;
 import org.silverpeas.core.util.file.FileRepositoryManager;
 import org.silverpeas.core.util.file.FileUtil;
@@ -78,9 +79,11 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
-import static java.util.Optional.ofNullable;
+import static java.util.Optional.*;
 import static javax.jcr.nodetype.NodeType.MIX_SIMPLE_VERSIONABLE;
 import static org.silverpeas.core.cache.service.CacheServiceProvider.getThreadCacheService;
+import static org.silverpeas.core.contribution.attachment.util.AttachmentSettings.YOUNGEST_TO_OLDEST_MANUAL_REORDER_THRESHOLD;
+import static org.silverpeas.core.contribution.attachment.util.AttachmentSettings.listFromYoungestToOldestAdd;
 import static org.silverpeas.core.i18n.I18NHelper.defaultLanguage;
 import static org.silverpeas.core.persistence.jcr.util.JcrConstants.*;
 
@@ -118,10 +121,17 @@ public class DocumentRepository {
    */
   public SimpleDocumentPK createDocument(Session session, SimpleDocument document) throws
       RepositoryException {
-    final SimpleDocument last = findLast(session, document.getInstanceId(), document.getForeignId(),
-        document.getDocumentType());
-    if ((null != last) && (0 >= document.getOrder())) {
-      document.setOrder(last.getOrder() + 1);
+    if (0 >= document.getOrder()) {
+      getMinMaxOrderIndexes(session, document.getInstanceId(), document.getForeignId(),
+          document.getDocumentType()).ifPresent(i -> {
+        final Integer minOrderIndex = i.getFirst();
+        if (listFromYoungestToOldestAdd() &&
+            minOrderIndex > YOUNGEST_TO_OLDEST_MANUAL_REORDER_THRESHOLD) {
+          document.setOrder(minOrderIndex - 1);
+        } else {
+          document.setOrder(i.getSecond() + 1);
+        }
+      });
     }
     Node docsNode = prepareComponentAttachments(session, document.getInstanceId(), document.
         getFolder());
@@ -605,6 +615,34 @@ public class DocumentRepository {
       }
     }
     return null;
+  }
+
+  /**
+   * Get the minimum and maximum order indexes of attachments linked to a resource for a given type.
+   *
+   * @param session the current JCR session.
+   * @param instanceId the component id containing the documents.
+   * @param foreignId the id of the container owning the documents.
+   * @param documentType the type of document.
+   * @return optional min and max order indexes of documents for the specified foreignId and type.
+   * Optional is empty when it exists no document for the foreign key and the type.
+   * @throws RepositoryException in case of JCR repository problem.
+   */
+  Optional<Pair<Integer, Integer>> getMinMaxOrderIndexes(Session session, String instanceId,
+      String foreignId, final DocumentType documentType) throws RepositoryException {
+    final NodeIterator iter = selectDocumentsByForeignIdAndType(session, instanceId, foreignId,
+        documentType);
+    int min = Integer.MAX_VALUE;
+    int max = Integer.MIN_VALUE;
+    while (iter.hasNext()) {
+      final Node node = iter.nextNode();
+      if (node.hasProperty(SLV_PROPERTY_ORDER)) {
+        final int currentOrder = (int) node.getProperty(SLV_PROPERTY_ORDER).getLong();
+        min = Math.min(min, currentOrder);
+        max = Math.max(max, currentOrder);
+      }
+    }
+    return min == Integer.MAX_VALUE ? empty() : of(Pair.of(min, max));
   }
 
   /**

--- a/core-library/src/main/java/org/silverpeas/core/contribution/attachment/repository/DocumentRepository.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/attachment/repository/DocumentRepository.java
@@ -60,6 +60,7 @@ import javax.jcr.query.qom.Comparison;
 import javax.jcr.query.qom.DescendantNode;
 import javax.jcr.query.qom.Ordering;
 import javax.jcr.query.qom.QueryObjectModel;
+import javax.jcr.query.qom.QueryObjectModelConstants;
 import javax.jcr.query.qom.QueryObjectModelFactory;
 import javax.jcr.query.qom.Selector;
 import javax.jcr.version.Version;
@@ -577,10 +578,10 @@ public class DocumentRepository {
     DescendantNode descendantdNodeConstraint = factory.descendantNode(SIMPLE_DOCUMENT_ALIAS,
         session.getRootNode().getPath() + instanceId);
     Comparison oldSilverpeasIdComparison = factory.comparison(factory.propertyValue(
-        SIMPLE_DOCUMENT_ALIAS, SLV_PROPERTY_OLD_ID), QueryObjectModelFactory.JCR_OPERATOR_EQUAL_TO,
+        SIMPLE_DOCUMENT_ALIAS, SLV_PROPERTY_OLD_ID), QueryObjectModelConstants.JCR_OPERATOR_EQUAL_TO,
         factory.literal(session.getValueFactory().createValue(oldSilverpeasId)));
     Comparison versionedComparison = factory.comparison(factory.propertyValue(SIMPLE_DOCUMENT_ALIAS,
-        SLV_PROPERTY_VERSIONED), QueryObjectModelFactory.JCR_OPERATOR_EQUAL_TO, factory.
+        SLV_PROPERTY_VERSIONED), QueryObjectModelConstants.JCR_OPERATOR_EQUAL_TO, factory.
         literal(session.getValueFactory().createValue(versioned)));
 
     QueryObjectModel query = factory.createQuery(source, factory.and(descendantdNodeConstraint,
@@ -768,7 +769,7 @@ public class DocumentRepository {
     DescendantNode descendantdNodeConstraint = factory.descendantNode(SIMPLE_DOCUMENT_ALIAS,
         session.getRootNode().getPath() + instanceId);
     Comparison foreignIdComparison = factory.comparison(factory.propertyValue(SIMPLE_DOCUMENT_ALIAS,
-        SLV_PROPERTY_FOREIGN_KEY), QueryObjectModelFactory.JCR_OPERATOR_EQUAL_TO, factory.
+        SLV_PROPERTY_FOREIGN_KEY), QueryObjectModelConstants.JCR_OPERATOR_EQUAL_TO, factory.
         literal(session.getValueFactory().createValue(foreignId)));
     Ordering order = factory.ascending(factory.propertyValue(SIMPLE_DOCUMENT_ALIAS,
         SLV_PROPERTY_ORDER));
@@ -795,7 +796,7 @@ public class DocumentRepository {
     ChildNode childNodeConstraint = factory.childNode(SIMPLE_DOCUMENT_ALIAS, session.getRootNode().
         getPath() + instanceId + '/' + type.getFolderName());
     Comparison foreignIdComparison = factory.comparison(factory.propertyValue(SIMPLE_DOCUMENT_ALIAS,
-        SLV_PROPERTY_FOREIGN_KEY), QueryObjectModelFactory.JCR_OPERATOR_EQUAL_TO, factory.
+        SLV_PROPERTY_FOREIGN_KEY), QueryObjectModelConstants.JCR_OPERATOR_EQUAL_TO, factory.
         literal(session.getValueFactory().createValue(foreignId)));
     Ordering order = factory.ascending(factory.propertyValue(SIMPLE_DOCUMENT_ALIAS,
         SLV_PROPERTY_ORDER));
@@ -823,7 +824,7 @@ public class DocumentRepository {
         getRootNode().getPath() + instanceId + '/');
     Comparison foreignIdComparison = factory
         .comparison(factory.propertyValue(SIMPLE_DOCUMENT_ALIAS, SLV_PROPERTY_FOREIGN_KEY),
-            QueryObjectModelFactory.JCR_OPERATOR_EQUAL_TO, factory.
+            QueryObjectModelConstants.JCR_OPERATOR_EQUAL_TO, factory.
                 literal(session.getValueFactory().createValue(foreignId))
         );
     Ordering order = factory.ascending(factory.propertyValue(SIMPLE_DOCUMENT_ALIAS,
@@ -927,7 +928,7 @@ public class DocumentRepository {
     expiry.setTime(DateUtil.getBeginOfDay(expiryDate));
     Selector source = factory.selector(SLV_SIMPLE_DOCUMENT, SIMPLE_DOCUMENT_ALIAS);
     Comparison foreignIdComparison = factory.comparison(factory.propertyValue(SIMPLE_DOCUMENT_ALIAS,
-        SLV_PROPERTY_EXPIRY_DATE), QueryObjectModelFactory.JCR_OPERATOR_EQUAL_TO, factory.
+        SLV_PROPERTY_EXPIRY_DATE), QueryObjectModelConstants.JCR_OPERATOR_EQUAL_TO, factory.
         literal(session.getValueFactory().createValue(expiry)));
     Ordering order = factory.ascending(factory.propertyValue(SIMPLE_DOCUMENT_ALIAS,
         SLV_PROPERTY_ORDER));
@@ -968,7 +969,7 @@ public class DocumentRepository {
     expiry.setTime(DateUtil.getBeginOfDay(expiryDate));
     Selector source = factory.selector(SLV_SIMPLE_DOCUMENT, SIMPLE_DOCUMENT_ALIAS);
     Comparison foreignIdComparison = factory.comparison(factory.propertyValue(SIMPLE_DOCUMENT_ALIAS,
-        SLV_PROPERTY_EXPIRY_DATE), QueryObjectModelFactory.JCR_OPERATOR_LESS_THAN, factory.
+        SLV_PROPERTY_EXPIRY_DATE), QueryObjectModelConstants.JCR_OPERATOR_LESS_THAN, factory.
         literal(session.getValueFactory().createValue(expiry)));
     Ordering order = factory.ascending(factory.propertyValue(SIMPLE_DOCUMENT_ALIAS,
         SLV_PROPERTY_ORDER));
@@ -993,7 +994,7 @@ public class DocumentRepository {
     alert.setTime(DateUtil.getBeginOfDay(alertDate));
     Selector source = factory.selector(SLV_SIMPLE_DOCUMENT, SIMPLE_DOCUMENT_ALIAS);
     Comparison foreignIdComparison = factory.comparison(factory.propertyValue(SIMPLE_DOCUMENT_ALIAS,
-        SLV_PROPERTY_ALERT_DATE), QueryObjectModelFactory.JCR_OPERATOR_EQUAL_TO, factory.
+        SLV_PROPERTY_ALERT_DATE), QueryObjectModelConstants.JCR_OPERATOR_EQUAL_TO, factory.
         literal(session.getValueFactory().createValue(alert)));
     Ordering order = factory.ascending(factory.propertyValue(SIMPLE_DOCUMENT_ALIAS,
         SLV_PROPERTY_ORDER));
@@ -1020,7 +1021,7 @@ public class DocumentRepository {
     ChildNode childNodeConstraint = factory.childNode(SIMPLE_DOCUMENT_ALIAS, session.getRootNode().
         getPath() + instanceId + '/' + DocumentType.attachment.getFolderName());
     Comparison ownerComparison = factory.comparison(factory.propertyValue(SIMPLE_DOCUMENT_ALIAS,
-        SLV_PROPERTY_OWNER), QueryObjectModelFactory.JCR_OPERATOR_EQUAL_TO, factory.literal(session.
+        SLV_PROPERTY_OWNER), QueryObjectModelConstants.JCR_OPERATOR_EQUAL_TO, factory.literal(session.
         getValueFactory().createValue(owner)));
     Ordering order = factory.ascending(factory.propertyValue(SIMPLE_DOCUMENT_ALIAS,
         SLV_PROPERTY_ORDER));
@@ -1044,7 +1045,7 @@ public class DocumentRepository {
     QueryObjectModelFactory factory = manager.getQOMFactory();
     Selector source = factory.selector(SLV_SIMPLE_DOCUMENT, SIMPLE_DOCUMENT_ALIAS);
     Comparison ownerComparison = factory.comparison(factory.propertyValue(SIMPLE_DOCUMENT_ALIAS,
-        SLV_PROPERTY_OWNER), QueryObjectModelFactory.JCR_OPERATOR_EQUAL_TO, factory.literal(session.
+        SLV_PROPERTY_OWNER), QueryObjectModelConstants.JCR_OPERATOR_EQUAL_TO, factory.literal(session.
         getValueFactory().createValue(owner)));
     Ordering order = factory.ascending(factory.propertyValue(SIMPLE_DOCUMENT_ALIAS,
         SLV_PROPERTY_ORDER));

--- a/core-library/src/main/java/org/silverpeas/core/contribution/attachment/util/AttachmentSettings.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/attachment/util/AttachmentSettings.java
@@ -37,6 +37,10 @@ import java.util.stream.Stream;
  */
 public class AttachmentSettings {
 
+  public static final int DEFAULT_REORDER_START = 1;
+  public static final int YOUNGEST_TO_OLDEST_MANUAL_REORDER_START = 200000;
+  public static final int YOUNGEST_TO_OLDEST_MANUAL_REORDER_THRESHOLD = 100000;
+
   private static SettingBundle settings =
       ResourceLocator.getSettingBundle("org.silverpeas.util.attachment.Attachment");
 

--- a/core-library/src/main/java/org/silverpeas/core/util/ArrayUtil.java
+++ b/core-library/src/main/java/org/silverpeas/core/util/ArrayUtil.java
@@ -27,4 +27,10 @@ import org.apache.commons.lang3.ArrayUtils;
 
 public class ArrayUtil extends ArrayUtils {
 
+  /**
+   * @see ArrayUtils#contains(Object[], Object)
+   */
+  public static boolean contains(final Object[] array, final Object objectToFind) {
+    return ArrayUtils.contains(array, objectToFind);
+  }
 }

--- a/core-library/src/test/java/org/silverpeas/core/contribution/attachment/util/SimpleDocumentListTest.java
+++ b/core-library/src/test/java/org/silverpeas/core/contribution/attachment/util/SimpleDocumentListTest.java
@@ -23,6 +23,7 @@
  */
 package org.silverpeas.core.contribution.attachment.util;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.silverpeas.core.contribution.attachment.model.HistorisedDocument;
 import org.silverpeas.core.contribution.attachment.model.SimpleAttachment;
@@ -30,24 +31,26 @@ import org.silverpeas.core.contribution.attachment.model.SimpleDocument;
 import org.silverpeas.core.test.UnitTest;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.stream.IntStream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @UnitTest
 public class SimpleDocumentListTest {
 
   @Test
-  public void removeLanguageFallbacksOnEmptyList() {
-    new SimpleDocumentList().setQueryLanguage("en").removeLanguageFallbacks();
+  void removeLanguageFallbacksOnEmptyList() {
+    final SimpleDocumentList list = new SimpleDocumentList().setQueryLanguage("en").removeLanguageFallbacks();
+    assertThat(list, notNullValue());
   }
 
   @Test
-  public void removeLanguageFallbacksOnListWithOneElement() {
+  void removeLanguageFallbacksOnListWithOneElement() {
     assertThrows(NullPointerException.class, () -> {
       //noinspection MismatchedQueryAndUpdateOfCollection
       SimpleDocumentList<SimpleDocument> test = new SimpleDocumentList<>().setQueryLanguage("en");
@@ -57,7 +60,7 @@ public class SimpleDocumentListTest {
   }
 
   @Test
-  public void removeLanguageFallbacksOnListWithOneElementButNoLanguageSet() {
+  void removeLanguageFallbacksOnListWithOneElementButNoLanguageSet() {
     //noinspection MismatchedQueryAndUpdateOfCollection
     SimpleDocumentList<SimpleDocument> test = new SimpleDocumentList<>().setQueryLanguage("");
     test.add(new SimpleDocument());
@@ -66,7 +69,7 @@ public class SimpleDocumentListTest {
   }
 
   @Test
-  public void removeLanguageFallbacksOnListWithSeveralElementsButNoLanguageSet() {
+  void removeLanguageFallbacksOnListWithSeveralElementsButNoLanguageSet() {
     //noinspection MismatchedQueryAndUpdateOfCollection
     SimpleDocumentList<SimpleDocument> test = new SimpleDocumentList<>().setQueryLanguage(null);
     int i = 1;
@@ -91,7 +94,7 @@ public class SimpleDocumentListTest {
   }
 
   @Test
-  public void removeLanguageFallbacksOnListWithSeveralElements() {
+  void removeLanguageFallbacksOnListWithSeveralElements() {
     //noinspection MismatchedQueryAndUpdateOfCollection
     SimpleDocumentList<SimpleDocument> test = new SimpleDocumentList<>().setQueryLanguage("en");
     int i = 1;
@@ -116,16 +119,18 @@ public class SimpleDocumentListTest {
   }
 
   @Test
-  public void orderByLanguageAndLastUpdateOnEmptyList() {
-    new SimpleDocumentList().orderByLanguageAndLastUpdate("fr", "en");
+  void orderByLanguageAndLastUpdateOnEmptyList() {
+    final SimpleDocumentList list = new SimpleDocumentList().orderByLanguageAndLastUpdate("fr", "en");
+    assertThat(list, notNullValue());
   }
 
   @Test
-  public void orderByLanguageAndLastUpdateOnListWithOneElement() {
+  void orderByLanguageAndLastUpdateOnListWithOneElement() {
     //noinspection MismatchedQueryAndUpdateOfCollection
     SimpleDocumentList<SimpleDocument> test = new SimpleDocumentList<>();
     test.add(new SimpleDocument());
     test.orderByLanguageAndLastUpdate("fr", "en");
+    assertThat(test, notNullValue());
   }
 
   /**
@@ -133,7 +138,7 @@ public class SimpleDocumentListTest {
    * @see #orderByLanguageAndLastUpdateOnListWithOneElement()
    */
   @Test
-  public void orderByLanguageAndLastUpdateOnListWithTwoElements() {
+  void orderByLanguageAndLastUpdateOnListWithTwoElements() {
     assertThrows(NullPointerException.class, () -> {
       //noinspection MismatchedQueryAndUpdateOfCollection
       SimpleDocumentList<SimpleDocument> test = new SimpleDocumentList<>();
@@ -147,7 +152,7 @@ public class SimpleDocumentListTest {
    * Default platform language priorities : fr, en, de
    */
   @Test
-  public void orderByLanguageAndLastUpdateOnListWithSeveralElements() {
+  void orderByLanguageAndLastUpdateOnListWithSeveralElements() {
     //noinspection MismatchedQueryAndUpdateOfCollection
     SimpleDocumentList<SimpleDocument> test = new SimpleDocumentList<>();
     int i = 1;
@@ -180,6 +185,105 @@ public class SimpleDocumentListTest {
     assertThat(ids, contains(12, 11, 9, 8, 6, 5, 1, 3, 10, 7, 4, 2));
   }
 
+  @Test
+  void isNotManuallySortedWhenEmpty() {
+    final SimpleDocumentList<SimpleDocument> test = new SimpleDocumentList<>();
+    assertThat(test, empty());
+    assertThat(test.isManuallySorted(), is(false));
+  }
+
+  @Test
+  void isNotManuallySortedWhenContainingOnlyOne() {
+    final SimpleDocumentList<SimpleDocument> test = createDocumentList(1, 1);
+    assertThat(test, hasSize(1));
+    assertThat(test.isManuallySorted(), is(false));
+  }
+
+  @Test
+  void isNotManuallySortedWithSeveralDocuments() {
+    // From 2 to 100 documents
+    IntStream.of(2, 3, 4, 5, 10, 50).forEach(d ->
+        // For each list size, applying a stepOrder from 1 to 100
+        IntStream.of(1, 2, 3, 4, 5, 10, 50, 1000).forEach(s -> {
+          final SimpleDocumentList<SimpleDocument> test = createDocumentList(d, s);
+          assertThat(
+              "For doc size " + d + " with stepOrder " + s + " the list should not be manually sorted",
+              test.isManuallySorted(), is(false));
+        }));
+    // From 2 to 100 documents
+    IntStream.of(2, 3, 4, 5, 10, 50).forEach(d ->
+        // For each list size, applying a stepOrder from 1 to 100
+        IntStream.of(1, 2, 3, 4, 5, 10, 50, 1000).forEach(s -> {
+          final SimpleDocumentList<SimpleDocument> source = createDocumentList(d, s);
+          IntStream.rangeClosed(1, source.size()).forEach(nbSwap -> {
+            final SimpleDocumentList<SimpleDocument> test = new SimpleDocumentList<>(source);
+            Collections.shuffle(test);
+            assertThat("For doc size " + d + " with stepOrder " + s +
+                " the list should not be manually sorted", test.isManuallySorted(), is(false));
+          });
+        }));
+  }
+
+  @Test
+  void isManuallySortedWithSeveralDocuments() {
+    // From 2 to 100 documents
+    IntStream.of(2, 3, 4, 5, 10, 50).forEach(d ->
+        // For each list size, applying a stepOrder from 1 to 100
+        IntStream.of(1, 2, 3, 4, 5, 10, 50, 1000).forEach(s -> {
+          final SimpleDocumentList<SimpleDocument> test = createDocumentList(d, s);
+          for (final SimpleDocument doc : test) {
+            doc.setOrder(doc.getOrder() + AttachmentSettings.YOUNGEST_TO_OLDEST_MANUAL_REORDER_START);
+          }
+          assertThat(
+              "For doc size " + d + " with stepOrder " + s + " the list should not be manually sorted",
+              test.isManuallySorted(), is(true));
+        }));
+    // From 2 to 100 documents
+    IntStream.of(2, 3, 4, 5, 10, 50).forEach(d ->
+        // For each list size, applying a stepOrder from 1 to 100
+        IntStream.of(1, 2, 3, 4, 5, 10, 50, 1000).forEach(s -> {
+          final SimpleDocumentList<SimpleDocument> source = createDocumentList(d, s);
+          IntStream.rangeClosed(1, source.size()).forEach(nbSwap -> {
+            final SimpleDocumentList<SimpleDocument> test = new SimpleDocumentList<>(source);
+            final SimpleDocument first = test.get(0);
+            Collections.shuffle(test);
+            if (!first.getId().equals(test.get(0).getId())) {
+              setOrder(test, s);
+              assertThat("For doc size " + d + " with stepOrder " + s +
+                  " the list should be manually sorted", test.isManuallySorted(), is(true));
+            }
+          });
+        }));
+  }
+
+  @Test
+  void isManuallySortedForeignIdError() {
+    final SimpleDocumentList<SimpleDocument> test = createDocumentList(5, 1);
+    test.get(2).setForeignId("badForeignId");
+    Assertions.assertThrows(IllegalStateException.class,
+        () -> assertThat(test.isManuallySorted(), is(false)));
+  }
+
+  private SimpleDocumentList<SimpleDocument> createDocumentList(final int nbDocs,
+      final int stepOrder) {
+    SimpleDocumentList<SimpleDocument> test = new SimpleDocumentList<>();
+    IntStream.rangeClosed(1, nbDocs)
+        .mapToObj(i -> {
+          final SimpleDocument doc = createDocument(i, "fr", createDate("2014-01-01"));
+          doc.setForeignId("aForeignId");
+          return doc;
+        })
+        .forEach(test::add);
+    setOrder(test, stepOrder);
+    return test;
+  }
+
+  private void setOrder(final SimpleDocumentList<SimpleDocument> test, final int step) {
+    for (int z = 0 ; z < test.size() ; z++) {
+      test.get(z).setOrder(z * step);
+    }
+  }
+
   private static List<Integer> extractIds(List<SimpleDocument> list) {
     List<Integer> ids = new ArrayList<>(list.size());
     for (SimpleDocument document : list) {
@@ -208,6 +312,7 @@ public class SimpleDocumentListTest {
       document = new SimpleDocument();
     }
     document.setId(String.valueOf(id));
+    document.setOldSilverpeasId(id);
     document.setAttachment(new SimpleAttachment());
     document.setLanguage(language);
     if (id % 5 == 0) {

--- a/core-test/src/main/java/org/silverpeas/core/test/extention/SettingBundleStub.java
+++ b/core-test/src/main/java/org/silverpeas/core/test/extention/SettingBundleStub.java
@@ -25,6 +25,7 @@
 package org.silverpeas.core.test.extention;
 
 import org.apache.commons.lang3.reflect.FieldUtils;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -32,10 +33,19 @@ import org.silverpeas.core.util.ResourceLocator;
 import org.silverpeas.core.util.SettingBundle;
 import org.silverpeas.core.util.SilverpeasBundle;
 
+import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.MissingResourceException;
+import java.util.Optional;
+import java.util.ResourceBundle;
 import java.util.Set;
+import java.util.function.Function;
+
+import static org.apache.commons.lang3.reflect.FieldUtils.readDeclaredField;
+import static org.apache.commons.lang3.reflect.FieldUtils.writeDeclaredField;
+import static org.silverpeas.core.util.StringUtil.isDefined;
 
 /**
  * Provides easy stubbing on the {@link SettingBundle} in unit tests.
@@ -43,12 +53,55 @@ import java.util.Set;
  */
 public class SettingBundleStub implements BeforeEachCallback, AfterEachCallback {
 
+  private final ResourceBundleTest resourceBundle;
   private final String bundleName;
   private final Map<String, String> settingMap = new HashMap<>();
   private final Set<String> settingNames = new HashSet<>();
   private Map<String, SilverpeasBundle> bundleCache;
 
+  /**
+   * @see #SettingBundleStub(SettingBundle)
+   * @param cls the static class containing the setting attribute.
+   * @param fieldName the name of setting attribute.
+   * @throws IllegalAccessException if the setting attribute can not be manipulated.
+   */
+  public SettingBundleStub(final Class<?> cls, final String fieldName)
+      throws IllegalAccessException {
+    this((SettingBundle) FieldUtils.readDeclaredStaticField(cls, fieldName, true));
+  }
+
+  /**
+   * Initializing the setting bundled by this way means that the setting could have already been
+   * accessed by another class or instance and the setting bundle instance is registered into a
+   * static attribute or an attribute that will be shared between all tests.
+   * <p>
+   * It is not mandatory to the caller to fill all the keys if a default property file has been
+   * registered into context. The given keys just overrides the default one.<br/>
+   * If a null value is returned by the stub for a key, then it is looking for the key into the
+   * default property file.
+   * </p>
+   * @param settingBundle the setting bundle to stub.
+   */
+  public SettingBundleStub(final SettingBundle settingBundle) {
+    this.resourceBundle = new ResourceBundleTest(settingBundle, settingMap);
+    this.bundleName = null;
+  }
+
+  /**
+   * Initializing the setting bundle by this way means that unit or integration test is looking
+   * for bundle registry at each test.
+   * <p>
+   * In other words, the setting bundle MUST not be a static attribute (or an attribute) that
+   * will be shared between each test.
+   * </p>
+   * <p>
+   * The caller MUST register all the needed keys because there is no fallback onto a default
+   * property file.
+   * </p>
+   * @param bundleName the bundle name to stub.
+   */
   public SettingBundleStub(final String bundleName) {
+    this.resourceBundle = null;
     this.bundleName = bundleName;
   }
 
@@ -73,28 +126,78 @@ public class SettingBundleStub implements BeforeEachCallback, AfterEachCallback 
     clear();
   }
 
-  @SuppressWarnings("unchecked")
+  @SuppressWarnings({"unchecked", "rawtypes"})
   private void init() throws IllegalAccessException {
-    bundleCache = (Map) FieldUtils.readStaticField(ResourceLocator.class, "bundles", true);
-    bundleCache.put(bundleName, new SettingBundleTest(settingMap));
-    settingNames.add(bundleName);
+    if (isDefined(bundleName)) {
+      bundleCache = (Map) FieldUtils.readStaticField(ResourceLocator.class, "bundles", true);
+      bundleCache.put(bundleName, new SettingBundleTest(bundleName, settingMap));
+      settingNames.add(bundleName);
+    } else {
+      resourceBundle.init();
+    }
   }
 
-  protected void clear() {
-    settingNames.forEach(bundleCache::remove);
+  protected void clear() throws IllegalAccessException {
+    if (isDefined(bundleName)) {
+      settingNames.forEach(bundleCache::remove);
+    } else {
+      resourceBundle.clear();
+    }
   }
 
-  private class SettingBundleTest extends SettingBundle {
+  private static class SettingBundleTest extends SettingBundle {
+    private final String bundleName;
     private final Map<String, String> settingMap;
 
-    private SettingBundleTest(final Map<String, String> settingMap) {
+    private SettingBundleTest(final String bundleName, final Map<String, String> settingMap) {
       super("", null);
+      this.bundleName = bundleName;
       this.settingMap = settingMap;
     }
 
     @Override
     public String getString(final String key) {
-      return settingMap.get(key);
+      return Optional.ofNullable(settingMap.get(key)).orElseThrow(() ->
+        new MissingResourceException(
+            "Can't find resource for bundle " + bundleName + ", key " + key, bundleName, key)
+      );
+    }
+  }
+
+  private static class ResourceBundleTest extends ResourceBundle {
+    public static final String LOADER_ATTRIBUTE = "loader";
+    private final SettingBundle settingBundle;
+    private final Map<String, String> settingMap;
+    private Function<String, ResourceBundle> originalLoader = null;
+
+    private ResourceBundleTest(final SettingBundle settingBundle,
+        final Map<String, String> settingMap) {
+      this.settingBundle = settingBundle;
+      this.settingMap = settingMap;
+    }
+
+    @SuppressWarnings("unchecked")
+    void init() throws IllegalAccessException {
+      originalLoader = (Function<String, ResourceBundle>) readDeclaredField(settingBundle,
+          LOADER_ATTRIBUTE, true);
+      Function<String, ResourceBundle> wrappedSettingBundleLoader = l -> this;
+      writeDeclaredField(settingBundle, LOADER_ATTRIBUTE, wrappedSettingBundleLoader, true);
+    }
+
+    void clear() throws IllegalAccessException {
+      writeDeclaredField(settingBundle, LOADER_ATTRIBUTE, originalLoader, true);
+    }
+
+    @Override
+    protected Object handleGetObject(@NotNull final String key) {
+      return Optional.ofNullable(settingMap.get(key))
+          .orElseGet(() -> originalLoader.apply(settingBundle.getBaseBundleName()).getString(key));
+    }
+
+    @NotNull
+    @Override
+    public Enumeration<String> getKeys() {
+      throw new UnsupportedOperationException("This method is not yet implemented");
     }
   }
 }

--- a/core-war/src/main/java/org/silverpeas/web/attachment/DragAndDrop.java
+++ b/core-war/src/main/java/org/silverpeas/web/attachment/DragAndDrop.java
@@ -25,7 +25,6 @@ package org.silverpeas.web.attachment;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.filefilter.FileFilterUtils;
-import org.silverpeas.core.ResourceReference;
 import org.silverpeas.core.admin.user.model.UserDetail;
 import org.silverpeas.core.contribution.attachment.model.DocumentType;
 import org.silverpeas.core.importexport.control.RepositoriesTypeManager;
@@ -48,7 +47,6 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 
-import static org.silverpeas.core.contribution.attachment.AttachmentServiceProvider.getAttachmentService;
 import static org.silverpeas.core.contribution.attachment.util.AttachmentSettings.listFromYoungestToOldestAdd;
 import static org.silverpeas.core.i18n.I18NHelper.checkLanguage;
 import static org.silverpeas.core.importexport.control.RepositoriesTypeManager.handleFileToAttach;
@@ -128,9 +126,7 @@ public class DragAndDrop extends SilverpeasAuthenticatedHttpServlet {
 
       final List<File> files = new ArrayList<>(
           FileUtils.listFiles(rootUploadFolder, FileFilterUtils.fileFileFilter(), FileFilterUtils.trueFileFilter()));
-      if (listFromYoungestToOldestAdd() && !getAttachmentService().
-          listDocumentsByForeignKeyAndType(new ResourceReference(resourceId, componentId),
-              documentType, null).isManuallySorted()) {
+      if (listFromYoungestToOldestAdd()) {
         Collections.reverse(files);
       }
       for (final File file : files) {


### PR DESCRIPTION
Now, even if the sort is manual, the attachments are added at top or at end of the list according to the parameter 'attachment.list.order' of parameter file 'org.silverpeas.util.attachment.Attachment.properties'