### PR TITLE
Feature #10260: creating standard and synchronized calendars from an Almanach instance (without using aggregation).

### DIFF
--- a/core-library/src/test/java/org/silverpeas/core/security/authorization/TestComponentAccessController.java
+++ b/core-library/src/test/java/org/silverpeas/core/security/authorization/TestComponentAccessController.java
@@ -75,6 +75,8 @@ public class TestComponentAccessController {
 
   private static final String USER_ID = "26";
   private static final String ANONYMOUS_ID = "26598";
+  private static final AccessControlOperation NONE = null;
+  private static final AccessControlOperation A_PERSIST_ACTION = AccessControlOperation.PERSIST_ACTIONS.iterator().next();
 
   @Rule
   public LibCoreCommonAPI4Test commonAPI4Test = new LibCoreCommonAPI4Test();
@@ -82,7 +84,6 @@ public class TestComponentAccessController {
   private OrganizationController controller;
 
   private ComponentAccessControl instance;
-  private AccessControlContext accessControlContext;
 
   private String currentUserId;
 
@@ -242,7 +243,7 @@ public class TestComponentAccessController {
    */
   @Test
   public void testGetUserRolesAndIsUserAuthorizedWithSpecificRoleRoleAndUnknownContext() {
-    assertGetUserRolesAndIsUserAuthorizedForSpecificRole();
+    assertGetUserRolesAndIsUserAuthorizedForSpecificRole(NONE);
   }
 
   /**
@@ -250,8 +251,7 @@ public class TestComponentAccessController {
    */
   @Test
   public void testGetUserRolesAndIsUserAuthorizedWithSpecificRoleRoleAndPersistContext() {
-    accessControlContext.onOperationsOf(AccessControlOperation.PERSIST_ACTIONS.iterator().next());
-    assertGetUserRolesAndIsUserAuthorizedForSpecificRole();
+    assertGetUserRolesAndIsUserAuthorizedForSpecificRole(A_PERSIST_ACTION);
   }
 
   /**
@@ -259,8 +259,7 @@ public class TestComponentAccessController {
    */
   @Test
   public void testGetUserRolesAndIsUserAuthorizedWithSpecificRoleRoleAndDownloadContext() {
-    accessControlContext.onOperationsOf(AccessControlOperation.download);
-    assertGetUserRolesAndIsUserAuthorizedForSpecificRole();
+    assertGetUserRolesAndIsUserAuthorizedForSpecificRole(AccessControlOperation.download);
   }
 
   /**
@@ -268,24 +267,34 @@ public class TestComponentAccessController {
    */
   @Test
   public void testGetUserRolesAndIsUserAuthorizedWithSpecificRoleRoleAndSharingContext() {
-    accessControlContext.onOperationsOf(AccessControlOperation.sharing);
-    assertGetUserRolesAndIsUserAuthorizedForSpecificRole();
+    assertGetUserRolesAndIsUserAuthorizedForSpecificRole(AccessControlOperation.sharing);
   }
 
-  private void assertGetUserRolesAndIsUserAuthorizedForSpecificRole() {
+  private void assertGetUserRolesAndIsUserAuthorizedForSpecificRole(
+      final AccessControlOperation operation) {
     setupUser("specificRole", UserState.VALID);
-    assertGetUserRolesAndIsUserAuthorized(null, true, SilverpeasRole.admin);
-    assertGetUserRolesAndIsUserAuthorized(toolId, true, SilverpeasRole.admin);
-    assertGetUserRolesAndIsUserAuthorized(componentAdminId, false);
-    assertGetUserRolesAndIsUserAuthorized(publicComponentId, true, SilverpeasRole.user);
-    assertGetUserRolesAndIsUserAuthorized(publicComponentIdWithUserRole, true, SilverpeasRole.user);
-    assertGetUserRolesAndIsUserAuthorized(publicFilesComponentId, true, SilverpeasRole.user);
-    assertGetUserRolesAndIsUserAuthorized(publicFilesComponentIdWithUserRole, true, SilverpeasRole.user);
-    assertGetUserRolesAndIsUserAuthorized(componentId, true, SilverpeasRole.user);
-    assertGetUserRolesAndIsUserAuthorized(forbiddenComponent, false);
-    assertGetUserRolesAndIsUserAuthorized(componentIdWithTopicRigths, true, SilverpeasRole.user);
-    assertGetUserRolesAndIsUserAuthorized(componentIdWithoutTopicRigths, true, SilverpeasRole.user);
-    assertGetUserRolesAndIsUserAuthorized(personalComponentId, true, SilverpeasRole.admin);
+    assertGetUserRolesAndIsUserAuthorized(null, operation, SilverpeasRole.admin);
+    assertGetUserRolesAndIsUserAuthorized(toolId, operation, SilverpeasRole.admin);
+    assertGetUserRolesAndIsUserAuthorized(componentAdminId, operation);
+    if (isPersistOperation(operation)) {
+      assertGetUserRolesAndIsUserAuthorized(publicComponentId, operation);
+      assertGetUserRolesAndIsUserAuthorized(publicComponentIdWithUserRole, operation);
+      assertGetUserRolesAndIsUserAuthorized(publicFilesComponentId, operation);
+      assertGetUserRolesAndIsUserAuthorized(publicFilesComponentIdWithUserRole, operation);
+      assertGetUserRolesAndIsUserAuthorized(componentId, operation);
+      assertGetUserRolesAndIsUserAuthorized(componentIdWithTopicRigths, operation);
+      assertGetUserRolesAndIsUserAuthorized(componentIdWithoutTopicRigths, operation);
+    } else {
+      assertGetUserRolesAndIsUserAuthorized(publicComponentId, operation, SilverpeasRole.user);
+      assertGetUserRolesAndIsUserAuthorized(publicComponentIdWithUserRole, operation, SilverpeasRole.user);
+      assertGetUserRolesAndIsUserAuthorized(publicFilesComponentId, operation, SilverpeasRole.user);
+      assertGetUserRolesAndIsUserAuthorized(publicFilesComponentIdWithUserRole, operation, SilverpeasRole.user);
+      assertGetUserRolesAndIsUserAuthorized(componentId, operation, SilverpeasRole.user);
+      assertGetUserRolesAndIsUserAuthorized(componentIdWithTopicRigths, operation, SilverpeasRole.user);
+      assertGetUserRolesAndIsUserAuthorized(componentIdWithoutTopicRigths, operation, SilverpeasRole.user);
+    }
+    assertGetUserRolesAndIsUserAuthorized(forbiddenComponent, operation);
+    assertGetUserRolesAndIsUserAuthorized(personalComponentId, operation, SilverpeasRole.admin);
   }
 
   /**
@@ -293,7 +302,7 @@ public class TestComponentAccessController {
    */
   @Test
   public void testGetUserRolesAndIsUserAuthorizedWithAdminUserRoleAndUnknownContext() {
-    assertGetUserRolesAndIsUserAuthorizedForAdmin();
+    assertGetUserRolesAndIsUserAuthorizedForAdmin(NONE);
   }
 
   /**
@@ -301,8 +310,7 @@ public class TestComponentAccessController {
    */
   @Test
   public void testGetUserRolesAndIsUserAuthorizedWithAdminUserRoleAndPersistContext() {
-    accessControlContext.onOperationsOf(AccessControlOperation.PERSIST_ACTIONS.iterator().next());
-    assertGetUserRolesAndIsUserAuthorizedForAdmin();
+    assertGetUserRolesAndIsUserAuthorizedForAdmin(A_PERSIST_ACTION);
   }
 
   /**
@@ -310,8 +318,7 @@ public class TestComponentAccessController {
    */
   @Test
   public void testGetUserRolesAndIsUserAuthorizedWithAdminUserRoleAndDownloadContext() {
-    accessControlContext.onOperationsOf(AccessControlOperation.download);
-    assertGetUserRolesAndIsUserAuthorizedForAdmin();
+    assertGetUserRolesAndIsUserAuthorizedForAdmin(AccessControlOperation.download);
   }
 
   /**
@@ -319,24 +326,30 @@ public class TestComponentAccessController {
    */
   @Test
   public void testGetUserRolesAndIsUserAuthorizedWithAdminUserRoleAndSharingContext() {
-    accessControlContext.onOperationsOf(AccessControlOperation.sharing);
-    assertGetUserRolesAndIsUserAuthorizedForAdmin();
+    assertGetUserRolesAndIsUserAuthorizedForAdmin(AccessControlOperation.sharing);
   }
 
-  private void assertGetUserRolesAndIsUserAuthorizedForAdmin() {
+  private void assertGetUserRolesAndIsUserAuthorizedForAdmin(final AccessControlOperation operation) {
     setupUser(SilverpeasRole.admin);
-    assertGetUserRolesAndIsUserAuthorized(null, true, SilverpeasRole.admin);
-    assertGetUserRolesAndIsUserAuthorized(toolId, true, SilverpeasRole.admin);
-    assertGetUserRolesAndIsUserAuthorized(componentAdminId, true, SilverpeasRole.admin);
-    assertGetUserRolesAndIsUserAuthorized(publicComponentId, true, SilverpeasRole.user);
-    assertGetUserRolesAndIsUserAuthorized(publicComponentIdWithUserRole, true, SilverpeasRole.admin, SilverpeasRole.user);
-    assertGetUserRolesAndIsUserAuthorized(publicFilesComponentId, true, SilverpeasRole.user);
-    assertGetUserRolesAndIsUserAuthorized(publicFilesComponentIdWithUserRole, true, SilverpeasRole.admin, SilverpeasRole.user);
-    assertGetUserRolesAndIsUserAuthorized(componentId, true, SilverpeasRole.admin);
-    assertGetUserRolesAndIsUserAuthorized(forbiddenComponent, false);
-    assertGetUserRolesAndIsUserAuthorized(componentIdWithTopicRigths, true, SilverpeasRole.admin);
-    assertGetUserRolesAndIsUserAuthorized(componentIdWithoutTopicRigths, true, SilverpeasRole.admin);
-    assertGetUserRolesAndIsUserAuthorized(personalComponentId, true, SilverpeasRole.admin);
+    assertGetUserRolesAndIsUserAuthorized(null, operation, SilverpeasRole.admin);
+    assertGetUserRolesAndIsUserAuthorized(toolId, operation, SilverpeasRole.admin);
+    assertGetUserRolesAndIsUserAuthorized(componentAdminId, operation, SilverpeasRole.admin);
+    if(isPersistOperation(operation)) {
+      assertGetUserRolesAndIsUserAuthorized(publicComponentId, operation);
+      assertGetUserRolesAndIsUserAuthorized(publicComponentIdWithUserRole, operation, SilverpeasRole.admin);
+      assertGetUserRolesAndIsUserAuthorized(publicFilesComponentId, operation);
+      assertGetUserRolesAndIsUserAuthorized(publicFilesComponentIdWithUserRole, operation, SilverpeasRole.admin);
+    } else {
+      assertGetUserRolesAndIsUserAuthorized(publicComponentId, operation, SilverpeasRole.user);
+      assertGetUserRolesAndIsUserAuthorized(publicComponentIdWithUserRole, operation, SilverpeasRole.admin, SilverpeasRole.user);
+      assertGetUserRolesAndIsUserAuthorized(publicFilesComponentId, operation, SilverpeasRole.user);
+      assertGetUserRolesAndIsUserAuthorized(publicFilesComponentIdWithUserRole, operation, SilverpeasRole.admin, SilverpeasRole.user);
+    }
+    assertGetUserRolesAndIsUserAuthorized(componentId, operation, SilverpeasRole.admin);
+    assertGetUserRolesAndIsUserAuthorized(forbiddenComponent, operation);
+    assertGetUserRolesAndIsUserAuthorized(componentIdWithTopicRigths, operation, SilverpeasRole.admin);
+    assertGetUserRolesAndIsUserAuthorized(componentIdWithoutTopicRigths, operation, SilverpeasRole.admin);
+    assertGetUserRolesAndIsUserAuthorized(personalComponentId, operation, SilverpeasRole.admin);
   }
 
   /**
@@ -344,7 +357,7 @@ public class TestComponentAccessController {
    */
   @Test
   public void testGetUserRolesAndIsUserAuthorizedWithWriterUserRoleAndUnknownContext() {
-    assertGetUserRolesAndIsUserAuthorizedForWriter();
+    assertGetUserRolesAndIsUserAuthorizedForWriter(NONE);
   }
 
   /**
@@ -352,8 +365,7 @@ public class TestComponentAccessController {
    */
   @Test
   public void testGetUserRolesAndIsUserAuthorizedWithWriterUserRoleAndPersistContext() {
-    accessControlContext.onOperationsOf(AccessControlOperation.PERSIST_ACTIONS.iterator().next());
-    assertGetUserRolesAndIsUserAuthorizedForWriter();
+    assertGetUserRolesAndIsUserAuthorizedForWriter(A_PERSIST_ACTION);
   }
 
   /**
@@ -361,8 +373,7 @@ public class TestComponentAccessController {
    */
   @Test
   public void testGetUserRolesAndIsUserAuthorizedWithWriterUserRoleAndDownloadContext() {
-    accessControlContext.onOperationsOf(AccessControlOperation.download);
-    assertGetUserRolesAndIsUserAuthorizedForWriter();
+    assertGetUserRolesAndIsUserAuthorizedForWriter(AccessControlOperation.download);
   }
 
   /**
@@ -370,24 +381,31 @@ public class TestComponentAccessController {
    */
   @Test
   public void testGetUserRolesAndIsUserAuthorizedWithWriterUserRoleAndSharingContext() {
-    accessControlContext.onOperationsOf(AccessControlOperation.sharing);
-    assertGetUserRolesAndIsUserAuthorizedForWriter();
+    assertGetUserRolesAndIsUserAuthorizedForWriter(AccessControlOperation.sharing);
   }
 
-  private void assertGetUserRolesAndIsUserAuthorizedForWriter() {
+  private void assertGetUserRolesAndIsUserAuthorizedForWriter(
+      final AccessControlOperation operation) {
     setupUser(SilverpeasRole.writer);
-    assertGetUserRolesAndIsUserAuthorized(null, true, SilverpeasRole.admin);
-    assertGetUserRolesAndIsUserAuthorized(toolId, true, SilverpeasRole.admin);
-    assertGetUserRolesAndIsUserAuthorized(componentAdminId, false);
-    assertGetUserRolesAndIsUserAuthorized(publicComponentId, true, SilverpeasRole.user);
-    assertGetUserRolesAndIsUserAuthorized(publicComponentIdWithUserRole, true, SilverpeasRole.writer, SilverpeasRole.user);
-    assertGetUserRolesAndIsUserAuthorized(publicFilesComponentId, true, SilverpeasRole.user);
-    assertGetUserRolesAndIsUserAuthorized(publicFilesComponentIdWithUserRole, true, SilverpeasRole.writer, SilverpeasRole.user);
-    assertGetUserRolesAndIsUserAuthorized(componentId, true, SilverpeasRole.writer);
-    assertGetUserRolesAndIsUserAuthorized(forbiddenComponent, false);
-    assertGetUserRolesAndIsUserAuthorized(componentIdWithTopicRigths, true, SilverpeasRole.writer);
-    assertGetUserRolesAndIsUserAuthorized(componentIdWithoutTopicRigths, true, SilverpeasRole.writer);
-    assertGetUserRolesAndIsUserAuthorized(personalComponentId, true, SilverpeasRole.admin);
+    assertGetUserRolesAndIsUserAuthorized(null, operation, SilverpeasRole.admin);
+    assertGetUserRolesAndIsUserAuthorized(toolId, operation, SilverpeasRole.admin);
+    assertGetUserRolesAndIsUserAuthorized(componentAdminId, operation);
+    if (isPersistOperation(operation)) {
+      assertGetUserRolesAndIsUserAuthorized(publicComponentId, operation);
+      assertGetUserRolesAndIsUserAuthorized(publicComponentIdWithUserRole, operation, SilverpeasRole.writer);
+      assertGetUserRolesAndIsUserAuthorized(publicFilesComponentId, operation);
+      assertGetUserRolesAndIsUserAuthorized(publicFilesComponentIdWithUserRole, operation, SilverpeasRole.writer);
+    } else {
+      assertGetUserRolesAndIsUserAuthorized(publicComponentId, operation, SilverpeasRole.user);
+      assertGetUserRolesAndIsUserAuthorized(publicComponentIdWithUserRole, operation, SilverpeasRole.writer, SilverpeasRole.user);
+      assertGetUserRolesAndIsUserAuthorized(publicFilesComponentId, operation, SilverpeasRole.user);
+      assertGetUserRolesAndIsUserAuthorized(publicFilesComponentIdWithUserRole, operation, SilverpeasRole.writer, SilverpeasRole.user);
+    }
+    assertGetUserRolesAndIsUserAuthorized(componentId, operation, SilverpeasRole.writer);
+    assertGetUserRolesAndIsUserAuthorized(forbiddenComponent, operation);
+    assertGetUserRolesAndIsUserAuthorized(componentIdWithTopicRigths, operation, SilverpeasRole.writer);
+    assertGetUserRolesAndIsUserAuthorized(componentIdWithoutTopicRigths, operation, SilverpeasRole.writer);
+    assertGetUserRolesAndIsUserAuthorized(personalComponentId, operation, SilverpeasRole.admin);
   }
 
   /**
@@ -395,7 +413,7 @@ public class TestComponentAccessController {
    */
   @Test
   public void testGetUserRolesAndIsUserAuthorizedWithReaderUserRoleAndUnknownContext() {
-    assertGetUserRolesAndIsUserAuthorizedForReader();
+    assertGetUserRolesAndIsUserAuthorizedForReader(NONE);
   }
 
   /**
@@ -403,8 +421,7 @@ public class TestComponentAccessController {
    */
   @Test
   public void testGetUserRolesAndIsUserAuthorizedWithReaderUserRoleAndPersistContext() {
-    accessControlContext.onOperationsOf(AccessControlOperation.PERSIST_ACTIONS.iterator().next());
-    assertGetUserRolesAndIsUserAuthorizedForReader();
+    assertGetUserRolesAndIsUserAuthorizedForReader(A_PERSIST_ACTION);
   }
 
   /**
@@ -412,8 +429,7 @@ public class TestComponentAccessController {
    */
   @Test
   public void testGetUserRolesAndIsUserAuthorizedWithReaderUserRoleAndDownloadContext() {
-    accessControlContext.onOperationsOf(AccessControlOperation.download);
-    assertGetUserRolesAndIsUserAuthorizedForReader();
+    assertGetUserRolesAndIsUserAuthorizedForReader(AccessControlOperation.download);
   }
 
   /**
@@ -421,24 +437,34 @@ public class TestComponentAccessController {
    */
   @Test
   public void testGetUserRolesAndIsUserAuthorizedWithReaderUserRoleAndSharingContext() {
-    accessControlContext.onOperationsOf(AccessControlOperation.sharing);
-    assertGetUserRolesAndIsUserAuthorizedForReader();
+    assertGetUserRolesAndIsUserAuthorizedForReader(AccessControlOperation.sharing);
   }
 
-  private void assertGetUserRolesAndIsUserAuthorizedForReader() {
+  private void assertGetUserRolesAndIsUserAuthorizedForReader(
+      final AccessControlOperation operation) {
     setupUser(SilverpeasRole.user);
-    assertGetUserRolesAndIsUserAuthorized(null, true, SilverpeasRole.admin);
-    assertGetUserRolesAndIsUserAuthorized(toolId, true, SilverpeasRole.admin);
-    assertGetUserRolesAndIsUserAuthorized(componentAdminId, false);
-    assertGetUserRolesAndIsUserAuthorized(publicComponentId, true, SilverpeasRole.user);
-    assertGetUserRolesAndIsUserAuthorized(publicComponentIdWithUserRole, true, SilverpeasRole.user);
-    assertGetUserRolesAndIsUserAuthorized(publicFilesComponentId, true, SilverpeasRole.user);
-    assertGetUserRolesAndIsUserAuthorized(publicFilesComponentIdWithUserRole, true, SilverpeasRole.user);
-    assertGetUserRolesAndIsUserAuthorized(componentId, true, SilverpeasRole.user);
-    assertGetUserRolesAndIsUserAuthorized(forbiddenComponent, false);
-    assertGetUserRolesAndIsUserAuthorized(componentIdWithTopicRigths, true, SilverpeasRole.user);
-    assertGetUserRolesAndIsUserAuthorized(componentIdWithoutTopicRigths, true, SilverpeasRole.user);
-    assertGetUserRolesAndIsUserAuthorized(personalComponentId, true, SilverpeasRole.admin);
+    assertGetUserRolesAndIsUserAuthorized(null, operation, SilverpeasRole.admin);
+    assertGetUserRolesAndIsUserAuthorized(toolId, operation, SilverpeasRole.admin);
+    assertGetUserRolesAndIsUserAuthorized(componentAdminId, operation);
+    if (isPersistOperation(operation)) {
+      assertGetUserRolesAndIsUserAuthorized(publicComponentId, operation);
+      assertGetUserRolesAndIsUserAuthorized(publicComponentIdWithUserRole, operation);
+      assertGetUserRolesAndIsUserAuthorized(publicFilesComponentId, operation);
+      assertGetUserRolesAndIsUserAuthorized(publicFilesComponentIdWithUserRole, operation);
+      assertGetUserRolesAndIsUserAuthorized(componentId, operation);
+      assertGetUserRolesAndIsUserAuthorized(componentIdWithTopicRigths, operation);
+      assertGetUserRolesAndIsUserAuthorized(componentIdWithoutTopicRigths, operation);
+    } else {
+      assertGetUserRolesAndIsUserAuthorized(publicComponentId, operation, SilverpeasRole.user);
+      assertGetUserRolesAndIsUserAuthorized(publicComponentIdWithUserRole, operation, SilverpeasRole.user);
+      assertGetUserRolesAndIsUserAuthorized(publicFilesComponentId, operation, SilverpeasRole.user);
+      assertGetUserRolesAndIsUserAuthorized(publicFilesComponentIdWithUserRole, operation, SilverpeasRole.user);
+      assertGetUserRolesAndIsUserAuthorized(componentId, operation, SilverpeasRole.user);
+      assertGetUserRolesAndIsUserAuthorized(componentIdWithTopicRigths, operation, SilverpeasRole.user);
+      assertGetUserRolesAndIsUserAuthorized(componentIdWithoutTopicRigths, operation, SilverpeasRole.user);
+    }
+    assertGetUserRolesAndIsUserAuthorized(personalComponentId, operation, SilverpeasRole.admin);
+    assertGetUserRolesAndIsUserAuthorized(forbiddenComponent, operation);
   }
 
   /**
@@ -446,7 +472,7 @@ public class TestComponentAccessController {
    */
   @Test
   public void testGetUserRolesAndIsUserAuthorizedWithReaderUserRoleButBlockedAndUnknownContext() {
-    assertGetUserRolesAndIsUserAuthorizedForBlockedReader();
+    assertGetUserRolesAndIsUserAuthorizedForBlockedReader(NONE);
   }
 
   /**
@@ -454,8 +480,7 @@ public class TestComponentAccessController {
    */
   @Test
   public void testGetUserRolesAndIsUserAuthorizedWithReaderUserRoleButBlockedAndPersistContext() {
-    accessControlContext.onOperationsOf(AccessControlOperation.PERSIST_ACTIONS.iterator().next());
-    assertGetUserRolesAndIsUserAuthorizedForBlockedReader();
+    assertGetUserRolesAndIsUserAuthorizedForBlockedReader(A_PERSIST_ACTION);
   }
 
   /**
@@ -463,8 +488,7 @@ public class TestComponentAccessController {
    */
   @Test
   public void testGetUserRolesAndIsUserAuthorizedWithReaderUserRoleButBlockedAndDownloadContext() {
-    accessControlContext.onOperationsOf(AccessControlOperation.download);
-    assertGetUserRolesAndIsUserAuthorizedForBlockedReader();
+    assertGetUserRolesAndIsUserAuthorizedForBlockedReader(AccessControlOperation.download);
   }
 
   /**
@@ -472,24 +496,34 @@ public class TestComponentAccessController {
    */
   @Test
   public void testGetUserRolesAndIsUserAuthorizedWithReaderUserRoleButBlockedAndSharingContext() {
-    accessControlContext.onOperationsOf(AccessControlOperation.sharing);
-    assertGetUserRolesAndIsUserAuthorizedForBlockedReader();
+    assertGetUserRolesAndIsUserAuthorizedForBlockedReader(AccessControlOperation.sharing);
   }
 
-  private void assertGetUserRolesAndIsUserAuthorizedForBlockedReader() {
+  private void assertGetUserRolesAndIsUserAuthorizedForBlockedReader(
+      final AccessControlOperation operation) {
     setupUser(SilverpeasRole.user, UserState.BLOCKED);
-    assertGetUserRolesAndIsUserAuthorized(null, true, SilverpeasRole.admin);
-    assertGetUserRolesAndIsUserAuthorized(toolId, true, SilverpeasRole.admin);
-    assertGetUserRolesAndIsUserAuthorized(componentAdminId, false);
-    assertGetUserRolesAndIsUserAuthorized(publicComponentId, true, SilverpeasRole.user);
-    assertGetUserRolesAndIsUserAuthorized(publicComponentIdWithUserRole, true, SilverpeasRole.user);
-    assertGetUserRolesAndIsUserAuthorized(publicFilesComponentId, true, SilverpeasRole.user);
-    assertGetUserRolesAndIsUserAuthorized(publicFilesComponentIdWithUserRole, true, SilverpeasRole.user);
-    assertGetUserRolesAndIsUserAuthorized(componentId, true, SilverpeasRole.user);
-    assertGetUserRolesAndIsUserAuthorized(forbiddenComponent, false);
-    assertGetUserRolesAndIsUserAuthorized(componentIdWithTopicRigths, true, SilverpeasRole.user);
-    assertGetUserRolesAndIsUserAuthorized(componentIdWithoutTopicRigths, true, SilverpeasRole.user);
-    assertGetUserRolesAndIsUserAuthorized(personalComponentId, true, SilverpeasRole.admin);
+    assertGetUserRolesAndIsUserAuthorized(null, operation, SilverpeasRole.admin);
+    assertGetUserRolesAndIsUserAuthorized(toolId, operation, SilverpeasRole.admin);
+    assertGetUserRolesAndIsUserAuthorized(componentAdminId, operation);
+    if (isPersistOperation(operation)) {
+      assertGetUserRolesAndIsUserAuthorized(publicComponentId, operation);
+      assertGetUserRolesAndIsUserAuthorized(publicComponentIdWithUserRole, operation);
+      assertGetUserRolesAndIsUserAuthorized(publicFilesComponentId, operation);
+      assertGetUserRolesAndIsUserAuthorized(publicFilesComponentIdWithUserRole, operation);
+      assertGetUserRolesAndIsUserAuthorized(componentId, operation);
+      assertGetUserRolesAndIsUserAuthorized(componentIdWithTopicRigths, operation);
+      assertGetUserRolesAndIsUserAuthorized(componentIdWithoutTopicRigths, operation);
+    } else {
+      assertGetUserRolesAndIsUserAuthorized(publicComponentId, operation, SilverpeasRole.user);
+      assertGetUserRolesAndIsUserAuthorized(publicComponentIdWithUserRole, operation, SilverpeasRole.user);
+      assertGetUserRolesAndIsUserAuthorized(publicFilesComponentId, operation, SilverpeasRole.user);
+      assertGetUserRolesAndIsUserAuthorized(publicFilesComponentIdWithUserRole, operation, SilverpeasRole.user);
+      assertGetUserRolesAndIsUserAuthorized(componentId, operation, SilverpeasRole.user);
+      assertGetUserRolesAndIsUserAuthorized(componentIdWithTopicRigths, operation, SilverpeasRole.user);
+      assertGetUserRolesAndIsUserAuthorized(componentIdWithoutTopicRigths, operation, SilverpeasRole.user);
+    }
+    assertGetUserRolesAndIsUserAuthorized(forbiddenComponent, operation);
+    assertGetUserRolesAndIsUserAuthorized(personalComponentId, operation, SilverpeasRole.admin);
   }
 
   /**
@@ -497,7 +531,7 @@ public class TestComponentAccessController {
    */
   @Test
   public void testGetUserRolesAndIsUserAuthorizedWithReaderUserRoleButExpiredAndUnknownContext() {
-    assertGetUserRolesAndIsUserAuthorizedForExpiredReader();
+    assertGetUserRolesAndIsUserAuthorizedForExpiredReader(NONE);
   }
 
   /**
@@ -505,8 +539,7 @@ public class TestComponentAccessController {
    */
   @Test
   public void testGetUserRolesAndIsUserAuthorizedWithReaderUserRoleButExpiredAndPersistContext() {
-    accessControlContext.onOperationsOf(AccessControlOperation.PERSIST_ACTIONS.iterator().next());
-    assertGetUserRolesAndIsUserAuthorizedForExpiredReader();
+    assertGetUserRolesAndIsUserAuthorizedForExpiredReader(A_PERSIST_ACTION);
   }
 
   /**
@@ -514,8 +547,7 @@ public class TestComponentAccessController {
    */
   @Test
   public void testGetUserRolesAndIsUserAuthorizedWithReaderUserRoleButExpiredAndDownloadContext() {
-    accessControlContext.onOperationsOf(AccessControlOperation.download);
-    assertGetUserRolesAndIsUserAuthorizedForExpiredReader();
+    assertGetUserRolesAndIsUserAuthorizedForExpiredReader(AccessControlOperation.download);
   }
 
   /**
@@ -523,24 +555,34 @@ public class TestComponentAccessController {
    */
   @Test
   public void testGetUserRolesAndIsUserAuthorizedWithReaderUserRoleButExpiredAndSharingContext() {
-    accessControlContext.onOperationsOf(AccessControlOperation.sharing);
-    assertGetUserRolesAndIsUserAuthorizedForExpiredReader();
+    assertGetUserRolesAndIsUserAuthorizedForExpiredReader(AccessControlOperation.sharing);
   }
 
-  private void assertGetUserRolesAndIsUserAuthorizedForExpiredReader() {
+  private void assertGetUserRolesAndIsUserAuthorizedForExpiredReader(
+      final AccessControlOperation operation) {
     setupUser(SilverpeasRole.user, UserState.EXPIRED);
-    assertGetUserRolesAndIsUserAuthorized(null, true, SilverpeasRole.admin);
-    assertGetUserRolesAndIsUserAuthorized(toolId, true, SilverpeasRole.admin);
-    assertGetUserRolesAndIsUserAuthorized(componentAdminId, false);
-    assertGetUserRolesAndIsUserAuthorized(publicComponentId, true, SilverpeasRole.user);
-    assertGetUserRolesAndIsUserAuthorized(publicComponentIdWithUserRole, true, SilverpeasRole.user);
-    assertGetUserRolesAndIsUserAuthorized(publicFilesComponentId, true, SilverpeasRole.user);
-    assertGetUserRolesAndIsUserAuthorized(publicFilesComponentIdWithUserRole, true, SilverpeasRole.user);
-    assertGetUserRolesAndIsUserAuthorized(componentId, true, SilverpeasRole.user);
-    assertGetUserRolesAndIsUserAuthorized(forbiddenComponent, false);
-    assertGetUserRolesAndIsUserAuthorized(componentIdWithTopicRigths, true, SilverpeasRole.user);
-    assertGetUserRolesAndIsUserAuthorized(componentIdWithoutTopicRigths, true, SilverpeasRole.user);
-    assertGetUserRolesAndIsUserAuthorized(personalComponentId, true, SilverpeasRole.admin);
+    assertGetUserRolesAndIsUserAuthorized(null, operation, SilverpeasRole.admin);
+    assertGetUserRolesAndIsUserAuthorized(toolId, operation, SilverpeasRole.admin);
+    assertGetUserRolesAndIsUserAuthorized(componentAdminId, operation);
+    if (isPersistOperation(operation)) {
+      assertGetUserRolesAndIsUserAuthorized(publicComponentId, operation);
+      assertGetUserRolesAndIsUserAuthorized(publicComponentIdWithUserRole, operation);
+      assertGetUserRolesAndIsUserAuthorized(publicFilesComponentId, operation);
+      assertGetUserRolesAndIsUserAuthorized(publicFilesComponentIdWithUserRole, operation);
+      assertGetUserRolesAndIsUserAuthorized(componentId, operation);
+      assertGetUserRolesAndIsUserAuthorized(componentIdWithTopicRigths, operation);
+      assertGetUserRolesAndIsUserAuthorized(componentIdWithoutTopicRigths, operation);
+    } else {
+      assertGetUserRolesAndIsUserAuthorized(publicComponentId, operation, SilverpeasRole.user);
+      assertGetUserRolesAndIsUserAuthorized(publicComponentIdWithUserRole, operation, SilverpeasRole.user);
+      assertGetUserRolesAndIsUserAuthorized(publicFilesComponentId, operation, SilverpeasRole.user);
+      assertGetUserRolesAndIsUserAuthorized(publicFilesComponentIdWithUserRole, operation, SilverpeasRole.user);
+      assertGetUserRolesAndIsUserAuthorized(componentId, operation, SilverpeasRole.user);
+      assertGetUserRolesAndIsUserAuthorized(componentIdWithTopicRigths, operation, SilverpeasRole.user);
+      assertGetUserRolesAndIsUserAuthorized(componentIdWithoutTopicRigths, operation, SilverpeasRole.user);
+    }
+    assertGetUserRolesAndIsUserAuthorized(forbiddenComponent, operation);
+    assertGetUserRolesAndIsUserAuthorized(personalComponentId, operation, SilverpeasRole.admin);
   }
 
   /**
@@ -548,7 +590,7 @@ public class TestComponentAccessController {
    */
   @Test
   public void testGetUserRolesAndAnonymousUserButExpiredAndUnknownContext() {
-    assertGetUserRolesAndIsUserAuthorizedForAnonymous();
+    assertGetUserRolesAndIsUserAuthorizedForAnonymous(NONE);
   }
 
   /**
@@ -556,8 +598,7 @@ public class TestComponentAccessController {
    */
   @Test
   public void testGetUserRolesAndAnonymousUserButExpiredAndPersistContext() {
-    accessControlContext.onOperationsOf(AccessControlOperation.PERSIST_ACTIONS.iterator().next());
-    assertGetUserRolesAndIsUserAuthorizedForAnonymous();
+    assertGetUserRolesAndIsUserAuthorizedForAnonymous(A_PERSIST_ACTION);
   }
 
   /**
@@ -565,8 +606,7 @@ public class TestComponentAccessController {
    */
   @Test
   public void testGetUserRolesAndAnonymousUserButExpiredAndDownloadContext() {
-    accessControlContext.onOperationsOf(AccessControlOperation.download);
-    assertGetUserRolesAndIsUserAuthorizedForAnonymous();
+    assertGetUserRolesAndIsUserAuthorizedForAnonymous(AccessControlOperation.download);
   }
 
   /**
@@ -574,24 +614,31 @@ public class TestComponentAccessController {
    */
   @Test
   public void testGetUserRolesAndAnonymousUserButExpiredAndSharingContext() {
-    accessControlContext.onOperationsOf(AccessControlOperation.sharing);
-    assertGetUserRolesAndIsUserAuthorizedForAnonymous();
+    assertGetUserRolesAndIsUserAuthorizedForAnonymous(AccessControlOperation.sharing);
   }
 
-  private void assertGetUserRolesAndIsUserAuthorizedForAnonymous() {
+  private void assertGetUserRolesAndIsUserAuthorizedForAnonymous(
+      final AccessControlOperation operation) {
     setupAnonymousUser();
-    assertGetUserRolesAndIsUserAuthorized(null, true, SilverpeasRole.admin);
-    assertGetUserRolesAndIsUserAuthorized(toolId, true, SilverpeasRole.admin);
-    assertGetUserRolesAndIsUserAuthorized(componentAdminId, false);
-    assertGetUserRolesAndIsUserAuthorized(publicComponentId, true, SilverpeasRole.user);
-    assertGetUserRolesAndIsUserAuthorized(publicComponentIdWithUserRole, true, SilverpeasRole.user);
-    assertGetUserRolesAndIsUserAuthorized(publicFilesComponentId, true, SilverpeasRole.user);
-    assertGetUserRolesAndIsUserAuthorized(publicFilesComponentIdWithUserRole, true, SilverpeasRole.user);
-    assertGetUserRolesAndIsUserAuthorized(componentId, false);
-    assertGetUserRolesAndIsUserAuthorized(forbiddenComponent, false);
-    assertGetUserRolesAndIsUserAuthorized(componentIdWithTopicRigths, false);
-    assertGetUserRolesAndIsUserAuthorized(componentIdWithoutTopicRigths, false);
-    assertGetUserRolesAndIsUserAuthorized(personalComponentId, false);
+    assertGetUserRolesAndIsUserAuthorized(null, operation, SilverpeasRole.admin);
+    assertGetUserRolesAndIsUserAuthorized(toolId, operation, SilverpeasRole.admin);
+    assertGetUserRolesAndIsUserAuthorized(componentAdminId, operation);
+    if (isPersistOperation(operation)) {
+      assertGetUserRolesAndIsUserAuthorized(publicComponentId, operation);
+      assertGetUserRolesAndIsUserAuthorized(publicComponentIdWithUserRole, operation);
+      assertGetUserRolesAndIsUserAuthorized(publicFilesComponentId, operation);
+      assertGetUserRolesAndIsUserAuthorized(publicFilesComponentIdWithUserRole, operation);
+    } else {
+      assertGetUserRolesAndIsUserAuthorized(publicComponentId, operation, SilverpeasRole.user);
+      assertGetUserRolesAndIsUserAuthorized(publicComponentIdWithUserRole, operation, SilverpeasRole.user);
+      assertGetUserRolesAndIsUserAuthorized(publicFilesComponentId, operation, SilverpeasRole.user);
+      assertGetUserRolesAndIsUserAuthorized(publicFilesComponentIdWithUserRole, operation, SilverpeasRole.user);
+    }
+    assertGetUserRolesAndIsUserAuthorized(componentId, operation);
+    assertGetUserRolesAndIsUserAuthorized(forbiddenComponent, operation);
+    assertGetUserRolesAndIsUserAuthorized(componentIdWithTopicRigths, operation);
+    assertGetUserRolesAndIsUserAuthorized(componentIdWithoutTopicRigths, operation);
+    assertGetUserRolesAndIsUserAuthorized(personalComponentId, operation);
   }
 
   /**
@@ -599,7 +646,7 @@ public class TestComponentAccessController {
    */
   @Test
   public void testGetUserRolesAndIsUserAuthorizedWithReaderUserRoleButDeletedAndUnknownContext() {
-    assertGetUserRolesAndIsUserAuthorizedForDeletedReader();
+    assertGetUserRolesAndIsUserAuthorizedForDeletedReader(NONE);
   }
 
   /**
@@ -607,8 +654,7 @@ public class TestComponentAccessController {
    */
   @Test
   public void testGetUserRolesAndIsUserAuthorizedWithReaderUserRoleButDeletedAndPersistContext() {
-    accessControlContext.onOperationsOf(AccessControlOperation.PERSIST_ACTIONS.iterator().next());
-    assertGetUserRolesAndIsUserAuthorizedForDeletedReader();
+    assertGetUserRolesAndIsUserAuthorizedForDeletedReader(A_PERSIST_ACTION);
   }
 
   /**
@@ -616,8 +662,7 @@ public class TestComponentAccessController {
    */
   @Test
   public void testGetUserRolesAndIsUserAuthorizedWithReaderUserRoleButDeletedAndDownloadContext() {
-    accessControlContext.onOperationsOf(AccessControlOperation.download);
-    assertGetUserRolesAndIsUserAuthorizedForDeletedReader();
+    assertGetUserRolesAndIsUserAuthorizedForDeletedReader(AccessControlOperation.download);
   }
 
   /**
@@ -625,24 +670,24 @@ public class TestComponentAccessController {
    */
   @Test
   public void testGetUserRolesAndIsUserAuthorizedWithReaderUserRoleButDeletedAndSharingContext() {
-    accessControlContext.onOperationsOf(AccessControlOperation.sharing);
-    assertGetUserRolesAndIsUserAuthorizedForDeletedReader();
+    assertGetUserRolesAndIsUserAuthorizedForDeletedReader(AccessControlOperation.sharing);
   }
 
-  private void assertGetUserRolesAndIsUserAuthorizedForDeletedReader() {
+  private void assertGetUserRolesAndIsUserAuthorizedForDeletedReader(
+      final AccessControlOperation operation) {
     setupUser(SilverpeasRole.user, UserState.DELETED);
-    assertGetUserRolesAndIsUserAuthorized(null, false);
-    assertGetUserRolesAndIsUserAuthorized(toolId, false);
-    assertGetUserRolesAndIsUserAuthorized(componentAdminId, false);
-    assertGetUserRolesAndIsUserAuthorized(publicComponentId, false);
-    assertGetUserRolesAndIsUserAuthorized(publicComponentIdWithUserRole, false);
-    assertGetUserRolesAndIsUserAuthorized(publicFilesComponentId, false);
-    assertGetUserRolesAndIsUserAuthorized(publicFilesComponentIdWithUserRole, false);
-    assertGetUserRolesAndIsUserAuthorized(componentId, false);
-    assertGetUserRolesAndIsUserAuthorized(forbiddenComponent, false);
-    assertGetUserRolesAndIsUserAuthorized(componentIdWithTopicRigths, false);
-    assertGetUserRolesAndIsUserAuthorized(componentIdWithoutTopicRigths, false);
-    assertGetUserRolesAndIsUserAuthorized(personalComponentId, false);
+    assertGetUserRolesAndIsUserAuthorized(null, operation);
+    assertGetUserRolesAndIsUserAuthorized(toolId, operation);
+    assertGetUserRolesAndIsUserAuthorized(componentAdminId, operation);
+    assertGetUserRolesAndIsUserAuthorized(publicComponentId, operation);
+    assertGetUserRolesAndIsUserAuthorized(publicComponentIdWithUserRole, operation);
+    assertGetUserRolesAndIsUserAuthorized(publicFilesComponentId, operation);
+    assertGetUserRolesAndIsUserAuthorized(publicFilesComponentIdWithUserRole, operation);
+    assertGetUserRolesAndIsUserAuthorized(componentId, operation);
+    assertGetUserRolesAndIsUserAuthorized(forbiddenComponent, operation);
+    assertGetUserRolesAndIsUserAuthorized(componentIdWithTopicRigths, operation);
+    assertGetUserRolesAndIsUserAuthorized(componentIdWithoutTopicRigths, operation);
+    assertGetUserRolesAndIsUserAuthorized(personalComponentId, operation);
   }
 
   /**
@@ -650,7 +695,7 @@ public class TestComponentAccessController {
    */
   @Test
   public void testGetUserRolesAndIsUserAuthorizedWithReaderUserRoleButDeactivatedAndUnknownContext() {
-    assertGetUserRolesAndIsUserAuthorizedForDeactivatedReader();
+    assertGetUserRolesAndIsUserAuthorizedForDeactivatedReader(NONE);
   }
 
   /**
@@ -658,8 +703,7 @@ public class TestComponentAccessController {
    */
   @Test
   public void testGetUserRolesAndIsUserAuthorizedWithReaderUserRoleButDeactivatedAndPersistContext() {
-    accessControlContext.onOperationsOf(AccessControlOperation.PERSIST_ACTIONS.iterator().next());
-    assertGetUserRolesAndIsUserAuthorizedForDeactivatedReader();
+    assertGetUserRolesAndIsUserAuthorizedForDeactivatedReader(A_PERSIST_ACTION);
   }
 
   /**
@@ -667,8 +711,7 @@ public class TestComponentAccessController {
    */
   @Test
   public void testGetUserRolesAndIsUserAuthorizedWithReaderUserRoleButDeactivatedAndDownloadContext() {
-    accessControlContext.onOperationsOf(AccessControlOperation.download);
-    assertGetUserRolesAndIsUserAuthorizedForDeactivatedReader();
+    assertGetUserRolesAndIsUserAuthorizedForDeactivatedReader(AccessControlOperation.download);
   }
 
   /**
@@ -676,24 +719,24 @@ public class TestComponentAccessController {
    */
   @Test
   public void testGetUserRolesAndIsUserAuthorizedWithReaderUserRoleButDeactivatedAndSharingContext() {
-    accessControlContext.onOperationsOf(AccessControlOperation.sharing);
-    assertGetUserRolesAndIsUserAuthorizedForDeactivatedReader();
+    assertGetUserRolesAndIsUserAuthorizedForDeactivatedReader(AccessControlOperation.sharing);
   }
 
-  private void assertGetUserRolesAndIsUserAuthorizedForDeactivatedReader() {
+  private void assertGetUserRolesAndIsUserAuthorizedForDeactivatedReader(
+      final AccessControlOperation operation) {
     setupUser(SilverpeasRole.user, UserState.DEACTIVATED);
-    assertGetUserRolesAndIsUserAuthorized(null, false);
-    assertGetUserRolesAndIsUserAuthorized(toolId, false);
-    assertGetUserRolesAndIsUserAuthorized(componentAdminId, false);
-    assertGetUserRolesAndIsUserAuthorized(publicComponentId, false);
-    assertGetUserRolesAndIsUserAuthorized(publicComponentIdWithUserRole, false);
-    assertGetUserRolesAndIsUserAuthorized(publicFilesComponentId, false);
-    assertGetUserRolesAndIsUserAuthorized(publicFilesComponentIdWithUserRole, false);
-    assertGetUserRolesAndIsUserAuthorized(componentId, false);
-    assertGetUserRolesAndIsUserAuthorized(forbiddenComponent, false);
-    assertGetUserRolesAndIsUserAuthorized(componentIdWithTopicRigths, false);
-    assertGetUserRolesAndIsUserAuthorized(componentIdWithoutTopicRigths, false);
-    assertGetUserRolesAndIsUserAuthorized(personalComponentId, false);
+    assertGetUserRolesAndIsUserAuthorized(null, operation);
+    assertGetUserRolesAndIsUserAuthorized(toolId, operation);
+    assertGetUserRolesAndIsUserAuthorized(componentAdminId, operation);
+    assertGetUserRolesAndIsUserAuthorized(publicComponentId, operation);
+    assertGetUserRolesAndIsUserAuthorized(publicComponentIdWithUserRole, operation);
+    assertGetUserRolesAndIsUserAuthorized(publicFilesComponentId, operation);
+    assertGetUserRolesAndIsUserAuthorized(publicFilesComponentIdWithUserRole, operation);
+    assertGetUserRolesAndIsUserAuthorized(componentId, operation);
+    assertGetUserRolesAndIsUserAuthorized(forbiddenComponent, operation);
+    assertGetUserRolesAndIsUserAuthorized(componentIdWithTopicRigths, operation);
+    assertGetUserRolesAndIsUserAuthorized(componentIdWithoutTopicRigths, operation);
+    assertGetUserRolesAndIsUserAuthorized(personalComponentId, operation);
   }
 
   /**
@@ -701,7 +744,7 @@ public class TestComponentAccessController {
    */
   @Test
   public void testGetUserRolesWithoutUserAndUnknownContext() {
-    assertGetUserRolesAndIsUserAuthorizedWithourUser();
+    assertGetUserRolesAndIsUserAuthorizedWithoutUser(NONE);
   }
 
   /**
@@ -709,8 +752,7 @@ public class TestComponentAccessController {
    */
   @Test
   public void testGetUserRolesWithoutUserAndPersistContext() {
-    accessControlContext.onOperationsOf(AccessControlOperation.PERSIST_ACTIONS.iterator().next());
-    assertGetUserRolesAndIsUserAuthorizedWithourUser();
+    assertGetUserRolesAndIsUserAuthorizedWithoutUser(A_PERSIST_ACTION);
   }
 
   /**
@@ -718,8 +760,7 @@ public class TestComponentAccessController {
    */
   @Test
   public void testGetUserRolesWithoutUserAndDownloadContext() {
-    accessControlContext.onOperationsOf(AccessControlOperation.download);
-    assertGetUserRolesAndIsUserAuthorizedWithourUser();
+    assertGetUserRolesAndIsUserAuthorizedWithoutUser(AccessControlOperation.download);
   }
 
   /**
@@ -727,37 +768,48 @@ public class TestComponentAccessController {
    */
   @Test
   public void testGetUserRolesWithoutUserAndSharingContext() {
-    accessControlContext.onOperationsOf(AccessControlOperation.sharing);
-    assertGetUserRolesAndIsUserAuthorizedWithourUser();
+    assertGetUserRolesAndIsUserAuthorizedWithoutUser(AccessControlOperation.sharing);
   }
 
-  private void assertGetUserRolesAndIsUserAuthorizedWithourUser() {
-    assertGetUserRolesAndIsUserAuthorized(null, false);
-    assertGetUserRolesAndIsUserAuthorized(toolId, false);
-    assertGetUserRolesAndIsUserAuthorized(componentAdminId, false);
-    assertGetUserRolesAndIsUserAuthorized(publicComponentId, false);
-    assertGetUserRolesAndIsUserAuthorized(publicComponentIdWithUserRole, false);
-    assertGetUserRolesAndIsUserAuthorized(publicFilesComponentId, false);
-    assertGetUserRolesAndIsUserAuthorized(publicFilesComponentIdWithUserRole, false);
-    assertGetUserRolesAndIsUserAuthorized(componentId, false);
-    assertGetUserRolesAndIsUserAuthorized(forbiddenComponent, false);
-    assertGetUserRolesAndIsUserAuthorized(componentIdWithTopicRigths, false);
-    assertGetUserRolesAndIsUserAuthorized(componentIdWithoutTopicRigths, false);
-    assertGetUserRolesAndIsUserAuthorized(personalComponentId, false);
+  private void assertGetUserRolesAndIsUserAuthorizedWithoutUser(
+      final AccessControlOperation operation) {
+    assertGetUserRolesAndIsUserAuthorized(null, operation);
+    assertGetUserRolesAndIsUserAuthorized(toolId, operation);
+    assertGetUserRolesAndIsUserAuthorized(componentAdminId, operation);
+    assertGetUserRolesAndIsUserAuthorized(publicComponentId, operation);
+    assertGetUserRolesAndIsUserAuthorized(publicComponentIdWithUserRole, operation);
+    assertGetUserRolesAndIsUserAuthorized(publicFilesComponentId, operation);
+    assertGetUserRolesAndIsUserAuthorized(publicFilesComponentIdWithUserRole, operation);
+    assertGetUserRolesAndIsUserAuthorized(componentId, operation);
+    assertGetUserRolesAndIsUserAuthorized(forbiddenComponent, operation);
+    assertGetUserRolesAndIsUserAuthorized(componentIdWithTopicRigths, operation);
+    assertGetUserRolesAndIsUserAuthorized(componentIdWithoutTopicRigths, operation);
+    assertGetUserRolesAndIsUserAuthorized(personalComponentId, operation);
+  }
+
+  private boolean isPersistOperation(final AccessControlOperation operation) {
+    return AccessControlOperation.PERSIST_ACTIONS.contains(operation);
   }
 
   /**
    * Centralization.
    */
   private void assertGetUserRolesAndIsUserAuthorized(String instanceId,
-      boolean expectedUserAuthorization, SilverpeasRole... expectedUserRoles) {
+      final AccessControlOperation operation, SilverpeasRole... expectedUserRoles) {
     initTest();
+    final AccessControlContext accessControlContext = AccessControlContext.init();
+    if (operation != null) {
+      accessControlContext.onOperationsOf(operation);
+    }
     final Set<SilverpeasRole> componentUserRole =
         instance.getUserRoles(currentUserId, instanceId, accessControlContext);
+    final boolean expectedUserAuthorization;
     if (expectedUserRoles.length > 0) {
       assertThat("User roles on " + instanceId, componentUserRole, contains(expectedUserRoles));
+      expectedUserAuthorization = true;
     } else {
       assertThat("User roles on " + instanceId, componentUserRole, empty());
+      expectedUserAuthorization = false;
     }
     boolean result = instance.isUserAuthorized(componentUserRole);
     assertEquals("User authorized on " + instanceId, expectedUserAuthorization, result);
@@ -803,7 +855,6 @@ public class TestComponentAccessController {
 
   private void initTest() {
     instance = new ComponentAccessController(controller);
-    accessControlContext = AccessControlContext.init();
     CacheServiceProvider.getRequestCacheService().clearAllCaches();
   }
 }

--- a/core-war/src/main/webapp/util/javaScript/angularjs/directives/calendar/silverpeas-calendar-event-form-main.jsp
+++ b/core-war/src/main/webapp/util/javaScript/angularjs/directives/calendar/silverpeas-calendar-event-form-main.jsp
@@ -74,7 +74,7 @@
       <div class="champs">
         <span class="txtnav" ng-if="$ctrl.potentialCalendars.length == 1 || !$ctrl.isFirstEventOccurrence()">{{$ctrl.data.calendar.title}}</span>
         <select ng-if="$ctrl.potentialCalendars.length > 1 && $ctrl.isFirstEventOccurrence()" ng-model="$ctrl.data.calendar"
-                ng-options="calendar as calendar.title for calendar in $ctrl.potentialCalendars | orderBy: 'createdDate' track by calendar.id"
+                ng-options="calendar as calendar.title for calendar in $ctrl.potentialCalendars | sortedCalendars track by calendar.id"
                 id="sp_cal_event_form_main_c" class="txtnav">
         </select>
       </div>

--- a/core-war/src/main/webapp/util/javaScript/angularjs/directives/calendar/silverpeas-calendar-list-item.jsp
+++ b/core-war/src/main/webapp/util/javaScript/angularjs/directives/calendar/silverpeas-calendar-list-item.jsp
@@ -45,7 +45,7 @@
           <a href="#" ng-click="$ctrl.view({calendar:$ctrl.calendar})">Info</a>
         </li>
         <li ng-if="(!$ctrl.calendar.userPersonal || $ctrl.calendar.canBeDeleted) && !$ctrl.calendar.canBeRemoved">
-          <a href="{{$ctrl.calendar.uri}}/export/ical" target="_blank" >Exporter</a>
+          <a href="{{$ctrl.calendar.uri}}/export/ical">Exporter</a>
         </li>
         <li ng-if="$ctrl.calendar.isSynchronized">
           <a href="#" ng-click="$ctrl.synchronize({calendar: $ctrl.calendar})">Synchroniser</a>

--- a/core-war/src/main/webapp/util/javaScript/angularjs/directives/calendar/silverpeas-calendar-list.jsp
+++ b/core-war/src/main/webapp/util/javaScript/angularjs/directives/calendar/silverpeas-calendar-list.jsp
@@ -29,7 +29,7 @@
 </silverpeas-calendar-management>
 <div class="calendars">
   <ul ng-if="$ctrl.calendars && $ctrl.calendars.length">
-    <li ng-repeat="calendar in $ctrl.calendars | orderBy: 'createdDate' track by calendar.id">
+    <li ng-repeat="calendar in $ctrl.calendars | sortedCalendars track by calendar.id" ng-class="calendar.__cssListClasses">
       <silverpeas-calendar-list-item calendar="calendar"
                                      calendar-potential-colors="$ctrl.calendarPotentialColors"
                                      on-calendar-color-select="$ctrl.onCalendarColorSelect({calendar:calendar,color:color})"

--- a/core-war/src/main/webapp/util/javaScript/angularjs/directives/calendar/silverpeas-calendar-management.jsp
+++ b/core-war/src/main/webapp/util/javaScript/angularjs/directives/calendar/silverpeas-calendar-management.jsp
@@ -138,7 +138,7 @@
     <div class="champs" ng-if="$ctrl.importEventCalendar">
       <span class="txtlibform">${icalFileImportIntoLabel}</span>
       <select ng-model="$ctrl.importEventCalendar"
-              ng-options="calendar as calendar.title for calendar in $ctrl.potentialCalendars | orderBy: 'createdDate' track by calendar.id"
+              ng-options="calendar as calendar.title for calendar in $ctrl.potentialCalendars | sortedCalendars track by calendar.id"
               class="txtnav">
       </select>
     </div>

--- a/core-war/src/main/webapp/util/javaScript/angularjs/directives/calendar/silverpeas-calendar.js
+++ b/core-war/src/main/webapp/util/javaScript/angularjs/directives/calendar/silverpeas-calendar.js
@@ -127,6 +127,50 @@
     };
   });
 
+  /**
+   * Custom AngularJS filter in charge of sorting the given array of calendars.
+   * The sorting is the one of {@link SilverpeasCalendarTools#sortCalendars}.
+   * <br/>
+   * CSS classes are also computed into '__cssListClasses' attribute of each calendar of the sorted
+   * list:
+   * <ul>
+   * <li>'calendar-on-host-instance' class when the component instance id of the calendar is the same
+   * as the one which is displaying (hosting) the calendar. The instance id of the host is read
+   * from attribute 'component' of context data</li>
+   * <li>'calendar-[calendar component instance identifier]' class (for client specific stuffs)</li>
+   * <li>'first-calendar-on-other-instance' to identify calendar component instance ruptures</li>
+   * <li>'main-calendar' to identify directly a main calendar</li>
+   * </ul>
+   */
+  angular.module('silverpeas.directives').filter('sortedCalendars', ['context', function(context) {
+    return function(items) {
+      let sortedCalendars = [];
+      Array.prototype.push.apply(sortedCalendars, items);
+      let instanceIdHost = typeof context === 'object' ? context.component : undefined;
+      SilverpeasCalendarTools.sortCalendars(sortedCalendars, instanceIdHost);
+      var previousInstanceId = '';
+      sortedCalendars.forEach(function(calendar) {
+        if (!calendar.__cssListClasses) {
+          let __cssListClasses = '';
+          let currentInstanceId = calendar.componentInstanceId();
+          __cssListClasses = 'calendar-' + currentInstanceId;
+          if (currentInstanceId === instanceIdHost) {
+            __cssListClasses += ' calendar-on-host-instance';
+          }
+          if (previousInstanceId && previousInstanceId !== currentInstanceId) {
+            __cssListClasses += ' first-calendar-on-other-instance';
+          }
+          if (calendar.main) {
+            __cssListClasses += ' main-calendar';
+          }
+          calendar.__cssListClasses = __cssListClasses;
+          previousInstanceId = currentInstanceId;
+        }
+      });
+      return sortedCalendars;
+    };
+  }]);
+
   angular.module('silverpeas.directives').directive('silverpeasCalendar',
       ['$compile', '$timeout', 'context', 'CalendarService', 'visibleFilter',
         function($compile, $timeout, context, CalendarService, visibleFilter) {

--- a/core-war/src/main/webapp/util/javaScript/angularjs/services/calendar/silverpeas-calendar.js
+++ b/core-war/src/main/webapp/util/javaScript/angularjs/services/calendar/silverpeas-calendar.js
@@ -278,6 +278,11 @@
           this.$onInit = function() {
             this.events = CalendarEventOccurrence.occurrences(this.uri);
             this.isSynchronized = StringUtil.isDefined(this.externalUrl);
+            SilverpeasCalendarTools.applyCalendarEntityAttributeWrappers(this);
+            if (context.component !== this.componentInstanceId()) {
+              this.canBeModified = false;
+              this.canBeDeleted = false;
+            }
           }
         };
 

--- a/core-war/src/main/webapp/util/javaScript/silverpeas.js
+++ b/core-war/src/main/webapp/util/javaScript/silverpeas.js
@@ -232,6 +232,12 @@ if (!String.prototype.asInteger) {
   };
 }
 
+if (!String.prototype.normalizeByRemovingAccent) {
+  String.prototype.normalizeByRemovingAccent = function() {
+    return this.normalize('NFD').replace(/[\u0300-\u036f]/g, "");
+  };
+}
+
 if (!Number.prototype.roundDown) {
   Number.prototype.roundDown = function(digit) {
     if (digit || digit === 0) {
@@ -307,7 +313,7 @@ if (!window.StringUtil) {
     };
     this.normalizeByRemovingAccent = function(aString) {
       if(_self.isDefined(aString)) {
-        return aString.normalize('NFD').replace(/[\u0300-\u036f]/g, "");
+        return aString.normalizeByRemovingAccent();
       }
       return aString;
     };

--- a/core-war/src/main/webapp/util/styleSheets/silverpeas-calendar.css
+++ b/core-war/src/main/webapp/util/styleSheets/silverpeas-calendar.css
@@ -214,12 +214,23 @@ silverpeas-calendar-list ul {
   display: inline-flex;
   margin: 0.25em 0 0.15em 0;
   padding: 0;
+  flex-flow: wrap;
 }
 
 silverpeas-calendar-list ul li {
   list-style: none;
   padding: 2px;
   margin-right: 10px;
+}
+
+silverpeas-calendar-list ul li.first-calendar-on-other-instance:before,
+silverpeas-calendar-list .participation-calendars li:before {
+  content:' | ';
+  margin-right:1em;
+  color: #000 ;
+  vertical-align:middle;
+  display:inline-block;
+  height:30px;
 }
 
 silverpeas-calendar-list ul li .synchronized {

--- a/core-web/src/main/java/org/silverpeas/core/web/util/viewgenerator/html/layout/BodyPartLayoutTag.java
+++ b/core-web/src/main/java/org/silverpeas/core/web/util/viewgenerator/html/layout/BodyPartLayoutTag.java
@@ -38,9 +38,14 @@ public class BodyPartLayoutTag extends SilverpeasLayout {
   private static final long serialVersionUID = 7740509977305998444L;
 
   private String cssClass;
+  private String ngController;
 
   public void setCssClass(final String cssClass) {
     this.cssClass = cssClass;
+  }
+
+  public void setNgController(final String ngController) {
+    this.ngController = ngController;
   }
 
   @Override
@@ -52,6 +57,9 @@ public class BodyPartLayoutTag extends SilverpeasLayout {
     if (isDefined(cssClass)) {
       body.setClass(cssClass);
     }
+    if (isDefined(ngController)) {
+      body.addAttribute("ng-controller", ngController);
+    }
     body.addElement(getBodyContent().getString());
     renderAngularJs(body);
     body.output(pageContext.getOut());
@@ -60,7 +68,7 @@ public class BodyPartLayoutTag extends SilverpeasLayout {
 
   private void renderAngularJs(final body body) {
     final String angularJsAppName = getParent().getAngularJsAppName();
-    if (isDefined(angularJsAppName)) {
+    if (isDefined(angularJsAppName) && !getParent().isAngularJsAppInitializedManually()) {
       // declare the module myapp and its dependencies (here in the silverpeas module)
       body.addElement(scriptContent("var myapp = angular.module('" + angularJsAppName + "', ['silverpeas.services', 'silverpeas.directives'])"));
     }

--- a/core-web/src/main/java/org/silverpeas/core/web/util/viewgenerator/html/layout/HtmlLayoutTag.java
+++ b/core-web/src/main/java/org/silverpeas/core/web/util/viewgenerator/html/layout/HtmlLayoutTag.java
@@ -52,12 +52,22 @@ public class HtmlLayoutTag extends SilverpeasLayout {
 
   private String angularJsAppName;
 
+  private boolean angularJsAppInitializedManually;
+
   public void setAngularJsAppName(final String angularJsAppName) {
     this.angularJsAppName = angularJsAppName;
   }
 
   String getAngularJsAppName() {
     return angularJsAppName;
+  }
+
+  public void setAngularJsAppInitializedManually(final boolean angularJsAppInitializedManually) {
+    this.angularJsAppInitializedManually = angularJsAppInitializedManually;
+  }
+
+  boolean isAngularJsAppInitializedManually() {
+    return angularJsAppInitializedManually;
   }
 
   @Override

--- a/core-web/src/main/java/org/silverpeas/core/webapi/calendar/CalendarWebManager.java
+++ b/core-web/src/main/java/org/silverpeas/core/webapi/calendar/CalendarWebManager.java
@@ -80,8 +80,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static java.util.Collections.emptyList;
-import static java.util.Collections.singletonList;
+import static java.util.Collections.*;
 import static org.silverpeas.core.calendar.CalendarEventOccurrence.COMPARATOR_BY_DATE_ASC;
 import static org.silverpeas.core.calendar.CalendarEventUtil.getDateWithOffset;
 import static org.silverpeas.core.contribution.attachment.AttachmentServiceProvider.getAttachmentService;
@@ -270,7 +269,7 @@ public class CalendarWebManager {
    * @return the list of calendars.
    */
   public List<Calendar> getCalendarsHandledBy(final String componentInstanceId) {
-    return Calendar.getByComponentInstanceId(componentInstanceId);
+    return getCalendarsHandledBy(singleton(componentInstanceId));
   }
 
   /**

--- a/core-web/src/main/resources/META-INF/viewGenerator.tld
+++ b/core-web/src/main/resources/META-INF/viewGenerator.tld
@@ -2620,6 +2620,12 @@
       <rtexprvalue>true</rtexprvalue>
       <type>java.lang.String</type>
     </attribute>
+    <attribute>
+      <name>angularJsAppInitializedManually</name>
+      <required>false</required>
+      <rtexprvalue>false</rtexprvalue>
+      <type>boolean</type>
+    </attribute>
   </tag>
   <tag>
     <description>HEAD HTML TAG OVERRIDE</description>
@@ -2668,6 +2674,12 @@
     </attribute>
     <attribute>
       <name>cssClass</name>
+      <required>false</required>
+      <rtexprvalue>true</rtexprvalue>
+      <type>java.lang.String</type>
+    </attribute>
+    <attribute>
+      <name>ngController</name>
       <required>false</required>
       <rtexprvalue>true</rtexprvalue>
       <type>java.lang.String</type>


### PR DESCRIPTION
- adding common calendar sorting for JavaScript calendar APIs (wiring Silverpeas's calendar list component)
- it is not possible to modify or delete a calendar displayed from an other component instance than the one it is hosted by
- export a calendar does not open a blank tab anymore- adding a normalization without method directly to JavaScript String instances
- fixing the computing of calendar access about modification operation case (the user MUST be an admin)
- fixing the ComponentAccessController which was authorizing access to a user role into modification context of a component instance
- adding some attributes to view:sp-page & co tags
- refactoring/centralizing some code

Linked to PR https://github.com/Silverpeas/Silverpeas-Components/pull/694

Checking integration with https://easybacklog.com/accounts/4659/backlogs/355925