### PR TITLE
Feature #11801: The LibreOffice/Online is now usable from a Silverpeas platform in order to edit the contribution file attachments.

### DIFF
--- a/core-api/src/main/java/org/silverpeas/core/annotation/WebService.java
+++ b/core-api/src/main/java/org/silverpeas/core/annotation/WebService.java
@@ -25,7 +25,6 @@ package org.silverpeas.core.annotation;
 
 import javax.enterprise.context.RequestScoped;
 import javax.enterprise.inject.Stereotype;
-import javax.inject.Named;
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/core-api/src/main/java/org/silverpeas/core/notification/system/AbstractResourceEvent.java
+++ b/core-api/src/main/java/org/silverpeas/core/notification/system/AbstractResourceEvent.java
@@ -68,19 +68,14 @@ public abstract class AbstractResourceEvent<T extends Serializable> implements R
    */
   public AbstractResourceEvent(Type type, @NotNull T... resource) {
     this.type = type;
-    switch (type) {
-      case CREATION:
-        this.transition = StateTransition.transitionBetween(null, resource[0]);
-        break;
-      case UPDATE:
-        this.transition = StateTransition.transitionBetween(resource[0], resource[1]);
-        break;
-      case REMOVING:
-        this.transition = StateTransition.transitionBetween(resource[0], resource[0]);
-        break;
-      case DELETION:
-        this.transition = StateTransition.transitionBetween(resource[0], null);
-        break;
+    if (type == Type.CREATION) {
+      this.transition = StateTransition.transitionBetween(null, resource[0]);
+    } else if (type == Type.UNLOCK || type == Type.UPDATE) {
+      this.transition = StateTransition.transitionBetween(resource[0], resource[1]);
+    } else if (type == Type.REMOVING) {
+      this.transition = StateTransition.transitionBetween(resource[0], resource[0]);
+    } else if (type == Type.DELETION) {
+      this.transition = StateTransition.transitionBetween(resource[0], null);
     }
   }
 

--- a/core-api/src/main/java/org/silverpeas/core/notification/system/ResourceEvent.java
+++ b/core-api/src/main/java/org/silverpeas/core/notification/system/ResourceEvent.java
@@ -128,7 +128,11 @@ public interface ResourceEvent<T extends Serializable> extends Serializable {
      * The notification is about the deletion of a resource in Silverpeas. When a resource is
      * deleted, it is then nonexistent and nonrecoverable.
      */
-    DELETION;
-
+    DELETION,
+    /**
+     * The notification is about the unlock of a resource in Silverpeas. When a resource is
+     * unlocked, it is again available.
+     */
+    UNLOCK;
   }
 }

--- a/core-api/src/main/java/org/silverpeas/core/notification/system/ResourceEventListener.java
+++ b/core-api/src/main/java/org/silverpeas/core/notification/system/ResourceEventListener.java
@@ -78,6 +78,14 @@ public interface ResourceEventListener<T extends ResourceEvent> {
   }
 
   /**
+   * An event on the unlock of a resource has be listened. By default, this method does nothing.
+   * @param event the event on the unlock of a resource.
+   * @throws java.lang.Exception if an error occurs while treating the event.
+   */
+  default void onUnlock(final T event) throws Exception {
+  }
+
+  /**
    * Dispatches the treatment of the specified event to the correct method according to its type:
    * <ul>
    *   <li>{@code org.silverpeas.core.notification.system.ResourceEventListener#onCreation(ResourceEvent} for
@@ -103,6 +111,9 @@ public interface ResourceEventListener<T extends ResourceEvent> {
           break;
         case UPDATE:
           onUpdate(event);
+          break;
+        case UNLOCK:
+          onUnlock(event);
           break;
         case REMOVING:
           onRemoving(event);

--- a/core-api/src/main/java/org/silverpeas/core/security/session/SilverpeasUserSession.java
+++ b/core-api/src/main/java/org/silverpeas/core/security/session/SilverpeasUserSession.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2000 - 2020 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.security.session;
+
+import org.silverpeas.core.admin.user.model.User;
+
+/**
+ * Represents a session opened by a {@link org.silverpeas.core.admin.user.model.User}.
+ * @author silveryocha
+ */
+public interface SilverpeasUserSession {
+
+  /**
+   * Gets the unique identifier of the session.
+   * @return the unique identifier as string.
+   */
+  String getId();
+
+  /**
+   * Gets the user which as opened to session.
+   * @return a {@link User} instance.
+   */
+  User getUser();
+}

--- a/core-api/src/main/java/org/silverpeas/core/util/MemoizedSupplier.java
+++ b/core-api/src/main/java/org/silverpeas/core/util/MemoizedSupplier.java
@@ -54,4 +54,9 @@ public class MemoizedSupplier<T> implements Supplier<T> {
     }
     return value;
   }
+
+  public void clear() {
+    memoized = false;
+    value = null;
+  }
 }

--- a/core-api/src/main/java/org/silverpeas/core/util/security/SecuritySettings.java
+++ b/core-api/src/main/java/org/silverpeas/core/util/security/SecuritySettings.java
@@ -199,11 +199,18 @@ public class SecuritySettings {
     private Map<String, List<String>> settings = new ConcurrentHashMap<>();
 
     public void registerDefaultSourceInCSP(final String sourceURL) {
-      settings.computeIfAbsent(DEFAULT_SRC, k -> new ArrayList<>()).add(sourceURL);
+      register(sourceURL, DEFAULT_SRC);
     }
 
     public void registerDomainInCORS(final String domain) {
-      settings.computeIfAbsent(CORS, k -> new ArrayList<>()).add(domain);
+      register(domain, CORS);
+    }
+
+    private void register(final String domain, final String cors) {
+      final List<String> list = settings.computeIfAbsent(cors, k -> new ArrayList<>());
+      if (!list.contains(domain)) {
+        list.add(domain);
+      }
     }
 
     List<String> getDefaultSourcesInCSP() {

--- a/core-api/src/main/java/org/silverpeas/core/wopi/WopiEdition.java
+++ b/core-api/src/main/java/org/silverpeas/core/wopi/WopiEdition.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2000 - 2020 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.wopi;
+
+/**
+ * Represents the preparation of a wopi edition.
+ * <p>
+ *   This object provides the following data:
+ *   <ul>
+ *     <li>a {@link WopiFile}, the aimed file by the edition</li>
+ *     <li>a {@link WopiUser}, the editor</li>
+ *     <li>a client base URL that permits to access the online editor that takes in charge de
+ *     {@link WopiFile#mimeType()}</li>
+ *   </ul>
+ * </p>
+ * @author silveryocha
+ */
+public class WopiEdition {
+
+  private WopiFile file;
+  private WopiUser user;
+  private String clientBaseUrl;
+
+  protected WopiEdition(final WopiFile file, final WopiUser user, final String clientBaseUrl) {
+    this.file = file;
+    this.user = user;
+    this.clientBaseUrl = clientBaseUrl;
+  }
+
+  /**
+   * Gets the WOPI file of the edition.
+   * @return a {@link WopiFile} instance.
+   */
+  public WopiFile getFile() {
+    return file;
+  }
+
+  /**
+   * Gets the WOPI user which is editing the file.
+   * @return a {@link WopiUser} instance.
+   */
+  public WopiUser getUser() {
+    return user;
+  }
+
+  /**
+   * The client base URL is the base URL which permits to load the WOPI editor which takes in
+   * charge the {@link WopiFile} into the WEB browser.
+   * @return an URL as string.
+   */
+  public String getClientBaseUrl() {
+    return clientBaseUrl;
+  }
+}

--- a/core-api/src/main/java/org/silverpeas/core/wopi/WopiFile.java
+++ b/core-api/src/main/java/org/silverpeas/core/wopi/WopiFile.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright (C) 2000 - 2020 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.wopi;
+
+import org.apache.commons.io.FilenameUtils;
+import org.silverpeas.core.ResourceReference;
+import org.silverpeas.core.admin.user.model.User;
+import org.silverpeas.core.security.Securable;
+import org.silverpeas.core.util.Charsets;
+import org.silverpeas.core.util.StringUtil;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.time.OffsetDateTime;
+import java.util.Optional;
+import java.util.StringJoiner;
+
+import static java.time.ZoneOffset.UTC;
+
+/**
+ * Representation of a Silverpeas's file exposed to the Office infrastructure.
+ * <p>
+ * The instance is not immutable and data returned by different signatures of a same instance MAY
+ * not the same during the time.
+ * </p>
+ * @author silveryocha
+ */
+public abstract class WopiFile implements Securable {
+
+  private OffsetDateTime lastEditionDate;
+  private WopiFileLock lock;
+
+  /**
+   * Gets the date of last edition.
+   * @return an {@link OffsetDateTime} instance.
+   */
+  public OffsetDateTime getLastEditionDate() {
+    return this.lastEditionDate;
+  }
+
+  /**
+   * Gets the optional resource reference the file is linked to.
+   * @return an optional {@link ResourceReference}.
+   */
+  public abstract Optional<ResourceReference> linkedToResource();
+
+  /**
+   * Silverpeas's identifier identifies the file from point of view of Silverpeas's platform.
+   * <p>
+   * In most of case, {@link #id()} will return same identifier as {@link #silverpeasId()} returns.
+   * </p>
+   * <p>
+   * But sometimes, when a temporary view exists for a file and that the temporary view is the
+   * content exposed for modifications, {@link #silverpeasId()} returns the identifier of the
+   * document and {@link #id()} returns the identifier of the view (the one used by WOPI exchanges).
+   * </p>
+   * @return a unique identifier as string.
+   */
+  public abstract String silverpeasId();
+
+  /**
+   * A File ID is a string that represents a file being operated on via WOPI operations. A host
+   * must issue a unique ID for any file used by a WOPI client. The client will, in turn, include
+   * the file ID when making requests to the WOPI host. Thus, a host must be able to use the file
+   * ID to locate a particular file.
+   * <p>
+   * A file ID must:
+   * <ul>
+   * <li>Represent a single file.</li>
+   * <li>Be an URL-safe string because IDs are passed in URLs, principally via the WOPISrc
+   * parameter.</li>
+   * <li>Remain the same when the file is edited.</li>
+   * <li>Remain the same when the file is moved or renamed.</li>
+   * <li>Remain the same when any ancestor container, including the parent container, is renamed
+   * .</li>
+   * <li>In the case of shared files, the ID for a given file must be the same for every user that
+   * accesses the file.</li>
+   * </ul>
+   * </p>
+   * @return a unique identifier as string.
+   */
+  public String id() {
+    return silverpeasId();
+  }
+
+  /**
+   * A string that uniquely identifies the owner of the file. In most cases, the user who
+   * uploaded or created the file should be considered the owner.
+   * @return the {@link User} which is the owner.
+   */
+  public abstract User owner();
+
+  /**
+   * Gets the string name of the file, including extension, without a path. Used for display in user
+   * interface (UI), and determining the extension of the file.
+   * @return a string representing a file name.
+   */
+  public abstract String name();
+
+  /**
+   * Gets the extension of the file.
+   * @return a string representing a mime-type.
+   */
+  public String ext() {
+    return FilenameUtils.getExtension(name());
+  }
+
+  /**
+   * Gets the mime type of the file.
+   * @return a string representing a mime-type.
+   */
+  public abstract String mimeType();
+
+  /**
+   * Gets the size of the file in bytes.
+   * @return a long representing a file content length.
+   */
+  public abstract long size();
+
+  /**
+   * Gets an {@link OffsetDateTime} instance that represents the last time that the file was
+   * modified.
+   * @return an {@link OffsetDateTime}.
+   */
+  public abstract OffsetDateTime lastModificationDate();
+
+  /**
+   * The current version of the file based on the server’s file version schema, as a string. This
+   * value must change when the file changes, and version values must never repeat for a given file.
+   * @return a version value as string.
+   */
+  public String version() {
+    return StringUtil.asBase64((name() + "#" +
+        lastModificationDate().withOffsetSameInstant(UTC)).getBytes(Charsets.UTF_8));
+  }
+
+  /**
+   * Updates the content of underlying Silverpeas's file from data provided by the given
+   * {@link InputStream}.
+   * @param input an {@link InputStream} from which the data are written.
+   * @throws IOException when it is not possible to write into the physical file.
+   */
+  public abstract void updateFrom(final InputStream input) throws IOException;
+
+  /**
+   * Loads the content of the underlying Silverpeas's file into the given {@link OutputStream}.
+   * @param output the stream into which content file MUST be loaded.
+   * @throws IOException when it is not possible to read the physical file.
+   */
+  public abstract void loadInto(final OutputStream output) throws IOException;
+
+  /**
+   * Gets the current lock identifier.
+   * @return a string.
+   */
+  public WopiFileLock lock() {
+    if (lock == null) {
+      lock = new WopiFileLock();
+    }
+    return lock;
+  }
+
+  /**
+   * Updates the last edition date with the current date and time.
+   */
+  public void setLastEditionDateAtNow() {
+    this.lastEditionDate = OffsetDateTime.now();
+  }
+
+  @Override
+  public String toString() {
+    return new StringJoiner(", ", WopiFile.class.getSimpleName() + "[", "]")
+        .add("silverpeasId=" + silverpeasId())
+        .add("id=" + id())
+        .add("name=" + name())
+        .add("lastModificationDate=" + lastModificationDate())
+        .add("mimeType=" + mimeType())
+        .add("size=" + size())
+        .add("version=" + version())
+        .add("lock=" + lock())
+        .add("lastEditionDate=" + getLastEditionDate())
+        .toString();
+  }
+}

--- a/core-api/src/main/java/org/silverpeas/core/wopi/WopiFileEditionManager.java
+++ b/core-api/src/main/java/org/silverpeas/core/wopi/WopiFileEditionManager.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (C) 2000 - 2020 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.wopi;
+
+import org.silverpeas.core.security.session.SilverpeasUserSession;
+import org.silverpeas.core.util.ServiceProvider;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.BiFunction;
+
+/**
+ * In charge of the management of WOPI contexts.
+ * <p>
+ * WOPI services can use directly the implementation of this interface in order to use the provided
+ * functionalities.
+ * </p>
+ * @author silveryocha
+ */
+public interface WopiFileEditionManager {
+
+  static WopiFileEditionManager get() {
+    return ServiceProvider.getService(WopiFileEditionManager.class);
+  }
+
+  /**
+   * Notifies the manager of the number of users which are editing the given file at an instant.
+   * @param file a {@link WopiFile} a file.
+   * @param userIds set of wopi user identifiers.
+   */
+  void notifyEditionWith(final WopiFile file, final Set<String> userIds);
+
+  /**
+   * Gets the list of file edited by the given user.
+   * @param user a {@link WopiUser} instance.
+   * @return a list of {@link WopiFile}.
+   */
+  List<WopiFile> getEditedFilesBy(final WopiUser user);
+
+  /**
+   * Gets the list of users which are editor of the given file.
+   * @param file a {@link WopiFile} instance.
+   * @return a list of {@link WopiUser}.
+   */
+  List<WopiUser> getEditorsOfFile(final WopiFile file);
+
+  /**
+   * Enables the services.
+   * <p>
+   * This usable only in the case of WOPI is enable by setting property file.<br/>
+   * When enabled by setting file, it is possible the enable/disable the services in order to get
+   * as fast as possible control on WOPI exchanges.
+   * </p>
+   * @param enable true to enable, false to disable.
+   */
+  void enable(final boolean enable);
+
+  /**
+   * Indicates if the WOPI edition is enabled.
+   * @return true if enabled, false otherwise.
+   */
+  boolean isEnabled();
+
+  /**
+   * Indicates if given {@link WopiFile} is handled by WOPI client.
+   * @param file the wopi file to check.
+   * @return true if handled, false otherwise.
+   */
+  boolean isHandled(WopiFile file);
+
+  /**
+   * Prepares a WOPI edition from given data.
+   * <p>
+   * If WOPI is enabled and if the file is handled by the WOPI client, a {@link WopiEdition}
+   * instance is returned. It contains the necessary data to initialize an edition from the WEB
+   * services.
+   * </p>
+   * @param spUserSession the silverpeas session from which the edition is needed.
+   * @param file a Silverpeas's WOPI file.
+   * @return an optional {@link WopiEdition} instance.
+   */
+  Optional<WopiEdition> prepareEditionWith(SilverpeasUserSession spUserSession, WopiFile file);
+
+  /**
+   * Gets the edition context from a WOPI file identifier and an access token.
+   * <p>
+   * If no file exists into context against the given file identifier, then the given optional
+   * WOPI file to context initializer is empty.
+   * </p>
+   * <p>
+   * If no user exists into context against the given access token, then the given optional WOPI
+   * user to context initializer is empty.
+   * </p>
+   * @param fileId a file identifier as string.
+   * @param accessToken an access token as string.
+   * @param contextInitializer the context initializer.
+   * @param <R> the type of the context.
+   * @return an initialized context.
+   */
+  <R> R getEditionContextFrom(final String fileId, final String accessToken,
+      BiFunction<Optional<WopiUser>, Optional<WopiFile>, R> contextInitializer);
+
+  /**
+   * Revokes from the WOPI edition context the given WOPI user.
+   * <p>
+   * The revocation is done from instance data and not directly from the instance reference.
+   * </p>
+   * @param user a {@link WopiUser} instance.
+   */
+  void revokeUser(final WopiUser user);
+
+  /**
+   * Revokes from the WOPI edition context the given WOPI file.
+   * <p>
+   * The revocation is done from instance data and not directly from the instance reference.
+   * </p>
+   * @param file a {@link WopiFile} instance.
+   */
+  void revokeFile(final WopiFile file);
+
+  /**
+   * Gets the list of WOPI users from the context.
+   * @return a list of {@link WopiUser} instances.
+   */
+  List<WopiUser> listCurrentUsers();
+
+  /**
+   * Gets the list of WOPI files from the context.
+   * @return a list of {@link WopiFile} instances.
+   */
+  List<WopiFile> listCurrentFiles();
+}

--- a/core-api/src/main/java/org/silverpeas/core/wopi/WopiFileLock.java
+++ b/core-api/src/main/java/org/silverpeas/core/wopi/WopiFileLock.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2000 - 2020 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.wopi;
+
+import java.time.OffsetDateTime;
+import java.util.StringJoiner;
+
+import static java.time.OffsetDateTime.now;
+import static org.apache.commons.lang3.StringUtils.EMPTY;
+import static org.silverpeas.core.util.StringUtil.isDefined;
+
+/**
+ * This class permits to handle WOPI file locking from point of view of WOPI host.
+ * <p>
+ * When a lock is set, it is alive for 30 minutes.
+ * </p>
+ * @author silveryocha
+ */
+public class WopiFileLock {
+
+  private String id;
+  private OffsetDateTime lastLockDate;
+
+  protected WopiFileLock() {
+    clear();
+  }
+
+  /**
+   * Gets the identifier of the lock if any.
+   * @return a string if any, empty string if none or if the lock timer is over.
+   */
+  public String id() {
+    checkTimer();
+    return id;
+  }
+
+  /**
+   * Sets a new lock identifier.
+   * <p>
+   * The lock timer is set with {@link OffsetDateTime#now()}.
+   * </p>
+   * @param id a lock identifier.
+   */
+  public void setId(final String id) {
+    this.id = id;
+    lastLockDate = now();
+  }
+
+  /**
+   * Clears the lock identifier and the associated timer.
+   */
+  public void clear() {
+    id = EMPTY;
+    lastLockDate = null;
+  }
+
+  /**
+   * Indicates if a lock exists.
+   * <p>
+   * Even if {@link #setId(String)} or {@link #clear()} have not been called, if lock timer is
+   * over, no lock is concidered.
+   * </p>
+   * @return true if exists, false otherwise.
+   */
+  public boolean exists() {
+    checkTimer();
+    return isDefined(id) && lastLockDate != null;
+  }
+
+  private void checkTimer() {
+    if (lastLockDate != null && lastLockDate.plusMinutes(30).compareTo(now()) < 0) {
+      clear();
+    }
+  }
+
+  @Override
+  public String toString() {
+    return new StringJoiner(", ", WopiFileLock.class.getSimpleName() + "[", "]")
+        .add("id='" + id + "'").add("lastLockDate=" + lastLockDate).toString();
+  }
+}

--- a/core-api/src/main/java/org/silverpeas/core/wopi/WopiUser.java
+++ b/core-api/src/main/java/org/silverpeas/core/wopi/WopiUser.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2000 - 2020 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.wopi;
+
+import org.silverpeas.core.admin.user.model.User;
+
+import java.time.OffsetDateTime;
+import java.util.StringJoiner;
+import java.util.UUID;
+
+/**
+ * Representation of a WopiUser. It associates finally a Silverpeas's user with a WOPI access token.
+ * <p>
+ * An access token is created on instance creation.
+ * </p>
+ * @author silveryocha
+ */
+public abstract class WopiUser {
+  private final String spSessionId;
+  private final User user;
+  private String accessToken;
+  private OffsetDateTime lastEditionDate;
+
+  protected WopiUser(final String spSessionId, final User user) {
+    this.spSessionId = spSessionId;
+    this.user = user;
+    renewAccessToken();
+  }
+
+  /**
+   * Gets the WOPI user identifier.
+   * @return an identifier as string.
+   */
+  public abstract String getId();
+
+  /**
+   * Gets the date of last edition.
+   * @return an {@link OffsetDateTime} instance.
+   */
+  public OffsetDateTime getLastEditionDate() {
+    return this.lastEditionDate;
+  }
+
+  /**
+   * Gets identifier of the Silverpeas's session the WOPI user is linked to.
+   * @return a Silverpeas's session identifier.
+   */
+  public String getSilverpeasSessionId() {
+    return spSessionId;
+  }
+
+  /**
+   * Gets the Silverpeas's user.
+   * @return a {@link User} instance.
+   */
+  public User asSilverpeas() {
+    return user;
+  }
+
+  /**
+   * Gets the WOPI access token linked to the Silverpeas's user.
+   * @return a string representing a WOPI access token.
+   */
+  public String getAccessToken() {
+    return accessToken;
+  }
+
+  /**
+   * Updates the last edition date with the current date and time.
+   */
+  public void setLastEditionDateAtNow() {
+    this.lastEditionDate = OffsetDateTime.now();
+  }
+
+  public User getUser() {
+    return user;
+  }
+
+  /**
+   * Renews access token.
+   */
+  private void renewAccessToken() {
+    accessToken = UUID.randomUUID().toString();
+  }
+
+  @Override
+  public String toString() {
+    return new StringJoiner(", ", WopiUser.class.getSimpleName() + "[", "]")
+        .add("spSessionId=" + getSilverpeasSessionId()).add("user=" + getId())
+        .add("accessToken='" + getAccessToken() + "'")
+        .add("lastEditionDate='" + getLastEditionDate() + "'").toString();
+  }
+}

--- a/core-configuration/src/main/config/properties/org/silverpeas/chat/settings/chat.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/chat/settings/chat.properties
@@ -17,6 +17,13 @@ chat.servers.ice =
 # Silverpeas in order to authorize the connexions with the remote XMPP service from the web browser.
 chat.servers.xmpp =
 
+# Sometimes, it can be useful to indicates that the chat URL is a safe one in order to bypass
+# all SSL certificate validation which could be in error.
+# It can unlock some situations of temporary bad SSL certificates (expired for example).
+# true indicates that the URL is safe and that SSL validations can be bypassed.
+# false (default value) indicates that the URL MUST be verified if it is necessary.
+chat.servers.xmpp.safe =
+
 # The URL at which the XMPP server is listening for HTTP file transfers between users. Usually, this
 # property doesn't need to be set as it is discovered by the chat client when negotiating with the
 # XMPP server. Nevertheless, it has to be explicitly set if the XMPP server is behind a proxy or the

--- a/core-configuration/src/main/config/properties/org/silverpeas/jobManagerPeas/multilang/jobManagerPeasBundle.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/jobManagerPeas/multilang/jobManagerPeasBundle.properties
@@ -68,3 +68,4 @@ JMAP.active = Activer
 JMAP.desactive = D\u00e9sactiver
 JCIPHER=Cryptage de contenu
 JDV=Variables
+JWO=WOPI

--- a/core-configuration/src/main/config/properties/org/silverpeas/jobManagerPeas/multilang/jobManagerPeasBundle_de.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/jobManagerPeas/multilang/jobManagerPeasBundle_de.properties
@@ -71,3 +71,4 @@ JMAP.active = Aktivieren
 JMAP.desactive = Deaktivieren
 JCIPHER=Content-Verschl\u00e4sselung
 JDV=Variablen
+JWO=WOPI

--- a/core-configuration/src/main/config/properties/org/silverpeas/jobManagerPeas/multilang/jobManagerPeasBundle_en.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/jobManagerPeas/multilang/jobManagerPeasBundle_en.properties
@@ -67,3 +67,4 @@ JMAP.active = Enable
 JMAP.desactive = Disable
 JCIPHER=Content encryption
 JDV=Variables
+JWO=WOPI

--- a/core-configuration/src/main/config/properties/org/silverpeas/jobManagerPeas/multilang/jobManagerPeasBundle_fr.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/jobManagerPeas/multilang/jobManagerPeasBundle_fr.properties
@@ -68,3 +68,4 @@ JMAP.active = Activer
 JMAP.desactive = D\u00e9sactiver
 JCIPHER=Cryptage de contenu
 JDV=Variables
+JWO=WOPI

--- a/core-configuration/src/main/config/properties/org/silverpeas/util/attachment/Attachment.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/util/attachment/Attachment.properties
@@ -108,6 +108,9 @@ attachment.onlineEditing.customProtocol = true
 # the necessary external program
 attachment.onlineEditing.customProtocol.alert = true
 
+# Turn on this parameter to indicate that a document CAN be edited simultaneously by several users (Need WOPI enabled, see wopi.properties)
+attachment.onlineEditing.simultaneously.default = true
+
 # Turn on this parameter if metadata of a file must be used to fill data (title & description) of
 # an attachment. By default metadata are not used.
 attachment.data.fromMetadata = false

--- a/core-configuration/src/main/config/properties/org/silverpeas/util/attachment/multilang/attachment.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/util/attachment/multilang/attachment.properties
@@ -72,6 +72,7 @@ attachment.xmlForm.ToolTip = Informations compl\u00e9mentaires sur
 
 attachment.checkOutAndDownload = R\u00e9server et t\u00e9l\u00e9charger
 attachment.checkOutAndEditOnline = Editer en ligne
+attachment.checkOutAndEditOnlineWebBrowner=Editer dans le navigateur
 
 attachment.dialog.add = Ajout d'un fichier
 attachment.dialog.delete = Suppression du fichier
@@ -107,6 +108,8 @@ attachment.download.forbidReaders=Interdire le t\u00e9l\u00e9chargement aux lect
 attachment.download.allowReaders=Autoriser le t\u00e9l\u00e9chargement aux lecteurs
 attachment.displayAsContent.disable=Ne pas afficher en tant que contenu
 attachment.displayAsContent.enable=Afficher en tant que contenu
+attachment.editSimultaneously.disable=D\u00e9sactiver l'\u00e9dition en simultan\u00e9
+attachment.editSimultaneously.enable=Activer l'\u00e9dition en simultan\u00e9
 attachment.dialog.checkin.webdav.multilang.language.help=la langue dans laquelle le contenu \u00e9tait affich\u00e9 lors de la r\u00e9servation du document
 attachment.warning.translations=Ce document existe dans plusieurs langues...
 attachment.warning.translations.label=Attention \!

--- a/core-configuration/src/main/config/properties/org/silverpeas/util/attachment/multilang/attachment_de.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/util/attachment/multilang/attachment_de.properties
@@ -72,6 +72,7 @@ attachment.xmlForm.ToolTip = Weitere Informationen \u00fcber
 
 attachment.checkOutAndDownload = Sperren und downloaden
 attachment.checkOutAndEditOnline = bearbeiten Online
+attachment.checkOutAndEditOnlineWebBrowner=Online im Browser bearbeiten
 
 attachment.dialog.add=Hinzuf\u00fcgen einer Datei
 attachment.dialog.delete=L\u00f6schen Sie die Datei
@@ -107,6 +108,8 @@ attachment.download.forbidReaders=Forbid downloading for readers
 attachment.download.allowReaders=Allow downloading for readers
 attachment.displayAsContent.disable=Not display as content
 attachment.displayAsContent.enable=Display as content
+attachment.editSimultaneously.disable=Disable simultaneous editing
+attachment.editSimultaneously.enable=Enable simultaneous editing
 attachment.dialog.checkin.webdav.multilang.language.help=the language in which the content was displayed on the document reservation
 attachment.warning.translations=Dieses Dokument ist in mehreren Sprachen verf\u00fcgbar...
 attachment.warning.translations.label=Achtung\!

--- a/core-configuration/src/main/config/properties/org/silverpeas/util/attachment/multilang/attachment_en.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/util/attachment/multilang/attachment_en.properties
@@ -72,6 +72,7 @@ attachment.xmlForm.ToolTip = Additional informations about
 
 attachment.checkOutAndDownload = Lock and download
 attachment.checkOutAndEditOnline = Edit online
+attachment.checkOutAndEditOnlineWebBrowner=Edit online int the browser
 
 attachment.dialog.add = Adding a file
 attachment.dialog.delete=Deleting the file
@@ -107,6 +108,8 @@ attachment.download.forbidReaders=Forbid downloading for readers
 attachment.download.allowReaders=Allow downloading for readers
 attachment.displayAsContent.disable=Not display as content
 attachment.displayAsContent.enable=Display as content
+attachment.editSimultaneously.disable=Disable simultaneous editing
+attachment.editSimultaneously.enable=Enable simultaneous editing
 attachment.dialog.checkin.webdav.multilang.language.help=the language in which the content was displayed on the document reservation
 attachment.warning.translations=This document is available in several languages...
 attachment.warning.translations.label=Warning\!

--- a/core-configuration/src/main/config/properties/org/silverpeas/util/attachment/multilang/attachment_fr.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/util/attachment/multilang/attachment_fr.properties
@@ -73,6 +73,7 @@ attachment.xmlForm.ToolTip = Informations compl\u00e9mentaires sur
 
 attachment.checkOutAndDownload = R\u00e9server et t\u00e9l\u00e9charger
 attachment.checkOutAndEditOnline = Editer en ligne
+attachment.checkOutAndEditOnlineWebBrowner=Editer dans le navigateur
 
 attachment.dialog.add = Ajout d'un fichier
 attachment.dialog.delete = Suppression du fichier
@@ -108,6 +109,8 @@ attachment.download.forbidReaders=Interdire le t\u00e9l\u00e9chargement aux lect
 attachment.download.allowReaders=Autoriser le t\u00e9l\u00e9chargement aux lecteurs
 attachment.displayAsContent.disable=Ne pas afficher en tant que contenu
 attachment.displayAsContent.enable=Afficher en tant que contenu
+attachment.editSimultaneously.disable=D\u00e9sactiver l'\u00e9dition en simultan\u00e9
+attachment.editSimultaneously.enable=Activer l'\u00e9dition en simultan\u00e9
 attachment.dialog.checkin.webdav.multilang.language.help=la langue dans laquelle le contenu \u00e9tait affich\u00e9 lors de la r\u00e9servation du document
 attachment.warning.translations.label=Attention \!
 attachment.dialog.onlineEditing.customProtocol.button.edit=J'ai install\u00e9 le programme

--- a/core-configuration/src/main/config/properties/org/silverpeas/util/logging/wopiLogging.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/util/logging/wopiLogging.properties
@@ -1,0 +1,36 @@
+#
+# Copyright (C) 2000 - 2019 Silverpeas
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# As a special exception to the terms and conditions of version 3.0 of
+# the GPL, you may redistribute this Program in connection with Free/Libre
+# Open Source Software ("FLOSS") applications as described in Silverpeas's
+# FLOSS exception.  You should have received a copy of the text describing
+# the FLOSS exception, and it is also available here:
+# "https://www.silverpeas.org/legal/floss_exception.html"
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+#
+# Logger definition.
+# Each logger is defined by its unique namespace and by a logging level.
+#
+# - namespace: identifies uniquely a logger and represents the hierarchical category to which
+#              messages are logged with the logger. Each substring before a dot is the namespace
+#              of a parent logger.
+# - level: defines the minimum level at which will be accepted the logged messages. If not
+#          set, the first defined parent logger's level will be then taken into account. Possible
+#          value is: ERROR, WARNING, INFO, DEBUG
+#
+namespace=silverpeas.core.wopi

--- a/core-configuration/src/main/config/properties/org/silverpeas/wopi/multilang/wopi.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/wopi/multilang/wopi.properties
@@ -1,0 +1,43 @@
+#
+# Copyright (C) 2000 - 2020 Silverpeas
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# As a special exception to the terms and conditions of version 3.0 of
+# the GPL, you may redistribute this Program in connection with Free/Libre
+# Open Source Software ("FLOSS") applications as described in Silverpeas's
+# FLOSS exception.  You should have received a copy of the text describing
+# the FLOSS exception, and it is also available here:
+# "https://www.silverpeas.org/legal/floss_exception.html"
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+wopi.breadcrumb=WOPI exchange management
+wopi.info.disabled=WOPI exchanges are deactivated for now.<br/>You can again activate them from the menu.
+wopi.client.admin.url=Access WOPI client administration
+wopi.action.enable=Activate exchanges
+wopi.action.disable=Disactivate exchanges
+wopi.action.disable.confirm=Are you sure you want to deactivate exchanges?
+wopi.action.disable.confirm.help=Users and files will be all revoked.
+wopi.action.selection.revoke=Revoke selection
+wopi.action.selection.revoke.confirm=Are you sure you want to revoke your selection?
+wopi.action.all.revoke=Revoke all
+wopi.action.all.revoke.confirm=Are you sure you want to revoke all?
+wopi.user.name=User
+wopi.user.editedFiles={0,choice, 1#Edited document| 1<Edited documents}
+wopi.user.editedFiles.nb=Total of edited documents
+wopi.user.lastEdition=Last edition
+wopi.file.name=File
+wopi.file.location=Location
+wopi.file.editors={0,choice, 1#Editor| 1<Editors}
+wopi.file.editors.nb=Total of editors
+wopi.file.lastEdition=Lest edition

--- a/core-configuration/src/main/config/properties/org/silverpeas/wopi/multilang/wopi_fr.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/wopi/multilang/wopi_fr.properties
@@ -1,0 +1,43 @@
+#
+# Copyright (C) 2000 - 2020 Silverpeas
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# As a special exception to the terms and conditions of version 3.0 of
+# the GPL, you may redistribute this Program in connection with Free/Libre
+# Open Source Software ("FLOSS") applications as described in Silverpeas's
+# FLOSS exception.  You should have received a copy of the text describing
+# the FLOSS exception, and it is also available here:
+# "https://www.silverpeas.org/legal/floss_exception.html"
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+wopi.breadcrumb=Gestion des \u00e9changes WOPI
+wopi.info.disabled=Les \u00e9changes WOPI sont momentan\u00e9ment d\u00e9sactiv\u00e9s.<br/>Vous pouvez les r\u00e9activer \u00e0 partir du menu.
+wopi.client.admin.url=Acc\u00e9der \u00e0 l''administration du WOPI client
+wopi.action.enable=Activer les \u00e9changes
+wopi.action.disable=D\u00e9sactiver les \u00e9changes
+wopi.action.disable.confirm=Etes-vous s\u00fbr(e) de vouloir d\u00e9sactiver les \u00e9changes ?
+wopi.action.disable.confirm.help=Les utilisateurs et fichiers seront tous r\u00e9voqu\u00e9s.
+wopi.action.selection.revoke=R\u00e9voquer la s\u00e9lection
+wopi.action.selection.revoke.confirm=Etes-vous s\u00fbr(e) de vouloir r\u00e9voquer d\u00e9finitivement votre s\u00e9lection ?
+wopi.action.all.revoke=Tout r\u00e9voquer
+wopi.action.all.revoke.confirm=Etes-vous s\u00fbr(e) de vouloir tout r\u00e9voquer ?
+wopi.user.name=Utilisateur
+wopi.user.editedFiles = {0,choice, 1#Document \u00e9dit\u00e9| 1<Documents \u00e9dit\u00e9s}
+wopi.user.editedFiles.nb=Nb de documents en \u00e9dition
+wopi.user.lastEdition=Derni\u00e8re \u00e9dition
+wopi.file.name=Fichier
+wopi.file.location=Emplacement
+wopi.file.editors={0,choice, 1#\u00c9diteur| 1<\u00c9diteurs}
+wopi.file.editors.nb=Nb d'\u00e9diteurs
+wopi.file.lastEdition=Derni\u00e8re \u00e9dition

--- a/core-configuration/src/main/config/properties/org/silverpeas/wopi/wopiSettings.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/wopi/wopiSettings.properties
@@ -1,0 +1,75 @@
+#
+# Copyright (C) 2000 - 2020 Silverpeas
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# As a special exception to the terms and conditions of version 3.0 of
+# the GPL, you may redistribute this Program in connection with Free/Libre
+# Open Source Software ("FLOSS") applications as described in Silverpeas's
+# FLOSS exception.  You should have received a copy of the text describing
+# the FLOSS exception, and it is also available here:
+# "https://www.silverpeas.org/legal/floss_exception.html"
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+# Permits to enable or not the WOPI exchanges.
+wopi.enabled = false
+
+# Permits to enable the lock feature on WOPI exchanges (not necessary with LibreOffice Online).
+# For LibreOffice by default
+wopi.lock.enabled = false
+
+# Timestamp verification can be done on put file operation. The request header containing the
+# timestamp to verify MUST be specified to enable the check.
+# For LibreOffice by default
+wopi.putFile.timestamp.field = X-LOOL-WOPI-Timestamp
+
+# When timestamp verification is enabled, in case of conflict, a json response is required.
+# This parameter MUST contains the entirely JSON response needed by the WOPI client.
+# For LibreOffice by default
+wopi.putFile.timestamp.conflict.json.response = {"LOOLStatusCode":1010}
+
+# This field name is looked into request headers in order to get an information about a close
+# of an editor on a particular file.
+# For LibreOffice by default
+wopi.client.exit.field=X-LOOL-WOPI-IsExitSave
+
+# The base URL of the WOPI host. If empty, the WOPI host is the Silverpeas's server itself.
+# So no need to specify this parameter in most of cases
+wopi.host.service.baseUrl =
+
+# The base URL of the WOPI client (LibreOffice Online for example)
+wopi.client.baseUrl =
+
+# The path to discover the capabilities of client.
+# For LibreOffice by default
+wopi.client.discovery.path = /hosting/discovery
+
+# The time to live in hours of the discovery cache
+wopi.client.discovery.timeToLive = 12
+
+# The path to access WOPI client administration.
+# For LibreOffice by default
+wopi.client.admin.path = /loleaflet/dist/admin/admin.html
+
+# Permits to set an id prefix in order to ensure a consistent unique identifier from WOPI point of view.
+wopi.user.id.prefix =
+
+# Some parts of the user interface can be hidden or shown based or what the integration needs.
+# The UI defaults MUST be set on iframe loading.
+# In Silverpeas's system, it is done by a hidden input.
+# See https://github.com/LibreOffice/online/blob/master/wsd/reference.md#user-interface-modifications
+wopi.ui.defaults =
+
+# The name of the hidden input in charge of UI defaults
+wopi.ui.defaults.param.name = ui_defaults

--- a/core-library/src/integration-test/java/org/silverpeas/core/contribution/attachment/mock/AttachmentServiceMockWrapper.java
+++ b/core-library/src/integration-test/java/org/silverpeas/core/contribution/attachment/mock/AttachmentServiceMockWrapper.java
@@ -315,4 +315,9 @@ public class AttachmentServiceMockWrapper implements AttachmentService {
   public void switchEnableDisplayAsContent(final SimpleDocumentPK pk, final boolean enable) {
     mock.switchEnableDisplayAsContent(pk, enable);
   }
+
+  @Override
+  public void switchEnableEditSimultaneously(final SimpleDocumentPK pk, final boolean enable) {
+    mock.switchEnableEditSimultaneously(pk, enable);
+  }
 }

--- a/core-library/src/integration-test/java/org/silverpeas/core/test/WarBuilder4LibCore.java
+++ b/core-library/src/integration-test/java/org/silverpeas/core/test/WarBuilder4LibCore.java
@@ -135,6 +135,7 @@ import org.silverpeas.core.util.file.FileServerUtils;
 import org.silverpeas.core.util.file.FileUtil;
 import org.silverpeas.core.util.logging.LogAnnotationProcessor;
 import org.silverpeas.core.util.logging.LogsAccessor;
+import org.silverpeas.core.wopi.StubbedWopiFileEditionManager;
 
 /**
  * This builder extends the {@link WarBuilder} in order to centralize the definition of common
@@ -432,6 +433,7 @@ public class WarBuilder4LibCore extends WarBuilder<WarBuilder4LibCore> {
     addSynchAndAsynchResourceEventFeatures();
     addPublicationTemplateFeatures();
     addImageToolFeatures();
+    addWopiManagementFeatures();
     addMavenDependencies("org.silverpeas.jcr:access-control");
     addMavenDependencies("commons-beanutils:commons-beanutils");
     if (!contains(JcrRepositoryProvider.class)) {
@@ -801,6 +803,15 @@ public class WarBuilder4LibCore extends WarBuilder<WarBuilder4LibCore> {
    */
   public WarBuilder4LibCore addApacheFileUploadFeatures() {
     addMavenDependencies("commons-fileupload:commons-fileupload");
+    return this;
+  }
+
+  /**
+   * Add WOPI management services in web archive (war)
+   * @return the instance of the war builder with WOPI management
+   */
+  public WarBuilder4LibCore addWopiManagementFeatures() {
+    addClasses(StubbedWopiFileEditionManager.class);
     return this;
   }
 

--- a/core-library/src/integration-test/java/org/silverpeas/core/wopi/StubbedWopiFileEditionManager.java
+++ b/core-library/src/integration-test/java/org/silverpeas/core/wopi/StubbedWopiFileEditionManager.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2000 - 2020 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.wopi;
+
+import org.silverpeas.core.security.session.SilverpeasUserSession;
+
+import javax.annotation.Priority;
+import javax.enterprise.inject.Alternative;
+import javax.inject.Singleton;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.BiFunction;
+
+import static javax.interceptor.Interceptor.Priority.APPLICATION;
+
+/**
+ * @author silveryocha
+ */
+@Singleton
+@Alternative
+@Priority(APPLICATION + 10)
+public class StubbedWopiFileEditionManager implements WopiFileEditionManager {
+
+  public boolean handled = true;
+
+  @Override
+  public void notifyEditionWith(final WopiFile file, final Set<String> userIds) {
+
+  }
+
+  @Override
+  public List<WopiFile> getEditedFilesBy(final WopiUser user) {
+    return null;
+  }
+
+  @Override
+  public List<WopiUser> getEditorsOfFile(final WopiFile file) {
+    return null;
+  }
+
+  @Override
+  public void enable(final boolean enable) {
+
+  }
+
+  @Override
+  public boolean isEnabled() {
+    return true;
+  }
+
+  @Override
+  public boolean isHandled(final WopiFile file) {
+    return handled;
+  }
+
+  @Override
+  public Optional<WopiEdition> prepareEditionWith(final SilverpeasUserSession spUserSession, final WopiFile file) {
+    return Optional.empty();
+  }
+
+  @Override
+  public <R> R getEditionContextFrom(final String fileId, final String accessToken,
+      final BiFunction<Optional<WopiUser>, Optional<WopiFile>, R> contextInitializer) {
+    return null;
+  }
+
+  @Override
+  public void revokeUser(final WopiUser user) {
+
+  }
+
+  @Override
+  public void revokeFile(final WopiFile file) {
+
+  }
+
+  @Override
+  public List<WopiUser> listCurrentUsers() {
+    return null;
+  }
+
+  @Override
+  public List<WopiFile> listCurrentFiles() {
+    return null;
+  }
+}

--- a/core-library/src/main/java/org/silverpeas/core/contribution/attachment/AttachmentService.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/attachment/AttachmentService.java
@@ -530,4 +530,11 @@ public interface AttachmentService extends DocumentIndexing {
    * @param enable enable the display if true
    */
   void switchEnableDisplayAsContent(SimpleDocumentPK pk, boolean enable);
+
+  /**
+   * Enables or not the simultaneous edition of the content of an attachment.
+   * @param pk the id of the document.
+   * @param enable enable edition simultaneously if true
+   */
+  void switchEnableEditSimultaneously(SimpleDocumentPK pk, boolean enable);
 }

--- a/core-library/src/main/java/org/silverpeas/core/contribution/attachment/model/RemoteContentDescriptor.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/attachment/model/RemoteContentDescriptor.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2000 - 2020 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.contribution.attachment.model;
+
+import java.time.OffsetDateTime;
+
+/**
+ * This class represents the description of a remotely content.
+ * @author silveryocha
+ */
+public class RemoteContentDescriptor {
+  private final SimpleDocument document;
+  private String id;
+  private String language;
+  private long size;
+  private OffsetDateTime lastModificationDate;
+
+  protected RemoteContentDescriptor(final SimpleDocument document) {
+    this.document = document;
+  }
+
+  /**
+   * Gets the document the remote content descriptor is linked to.
+   * @return a {@link SimpleDocument} instance.
+   */
+  public SimpleDocument getDocument() {
+    return document;
+  }
+
+  /**
+   * Gets the identifier of remote content.
+   * @return a string representing an unique identifier.
+   */
+  public String getId() {
+    return id;
+  }
+
+  protected void setId(final String id) {
+    this.id = id;
+  }
+
+  /**
+   * Gets the language of the remote content.
+   * @return a string representing the language.
+   */
+  public String getLanguage() {
+    return language;
+  }
+
+  protected void setLanguage(final String language) {
+    this.language = language;
+  }
+
+  /**
+   * Gets the size of the remote content.
+   * @return a long representing a size in bytes.
+   */
+  public long getSize() {
+    return size;
+  }
+
+  protected void setSize(final long size) {
+    this.size = size;
+  }
+
+  /**
+   * Gets the last modification date of the remote content.
+   * @return an {@link OffsetDateTime} representing a date.
+   */
+  public OffsetDateTime getLastModificationDate() {
+    return lastModificationDate;
+  }
+
+  protected void setLastModificationDate(final OffsetDateTime lastModificationDate) {
+    this.lastModificationDate = lastModificationDate;
+  }
+}

--- a/core-library/src/main/java/org/silverpeas/core/contribution/attachment/util/AttachmentSettings.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/attachment/util/AttachmentSettings.java
@@ -110,4 +110,12 @@ public class AttachmentSettings {
         .findFirst()
         .orElse(false);
   }
+
+  /**
+   * Gets the default value of the JCR flag which indicates if a document is editable simultaneously.
+   * @return true if editable simultaneously, false otherwise.
+   */
+  public static boolean defaultValueOfEditableSimultaneously() {
+    return settings.getBoolean("attachment.onlineEditing.simultaneously.default", true);
+  }
 }

--- a/core-library/src/main/java/org/silverpeas/core/contribution/attachment/webdav/AttachmentWebdavListener.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/attachment/webdav/AttachmentWebdavListener.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2000 - 2020 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.contribution.attachment.webdav;
+
+import org.silverpeas.core.annotation.Bean;
+import org.silverpeas.core.contribution.attachment.notification.AttachmentEvent;
+import org.silverpeas.core.contribution.attachment.notification.AttachmentRef;
+import org.silverpeas.core.notification.system.CDIResourceEventListener;
+import org.silverpeas.core.wopi.WopiFileEditionManager;
+
+/**
+ * Handles the WOPI releasing on attachment manipulations.
+ * @author silveryocha
+ */
+@Bean
+public class AttachmentWebdavListener extends CDIResourceEventListener<AttachmentEvent> {
+
+
+  @Override
+  public void onUpdate(final AttachmentEvent event) {
+    final AttachmentRef attachment = event.getTransition().getBefore();
+    release(attachment);
+  }
+
+  @Override
+  public void onUnlock(final AttachmentEvent event) {
+    onUpdate(event);
+  }
+
+  @Override
+  public void onRemoving(final AttachmentEvent event) {
+    onUpdate(event);
+  }
+
+  @Override
+  public void onDeletion(final AttachmentEvent event) {
+    onUpdate(event);
+  }
+
+  private void release(final AttachmentRef attachment) {
+    WopiFileEditionManager.get().revokeFile(new WebdavWopiFile(attachment.getId(), null));
+  }
+}

--- a/core-library/src/main/java/org/silverpeas/core/contribution/attachment/webdav/WebdavRepository.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/attachment/webdav/WebdavRepository.java
@@ -24,10 +24,14 @@
 package org.silverpeas.core.contribution.attachment.webdav;
 
 import org.silverpeas.core.contribution.attachment.model.SimpleDocument;
+import org.silverpeas.core.contribution.attachment.webdav.impl.WebdavContentDescriptor;
 
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Optional;
 
 public interface WebdavRepository {
   /**
@@ -130,4 +134,45 @@ public interface WebdavRepository {
    */
   long getContentEditionSize(Session session, SimpleDocument attachment)
       throws RepositoryException;
+
+  /**
+   * Gets the current webdav descriptor of the specified attachment.
+   * If several webdav document exists (several content languages), then the one which has the
+   * highest modified date is taken into account.
+   * @param session the JCR session.
+   * @param attachment the attachment.
+   * @return the optional content edition webdav descriptor if the specified attachment exists in
+   * the webdav repository.
+   * @throws RepositoryException on JCR access error.
+   */
+  Optional<WebdavContentDescriptor> getDescriptor(Session session, SimpleDocument attachment)
+      throws RepositoryException;
+
+  /**
+   * Updates a document content into the WEBDAV repository.
+   * <p>
+   *  If several webdav document exists (several content languages), then the one which has the
+   *  highest modified date is taken into account.
+   * </p>
+   * @param session the JCR session.
+   * @param document the aimed document.
+   * @param input the data to write.
+   * @throws RepositoryException
+   */
+  void updateContentFrom(Session session, SimpleDocument document, InputStream input)
+      throws RepositoryException, IOException;
+
+  /**
+   * Reads a document content from the WEBDAV repository and writes it into given output.
+   * <p>
+   *  If several webdav document exists (several content languages), then the one which has the
+   *  highest modified date is taken into account.
+   * </p>
+   * @param session the JCR session.
+   * @param document the aimed document.
+   * @param output the stream to write into.
+   * @throws RepositoryException
+   */
+  void loadContentInto(Session session, SimpleDocument document, OutputStream output)
+      throws RepositoryException, IOException;
 }

--- a/core-library/src/main/java/org/silverpeas/core/contribution/attachment/webdav/WebdavService.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/attachment/webdav/WebdavService.java
@@ -24,6 +24,12 @@
 package org.silverpeas.core.contribution.attachment.webdav;
 
 import org.silverpeas.core.contribution.attachment.model.SimpleDocument;
+import org.silverpeas.core.contribution.attachment.webdav.impl.WebdavContentDescriptor;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Optional;
 
 public interface WebdavService {
 
@@ -55,4 +61,38 @@ public interface WebdavService {
    * @throws javax.jcr.RepositoryException
    */
   long getContentEditionSize(SimpleDocument document);
+
+  /**
+   * Gets the current webdav descriptor of the specified attachment.
+   * If several webdav document exists (several content languages), then the one which has the
+   * highest modified date is taken into account.
+   * @param document the attachment.
+   * @return the optional content edition webdav descriptor if the specified attachment exists in
+   * the webdav repository.
+   */
+  Optional<WebdavContentDescriptor> getDescriptor(SimpleDocument document);
+
+  /**
+   * Updates a document content into the WEBDAV repository.
+   * <p>
+   *  If several webdav document exists (several content languages), then the one which has the
+   *  highest modified date is taken into account.
+   * </p>
+   * @param document the aimed document.
+   * @param input the data to write.
+   * @throws IOException when it is not possible to write physically the data.
+   */
+  void updateContentFrom(final SimpleDocument document, final InputStream input) throws IOException;
+
+  /**
+   * Loads a document content from the WEBDAV repository and writes it into given output.
+   * <p>
+   *  If several webdav document exists (several content languages), then the one which has the
+   *  highest modified date is taken into account.
+   * </p>
+   * @param document the aimed document.
+   * @param output the stream to write into.
+   * @throws IOException when it is not possible to write physically the data.
+   */
+  void loadContentInto(final SimpleDocument document, final OutputStream output) throws IOException;
 }

--- a/core-library/src/main/java/org/silverpeas/core/contribution/attachment/webdav/WebdavWopiFile.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/attachment/webdav/WebdavWopiFile.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright (C) 2000 - 2020 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.contribution.attachment.webdav;
+
+import org.silverpeas.core.ResourceReference;
+import org.silverpeas.core.SilverpeasRuntimeException;
+import org.silverpeas.core.admin.user.model.User;
+import org.silverpeas.core.cache.model.SimpleCache;
+import org.silverpeas.core.contribution.attachment.AttachmentService;
+import org.silverpeas.core.contribution.attachment.model.SimpleDocument;
+import org.silverpeas.core.contribution.attachment.model.SimpleDocumentPK;
+import org.silverpeas.core.contribution.attachment.webdav.impl.WebdavContentDescriptor;
+import org.silverpeas.core.util.StringUtil;
+import org.silverpeas.core.wopi.WopiFile;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.time.OffsetDateTime;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static java.text.MessageFormat.format;
+import static java.util.Optional.empty;
+import static org.apache.commons.io.FilenameUtils.getExtension;
+import static org.silverpeas.core.cache.service.CacheServiceProvider.getRequestCacheService;
+import static org.silverpeas.core.contribution.attachment.WebdavServiceProvider.getWebdavService;
+import static org.silverpeas.core.util.file.FileUtil.getMimeType;
+
+/**
+ * This class represents a file content stored into WEBDAV repository from point of view of WOPI
+ * services.
+ * <p>
+ * This file representation permits to the WEBDAV content to be taken in charge by WOPI services
+ * and so to be edited by online editors.
+ * </p>
+ * @author silveryocha
+ */
+public class WebdavWopiFile extends WopiFile {
+
+  public static final String DOC_CACHE_KEY_PREFIX = WebdavWopiFile.class.getSimpleName() + "DOC";
+  public static final String DESC_CACHE_KEY_PREFIX = WebdavWopiFile.class.getSimpleName() + "DESC";
+  private final String docId;
+  private final String docLanguage;
+
+  public WebdavWopiFile(final SimpleDocument document) {
+    this(document.getId(), document.getLanguage());
+  }
+
+  protected WebdavWopiFile(final String docId, final String docLanguage) {
+    this.docId = docId;
+    this.docLanguage = docLanguage;
+  }
+
+  @Override
+  public Optional<ResourceReference> linkedToResource() {
+    final SimpleDocument document = getDocument();
+    return Optional.of(new ResourceReference(document.getId(), document.getInstanceId()));
+  }
+
+  @Override
+  public String silverpeasId() {
+    return docId;
+  }
+
+  @Override
+  public String id() {
+    return getContentDescriptor().getId();
+  }
+
+  @Override
+  public User owner() {
+    return User.getById(getDocument().getEditedBy());
+  }
+
+  @Override
+  public String name() {
+    final SimpleDocument document = getDocument();
+    return Optional.ofNullable(document.getTitle())
+        .filter(StringUtil::isDefined)
+        .map(t -> t + "." + ext())
+        .orElse(document.getFilename());
+  }
+
+  @Override
+  public String ext() {
+    return getExtension(getDocument().getFilename());
+  }
+
+  @Override
+  public String mimeType() {
+    return getMimeType(getDocument().getAttachmentPath());
+  }
+
+  @Override
+  public long size() {
+    return getContentDescriptor().getSize();
+  }
+
+  @Override
+  public OffsetDateTime lastModificationDate() {
+    return getContentDescriptor().getLastModificationDate();
+  }
+
+  @Override
+  public void updateFrom(final InputStream input) throws IOException {
+    getWebdavService().updateContentFrom(getDocument(), input);
+    clearCaches();
+  }
+
+  @Override
+  public void loadInto(final OutputStream output) throws IOException {
+    getWebdavService().loadContentInto(getDocument(), output);
+  }
+
+  @Override
+  public boolean canBeAccessedBy(final User user) {
+    final SimpleDocument doc = getDocument();
+    return doc.isReadOnly() &&
+        (doc.getEditedBy().equals(user.getId()) || doc.editableSimultaneously().orElse(false)) &&
+        doc.canBeAccessedBy(user);
+  }
+
+  @Override
+  public boolean canBeModifiedBy(final User user) {
+    final SimpleDocument doc = getDocument();
+    return doc.isReadOnly() &&
+        (doc.getEditedBy().equals(user.getId()) || doc.editableSimultaneously().orElse(false)) &&
+        doc.canBeModifiedBy(user);
+  }
+
+  private SimpleDocument getDocument() {
+    final SimpleCache cache = getRequestCacheService().getCache();
+    final String key = DOC_CACHE_KEY_PREFIX + docId;
+    return cache.computeIfAbsent(key, SimpleDocument.class, () -> Optional.ofNullable(
+        AttachmentService.get().searchDocumentById(new SimpleDocumentPK(docId), docLanguage))
+        .orElseThrow(() -> new SilverpeasRuntimeException(
+            format("document {0}[{1}] does not exist anymore", docId, docLanguage))));
+  }
+
+  private WebdavContentDescriptor getContentDescriptor() {
+    final SimpleCache cache = getRequestCacheService().getCache();
+    final String key = DESC_CACHE_KEY_PREFIX + docId;
+    return cache.computeIfAbsent(key, WebdavContentDescriptor.class,
+        () -> getWebdavContentDescriptor().orElseThrow(
+            () -> new SilverpeasRuntimeException(
+                format("no WEBDAV description for document {0}[{1}]", docId, docLanguage))));
+  }
+
+  private Optional<WebdavContentDescriptor> getWebdavContentDescriptor() {
+    if (getDocument().isOpenOfficeCompatible() && getDocument().isReadOnly()) {
+      return getWebdavService().getDescriptor(getDocument().getVersionMaster());
+    }
+    return empty();
+  }
+
+  private void clearCaches() {
+    final SimpleCache cache = getRequestCacheService().getCache();
+    Stream.of(DOC_CACHE_KEY_PREFIX, DESC_CACHE_KEY_PREFIX)
+        .map(p -> p + docId)
+        .forEach(cache::remove);
+  }
+}

--- a/core-library/src/main/java/org/silverpeas/core/contribution/attachment/webdav/impl/WebDavDocumentService.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/attachment/webdav/impl/WebDavDocumentService.java
@@ -33,6 +33,9 @@ import org.silverpeas.core.persistence.jcr.JcrSession;
 import javax.inject.Inject;
 import javax.jcr.RepositoryException;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Optional;
 
 import static org.silverpeas.core.persistence.jcr.JcrRepositoryConnector.openSystemSession;
 
@@ -65,6 +68,35 @@ public class WebDavDocumentService implements WebdavService {
   public long getContentEditionSize(final SimpleDocument document) {
     try(JcrSession session = openSystemSession()) {
       return webdavRepository.getContentEditionSize(session, document);
+    } catch (RepositoryException ex) {
+      throw new AttachmentException("Document not found", ex);
+    }
+  }
+
+  @Override
+  public Optional<WebdavContentDescriptor> getDescriptor(final SimpleDocument document) {
+    try(JcrSession session = openSystemSession()) {
+      return webdavRepository.getDescriptor(session, document);
+    } catch (RepositoryException ex) {
+      throw new AttachmentException("Document not found", ex);
+    }
+  }
+
+  @Override
+  public void updateContentFrom(final SimpleDocument document, final InputStream input)
+      throws IOException {
+    try(JcrSession session = openSystemSession()) {
+      webdavRepository.updateContentFrom(session, document, input);
+    } catch (RepositoryException ex) {
+      throw new AttachmentException("Document not found", ex);
+    }
+  }
+
+  @Override
+  public void loadContentInto(final SimpleDocument document, final OutputStream output)
+      throws IOException {
+    try(JcrSession session = openSystemSession()) {
+      webdavRepository.loadContentInto(session, document, output);
     } catch (RepositoryException ex) {
       throw new AttachmentException("Document not found", ex);
     }

--- a/core-library/src/main/java/org/silverpeas/core/contribution/attachment/webdav/impl/WebdavContentDescriptor.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/attachment/webdav/impl/WebdavContentDescriptor.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2000 - 2020 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.contribution.attachment.webdav.impl;
+
+import org.silverpeas.core.contribution.attachment.model.RemoteContentDescriptor;
+import org.silverpeas.core.contribution.attachment.model.SimpleDocument;
+
+import java.time.OffsetDateTime;
+
+/**
+ * This class represents the description of a remotely content.
+ * @author silveryocha
+ */
+public class WebdavContentDescriptor extends RemoteContentDescriptor {
+
+  WebdavContentDescriptor(final SimpleDocument document) {
+    super(document);
+  }
+
+  void set(final String id, final String language, final long size,
+      final OffsetDateTime lastModificationDate) {
+    setId(id);
+    setLanguage(language);
+    setSize(size);
+    setLastModificationDate(lastModificationDate);
+  }
+}

--- a/core-library/src/main/java/org/silverpeas/core/persistence/jcr/util/JcrConstants.java
+++ b/core-library/src/main/java/org/silverpeas/core/persistence/jcr/util/JcrConstants.java
@@ -204,6 +204,11 @@ public interface JcrConstants extends Property {
   String SLV_VIEWABLE_MIXIN = "slv:viewable";
 
   /**
+   * Silverpeas Mixin to add viewable data to the node.
+   */
+  String SLV_EDITABLE_MIXIN = "slv:editable";
+
+  /**
    * Translation node 's name prefix. A translation's name should be TRANSLATION_NAME_PREFIX+ lang.
    */
   String TRANSLATION_NAME_PREFIX = "traduction_";
@@ -262,4 +267,5 @@ public interface JcrConstants extends Property {
   String SLV_PROPERTY_COMMENT = "slv:comment";
   String SLV_PROPERTY_FORBIDDEN_DOWNLOAD_FOR_ROLES = "slv:forbiddenDownloadForRoles";
   String SLV_PROPERTY_DISPLAYABLE_AS_CONTENT = "slv:displayableAsContent";
+  String SLV_PROPERTY_EDITABLE_SIMULTANEOUSLY = "slv:editableSimultaneously";
 }

--- a/core-library/src/main/java/org/silverpeas/core/security/authorization/PublicationAccessController.java
+++ b/core-library/src/main/java/org/silverpeas/core/security/authorization/PublicationAccessController.java
@@ -307,8 +307,16 @@ public class PublicationAccessController extends AbstractAccessController<Public
   }
 
   private static boolean isNotCreationContext(final String pubId, final String instanceId) {
-    return StringUtil.isInteger(pubId) &&
-        !getSessionVolatileResourceCacheService().contains(pubId, instanceId);
+    return StringUtil.isInteger(pubId) && notAVolatileResource(pubId, instanceId);
+  }
+
+  private static boolean notAVolatileResource(final String pubId, final String instanceId) {
+    try {
+      return !getSessionVolatileResourceCacheService().contains(pubId, instanceId);
+    } catch (Exception ignore) {
+      // Case where rights are verified out of a user session (batch, wopi, etc.)
+      return true;
+    }
   }
 
   /**

--- a/core-library/src/main/java/org/silverpeas/core/security/session/SessionInfo.java
+++ b/core-library/src/main/java/org/silverpeas/core/security/session/SessionInfo.java
@@ -23,6 +23,7 @@
  */
 package org.silverpeas.core.security.session;
 
+import org.silverpeas.core.admin.user.model.User;
 import org.silverpeas.core.admin.user.model.UserDetail;
 import org.silverpeas.core.cache.model.SimpleCache;
 import org.silverpeas.core.cache.service.CacheServiceProvider;
@@ -34,7 +35,7 @@ import java.util.concurrent.ConcurrentHashMap;
 /**
  * It gathers information about an opened session of a user.
  */
-public class SessionInfo {
+public class SessionInfo implements SilverpeasUserSession {
 
   public static final SessionInfo NoneSession = new SessionInfo(null, null);
   public static final SessionInfo AnonymousSession = getAnonymousSession();
@@ -75,6 +76,16 @@ public class SessionInfo {
       return new SessionInfo(null, anonymousUser);
     }
     return NoneSession;
+  }
+
+  @Override
+  public String getId() {
+    return getSessionId();
+  }
+
+  @Override
+  public User getUser() {
+    return getUserDetail();
   }
 
   /**

--- a/core-library/src/main/java/org/silverpeas/core/wopi/DefaultWopiFileEditionManager.java
+++ b/core-library/src/main/java/org/silverpeas/core/wopi/DefaultWopiFileEditionManager.java
@@ -1,0 +1,292 @@
+/*
+ * Copyright (C) 2000 - 2020 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.wopi;
+
+import org.silverpeas.core.annotation.Service;
+import org.silverpeas.core.initialization.Initialization;
+import org.silverpeas.core.scheduler.Job;
+import org.silverpeas.core.scheduler.JobExecutionContext;
+import org.silverpeas.core.scheduler.Scheduler;
+import org.silverpeas.core.scheduler.trigger.JobTrigger;
+import org.silverpeas.core.scheduler.trigger.TimeUnit;
+import org.silverpeas.core.security.session.SessionInfo;
+import org.silverpeas.core.security.session.SilverpeasUserSession;
+import org.silverpeas.core.util.Pair;
+import org.silverpeas.core.util.security.SecuritySettings;
+import org.silverpeas.core.wopi.discovery.WopiDiscovery;
+
+import javax.inject.Inject;
+import javax.ws.rs.WebApplicationException;
+import java.io.InputStream;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.BiFunction;
+import java.util.stream.Stream;
+
+import static java.net.http.HttpResponse.BodyHandlers.ofInputStream;
+import static java.text.MessageFormat.format;
+import static java.time.temporal.ChronoUnit.HOURS;
+import static java.time.temporal.ChronoUnit.SECONDS;
+import static java.util.Optional.*;
+import static javax.ws.rs.core.Response.Status.OK;
+import static org.silverpeas.core.security.session.SessionManagementProvider.getSessionManagement;
+import static org.silverpeas.core.util.HttpUtil.httpClientTrustingAnySslContext;
+import static org.silverpeas.core.util.HttpUtil.toUrl;
+import static org.silverpeas.core.util.StringUtil.isDefined;
+import static org.silverpeas.core.wopi.WopiLogger.logger;
+import static org.silverpeas.core.wopi.WopiSettings.*;
+
+@Service
+public class DefaultWopiFileEditionManager implements WopiFileEditionManager, Initialization {
+
+  private final Map<String, String> baseUrlByMimeTypes = new ConcurrentHashMap<>();
+  private final Map<String, String> baseUrlByExtension = new ConcurrentHashMap<>();
+  private final WopiCache cache = new WopiCache();
+  private LocalDateTime lastDateTimeOfDiscoveryGet;
+  private String lastDiscoveryUrl;
+
+  private boolean enabled = true;
+
+  protected DefaultWopiFileEditionManager() {
+  }
+
+  @Override
+  public void init() throws Exception {
+    registerSecurityDomains();
+  }
+
+  @Override
+  public void notifyEditionWith(final WopiFile file, final Set<String> userIds) {
+    if (isEnabled()) {
+      cache.registerEdition(file, userIds);
+    }
+  }
+
+  @Override
+  public List<WopiFile> getEditedFilesBy(final WopiUser user) {
+    return cache.getEditedFilesBy(user);
+  }
+
+  @Override
+  public List<WopiUser> getEditorsOfFile(final WopiFile file) {
+    return cache.getEditorsOfFile(file);
+  }
+
+  @Override
+  public void enable(final boolean enable) {
+    this.enabled = enable;
+    if (!enable) {
+      clear();
+    }
+  }
+
+  @Override
+  public boolean isEnabled() {
+    return WopiSettings.isEnabled() && enabled;
+  }
+
+  @Override
+  public boolean isHandled(final WopiFile file) {
+    try {
+      return getClientBaseUrlFor(file).isPresent();
+    } catch (WebApplicationException e) {
+      return false;
+    }
+  }
+
+  @Override
+  public Optional<WopiEdition> prepareEditionWith(final SilverpeasUserSession spUserSession,
+      final WopiFile anyFile) {
+    final String spUserSessionId = spUserSession.getId();
+    final Optional<String> clientBaseUrl = getClientBaseUrlFor(anyFile);
+    if (clientBaseUrl.isPresent()) {
+      final WopiUser user = cache.computeUserIfAbsent(spUserSessionId, () -> new DefaultWopiUser(spUserSession));
+      final WopiFile file = cache.computeFileIfAbsent(anyFile);
+      user.setLastEditionDateAtNow();
+      file.setLastEditionDateAtNow();
+      return of(new WopiEdition(file, user, clientBaseUrl.get()));
+    } else {
+      logger().debug(() -> format(
+          "from {0} preparing WOPI edition for {1} and for user {2} but WOPI is not enabled!!!",
+          spUserSessionId, anyFile, spUserSession.getUser().getId()));
+    }
+    return empty();
+  }
+
+  @Override
+  public <R> R getEditionContextFrom(final String fileId, final String accessToken,
+      final BiFunction<Optional<WopiUser>, Optional<WopiFile>, R> contextInitializer) {
+    final Optional<WopiFile> file = cache.getFileFromId(fileId);
+    final Optional<Pair<String, WopiUser>> user = cache.getFileFromAccessToken(accessToken);
+    user.ifPresent(p -> {
+      final SessionInfo sessionInfo = getSessionManagement().getSessionInfo(p.getFirst());
+      if (sessionInfo != null) {
+        sessionInfo.updateLastAccess();
+      }
+    });
+    logger().debug(() -> format("getting edition context from {0} and {1}", user, file));
+    return contextInitializer.apply(user.map(Pair::getSecond), file);
+  }
+
+  @Override
+  public void revokeUser(final WopiUser user) {
+    if (isEnabled()) {
+      cache.removeUser(user);
+    }
+  }
+
+  @Override
+  public void revokeFile(final WopiFile file) {
+    if (isEnabled()) {
+      cache.removeFile(file);
+    }
+  }
+
+  @Override
+  public List<WopiUser> listCurrentUsers() {
+    return cache.listAllUsers();
+  }
+
+  @Override
+  public List<WopiFile> listCurrentFiles() {
+    return cache.listAllFiles();
+  }
+
+  /**
+   * WOPI discovery is the process by which a WOPI host identifies Office for the web
+   * capabilities and how to initialize Office for the web applications within a site. WOPI hosts
+   * use the discovery XML to determine how to interact with Office for the web.
+   * <p>
+   *   The discovery is processed every {@link WopiSettings#getWopiClientDiscoveryTimeToLive}
+   *   hours to ensures the most up-to-date capabilities.
+   * </p>
+   */
+  private synchronized void discover() {
+    final String discoveryUrl = getWopiClientDiscoveryUrl();
+    if (lastDiscoveryUrl == null ||
+        !lastDiscoveryUrl.equals(discoveryUrl) ||
+        baseUrlByMimeTypes.isEmpty() ||
+        HOURS.between(lastDateTimeOfDiscoveryGet, LocalDateTime.now()) >= getWopiClientDiscoveryTimeToLive()) {
+      clear();
+      logger().debug(() -> format("discovering WOPI client with URL {0}", discoveryUrl));
+      try {
+        final HttpResponse<InputStream> response = httpClientTrustingAnySslContext().send(toUrl(discoveryUrl)
+            .timeout(Duration.of(2, SECONDS))
+            .build(), ofInputStream());
+        if (response.statusCode() != OK.getStatusCode()) {
+          throw new WebApplicationException(response.statusCode());
+        }
+        final WopiDiscovery wopiDiscovery;
+        try (final InputStream body = response.body()) {
+          wopiDiscovery = WopiDiscovery.load(body);
+        }
+        wopiDiscovery.consumeBaseUrlMimeType((n, a) -> {
+          baseUrlByMimeTypes.put(n, a.getUrlsrc());
+          if (isDefined(a.getExt())) {
+            baseUrlByExtension.put(a.getExt(), a.getUrlsrc());
+          }
+        });
+      } catch (Exception e) {
+        logger().error(e);
+        throw new WebApplicationException(e);
+      }
+      registerSecurityDomains();
+      lastDiscoveryUrl = discoveryUrl;
+      lastDateTimeOfDiscoveryGet = LocalDateTime.now();
+    }
+  }
+
+  private void clear() {
+    baseUrlByMimeTypes.clear();
+    baseUrlByExtension.clear();
+    cache.clear();
+  }
+
+  private void registerSecurityDomains() {
+    getWopiClientBaseUrl()
+        .map(u -> Stream.of(u, u.replaceFirst("^http", "ws")))
+        .orElse(Stream.empty())
+        .forEach(u -> {
+          final SecuritySettings.Registration registration = SecuritySettings.registration();
+          registration.registerDefaultSourceInCSP(u);
+          registration.registerDomainInCORS(u);
+          logger().debug(() -> format("registering into security WOPI client base URL {0}", u));
+        });
+  }
+
+  private Optional<String> getClientBaseUrlFor(final WopiFile file) {
+    if (isEnabled()) {
+      discover();
+      final String clientBaseUrl = baseUrlByMimeTypes.get(file.mimeType());
+      if (isDefined(clientBaseUrl)) {
+        return of(clientBaseUrl);
+      }
+      return ofNullable(baseUrlByExtension.get(file.ext()));
+    } else if (!baseUrlByMimeTypes.isEmpty()){
+      clear();
+      logger().debug(() -> format("removing all discovered actions because of WOPI disabling"));
+    }
+    return empty();
+  }
+
+  public static class WopiCacheCleanerJob extends Job implements Initialization {
+
+    private static final String WOPI_CLEANER_JOB_NAME = "WopiCleanerJob";
+
+    @Inject
+    private Scheduler scheduler;
+
+    @Inject
+    private DefaultWopiFileEditionManager manager;
+
+    /**
+     * Creates a new job.
+     */
+    private WopiCacheCleanerJob() {
+      super(WOPI_CLEANER_JOB_NAME);
+    }
+
+    @Override
+    public void execute(final JobExecutionContext context) {
+      logger().debug(() -> "executing WOPI cleaner JOB");
+      final OffsetDateTime offset = OffsetDateTime.now().minusHours(8);
+      manager.cache.clearAllBefore(offset);
+    }
+
+    @Override
+    public void init() throws Exception {
+      logger().debug(() -> "initializing WOPI cleaner JOB");
+      scheduler.unscheduleJob(WOPI_CLEANER_JOB_NAME);
+      scheduler.scheduleJob(this, JobTrigger.triggerEvery(5, TimeUnit.MINUTE));
+    }
+  }
+}

--- a/core-library/src/main/java/org/silverpeas/core/wopi/DefaultWopiUser.java
+++ b/core-library/src/main/java/org/silverpeas/core/wopi/DefaultWopiUser.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2000 - 2020 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.wopi;
+
+import org.silverpeas.core.admin.user.model.User;
+import org.silverpeas.core.security.session.SilverpeasUserSession;
+
+import static org.silverpeas.core.wopi.WopiSettings.getWopiUserIdPrefix;
+
+/**
+ * Default implementation of {@link WopiUser}.
+ * @author silveryocha
+ */
+public class DefaultWopiUser extends WopiUser {
+
+  public DefaultWopiUser(final SilverpeasUserSession spUserSession) {
+    super(spUserSession.getId(), User.getById(spUserSession.getUser().getId()));
+  }
+
+  @Override
+  public String getId() {
+    return getWopiUserIdPrefix() + getUser().getId();
+  }
+}

--- a/core-library/src/main/java/org/silverpeas/core/wopi/SimpleWopiFile.java
+++ b/core-library/src/main/java/org/silverpeas/core/wopi/SimpleWopiFile.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2000 - 2020 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.wopi;
+
+import org.apache.commons.io.IOUtils;
+import org.silverpeas.core.ResourceReference;
+import org.silverpeas.core.admin.user.model.User;
+import org.silverpeas.core.util.Charsets;
+import org.silverpeas.core.util.StringUtil;
+import org.silverpeas.core.util.file.FileUtil;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.time.OffsetDateTime;
+import java.util.Date;
+import java.util.Optional;
+
+import static java.time.OffsetDateTime.ofInstant;
+import static java.time.ZoneId.systemDefault;
+
+/**
+ * @author silveryocha
+ */
+public class SimpleWopiFile extends WopiFile {
+
+  private final File file;
+
+  public SimpleWopiFile(final File file) {
+    this.file = file;
+  }
+
+  @Override
+  public Optional<ResourceReference> linkedToResource() {
+    return Optional.empty();
+  }
+
+  @Override
+  public String silverpeasId() {
+    return StringUtil.asBase64(name().getBytes(Charsets.UTF_8)).replace("=", "-");
+  }
+
+  @Override
+  public User owner() {
+    return User.getById("0");
+  }
+
+  @Override
+  public String name() {
+    return file.getName();
+  }
+
+  @Override
+  public String mimeType() {
+    return FileUtil.getMimeType(file.getPath()) ;
+  }
+
+  @Override
+  public long size() {
+    return file.length();
+  }
+
+  @Override
+  public OffsetDateTime lastModificationDate() {
+    return ofInstant(new Date(file.lastModified()).toInstant(), systemDefault());
+  }
+
+  @Override
+  public void updateFrom(final InputStream input) throws IOException {
+    try (final OutputStream stream = new BufferedOutputStream(new FileOutputStream(file))) {
+      IOUtils.copy(input, stream);
+    }
+  }
+
+  @Override
+  public void loadInto(final OutputStream output) throws IOException {
+    try (final InputStream stream = new BufferedInputStream(new FileInputStream(file))) {
+      IOUtils.copy(stream, output);
+    }
+  }
+
+  @Override
+  public boolean canBeAccessedBy(final User user) {
+    return true;
+  }
+}

--- a/core-library/src/main/java/org/silverpeas/core/wopi/WopiCache.java
+++ b/core-library/src/main/java/org/silverpeas/core/wopi/WopiCache.java
@@ -1,0 +1,328 @@
+/*
+ * Copyright (C) 2000 - 2020 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.wopi;
+
+import org.silverpeas.core.util.Pair;
+import org.silverpeas.core.util.StringUtil;
+
+import java.time.OffsetDateTime;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.StringJoiner;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import static java.text.MessageFormat.format;
+import static java.util.Collections.emptySet;
+import static java.util.Collections.synchronizedSet;
+import static java.util.Optional.ofNullable;
+import static java.util.stream.Collectors.toList;
+import static org.silverpeas.core.wopi.WopiLogger.logger;
+
+/**
+ * @author silveryocha
+ */
+public class WopiCache {
+  private final Map<String, Element<WopiUser>> wopiUserCache = new ConcurrentHashMap<>();
+  private final Map<String, String> wopiAccessTokenUserMapping = new ConcurrentHashMap<>();
+  private final Map<String, String> wopiUserIdUserMapping = new ConcurrentHashMap<>();
+  private final Map<String, Element<WopiFile>> wopiFileCache = new ConcurrentHashMap<>();
+  private final Map<String, String> silverpeasResourceWopiFileMapping = new ConcurrentHashMap<>();
+  private final Map<String, Set<String>> wopiFileUsersEditionCache = new ConcurrentHashMap<>();
+  private final Map<String, Set<String>> wopiUserFilesEditionCache = new ConcurrentHashMap<>();
+
+  /**
+   * Gets the list of WOPI users from the context.
+   * @return a list of {@link WopiUser} instances.
+   */
+  List<WopiUser> listAllUsers() {
+    return getConsistentWopiUserCache().values().stream().map(Element::get).collect(toList());
+  }
+
+  /**
+   * Gets the list of WOPI files from the context.
+   * @return a list of {@link WopiFile} instances.
+   */
+  List<WopiFile> listAllFiles() {
+    return getConsistentWopiFileCache().values().stream().map(Element::get).collect(toList());
+  }
+
+  /**
+   * Gets a pair of user session identifier and {@link WopiUser} registered into the cache from
+   * its access token.
+   * @param accessToken an access token as string.
+   * @return an optional pair of spSessionId and {@link WopiUser}.
+   */
+  Optional<Pair<String, WopiUser>> getFileFromAccessToken(final String accessToken) {
+    return ofNullable(wopiAccessTokenUserMapping.get(accessToken))
+        .map(j -> Pair.of(j, wopiUserCache.get(j)))
+        .filter(p -> p.getSecond() != null)
+        .map(p -> Pair.of(p.getFirst(), p.getSecond().get()));
+  }
+
+  /**
+   * Gets a {@link WopiFile} registered into the cache from its identifier.
+   * @param fileId a file identifier as string.
+   * @return an optional {@link WopiFile}.
+   */
+  Optional<WopiFile> getFileFromId(final String fileId) {
+    return ofNullable(wopiFileCache.get(fileId)).map(Element::get);
+  }
+
+  /**
+   * Adds a new user into context if it does not yet exists.
+   * @param spSessionId the identifier of session of the user.
+   * @param userSupplier the {@link WopiUser} supplier.
+   * @return the {@link WopiUser} registered into the cache.
+   */
+  WopiUser computeUserIfAbsent(final String spSessionId, Supplier<WopiUser> userSupplier) {
+    return wopiUserCache.computeIfAbsent(spSessionId, j -> {
+      final WopiUser wopiUser = userSupplier.get();
+      wopiAccessTokenUserMapping.putIfAbsent(wopiUser.getAccessToken(), spSessionId);
+      wopiUserIdUserMapping.putIfAbsent(wopiUser.getId(), spSessionId);
+      return new Element<>(wopiUser, w -> {
+        final String wuId = wopiAccessTokenUserMapping.remove(w.getAccessToken());
+        wopiUserIdUserMapping.remove(w.getId());
+        wopiUserFilesEditionCache.remove(wuId);
+        wopiFileUsersEditionCache.forEach((k, v) -> v.remove(wuId));
+      });
+    }).get();
+  }
+
+  /**
+   * Adds a new file into context if it does not yet exists.
+   * @param file the file to handle.
+   * @return the {@link WopiFile} registered into the cache.
+   */
+  WopiFile computeFileIfAbsent(final WopiFile file) {
+    final String silverpeasId = file.silverpeasId();
+    final String fileId = file.id();
+    final String existingFileId = silverpeasResourceWopiFileMapping.get(silverpeasId);
+    if (existingFileId != null && !existingFileId.equals(fileId)) {
+      try {
+        wopiFileCache.remove(existingFileId).notifyRemove();
+      } catch (NullPointerException e) {
+        silverpeasResourceWopiFileMapping.remove(silverpeasId);
+        logger().warn("file {0} was altered into cache... Cache has been cleaned", existingFileId);
+      }
+    }
+    return wopiFileCache.computeIfAbsent(fileId,
+        i -> {
+          silverpeasResourceWopiFileMapping.putIfAbsent(silverpeasId, fileId);
+          return new Element<>(file, f -> {
+            final String wfId = silverpeasResourceWopiFileMapping.remove(silverpeasId);
+            wopiFileUsersEditionCache.remove(wfId);
+            wopiUserFilesEditionCache.forEach((key, value) -> value.remove(wfId));
+          });
+        }).get();
+  }
+
+  /**
+   * Releases the given user from the cache if handled.
+   * @param user a Silverpeas's WOPI user.
+   */
+  void removeUser(final WopiUser user) {
+    final String sessionId = user.getSilverpeasSessionId();
+    final Element<WopiUser> wopiUser = wopiUserCache.get(sessionId);
+    if (wopiUser != null) {
+      wopiUser.notifyRemove();
+      wopiUserCache.remove(sessionId);
+      logger().debug(() ->
+          format("releasing user with sessionId {0} (user {1})", sessionId, wopiUser));
+    } else {
+      logger().warn("releasing user with sessionId {0} which was altered into context (user {1})",
+          sessionId, user);
+    }
+  }
+
+  /**
+   * Releases the given wopi file from the cache if handled.
+   * @param file a Silverpeas's WOPI file.
+   */
+  void removeFile(final WopiFile file) {
+    final String wopiFileId = silverpeasResourceWopiFileMapping.get(file.silverpeasId());
+    if (wopiFileId != null) {
+      final Element<WopiFile> wopiFileElement = wopiFileCache.get(wopiFileId);
+      if (wopiFileElement != null) {
+        wopiFileElement.notifyRemove();
+        wopiFileCache.remove(wopiFileId);
+        logger().debug(() -> format("releasing silverpeas file with id {0} (wopi id {1})",
+            file.silverpeasId(), wopiFileId));
+      } else {
+        logger().warn("releasing document {0} from cache which was altered for this document",
+            file.silverpeasId());
+      }
+    }
+  }
+
+  /**
+   * Clears the cache.
+   */
+  void clear() {
+    wopiAccessTokenUserMapping.clear();
+    wopiUserCache.clear();
+    silverpeasResourceWopiFileMapping.clear();
+    wopiFileCache.clear();
+    wopiFileUsersEditionCache.clear();
+    wopiUserFilesEditionCache.clear();
+  }
+
+  /**
+   * Clears all the date that have not been manipulated since the given date.
+   * @param offset the offset date.
+   */
+  void clearAllBefore(final OffsetDateTime offset) {
+    wopiFileCache.entrySet().removeIf(e -> {
+      final boolean toRemove = offset.compareTo(e.getValue().getLastAccess()) > 0;
+      if (toRemove) {
+        logger().debug(() -> format("removing from cache {0}", e));
+        e.getValue().notifyRemove();
+      }
+      return toRemove;
+    });
+  }
+
+  /**
+   * Registers a set of users on a file.
+   * @param file a {@link WopiFile}.
+   * @param userIds a set of WOPI user identifiers.
+   */
+  void registerEdition(final WopiFile file, final Set<String> userIds) {
+    final Set<String> spSessionIds = userIds.stream()
+        .map(wopiUserIdUserMapping::get)
+        .filter(StringUtil::isDefined)
+        .collect(Collectors.toSet());
+    final String fileId = file.id();
+    final Set<String> userIdsInCache = wopiFileUsersEditionCache
+        .computeIfAbsent(fileId, s -> synchronizedSet(new HashSet<>()));
+    synchronized (userIdsInCache) {
+      final Set<String> removed = new HashSet<>(userIdsInCache.size());
+      final Set<String> added = new HashSet<>(userIdsInCache.size());
+      spSessionIds.forEach(i -> {
+        if (!userIdsInCache.contains(i)) {
+          added.add(i);
+        }
+      });
+      userIdsInCache.forEach(i -> {
+        if (!spSessionIds.contains(i)) {
+          removed.add(i);
+        }
+      });
+      userIdsInCache.removeAll(removed);
+      userIdsInCache.addAll(added);
+      removed.forEach(i -> wopiUserFilesEditionCache.computeIfPresent(i, (s, l) -> {
+        l.remove(fileId);
+        return l;
+      }));
+      added.forEach(i -> {
+        final Set<String> fileIdsInCache = wopiUserFilesEditionCache
+            .computeIfAbsent(i, s -> synchronizedSet(new HashSet<>()));
+        fileIdsInCache.add(fileId);
+      });
+    }
+  }
+
+  /**
+   * Gets the list of file edited by the given user.
+   * @param user a {@link WopiUser} instance.
+   * @return a list of {@link WopiFile}.
+   */
+  List<WopiFile> getEditedFilesBy(final WopiUser user) {
+    final String spSessionId = wopiUserIdUserMapping.get(user.getId());
+    return wopiUserFilesEditionCache.getOrDefault(spSessionId, emptySet()).stream()
+        .map(wopiFileCache::get)
+        .filter(Objects::nonNull)
+        .map(Element::get)
+        .collect(toList());
+  }
+
+  /**
+   * Gets the list of users which are editor of the given file.
+   * @param file a {@link WopiFile} instance.
+   * @return a list of {@link WopiUser}.
+   */
+  List<WopiUser> getEditorsOfFile(final WopiFile file) {
+    return wopiFileUsersEditionCache.getOrDefault(file.id(), emptySet()).stream()
+        .map(wopiUserCache::get)
+        .filter(Objects::nonNull)
+        .map(Element::get)
+        .collect(toList());
+  }
+
+  private Map<String, Element<WopiUser>> getConsistentWopiUserCache() {
+    return wopiUserCache;
+  }
+
+  private Map<String, Element<WopiFile>> getConsistentWopiFileCache() {
+    final Iterator<Map.Entry<String, Element<WopiFile>>> it = wopiFileCache.entrySet().iterator();
+    while (it.hasNext()) {
+      final Map.Entry<String, Element<WopiFile>> entry = it.next();
+      try {
+        entry.getValue().get().id();
+      } catch (final Exception e) {
+        it.remove();
+        logger().warn("removing WOPI file indexed by id {0}", entry.getKey());
+      }
+    }
+    return wopiFileCache;
+  }
+
+  private static class Element<T> {
+    private final T value;
+    private final Consumer<T> onRemove;
+    private OffsetDateTime lastAccess = OffsetDateTime.now();
+
+    private Element(final T value, final Consumer<T> onRemove) {
+      this.value = value;
+      this.onRemove = onRemove;
+    }
+
+    T get() {
+      lastAccess = OffsetDateTime.now();
+      return value;
+    }
+
+    OffsetDateTime getLastAccess() {
+      return lastAccess;
+    }
+
+    void notifyRemove() {
+      onRemove.accept(value);
+    }
+
+    @Override
+    public String toString() {
+      return new StringJoiner(", ", Element.class.getSimpleName() + "[", "]")
+          .add("element=" + value).add("lastAccess=" + lastAccess).toString();
+    }
+  }
+}

--- a/core-library/src/main/java/org/silverpeas/core/wopi/WopiLogger.java
+++ b/core-library/src/main/java/org/silverpeas/core/wopi/WopiLogger.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2000 - 2020 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.wopi;
+
+import org.silverpeas.core.util.logging.SilverLogger;
+
+/**
+ * A Silverpeas's logger dedicated to WOPI host features.
+ * @author silveryocha
+ */
+public class WopiLogger {
+
+  private static SilverLogger logger;
+
+  private WopiLogger() {
+  }
+
+  public static SilverLogger logger() {
+    if (logger == null) {
+      logger = SilverLogger.getLogger("silverpeas.core.wopi");
+    }
+    return logger;
+  }
+}

--- a/core-library/src/main/java/org/silverpeas/core/wopi/WopiSettings.java
+++ b/core-library/src/main/java/org/silverpeas/core/wopi/WopiSettings.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright (C) 2000 - 2020 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.wopi;
+
+import org.silverpeas.core.SilverpeasRuntimeException;
+import org.silverpeas.core.util.Pair;
+import org.silverpeas.core.util.ResourceLocator;
+import org.silverpeas.core.util.SettingBundle;
+import org.silverpeas.core.util.StringUtil;
+import org.silverpeas.core.util.URLUtil;
+
+import javax.ws.rs.core.UriBuilder;
+import java.net.URI;
+import java.util.Optional;
+
+import static java.util.Optional.ofNullable;
+import static org.silverpeas.core.util.StringUtil.isDefined;
+
+/**
+ * @author silveryocha
+ */
+public class WopiSettings {
+
+  public static final String SETTINGS_PATH = "org.silverpeas.wopi.wopiSettings";
+
+  private WopiSettings() {
+  }
+
+  /**
+   * Indicates if WOPI is enabled.
+   * @return true if enabled, false otherwise.
+   */
+  public static boolean isEnabled() {
+    return getSettings().getBoolean("wopi.enabled", false);
+  }
+
+  /**
+   * Indicates if WOPI lock capability is enabled.
+   * @return true if enabled, false otherwise.
+   */
+  public static boolean isLockCapabilityEnabled() {
+    return isEnabled() && getSettings().getBoolean("wopi.lock.enabled", false);
+  }
+
+  /**
+   * Gets the elements for timestamp verification feature on put file operation.
+   * @return an optional pair containing on left the timestamp request header name and on right
+   * the JSON response in case of conflict.
+   */
+  public static Optional<Pair<String, String>> getTimestampVerificationElements() {
+    return Optional.of(isEnabled())
+        .filter(b -> b)
+        .map(b -> Pair.of(
+            getSettings().getString("wopi.putFile.timestamp.field", ""),
+            getSettings().getString("wopi.putFile.timestamp.conflict.json.response", "{}")))
+        .filter(p -> isDefined(p.getFirst()));
+  }
+
+  /**
+   * Gets the field name to check in order to detected an editor close.
+   * @return an optional string.
+   */
+  public static Optional<String> getExitFieldNameDetection() {
+    return Optional.of(isEnabled())
+        .filter(b -> b)
+        .map(b -> getSettings().getString("wopi.client.exit.field", ""))
+        .filter(StringUtil::isDefined);
+  }
+
+  /**
+   * Gets the base URL of the WOPI host.
+   * @return an string.
+   */
+  public static String getWopiHostServiceBaseUrl() {
+    return getSettings().getString("wopi.host.service.baseUrl",
+        URLUtil.getAbsoluteApplicationURL() + "/services/wopi/files");
+  }
+
+  /**
+   * Gets the base URL of the WOPI client if any.
+   * @return an optional string.
+   */
+  public static Optional<String> getWopiClientBaseUrl() {
+    return Optional.of(WopiSettings.isEnabled())
+        .filter(b -> b)
+        .map(b -> getSettings().getString("wopi.client.baseUrl", null))
+        .filter(StringUtil::isDefined);
+  }
+
+  /**
+   * Gets the WOPI client discovery URL.
+   * @return a string.
+   */
+  public static String getWopiClientDiscoveryUrl() {
+    return getWopiClientBaseUrl()
+        .map(UriBuilder::fromUri)
+        .map(b -> b.path(getSettings().getString("wopi.client.discovery.path")))
+        .map(UriBuilder::build)
+        .map(URI::toString)
+        .orElseThrow(() -> new SilverpeasRuntimeException(
+            "wopi is not enabled or wopi.client.baseUrl or wopi.client.discovery.path are not " +
+                "defined"));
+  }
+
+  /**
+   * Gets the time to live in hours of the discovery cache.
+   * <p>
+   *   12 hours by default.
+   * </p>
+   * @return a number of hours as long.
+   */
+  public static long getWopiClientDiscoveryTimeToLive() {
+    return getSettings().getLong("wopi.client.discovery.timeToLive", 12);
+  }
+
+  /**
+   * Gets the WOPI client administration URL.
+   * @return a string.
+   */
+  public static String getWopiClientAdministrationUrl() {
+    return getWopiClientBaseUrl()
+        .map(UriBuilder::fromUri)
+        .map(b -> b.path(getSettings().getString("wopi.client.admin.path")))
+        .map(UriBuilder::build)
+        .map(URI::toString)
+        .orElseThrow(() -> new SilverpeasRuntimeException(
+            "wopi is not enabled or wopi.client.baseUrl or wopi.client.admin.path are not " +
+                "defined"));
+  }
+
+  /**
+   * Gets the prefix of WOPI user ids to exchange.
+   * @return a string which could be empty but never null.
+   */
+  public static String getWopiUserIdPrefix() {
+    return getSettings().getString("wopi.user.id.prefix", "");
+  }
+
+  /**
+   * Gets the UI defaults.
+   * @return a {@link Pair} containing the hidden parameter name on left and the UI defaults
+   * string on right.
+   */
+  public static Optional<Pair<String, String>> getUIDefaults() {
+    return ofNullable(getSettings().getString("wopi.ui.defaults.param.name", null))
+        .filter(StringUtil::isDefined)
+        .flatMap(n -> ofNullable(getSettings().getString("wopi.ui.defaults", null))
+            .filter(StringUtil::isDefined)
+            .map(d -> Pair.of(n, d)));
+  }
+
+  private static SettingBundle getSettings() {
+    return ResourceLocator.getSettingBundle(SETTINGS_PATH);
+  }
+}

--- a/core-library/src/main/java/org/silverpeas/core/wopi/discovery/Action.java
+++ b/core-library/src/main/java/org/silverpeas/core/wopi/discovery/Action.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2000 - 2020 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.wopi.discovery;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlRootElement;
+import java.io.Serializable;
+
+/**
+ * The action element and its attributes in the discovery XML provides some important information
+ * about Office for the web.
+ * <p>
+ * It provides:
+ *   <ul>
+ *     <li>the name of the action, (view, edit) which permits to know from Silverpeas's point of
+ *     view what kind of manipulations it will be possible with the document</li>
+ *     <li>the handled extension</li>
+ *     <li>the client URL that permits to edit into the browser file a document</li>
+ *   </ul>
+ * </p>
+ * @author silveryocha
+ */
+@XmlRootElement(name = "action")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class Action implements Serializable {
+  private static final long serialVersionUID = -24246963248719096L;
+
+  @XmlAttribute
+  private String ext;
+
+  @XmlAttribute
+  private String name;
+
+  @XmlAttribute
+  private String urlsrc;
+
+  public String getExt() {
+    return ext;
+  }
+
+  protected String getName() {
+    return name;
+  }
+
+  public String getUrlsrc() {
+    return urlsrc;
+  }
+}

--- a/core-library/src/main/java/org/silverpeas/core/wopi/discovery/App.java
+++ b/core-library/src/main/java/org/silverpeas/core/wopi/discovery/App.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2000 - 2020 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.wopi.discovery;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * Defines an application that can takes in charge a kind of document.
+ * @author silveryocha
+ */
+@XmlRootElement(name = "app")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class App implements Serializable {
+  private static final long serialVersionUID = -2370009372124602067L;
+
+  @XmlAttribute
+  private String name;
+
+  @XmlElement(name = "action")
+  private List<Action> actions;
+
+  protected String getName() {
+    return name;
+  }
+
+  protected List<Action> getActions() {
+    return actions;
+  }
+}

--- a/core-library/src/main/java/org/silverpeas/core/wopi/discovery/NetZone.java
+++ b/core-library/src/main/java/org/silverpeas/core/wopi/discovery/NetZone.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2000 - 2020 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.wopi.discovery;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * Defines a net zone into which the client is provided.
+ * <p>
+ *   In most of cases, to not say in all cases, an "external-http" zone is defined. That means
+ *   that the editors are provided from an external infrastructure.
+ * </p>
+ * @author silveryocha
+ */
+@XmlRootElement(name = "net-zone")
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "net-zone")
+public class NetZone implements Serializable {
+  private static final long serialVersionUID = 5086651622500970875L;
+
+  @XmlAttribute
+  private String name;
+
+  @XmlElement(name = "app")
+  private List<App> apps;
+
+  protected String getName() {
+    return name;
+  }
+
+  protected List<App> getApps() {
+    return apps;
+  }
+}

--- a/core-library/src/main/java/org/silverpeas/core/wopi/discovery/WopiDiscovery.java
+++ b/core-library/src/main/java/org/silverpeas/core/wopi/discovery/WopiDiscovery.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2000 - 2020 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.wopi.discovery;
+
+import org.silverpeas.core.SilverpeasRuntimeException;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Unmarshaller;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import java.io.InputStream;
+import java.io.Serializable;
+import java.util.function.BiConsumer;
+
+/**
+ * WOPI discovery is the process by which a WOPI host identifies Office for the web capabilities
+ * and how to initialize Office for the web applications within a site. WOPI hosts use the
+ * discovery XML to determine how to interact with Office for the web.
+ * <p>
+ *   This class represents the root element of a discovery XML description file.
+ * </p>
+ * <a href="https://wopi.readthedocs.io/en/latest/discovery.html#">See the explanations of WOPI discovery from official doc.</a>
+ * @author silveryocha
+ */
+@XmlRootElement(name = "wopi-discovery")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class WopiDiscovery implements Serializable {
+  private static final long serialVersionUID = -4834847364477784378L;
+
+  @XmlElement(name = "net-zone")
+  private NetZone netZone;
+
+  protected NetZone getNetZone() {
+    return netZone;
+  }
+
+  public void consumeBaseUrlMimeType(BiConsumer<String, Action> consumer) {
+    netZone.getApps().forEach(ap ->
+        ap.getActions().stream()
+            .filter(ac -> ac.getName().contains("edit"))
+            .forEach(ac -> consumer.accept(ap.getName(), ac)));
+  }
+
+  public static WopiDiscovery load(InputStream in) {
+    try {
+      final JAXBContext context = JAXBContext.newInstance(WopiDiscovery.class);
+      final Unmarshaller unmarshaller = context.createUnmarshaller();
+      return (WopiDiscovery) unmarshaller.unmarshal(in);
+    } catch (JAXBException e) {
+      throw new SilverpeasRuntimeException(e.getMessage(), e);
+    }
+  }
+}

--- a/core-library/src/main/resources/silverpeas-jcr.cnd
+++ b/core-library/src/main/resources/silverpeas-jcr.cnd
@@ -24,6 +24,11 @@
   mixin
   - slv:displayableAsContent (BOOLEAN) IGNORE
 
+/* Mixin editable */
+[slv:editable]
+  mixin
+  - slv:editableSimultaneously (BOOLEAN) IGNORE
+
 [slv:simpleDocument] >  nt:folder, mix:referenceable, slv:ownable, slv:commentable
   - slv:foreignKey (STRING)
   - slv:instanceId (STRING) MANDATORY

--- a/core-library/src/test/java/org/silverpeas/core/wopi/discovery/WopiDiscoveryTest.java
+++ b/core-library/src/test/java/org/silverpeas/core/wopi/discovery/WopiDiscoveryTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2000 - 2020 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.wopi.discovery;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * @author silveryocha
+ */
+class WopiDiscoveryTest {
+
+  @Test
+  void libreOfficeDiscoveryXmlContent() throws IOException {
+    final WopiDiscovery discovery;
+    try (InputStream in = getDiscoveryXmlStream()){
+      discovery = WopiDiscovery.load(in);
+    }
+    assertThat(discovery, notNullValue());
+    final NetZone netZone = discovery.getNetZone();
+    assertThat(netZone, notNullValue());
+    assertThat(netZone.getName(), is("external-http"));
+    final List<App> apps = netZone.getApps();
+    assertThat(apps, notNullValue());
+    assertThat(apps, not(empty()));
+    final App app = apps.get(0);
+    assertThat(app, notNullValue());
+    assertThat(app.getName(), is("image/svg+xml"));
+    final List<Action> actions = app.getActions();
+    assertThat(actions, notNullValue());
+    assertThat(actions, not(empty()));
+    Action action = actions.get(0);
+    assertThat(action.getExt(), is("svg"));
+    assertThat(action.getName(), is("view"));
+    assertThat(action.getUrlsrc(), is("http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"));
+    action = actions.get(1);
+    assertThat(action.getExt(), is("xsvg"));
+    assertThat(action.getName(), is("edit"));
+    assertThat(action.getUrlsrc(), is("http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"));
+  }
+
+  private InputStream getDiscoveryXmlStream() {
+    return WopiDiscoveryTest.class.getClassLoader()
+        .getResourceAsStream("org/silverpeas/wopi/discovery.xml");
+  }
+}

--- a/core-library/src/test/resources/org/silverpeas/wopi/discovery.xml
+++ b/core-library/src/test/resources/org/silverpeas/wopi/discovery.xml
@@ -1,0 +1,345 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<wopi-discovery>
+  <net-zone name="external-http">
+    <app name="image/svg+xml">
+      <action ext="svg" name="view" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+      <action ext="xsvg" name="edit" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+    <app name="application/vnd.ms-powerpoint">
+      <action ext="pot" name="edit" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+    <app name="application/vnd.ms-excel">
+      <action ext="xla" name="edit" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+
+    <!-- Writer documents -->
+    <app name="application/vnd.sun.xml.writer">
+      <action ext="sxw" name="view" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+    <app name="application/vnd.oasis.opendocument.text">
+      <action ext="odt" name="edit" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+    <app name="application/vnd.oasis.opendocument.text-flat-xml">
+      <action ext="fodt" name="edit" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+
+    <!-- Calc documents -->
+    <app name="application/vnd.sun.xml.calc">
+      <action ext="sxc" name="view" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+    <app name="application/vnd.oasis.opendocument.spreadsheet">
+      <action ext="ods" name="edit" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+    <app name="application/vnd.oasis.opendocument.spreadsheet-flat-xml">
+      <action ext="fods" name="edit" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+
+    <!-- Impress documents -->
+    <app name="application/vnd.sun.xml.impress">
+      <action ext="sxi" name="view" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+    <app name="application/vnd.oasis.opendocument.presentation">
+      <action ext="odp" name="edit" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+    <app name="application/vnd.oasis.opendocument.presentation-flat-xml">
+      <action ext="fodp" name="edit" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+
+    <!-- Draw documents -->
+    <app name="application/vnd.sun.xml.draw">
+      <action ext="sxd" name="view" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+    <app name="application/vnd.oasis.opendocument.graphics">
+      <action ext="odg" name="view" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+    <app name="application/vnd.oasis.opendocument.graphics-flat-xml">
+      <action ext="fodg" name="view" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+
+    <!-- Chart documents -->
+    <app name="application/vnd.oasis.opendocument.chart">
+      <action ext="odc" name="edit" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+
+    <!-- Text master documents -->
+    <app name="application/vnd.sun.xml.writer.global">
+      <action ext="sxg" name="view" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+    <app name="application/vnd.oasis.opendocument.text-master">
+      <action ext="odm" name="edit" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+
+    <!-- Math documents -->
+    <!-- In fact Math documents are not supported at all.
+         See: https://bugs.documentfoundation.org/show_bug.cgi?id=97006
+    <app name="application/vnd.sun.xml.math">
+              <action name="view" ext="sxm"/>
+          </app>
+    <app name="application/vnd.oasis.opendocument.formula">
+              <action name="edit" ext="odf"/>
+          </app>
+    -->
+    <!-- Text template documents -->
+    <app name="application/vnd.sun.xml.writer.template">
+      <action ext="stw" name="view" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+    <app name="application/vnd.oasis.opendocument.text-template">
+      <action ext="ott" name="edit" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+
+    <!-- Writer master document templates -->
+    <app name="application/vnd.oasis.opendocument.text-master-template">
+      <action ext="otm" name="edit" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+
+    <!-- Spreadsheet template documents -->
+    <app name="application/vnd.sun.xml.calc.template">
+      <action ext="stc" name="view" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+    <app name="application/vnd.oasis.opendocument.spreadsheet-template">
+      <action ext="ots" name="edit" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+
+    <!-- Presentation template documents -->
+    <app name="application/vnd.sun.xml.impress.template">
+      <action ext="sti" name="view" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+    <app name="application/vnd.oasis.opendocument.presentation-template">
+      <action ext="otp" name="edit" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+
+    <!-- Drawing template documents -->
+    <app name="application/vnd.sun.xml.draw.template">
+      <action ext="std" name="view" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+    <app name="application/vnd.oasis.opendocument.graphics-template">
+      <action ext="otg" name="edit" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+
+    <!-- Base documents -->
+    <app name="application/vnd.oasis.opendocument.database">
+      <action ext="odb" name="edit" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+
+    <!-- Extensions -->
+    <app name="application/vnd.openofficeorg.extension">
+      <action ext="oxt" name="edit" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+
+    <!-- MS Word -->
+    <app name="application/msword">
+      <action ext="doc" name="edit" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+    <app name="application/msword">
+      <action ext="dot" name="edit" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+
+    <!-- MS Excel -->
+    <app name="application/vnd.ms-excel">
+      <action ext="xls" name="edit" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+
+    <!-- MS PowerPoint -->
+    <app name="application/vnd.ms-powerpoint">
+      <action ext="ppt" name="edit" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+
+    <!-- OOXML wordprocessing -->
+    <app name="application/vnd.openxmlformats-officedocument.wordprocessingml.document">
+      <action ext="docx" name="edit" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+    <app name="application/vnd.ms-word.document.macroEnabled.12">
+      <action ext="docm" name="edit" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+    <app name="application/vnd.openxmlformats-officedocument.wordprocessingml.template">
+      <action ext="dotx" name="view" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+    <app name="application/vnd.ms-word.template.macroEnabled.12">
+      <action ext="dotm" name="view" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+
+    <!-- OOXML spreadsheet -->
+    <app name="application/vnd.openxmlformats-officedocument.spreadsheetml.template">
+      <action ext="xltx" name="view" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+    <app name="application/vnd.ms-excel.template.macroEnabled.12">
+      <action ext="xltm" name="view" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+    <app name="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet">
+      <action ext="xlsx" name="edit" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+    <app name="application/vnd.ms-excel.sheet.binary.macroEnabled.12">
+      <action ext="xlsb" name="edit" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+    <app name="application/vnd.ms-excel.sheet.macroEnabled.12">
+      <action ext="xlsm" name="edit" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+
+    <!-- OOXML presentation -->
+    <app name="application/vnd.openxmlformats-officedocument.presentationml.presentation">
+      <action ext="pptx" name="edit" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+    <app name="application/vnd.ms-powerpoint.presentation.macroEnabled.12">
+      <action ext="pptm" name="edit" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+    <app name="application/vnd.openxmlformats-officedocument.presentationml.template">
+      <action ext="potx" name="edit" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+    <app name="application/vnd.ms-powerpoint.template.macroEnabled.12">
+      <action ext="potm" name="edit" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+
+    <!-- Others -->
+    <app name="application/vnd.wordperfect">
+      <action ext="wpd" name="view" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+    <app name="application/x-aportisdoc">
+      <action ext="pdb" name="view" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+    <app name="application/x-hwp">
+      <action ext="hwp" name="view" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+    <app name="application/vnd.ms-works">
+      <action ext="wps" name="view" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+    <app name="application/x-mswrite">
+      <action ext="wri" name="view" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+    <app name="application/x-dif-document">
+      <action ext="dif" name="edit" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+    <app name="text/spreadsheet">
+      <action ext="slk" name="edit" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+    <app name="text/csv">
+      <action ext="csv" name="edit" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+    <app name="application/x-dbase">
+      <action ext="dbf" name="edit" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+    <app name="application/vnd.lotus-1-2-3">
+      <action ext="wk1" name="view" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+    <app name="image/cgm">
+      <action ext="cgm" name="view" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+    <app name="image/vnd.dxf">
+      <action ext="dxf" name="view" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+    <app name="image/x-emf">
+      <action ext="emf" name="view" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+    <app name="image/x-wmf">
+      <action ext="wmf" name="view" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+    <app name="application/coreldraw">
+      <action ext="cdr" name="view" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+    <app name="application/vnd.visio2013">
+      <action ext="vsd" name="view" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+    <app name="application/vnd.visio">
+      <action ext="vss" name="view" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+    <app name="application/x-mspublisher">
+      <action ext="pub" name="view" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+    <app name="application/x-sony-bbeb">
+      <action ext="lrf" name="view" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+    <app name="application/x-gnumeric">
+      <action ext="gnumeric" name="view" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+    <app name="application/macwriteii">
+      <action ext="mw" name="view" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+    <app name="application/x-iwork-numbers-sffnumbers">
+      <action ext="numbers" name="view" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+    <app name="application/vnd.oasis.opendocument.text-web">
+      <action ext="oth" name="edit" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+    <app name="application/x-pagemaker">
+      <action ext="p65" name="view" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+    <app name="application/rtf">
+      <action ext="rtf" name="edit" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+    <app name="text/rtf">
+      <action ext="rtf" name="edit" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+    <app name="text/plain">
+      <action ext="txt" name="edit" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+    <app name="application/x-fictionbook+xml">
+      <action ext="fb2" name="view" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+    <app name="application/clarisworks">
+      <action ext="cwk" name="view" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+    <app name="application/vnd.corel-draw">
+      <action ext="cdr" name="view" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+    <app name="image/x-wpg">
+      <action ext="wpg" name="view" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+    <app name="application/prs.plucker">
+      <action ext="pdb" name="view" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+    <app name="application/x-iwork-pages-sffpages">
+      <action ext="pages" name="view" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+    <app name="application/vnd.openxmlformats-officedocument.presentationml.slideshow">
+      <action ext="ppsx" name="edit" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+    <app name="application/x-iwork-keynote-sffkey">
+      <action ext="key" name="view" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+    <app name="application/x-abiword">
+      <action ext="abw" name="view" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+    <app name="image/x-freehand">
+      <action ext="fh" name="view" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+    <app name="application/vnd.palm">
+      <action ext="pdb" name="view" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+    <app name="application/vnd.sun.xml.chart">
+      <action ext="sxs" name="view" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+    <app name="application/vnd.sun.xml.writer.web">
+      <action ext="stw" name="view" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+    <app name="application/x-t602">
+      <action ext="602" name="view" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+    <app name="application/vnd.sun.xml.report.chart">
+      <action ext="odc" name="edit" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+    <app name="image/bmp">
+      <action ext="bmp" name="view" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+    <app name="image/png">
+      <action ext="png" name="view" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+    <app name="image/gif">
+      <action ext="gif" name="view" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+    <app name="image/tiff">
+      <action ext="tiff" name="view" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+    <app name="image/jpg">
+      <action ext="jpg" name="view" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+    <app name="image/jpeg">
+      <action ext="jpeg" name="view" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+    <app name="application/pdf">
+      <action ext="pdf" name="view" urlsrc="http://CLIENT_HOST/loleaflet/b889fbb/loleaflet.html?"/>
+    </app>
+
+    <app name="Capabilities">
+      <action ext="" name="getinfo" urlsrc="http://CLIENT_HOST/hosting/capabilities"/>
+    </app>
+  </net-zone>
+</wopi-discovery>

--- a/core-services/chat/src/main/java/org/silverpeas/core/chat/ChatSettings.java
+++ b/core-services/chat/src/main/java/org/silverpeas/core/chat/ChatSettings.java
@@ -79,6 +79,18 @@ public class ChatSettings {
   }
 
   /**
+   * Is the URL given by {@link #getChatServerUrl()} a safe one.
+   * <p>
+   *   In case it is, SSL validations of requests performed between Silverpeas's server and the
+   *   XMPP server are bypassed.
+   * </p>
+   * @return the chat server's URL.
+   */
+  public boolean isChatServerSafeUrl() {
+    return settings.getBoolean("chat.servers.xmpp.safe", false);
+  }
+
+  /**
    * Gets the fully qualified hostname or the IP address of the ICE server listening for audio/video
    * communications.
    * @return the hostname or the IP address of the ICE server.
@@ -159,7 +171,7 @@ public class ChatSettings {
    * domain. If no such default XMPP domain is defined, then the Silverpeas domains with no mapping
    * rule won't be mapped to a XMPP domain and hence the users of those domains won't have an XMPP
    * account; the chat won't be enabled for them.
-   * @return
+   * @return default domain identifier as string.
    */
   public String getDefaultXmppDomain() {
     return settings.getString("chat.xmpp.domain.default", "").trim();

--- a/core-services/chat/src/main/java/org/silverpeas/core/chat/servers/HttpRequester.java
+++ b/core-services/chat/src/main/java/org/silverpeas/core/chat/servers/HttpRequester.java
@@ -23,6 +23,9 @@
  */
 package org.silverpeas.core.chat.servers;
 
+import com.google.api.client.util.SslUtils;
+import org.silverpeas.core.chat.ChatServerException;
+import org.silverpeas.core.chat.ChatSettings;
 import org.silverpeas.core.util.JSONCodec;
 import org.silverpeas.core.util.JSONCodec.JSONObject;
 
@@ -33,6 +36,7 @@ import javax.ws.rs.client.Invocation;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import java.security.GeneralSecurityException;
 import java.util.function.UnaryOperator;
 
 /**
@@ -75,7 +79,7 @@ public class HttpRequester implements AutoCloseable {
    */
   public static final int STATUS_CREATED = 201;
 
-  private Client client = ClientBuilder.newClient();
+  private final Client client;
   private Invocation.Builder builder;
   private final String token;
 
@@ -86,6 +90,13 @@ public class HttpRequester implements AutoCloseable {
    * access its API.
    */
   public HttpRequester(final String authenticationToken) {
+    try {
+      this.client = ChatSettings.get().isChatServerSafeUrl()
+          ? ClientBuilder.newBuilder().sslContext(SslUtils.trustAllSSLContext()).build()
+          : ClientBuilder.newClient();
+    } catch (GeneralSecurityException e) {
+      throw new ChatServerException(e);
+    }
     this.token = authenticationToken;
   }
 

--- a/core-services/silverstatistics/src/integration-test/java/org/silverpeas/core/silverstatistics/test/WarBuilder4Statistics.java
+++ b/core-services/silverstatistics/src/integration-test/java/org/silverpeas/core/silverstatistics/test/WarBuilder4Statistics.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2000 - 2020 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.silverpeas.core.silverstatistics.test;
+
+import org.silverpeas.core.test.BasicWarBuilder;
+import org.silverpeas.core.test.WarBuilder;
+
+/**
+ * This builder extends the {@link WarBuilder} in order to centralize the
+ * definition of common archive part definitions.
+ * @author Yohann Chastagnier
+ */
+public class WarBuilder4Statistics extends BasicWarBuilder {
+
+  /**
+   * Constructs a war builder for the specified test class. It will load all the resources in the
+   * same packages of the specified test class.
+   * @param test the class of the test for which a war archive will be build.
+   */
+  protected <T> WarBuilder4Statistics(final Class<T> test) {
+    super(test);
+    addMavenDependenciesWithPersistence("org.silverpeas.core:silverpeas-core");
+    createMavenDependencies("org.silverpeas.core.services:silverpeas-core-tagcloud");
+  }
+
+  /**
+   * Gets an instance of a war archive builder for the specified test class.
+   * @return the instance of the war archive builder.
+   */
+  public static <T> WarBuilder4Statistics onWarForTestClass(Class<T> test) {
+    return new WarBuilder4Statistics(test);
+  }
+}

--- a/core-services/silverstatistics/src/integration-test/java/org/silverpeas/core/silverstatistics/volume/model/StatisticsConfigIT.java
+++ b/core-services/silverstatistics/src/integration-test/java/org/silverpeas/core/silverstatistics/volume/model/StatisticsConfigIT.java
@@ -30,7 +30,7 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.silverpeas.core.test.BasicWarBuilder;
+import org.silverpeas.core.silverstatistics.test.WarBuilder4Statistics;
 import org.silverpeas.core.util.ResourceLocator;
 import org.silverpeas.core.util.SettingBundle;
 
@@ -38,7 +38,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
 /**
@@ -49,9 +49,7 @@ public class StatisticsConfigIT {
 
   @Deployment
   public static Archive<?> createTestArchive() {
-    return BasicWarBuilder.onWarForTestClass(StatisticsConfigIT.class)
-        .addMavenDependenciesWithPersistence("org.silverpeas.core:silverpeas-core")
-        .createMavenDependencies("org.silverpeas.core.services:silverpeas-core-tagcloud")
+    return WarBuilder4Statistics.onWarForTestClass(StatisticsConfigIT.class)
         .testFocusedOn(war -> {
           war.addPackages(true, "org.silverpeas.core.silverstatistics");
           war.addAsResource("org/silverpeas/silverstatistics/SilverStatisticsTest.properties");

--- a/core-services/silverstatistics/src/integration-test/java/org/silverpeas/core/silverstatistics/volume/service/ConnexionSilverStatisticsManagerDAOIT.java
+++ b/core-services/silverstatistics/src/integration-test/java/org/silverpeas/core/silverstatistics/volume/service/ConnexionSilverStatisticsManagerDAOIT.java
@@ -25,10 +25,6 @@ package org.silverpeas.core.silverstatistics.volume.service;
 
 import com.ninja_squad.dbsetup.Operations;
 import com.ninja_squad.dbsetup.operation.Operation;
-import org.silverpeas.core.silverstatistics.volume.dao.SilverStatisticsManagerDAO;
-import org.silverpeas.core.silverstatistics.volume.model.DataStatsCumul;
-import org.silverpeas.core.silverstatistics.volume.model.StatisticsConfig;
-import org.silverpeas.core.silverstatistics.volume.model.StatType;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.Archive;
@@ -36,16 +32,20 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.silverpeas.core.test.DataSetTest;
 import org.silverpeas.core.persistence.jdbc.sql.JdbcSqlQuery;
-import org.silverpeas.core.test.BasicWarBuilder;
+import org.silverpeas.core.silverstatistics.test.WarBuilder4Statistics;
+import org.silverpeas.core.silverstatistics.volume.dao.SilverStatisticsManagerDAO;
+import org.silverpeas.core.silverstatistics.volume.model.DataStatsCumul;
+import org.silverpeas.core.silverstatistics.volume.model.StatType;
+import org.silverpeas.core.silverstatistics.volume.model.StatisticsConfig;
+import org.silverpeas.core.test.DataSetTest;
 
 import java.sql.Connection;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
 
 /**
  * @author ehugonnet
@@ -73,9 +73,7 @@ public class ConnexionSilverStatisticsManagerDAOIT extends DataSetTest {
 
   @Deployment
   public static Archive<?> createTestArchive() {
-    return BasicWarBuilder.onWarForTestClass(ConnexionSilverStatisticsManagerDAOIT.class)
-        .addMavenDependenciesWithPersistence("org.silverpeas.core:silverpeas-core")
-        .createMavenDependencies("org.silverpeas.core.services:silverpeas-core-tagcloud")
+    return WarBuilder4Statistics.onWarForTestClass(ConnexionSilverStatisticsManagerDAOIT.class)
         .testFocusedOn(war -> {
           war.addPackages(true, "org.silverpeas.core.silverstatistics");
           war.addAsResource("org/silverpeas/silverstatistics/SilverStatisticsTest.properties");

--- a/core-test/src/main/resources/silverpeas-jcr.txt
+++ b/core-test/src/main/resources/silverpeas-jcr.txt
@@ -24,6 +24,11 @@
   mixin
   - slv:displayableAsContent (BOOLEAN) IGNORE
 
+/* Mixin editable */
+[slv:editable]
+  mixin
+  - slv:editableSimultaneously (BOOLEAN) IGNORE
+
 [slv:simpleDocument] >  nt:folder, mix:referenceable, slv:ownable, slv:commentable
   - slv:foreignKey (STRING)
   - slv:instanceId (STRING) MANDATORY

--- a/core-war/src/main/java/org/silverpeas/web/jobmanager/control/JobManagerPeasSessionController.java
+++ b/core-war/src/main/java/org/silverpeas/web/jobmanager/control/JobManagerPeasSessionController.java
@@ -30,6 +30,7 @@ import org.silverpeas.core.util.logging.SilverLogger;
 import org.silverpeas.core.web.mvc.controller.AbstractComponentSessionController;
 import org.silverpeas.core.web.mvc.controller.ComponentContext;
 import org.silverpeas.core.web.mvc.controller.MainSessionController;
+import org.silverpeas.core.wopi.WopiSettings;
 import org.silverpeas.web.jobmanager.JobManagerService;
 import org.silverpeas.web.jobmanager.JobManagerSettings;
 
@@ -122,6 +123,8 @@ public class JobManagerPeasSessionController extends AbstractComponentSessionCon
         + "/silverpeasinfos.jsp", null, false);
     JobManagerService variables = new JobManagerService("51", "JDV", LEVEL_OPERATION, webContext
         + "/Rvariables/jsp/Main", null, false);
+    JobManagerService wopi = new JobManagerService("52", "JWO", LEVEL_OPERATION, webContext
+        + "/Rwopi/jsp/Main", null, false);
 
     // initialisation des opérations du service jKM
     JobManagerService jKM1 = new JobManagerService("21", "JKM1", LEVEL_OPERATION, webContext
@@ -183,6 +186,10 @@ public class JobManagerPeasSessionController extends AbstractComponentSessionCon
         if (jobManagerSettings.isPortletDeployerVisible()) {
           ids.add(portletDeployer.getId());
           services.put(portletDeployer.getId(), portletDeployer);
+        }
+        if (WopiSettings.isEnabled()) {
+          ids.add(wopi.getId());
+          services.put(wopi.getId(), wopi);
         }
         ids.add(jst.getId());
         services.put(jst.getId(), jst);

--- a/core-war/src/main/java/org/silverpeas/web/wopi/WopiFileUIEntity.java
+++ b/core-war/src/main/java/org/silverpeas/web/wopi/WopiFileUIEntity.java
@@ -1,0 +1,63 @@
+package org.silverpeas.web.wopi;
+
+import org.silverpeas.core.admin.component.model.SilverpeasComponentInstance;
+import org.silverpeas.core.admin.service.OrganizationController;
+import org.silverpeas.core.util.SilverpeasList;
+import org.silverpeas.core.util.StringUtil;
+import org.silverpeas.core.web.util.SelectableUIEntity;
+import org.silverpeas.core.wopi.WopiFile;
+import org.silverpeas.core.wopi.WopiFileEditionManager;
+import org.silverpeas.core.wopi.WopiUser;
+
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class WopiFileUIEntity extends SelectableUIEntity<WopiFile> {
+
+  private static final String SEP = " > ";
+
+  private SilverpeasList<WopiUserUIEntity> editors = null;
+
+  private WopiFileUIEntity(final WopiFile data, final Set<String> selectedIds) {
+    super(data, selectedIds);
+  }
+
+  @Override
+  public String getId() {
+    return getData().id();
+  }
+
+  public static SilverpeasList<WopiFileUIEntity> convertList(
+      final SilverpeasList<WopiFile> values, final Set<String> selectedIds) {
+    final Function<WopiFile, WopiFileUIEntity> converter = c -> new WopiFileUIEntity(c, selectedIds);
+    return values.stream().map(converter).collect(SilverpeasList.collector(values));
+  }
+
+  public String getLocation(final String userLanguage) {
+    return getData().linkedToResource()
+        .flatMap(r -> getOrganizationController().getComponentInstance(r.getComponentInstanceId()))
+        .map(i -> getPath(i, userLanguage) + SEP + i.getLabel(userLanguage))
+        .orElse(StringUtil.EMPTY);
+  }
+
+  public SilverpeasList<WopiUserUIEntity> editors() {
+    if (editors == null) {
+      final List<WopiUser> list = WopiFileEditionManager.get().getEditorsOfFile(getData());
+      editors = WopiUserUIEntity.convertList(SilverpeasList.wrap(list), null);
+    }
+    return editors;
+  }
+
+  private String getPath(SilverpeasComponentInstance instance, final String language) {
+    return getOrganizationController().getPathToComponent(instance.getId()).stream()
+        .map(s -> s.getName(language))
+        .collect(Collectors.joining(SEP));
+  }
+
+  private OrganizationController getOrganizationController() {
+    return OrganizationController.get();
+  }
+
+}

--- a/core-war/src/main/java/org/silverpeas/web/wopi/WopiUserUIEntity.java
+++ b/core-war/src/main/java/org/silverpeas/web/wopi/WopiUserUIEntity.java
@@ -1,0 +1,39 @@
+package org.silverpeas.web.wopi;
+
+import org.silverpeas.core.util.SilverpeasList;
+import org.silverpeas.core.web.util.SelectableUIEntity;
+import org.silverpeas.core.wopi.WopiFile;
+import org.silverpeas.core.wopi.WopiFileEditionManager;
+import org.silverpeas.core.wopi.WopiUser;
+
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+
+public class WopiUserUIEntity extends SelectableUIEntity<WopiUser> {
+
+  private SilverpeasList<WopiFileUIEntity> editedFiles = null;
+
+  private WopiUserUIEntity(final WopiUser data, final Set<String> selectedIds) {
+    super(data, selectedIds);
+  }
+
+  @Override
+  public String getId() {
+    return getData().getId();
+  }
+
+  public static SilverpeasList<WopiUserUIEntity> convertList(
+      final SilverpeasList<WopiUser> values, final Set<String> selectedIds) {
+    final Function<WopiUser, WopiUserUIEntity> converter = c -> new WopiUserUIEntity(c, selectedIds);
+    return values.stream().map(converter).collect(SilverpeasList.collector(values));
+  }
+
+  public SilverpeasList<WopiFileUIEntity> editedFiles() {
+    if (editedFiles == null) {
+      final List<WopiFile> list = WopiFileEditionManager.get().getEditedFilesBy(getData());
+      editedFiles = WopiFileUIEntity.convertList(SilverpeasList.wrap(list), null);
+    }
+    return editedFiles;
+  }
+}

--- a/core-war/src/main/java/org/silverpeas/web/wopi/WopiWebController.java
+++ b/core-war/src/main/java/org/silverpeas/web/wopi/WopiWebController.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (C) 2000 - 2019 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.silverpeas.web.wopi;
+
+import org.silverpeas.core.admin.user.model.SilverpeasRole;
+import org.silverpeas.core.util.SilverpeasList;
+import org.silverpeas.core.web.http.HttpRequest;
+import org.silverpeas.core.web.mvc.controller.ComponentContext;
+import org.silverpeas.core.web.mvc.controller.MainSessionController;
+import org.silverpeas.core.web.mvc.webcomponent.annotation.Homepage;
+import org.silverpeas.core.web.mvc.webcomponent.annotation.LowestRoleAccess;
+import org.silverpeas.core.web.mvc.webcomponent.annotation.RedirectToInternalJsp;
+import org.silverpeas.core.web.mvc.webcomponent.annotation.WebComponentController;
+import org.silverpeas.core.wopi.WopiFile;
+import org.silverpeas.core.wopi.WopiFileEditionManager;
+import org.silverpeas.core.wopi.WopiUser;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static java.util.Collections.synchronizedSet;
+
+/**
+ * @author silveryocha
+ */
+@WebComponentController(WopiWebController.WOPI_COMPONENT_NAME)
+public class WopiWebController extends
+    org.silverpeas.core.web.mvc.webcomponent.WebComponentController<WopiWebRequestContext> {
+  private static final long serialVersionUID = -800453654549621458L;
+
+  public static final String WOPI_COMPONENT_NAME = "wopi";
+  private final Set<String> selectedUserIds = synchronizedSet(new HashSet<>());
+  private final Set<String> selectedFileIds = synchronizedSet(new HashSet<>());
+
+  public WopiWebController(final MainSessionController controller, final ComponentContext context) {
+    super(controller, context, "org.silverpeas.wopi.multilang.wopi");
+  }
+
+  @Override
+  protected void onInstantiation(final WopiWebRequestContext context) {
+    // nothing to do
+  }
+
+  @Override
+  public String getComponentName() {
+    return WOPI_COMPONENT_NAME;
+  }
+
+  @GET
+  @Path("Main")
+  @Homepage
+  @RedirectToInternalJsp("wopi.jsp")
+  @LowestRoleAccess(SilverpeasRole.admin)
+  public void home(WopiWebRequestContext context) {
+    mergeSelectedItems(context);
+    setCommons(context);
+  }
+
+  @POST
+  @Path("enable")
+  @RedirectToInternalJsp("wopi.jsp")
+  @LowestRoleAccess(SilverpeasRole.admin)
+  public void enable(WopiWebRequestContext context) {
+    getManager().enable(true);
+    setCommons(context);
+  }
+
+  @POST
+  @Path("disable")
+  @RedirectToInternalJsp("wopi.jsp")
+  @LowestRoleAccess(SilverpeasRole.admin)
+  public void disable(WopiWebRequestContext context) {
+    getManager().enable(false);
+    setCommons(context);
+  }
+
+  @POST
+  @Path("revokeSelected")
+  @RedirectToInternalJsp("wopi.jsp")
+  @LowestRoleAccess(SilverpeasRole.admin)
+  public void revokeSelected(WopiWebRequestContext context) {
+    mergeSelectedItems(context);
+    getAllUsers().stream()
+        .filter(u -> selectedUserIds.contains(u.getId()))
+        .forEach(getManager()::revokeUser);
+    getAllFiles().stream()
+        .filter(u -> selectedFileIds.contains(u.id()))
+        .forEach(getManager()::revokeFile);
+    selectedUserIds.clear();
+    selectedFileIds.clear();
+    setCommons(context);
+  }
+
+  @POST
+  @Path("revokeAll")
+  @RedirectToInternalJsp("wopi.jsp")
+  @LowestRoleAccess(SilverpeasRole.admin)
+  public void revokeAll(WopiWebRequestContext context) {
+    getAllUsers().forEach(getManager()::revokeUser);
+    getAllFiles().forEach(getManager()::revokeFile);
+    selectedUserIds.clear();
+    selectedFileIds.clear();
+    setCommons(context);
+  }
+
+  private void setCommons(final WopiWebRequestContext context) {
+    final HttpRequest request = context.getRequest();
+    request.setAttribute("isEnabled", getManager().isEnabled());
+    request.setAttribute("AllUsers", SilverpeasList.wrap(getAllUsers()));
+    request.setAttribute("AllFiles", SilverpeasList.wrap(getAllFiles()));
+    request.setAttribute("SelectedUserIds", selectedUserIds);
+    request.setAttribute("SelectedFileIds", selectedFileIds);
+  }
+
+  private void mergeSelectedItems(final WopiWebRequestContext context) {
+    final HttpRequest request = context.getRequest();
+    request.mergeSelectedItemsInto(selectedUserIds, "selectedUserIds", "unselectedUserIds");
+    request.mergeSelectedItemsInto(selectedFileIds, "selectedFileIds", "unselectedFileIds");
+  }
+
+  private List<WopiUser> getAllUsers() {
+    return getManager().listCurrentUsers();
+  }
+
+  private List<WopiFile> getAllFiles() {
+    return getManager().listCurrentFiles();
+  }
+
+  private WopiFileEditionManager getManager() {
+    return WopiFileEditionManager.get();
+  }
+}

--- a/core-war/src/main/java/org/silverpeas/web/wopi/WopiWebRequestContext.java
+++ b/core-war/src/main/java/org/silverpeas/web/wopi/WopiWebRequestContext.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2000 - 2019 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception. You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "http://www.silverpeas.org/docs/core/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.silverpeas.web.wopi;
+
+import org.silverpeas.core.admin.user.model.SilverpeasRole;
+import org.silverpeas.core.web.mvc.webcomponent.WebComponentRequestContext;
+
+import java.util.Collection;
+
+import static java.util.Collections.singleton;
+import static org.silverpeas.core.admin.user.model.SilverpeasRole.admin;
+import static org.silverpeas.core.admin.user.model.SilverpeasRole.reader;
+import static org.silverpeas.core.admin.user.model.User.getCurrentRequester;
+
+/**
+ * @author silveryocha
+ */
+public class WopiWebRequestContext extends WebComponentRequestContext<WopiWebController> {
+
+  @Override
+  public Collection<SilverpeasRole> getUserRoles() {
+    return singleton(getCurrentRequester().isAccessAdmin() ? admin : reader);
+  }
+}

--- a/core-war/src/main/webapp/WEB-INF/web.xml
+++ b/core-war/src/main/webapp/WEB-INF/web.xml
@@ -123,6 +123,15 @@
     <async-supported>true</async-supported>
   </filter>
   <filter>
+    <!-- WopiFilter Filter -->
+    <description>
+      To manage for each incoming request, the life-cycle of a WOPI host.
+    </description>
+    <filter-name>WopiServerFilter</filter-name>
+    <filter-class>org.silverpeas.core.webapi.wopi.WopiServerFilter</filter-class>
+    <async-supported>true</async-supported>
+  </filter>
+  <filter>
     <description>
       To validate each incoming HTTP request to a protected resource by using a synchronizer token
       mechanism.
@@ -184,6 +193,10 @@
   <filter-mapping>
     <filter-name>ScimServerFilter</filter-name>
     <url-pattern>/services/domains/*</url-pattern>
+  </filter-mapping>
+  <filter-mapping>
+    <filter-name>WopiServerFilter</filter-name>
+    <url-pattern>/services/wopi/*</url-pattern>
   </filter-mapping>
   <filter-mapping>
     <filter-name>SessionSynchronizerTokenValidator</filter-name>
@@ -677,6 +690,15 @@
     <servlet-name>VariablesRequestRouter</servlet-name>
     <servlet-class>org.silverpeas.web.variables.VariablesRequestRouter</servlet-class>
   </servlet>
+  <servlet>
+    <display-name>WopiRequestRouter</display-name>
+    <servlet-name>WopiRequestRouter</servlet-name>
+    <servlet-class>org.silverpeas.core.web.mvc.webcomponent.WebComponentRequestRouter</servlet-class>
+    <init-param>
+      <param-name>WebComponentController</param-name>
+      <param-value>org.silverpeas.web.wopi.WopiWebController</param-value>
+    </init-param>
+  </servlet>
 
   <servlet-mapping>
     <servlet-name>LoginDispatcher</servlet-name>
@@ -1080,6 +1102,10 @@
   <servlet-mapping>
     <servlet-name>VariablesRequestRouter</servlet-name>
     <url-pattern>/Rvariables/*</url-pattern>
+  </servlet-mapping>
+  <servlet-mapping>
+    <servlet-name>WopiRequestRouter</servlet-name>
+    <url-pattern>/Rwopi/*</url-pattern>
   </servlet-mapping>
 
   <jsp-config>

--- a/core-war/src/main/webapp/media/jsp/wopi/editor.jsp
+++ b/core-war/src/main/webapp/media/jsp/wopi/editor.jsp
@@ -1,0 +1,158 @@
+<%--
+  ~ Copyright (C) 2000 - 2019 Silverpeas
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as
+  ~ published by the Free Software Foundation, either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ As a special exception to the terms and conditions of version 3.0 of
+  ~ the GPL, you may redistribute this Program in connection with Free/Libre
+  ~ Open Source Software ("FLOSS") applications as described in Silverpeas's
+  ~ FLOSS exception.  You should have received a copy of the text describing
+  ~ the FLOSS exception, and it is also available here:
+  ~ "https://www.silverpeas.org/legal/floss_exception.html"
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  --%>
+<%@ page import="org.silverpeas.core.admin.user.model.User" %>
+<%@ page import="org.silverpeas.core.util.URLUtil" %>
+<%@ page import="org.silverpeas.core.wopi.WopiSettings" %>
+<%@page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
+<%@ taglib uri="http://www.silverpeas.com/tld/viewGenerator" prefix="view" %>
+<%@ taglib tagdir="/WEB-INF/tags/silverpeas/util" prefix="viewTags" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+
+<c:set var="origin" value="<%=URLUtil.getServerURL(request)%>"/>
+<c:set var="wopiClientUrl" value="${requestScope.WopiClientUrl}"/>
+<c:set var="currentUser" value="<%=User.getCurrentRequester()%>"/>
+<c:set var="wopiUser" value="${requestScope.WopiUser}"/>
+<jsp:useBean id="wopiUser" type="org.silverpeas.core.wopi.WopiUser"/>
+<c:set var="wopiFile" value="${requestScope.WopiFile}"/>
+<jsp:useBean id="wopiFile" type="org.silverpeas.core.wopi.WopiFile"/>
+<c:set var="hideTrackChanges" value="${not(currentUser.accessAdmin or wopiFile.owner().id eq currentUser.id)}"/>
+<c:set var="uiDefaults" value="<%=WopiSettings.getUIDefaults()%>"/>
+
+<view:sp-page>
+  <view:sp-head-part minimalSilverpeasScriptEnv="true">
+    <meta charset="utf-8">
+    <%-- Enable IE Standards mode --%>
+    <meta http-equiv="x-ua-compatible" content="ie=edge">
+    <meta name="viewport"
+          content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no">
+
+    <style type="text/css">
+      html, body {
+        height: 100%;
+        margin: 0;
+        padding: 0;
+        overflow: hidden;
+        -ms-content-zooming: none;
+      }
+
+      iframe {
+        display: block;
+        border: none;
+        width: 100%;
+        height: 100%;
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        margin: 0;
+      }
+    </style>
+  </view:sp-head-part>
+  <view:sp-body-part>
+    <div id="wopicontainer"></div>
+    <form name="wopiform" method="post" action="${wopiClientUrl}" target="wopiframe">
+    <c:if test="${uiDefaults.present}">
+      <input name="${uiDefaults.get().first}" value="${uiDefaults.get().second}" type="hidden">
+    </c:if>
+    </form>
+    <script type="text/javascript">
+      (function() {
+        let $container = document.querySelector('#wopicontainer');
+        let $iframe = document.createElement('iframe');
+        $iframe.name = 'wopiframe';
+        $iframe.id = 'wopiframe';
+        $iframe.title = 'Online Editing';
+        // $iframe.setAttribute('allowfullscreen', 'true');
+        // $iframe.setAttribute('sandbox', 'allow-scripts allow-same-origin allow-forms allow-modals allow-popups allow-top-navigation allow-popups-to-escape-sandbox');
+        $container.appendChild($iframe);
+
+        window.addEventListener("message", function (event) {
+          if ('${origin}' === event.origin && event.data) {
+            let data = JSON.parse(event.data);
+            sp.log.debug('receive', data);
+            let msgId = data['MessageId'];
+            if ('App_LoadingStatus' === msgId) {
+              ClientMessageManager.post('Host_PostmessageReady');
+              ClientMessageManager.post('Hide_Menu_Item', {id : 'signdocument'});
+              <c:if test="${hideTrackChanges}">
+              ClientMessageManager.post('Hide_Menu_Item', {id : 'changesmenu'});
+              </c:if>
+            } else if ('Views_List' === msgId) {
+              if (data.Values) {
+                const userIds = data.Values
+                    .map(function(view) {
+                      return view['UserId'];
+                    })
+                    .filter(function(id) {
+                      return id && id !== ''
+                    })
+                    .join(',');
+                HostMessageManager.post('SP_CURRENT_USERS', {
+                  'X-WOPI-ViewUserIds' : userIds
+                });
+              }
+            } else if ('UI_Close' === msgId) {
+              window.top.close();
+            }
+            return;
+          }
+          sp.log.warning("received an event from an unknown origin");
+        }, false);
+
+        let ClientMessageManager = new function() {
+          let $window = $iframe.contentWindow;
+          this.post = function(msgId, values) {
+            let data = JSON.stringify({
+              'MessageId' : msgId,
+              'SendTime' : Date.now(),
+              'Values' : values ? values : {}
+            });
+            sp.log.debug('send', data);
+            $window.postMessage(data, '${origin}');
+          }
+        };
+
+        let HostMessageManager = new function() {
+          const baseUrl = webContext + '/services/wopi/files/${wopiFile.id()}';
+          this.post = function(msgType, values) {
+            let ajaxRequest = sp.ajaxRequest(baseUrl)
+                .withHeader('X-WOPI-Override', msgType)
+                .withHeader('access_token', '${wopiUser.accessToken}');
+            if (typeof values ===  'object') {
+              for (let key in values) {
+                ajaxRequest.withHeader(key, values[key]);
+              }
+            }
+            return ajaxRequest.byPostMethod().send();
+          }
+        };
+
+        setTimeout(function() {
+          document.wopiform.submit();
+        }, 0);
+      })();
+    </script>
+  </view:sp-body-part>
+</view:sp-page>

--- a/core-war/src/main/webapp/util/javaScript/silverpeas.js
+++ b/core-war/src/main/webapp/util/javaScript/silverpeas.js
@@ -338,13 +338,18 @@ if (!window.SilverpeasError) {
     };
     this.show = function() {
       if (_self.existsAtLeastOne()) {
-        var errorContainer = jQuery('<div>');
-        for (var i = 0; i < _errors.length; i++) {
-          jQuery('<div>').append(_errors[i]).appendTo(errorContainer);
-        }
-        jQuery.popup.error(errorContainer.html());
-        _self.reset();
-        return true;
+        return new Promise(function(resolve) {
+          let errorContainer = jQuery('<div>');
+          for (let i = 0; i < _errors.length; i++) {
+            jQuery('<div>').append(_errors[i]).appendTo(errorContainer);
+          }
+          jQuery.popup.error(errorContainer.html(), {
+            callback : resolve,
+            alternativeCallback : resolve,
+            callbackOnClose : resolve
+          });
+          _self.reset();
+        });
       }
       return false;
     };
@@ -940,7 +945,9 @@ if (typeof window.silverpeasAjax === 'undefined') {
     form.setAttribute('method', silverpeasFormConfig.getMethod());
     form.setAttribute('target', silverpeasFormConfig.getTarget());
     form.innerHTML = '';
-    applyTokenSecurity(form.parentNode);
+    if(!silverpeasFormConfig.getMethod().startsWith('G')) {
+      applyTokenSecurity(form.parentNode);
+    }
     for (var paramKey in silverpeasFormConfig.getParams()) {
       var paramValue = silverpeasFormConfig.getParams()[paramKey];
       var paramInput = document.createElement("input");

--- a/core-war/src/main/webapp/wopi/jsp/wopi.jsp
+++ b/core-war/src/main/webapp/wopi/jsp/wopi.jsp
@@ -1,0 +1,325 @@
+<%--
+
+    Copyright (C) 2000 - 2019 Silverpeas
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    As a special exception to the terms and conditions of version 3.0 of
+    the GPL, you may redistribute this Program in connection with Free/Libre
+    Open Source Software ("FLOSS") applications as described in Silverpeas's
+    FLOSS exception.  You should have received a copy of the text describing
+    the FLOSS exception, and it is also available here:
+    "http://www.silverpeas.org/docs/core/legal/floss_exception.html"
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+--%>
+<%@ page import="org.silverpeas.web.wopi.WopiFileUIEntity" %>
+<%@ page import="org.silverpeas.web.wopi.WopiUserUIEntity" %>
+<%@ page import="org.silverpeas.core.wopi.WopiSettings" %>
+
+<%@page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
+
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn" %>
+<%@ taglib uri="http://www.silverpeas.com/tld/silverFunctions" prefix="silfn" %>
+<%@ taglib uri="http://www.silverpeas.com/tld/viewGenerator" prefix="view" %>
+
+<c:set var="lang" value="${sessionScope['SilverSessionController'].favoriteLanguage}"/>
+<c:set var="zoneId" value="${sessionScope['SilverSessionController'].favoriteZoneId}"/>
+<fmt:setLocale value="${lang}"/>
+<view:setBundle bundle="${requestScope.resources.multilangBundle}"/>
+
+<c:set var="isEnabled" value="${requestScope['isEnabled']}"/>
+<c:set var="allUsers" value="${requestScope['AllUsers']}"/>
+<jsp:useBean id="allUsers" type="org.silverpeas.core.util.SilverpeasList<org.silverpeas.core.wopi.WopiUser>"/>
+<c:set var="allFiles" value="${requestScope['AllFiles']}"/>
+<jsp:useBean id="allFiles" type="org.silverpeas.core.util.SilverpeasList<org.silverpeas.core.wopi.WopiFile>"/>
+<c:set var="selectedUserIds" value="${requestScope.SelectedUserIds}"/>
+<jsp:useBean id="selectedUserIds" type="java.util.Set<java.lang.String>"/>
+<c:set var="selectedFileIds" value="${requestScope.SelectedFileIds}"/>
+<jsp:useBean id="selectedFileIds" type="java.util.Set<java.lang.String>"/>
+
+<fmt:message var="browseBarAll" key="wopi.breadcrumb"/>
+<fmt:message var="enable" key="wopi.action.enable"/>
+<fmt:message var="disable" key="wopi.action.disable"/>
+<fmt:message var="disableConfirm" key="wopi.action.disable.confirm"/>
+<fmt:message var="disableConfirmHelp" key="wopi.action.disable.confirm.help"/>
+<fmt:message var="revokeSelected" key="wopi.action.selection.revoke"/>
+<fmt:message var="revokeSelectedConfirm" key="wopi.action.selection.revoke.confirm"/>
+<fmt:message var="revokeAll" key="wopi.action.all.revoke"/>
+<fmt:message var="revokeAllConfirm" key="wopi.action.all.revoke.confirm"/>
+
+<fmt:message var="userNameLabel" key="wopi.user.name"/>
+<fmt:message var="userEditedFileLabel" key="wopi.user.editedFiles"><fmt:param value="${1}"/></fmt:message>
+<fmt:message var="userEditedFilesLabel" key="wopi.user.editedFiles"><fmt:param value="${2}"/></fmt:message>
+<fmt:message var="userNbEditedFilesLabel" key="wopi.user.editedFiles.nb"/>
+<fmt:message var="userLastEditionLabel" key="wopi.user.lastEdition"/>
+<fmt:message var="fileNameLabel" key="wopi.file.name"/>
+<fmt:message var="fileLocationLabel" key="wopi.file.location"/>
+<fmt:message var="fileEditorLabel" key="wopi.file.editors"><fmt:param value="${1}"/></fmt:message>
+<fmt:message var="fileEditorsLabel" key="wopi.file.editors"><fmt:param value="${2}"/></fmt:message>
+<fmt:message var="fileNbEditorsLabel" key="wopi.file.editors.nb"/>
+<fmt:message var="fileLastEditionLabel" key="wopi.file.lastEdition"/>
+
+<view:sp-page>
+  <view:sp-head-part>
+    <c:if test="${isEnabled}">
+      <style type="text/css">
+        #disableFormDialog .help {
+          font-size: 0.8em;
+        }
+        #dynamic-containers {
+          display: table;
+          width: 100%;
+        }
+        #dynamic-user-container,
+        #dynamic-user-container {
+          display: table-cell;
+        }
+        #dynamic-user-container {
+          width: auto;
+          padding-right: 5px;
+        }
+        #dynamic-file-container {
+          width: auto;
+          padding-left: 5px;
+        }
+        .tip-extra-info {
+          max-width: 1000px;
+        }
+      </style>
+    </c:if>
+    <script type="text/javascript">
+      <c:choose>
+      <c:when test="${isEnabled}">
+      let refreshTimer;
+      const userSelectionOptions = {
+        paramSelectedIds : 'selectedUserIds', paramUnselectedIds : 'unselectedUserIds'
+      };
+      const fileSelectionOptions = {
+        paramSelectedIds : 'selectedFileIds', paramUnselectedIds : 'unselectedFileIds'
+      };
+      let userArrayPaneAjaxControl;
+      let fileArrayPaneAjaxControl;
+      const userCheckboxMonitor = sp.selection.newCheckboxMonitor(
+          '#dynamic-user-container input[name=selection]');
+      const fileCheckboxMonitor = sp.selection.newCheckboxMonitor(
+          '#dynamic-file-container input[name=selection]');
+
+      function revokeSelected() {
+        jQuery.popup.confirm('${silfn:escapeJs(revokeSelectedConfirm)}', function() {
+          spProgressMessage.show();
+          const ajaxRequest = sp.ajaxRequest("revokeSelected").byPostMethod();
+          userCheckboxMonitor.prepareAjaxRequest(ajaxRequest, userSelectionOptions);
+          fileCheckboxMonitor.prepareAjaxRequest(ajaxRequest, fileSelectionOptions);
+          ajaxRequest.send().then(function(request) {
+            userArrayPaneAjaxControl.refreshFromRequestResponse(request);
+            fileArrayPaneAjaxControl.refreshFromRequestResponse(request);
+          });
+        });
+      }
+
+      function revokeAll() {
+        jQuery.popup.confirm("${silfn:escapeJs(revokeAllConfirm)}", function() {
+          spProgressMessage.show();
+          const ajaxRequest = sp.ajaxRequest("revokeAll").byPostMethod();
+          ajaxRequest.send().then(function(request) {
+            userArrayPaneAjaxControl.refreshFromRequestResponse(request);
+            fileArrayPaneAjaxControl.refreshFromRequestResponse(request);
+          });
+        });
+      }
+
+      function disable() {
+        jQuery('#disableFormDialog').popup('confirmation', {
+          callback : function() {
+            spProgressMessage.show();
+            sp.formRequest('disable').byPostMethod().submit();
+          }
+        });
+      }
+
+      function updateRefreshTimeout(timeout) {
+        clearTimeout(refreshTimer);
+        refreshTimer = setTimeout(function() {
+          let ajaxRequest = sp.ajaxRequest("Main");
+          userCheckboxMonitor.prepareAjaxRequest(ajaxRequest, userSelectionOptions);
+          fileCheckboxMonitor.prepareAjaxRequest(ajaxRequest, fileSelectionOptions);
+          ajaxRequest.send().then(function(request) {
+            userArrayPaneAjaxControl.refreshFromRequestResponse(request);
+            fileArrayPaneAjaxControl.refreshFromRequestResponse(request);
+          });
+        }, timeout ? timeout : 10000);
+      }
+
+      let qtipApi;
+
+      function showEditedFilesTip(element, editedFiles) {
+        clearTimeout(refreshTimer);
+        let $container = document.createElement('div');
+        editedFiles.forEach(function(editedFile) {
+          let $fileContainer = document.createElement('div');
+          let fileHTML = editedFile.name;
+          if (editedFile.location) {
+            fileHTML = editedFile.location + ' > ' + fileHTML;
+          }
+          $fileContainer.innerHTML = fileHTML;
+          $container.appendChild($fileContainer);
+        });
+        qtipApi = TipManager.simpleDetails(element, function() {
+          return $container;
+        }, tipOptionsWithSingularOrPluralLabel(editedFiles.length, '${silfn:escapeJs(userEditedFileLabel)}', '${silfn:escapeJs(userEditedFilesLabel)}'));
+        qtipApi.show();
+      }
+
+      function showEditorsTip(element, editors) {
+        clearTimeout(refreshTimer);
+        let $container = document.createElement('div');
+        editors.forEach(function(editor) {
+          let $fileContainer = document.createElement('div');
+          $fileContainer.innerHTML = editor.name;
+          $container.appendChild($fileContainer);
+        });
+        qtipApi = TipManager.simpleDetails(element, function() {
+          return $container;
+        }, tipOptionsWithSingularOrPluralLabel(editors.length, '${silfn:escapeJs(fileEditorLabel)}', '${silfn:escapeJs(fileEditorsLabel)}'));
+        qtipApi.show();
+      }
+
+      function hideTip() {
+        updateRefreshTimeout(2000);
+        qtipApi.destroy();
+      }
+
+      function tipOptionsWithSingularOrPluralLabel(nbItems, singular, plural) {
+        return {
+          content : {
+            title : {
+              text : nbItems > 1 ? plural : singular
+            }
+          },
+          style : {
+            classes : 'tip-extra-info qtip-free-width'
+          }
+        }
+      }
+      </c:when>
+      <c:otherwise>
+      function enable() {
+        sp.formRequest('enable').byPostMethod().submit();
+      }
+      </c:otherwise>
+      </c:choose>
+    </script>
+  </view:sp-head-part>
+  <view:sp-body-part cssClass="page_content_admin wopi_admin">
+    <view:browseBar extraInformations="${browseBarAll}"/>
+    <view:operationPane>
+      <view:operation action="javascript:${isEnabled ? 'dis' : 'en' }able()" icon="" altText="${isEnabled ? disable : enable}"/>
+      <c:if test="${isEnabled}">
+        <view:operationSeparator/>
+        <view:operation action="javascript:revokeSelected()" icon="" altText="${revokeSelected}"/>
+        <view:operation action="javascript:revokeAll()" icon="" altText="${revokeAll}"/>
+      </c:if>
+    </view:operationPane>
+    <view:window>
+      <view:frame>
+        <c:choose>
+          <c:when test="${isEnabled}">
+            <p>
+              <c:set var="wopiClientAdminUrl" value="<%=WopiSettings.getWopiClientAdministrationUrl()%>"/>
+              <a href="${wopiClientAdminUrl}" target="_blank"><fmt:message key="wopi.client.admin.url"/></a>
+            </p>
+            <div id="dynamic-containers">
+              <div id="dynamic-user-container">
+                <view:arrayPane var="arrayOfWopiUsers" routingAddress="Main" numberLinesPerPage="25">
+                  <view:arrayColumn width="10" sortable="false"/>
+                  <view:arrayColumn title="${userNameLabel}" compareOn="${r -> r.data.asSilverpeas().displayedName}"/>
+                  <view:arrayColumn title="${userNbEditedFilesLabel}" compareOn="${r -> r.editedFiles().size()}"/>
+                  <view:arrayColumn title="${userLastEditionLabel}" compareOn="${r -> r.data.lastEditionDate}"/>
+                  <view:arrayLines var="user" items="<%=WopiUserUIEntity.convertList(allUsers, selectedUserIds)%>">
+                    <view:arrayLine>
+                      <view:arrayCellCheckbox name="selection" checked="${user.selected}" value="${user.id}"/>
+                      <view:arrayCellText>${user.data.asSilverpeas().displayedName}</view:arrayCellText>
+                      <c:set var="editedFilesAsJson">
+                        [<c:forEach var="file" varStatus="status" items="${user.editedFiles()}">
+                        <c:if test="${not status.first}">,</c:if>{'name':'${file.data.name()}','location':'${file.getLocation(lang)}'}
+                        </c:forEach>]</c:set>
+                      <view:arrayCellText><a href="javascript:void(0)" onmouseenter="showEditedFilesTip(this, ${editedFilesAsJson})" onmouseleave="hideTip()">${user.editedFiles().size()}</a></view:arrayCellText>
+                      <view:arrayCellText>${silfn:formatTemporal(user.data.lastEditionDate, zoneId, lang)}</view:arrayCellText>
+                    </view:arrayLine>
+                  </view:arrayLines>
+                </view:arrayPane>
+                <script type="text/javascript">
+                  whenSilverpeasReady(function() {
+                    userCheckboxMonitor.pageChanged();
+                    userArrayPaneAjaxControl =
+                        sp.arrayPane.ajaxControls('#dynamic-user-container', {
+                          before : function(ajaxRequest) {
+                            userCheckboxMonitor.prepareAjaxRequest(ajaxRequest, userSelectionOptions)
+                          }
+                        });
+                    updateRefreshTimeout();
+                  });
+                </script>
+              </div>
+              <div id="dynamic-file-container">
+                <view:arrayPane var="arrayOfWopiFiles" routingAddress="Main" numberLinesPerPage="25">
+                  <view:arrayColumn width="10" sortable="false"/>
+                  <view:arrayColumn title="${fileNameLabel}" compareOn="${r -> r.data.name()}"/>
+                  <view:arrayColumn title="${fileLocationLabel}" compareOn="${r -> r.getLocation(lang)}"/>
+                  <view:arrayColumn title="${fileNbEditorsLabel}" compareOn="${r -> r.editors().size()}"/>
+                  <view:arrayColumn title="${fileLastEditionLabel}" compareOn="${r -> r.data.lastEditionDate}"/>
+                  <view:arrayLines var="file" items="<%=WopiFileUIEntity.convertList(allFiles, selectedFileIds)%>">
+                    <view:arrayLine>
+                      <view:arrayCellCheckbox name="selection" checked="${file.selected}" value="${file.id}"/>
+                      <view:arrayCellText>${file.data.name()}</view:arrayCellText>
+                      <view:arrayCellText>${file.getLocation(lang)}</view:arrayCellText>
+                      <c:set var="editorsAsJson">
+                        [<c:forEach var="user" varStatus="status" items="${file.editors()}">
+                        <c:if test="${not status.first}">,</c:if>{'name':'${user.data.asSilverpeas().displayedName}'}
+                      </c:forEach>]</c:set>
+                      <view:arrayCellText><a href="javascript:void(0)" onmouseenter="showEditorsTip(this, ${editorsAsJson})" onmouseleave="hideTip()">${file.editors().size()}</a></view:arrayCellText>
+                      <view:arrayCellText>${silfn:formatTemporal(file.data.lastEditionDate, zoneId, lang)}</view:arrayCellText>
+                    </view:arrayLine>
+                  </view:arrayLines>
+                </view:arrayPane>
+                <script type="text/javascript">
+                  whenSilverpeasReady(function() {
+                    fileCheckboxMonitor.pageChanged();
+                    fileArrayPaneAjaxControl =
+                        sp.arrayPane.ajaxControls('#dynamic-file-container', {
+                          before : function(ajaxRequest) {
+                            fileCheckboxMonitor.prepareAjaxRequest(ajaxRequest, fileSelectionOptions)
+                          }
+                        });
+                    updateRefreshTimeout();
+                  });
+                </script>
+              </div>
+            </div>
+            <div id="disableFormDialog" style="display: none;">
+                ${disableConfirm}
+              <div class="help">(${disableConfirmHelp})</div>
+            </div>
+          </c:when>
+          <c:otherwise>
+            <div class="inlineMessage"><fmt:message key="wopi.info.disabled"/></div>
+          </c:otherwise>
+        </c:choose>
+      </view:frame>
+    </view:window>
+    <view:progressMessage/>
+  </view:sp-body-part>
+</view:sp-page>

--- a/core-web/src/main/java/org/silverpeas/core/web/filter/MassiveWebSecurityFilter.java
+++ b/core-web/src/main/java/org/silverpeas/core/web/filter/MassiveWebSecurityFilter.java
@@ -30,13 +30,13 @@ import org.silverpeas.core.persistence.jdbc.DBUtil;
 import org.silverpeas.core.util.StringUtil;
 import org.silverpeas.core.util.URLUtil;
 import org.silverpeas.core.util.logging.SilverLogger;
+import org.silverpeas.core.util.security.SecuritySettings;
 import org.silverpeas.core.web.SilverpeasWebResource;
 import org.silverpeas.core.web.attachment.WebDavProtocol;
 import org.silverpeas.core.web.filter.exception.WebSecurityException;
 import org.silverpeas.core.web.filter.exception.WebSqlInjectionSecurityException;
 import org.silverpeas.core.web.filter.exception.WebXssInjectionSecurityException;
 import org.silverpeas.core.web.http.HttpRequest;
-import org.silverpeas.core.util.security.SecuritySettings;
 
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;

--- a/core-web/src/main/java/org/silverpeas/core/web/mvc/controller/AbstractComponentSessionController.java
+++ b/core-web/src/main/java/org/silverpeas/core/web/mvc/controller/AbstractComponentSessionController.java
@@ -58,6 +58,7 @@ import java.util.List;
  */
 public abstract class AbstractComponentSessionController implements ComponentSessionController,
     SessionCloseable {
+  private static final long serialVersionUID = -6941005626660183283L;
 
   /**
    * The default character encoded supported by Silverpeas.

--- a/core-web/src/main/java/org/silverpeas/core/web/mvc/webcomponent/WebComponentController.java
+++ b/core-web/src/main/java/org/silverpeas/core/web/mvc/webcomponent/WebComponentController.java
@@ -36,6 +36,7 @@ import org.silverpeas.core.web.mvc.controller.MainSessionController;
  */
 public abstract class WebComponentController<T extends WebComponentRequestContext>
     extends AbstractComponentSessionController {
+  private static final long serialVersionUID = 3379576329820759648L;
 
   boolean onCreationCalled = false;
 

--- a/core-web/src/main/java/org/silverpeas/core/web/session/SessionManager.java
+++ b/core-web/src/main/java/org/silverpeas/core/web/session/SessionManager.java
@@ -33,9 +33,9 @@ import org.silverpeas.core.cache.service.SessionCacheService;
 import org.silverpeas.core.cache.service.VolatileResourceCacheService;
 import org.silverpeas.core.initialization.Initialization;
 import org.silverpeas.core.io.upload.UploadSession;
+import org.silverpeas.core.notification.NotificationException;
 import org.silverpeas.core.notification.sse.DefaultServerEventNotifier;
 import org.silverpeas.core.notification.sse.ServerEventDispatcherTask;
-import org.silverpeas.core.notification.NotificationException;
 import org.silverpeas.core.notification.user.client.NotificationMetaData;
 import org.silverpeas.core.notification.user.client.NotificationParameters;
 import org.silverpeas.core.notification.user.client.NotificationSender;
@@ -60,6 +60,7 @@ import org.silverpeas.core.util.SettingBundle;
 import org.silverpeas.core.util.StringUtil;
 import org.silverpeas.core.util.logging.SilverLogger;
 
+import javax.enterprise.event.Event;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import javax.servlet.http.HttpServletRequest;
@@ -123,6 +124,8 @@ public class SessionManager implements SessionManagement, Initialization {
   private Scheduler scheduler;
   @Inject
   private DefaultServerEventNotifier defaultServerEventNotifier;
+  @Inject
+  private Event<UserSessionEvent> userSessionNotifier;
 
   /**
    * Prevent the class from being instantiate (private)
@@ -253,6 +256,7 @@ public class SessionManager implements SessionManagement, Initialization {
       }
 
       defaultServerEventNotifier.notify(UserSessionServerEvent.aClosingOneFor(si));
+      userSessionNotifier.fire(new UserSessionEvent(si));
     } catch (Exception ex) {
       SilverLogger.getLogger(this).error(ex.getMessage(), ex);
     }

--- a/core-web/src/main/java/org/silverpeas/core/web/session/UserSessionEvent.java
+++ b/core-web/src/main/java/org/silverpeas/core/web/session/UserSessionEvent.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2000 - 2020 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.web.session;
+
+import org.silverpeas.core.security.session.SessionInfo;
+
+/**
+ * Representation of a user session event which is sent today on session closing only.
+ * @author silveryocha
+ */
+public class UserSessionEvent {
+  private final SessionInfo sessionInfo;
+
+  public UserSessionEvent(final SessionInfo sessionInfo) {
+    this.sessionInfo = sessionInfo;
+  }
+
+  public SessionInfo getSessionInfo() {
+    return sessionInfo;
+  }
+
+  public boolean isClosing() {
+    return true;
+  }
+}

--- a/core-web/src/main/java/org/silverpeas/core/web/token/SynchronizerTokenService.java
+++ b/core-web/src/main/java/org/silverpeas/core/web/token/SynchronizerTokenService.java
@@ -65,7 +65,7 @@ public class SynchronizerTokenService {
   public static final String SESSION_TOKEN_KEY = "X-STKN";
   public static final String NAVIGATION_TOKEN_KEY = "X-NTKN";
   private static final String UNPROTECTED_URI_RULE =
-      "(?i)(?!.*(/qaptcha|rpdcsearch/|rclipboard/|rselectionpeaswrapper/|rusernotification/|services/usernotifications/|blockingNews|services/password/)).*";
+      "(?i)(?!.*(/qaptcha|rpdcsearch/|rclipboard/|rselectionpeaswrapper/|rusernotification/|services/wopi/|services/usernotifications/|blockingNews|services/password/)).*";
   private static final String DEFAULT_GET_RULE
       = "(?i)^/\\w+[\\w/]*/jsp/.*(delete|update|creat|block|unblock).*$";
   private static final SilverLogger logger = SilverLogger.getLogger("silverpeas.core.security");

--- a/core-web/src/main/java/org/silverpeas/core/webapi/attachment/SimpleDocumentResource.java
+++ b/core-web/src/main/java/org/silverpeas/core/webapi/attachment/SimpleDocumentResource.java
@@ -520,6 +520,26 @@ public class SimpleDocumentResource extends AbstractSimpleDocumentResource {
   }
 
   /**
+   * Enable or not the simultaneous edition of an attachment.
+   * @return JSON simultaneous edition state. editableSimultaneously = true or false.
+   */
+  @POST
+  @Path("switchEditSimultaneouslyEnabled")
+  @Produces(MediaType.APPLICATION_JSON)
+  public String switchEditSimultaneouslyEnabled(@FormParam("enabled") final boolean enabled) {
+
+    // Performing the request
+    SimpleDocument document = getSimpleDocument(null);
+    AttachmentServiceProvider.getAttachmentService()
+        .switchEnableEditSimultaneously(document.getPk(), enabled);
+
+    // JSON Response.
+    return MessageFormat.format(
+        "'{'\"editableSimultaneously\":{0}, \"id\":{1,number,#}, \"attachmentId\":\"{2}\"}",
+        enabled, document.getOldSilverpeasId(), document.getId());
+  }
+
+  /**
    * Return the current document
    * @param lang
    * @return SimpleDocument

--- a/core-web/src/main/java/org/silverpeas/core/webapi/base/SilverpeasRequestContext.java
+++ b/core-web/src/main/java/org/silverpeas/core/webapi/base/SilverpeasRequestContext.java
@@ -39,7 +39,7 @@ public abstract class SilverpeasRequestContext {
   private HttpServletResponse response;
   private User user;
 
-  protected void init(final HttpServletRequest request, final HttpServletResponse response) {
+  public void init(final HttpServletRequest request, final HttpServletResponse response) {
     this.request = request;
     this.response = response;
     final String httpMethod = request.getMethod().toUpperCase();

--- a/core-web/src/main/java/org/silverpeas/core/webapi/wopi/AbstractWopiFileResource.java
+++ b/core-web/src/main/java/org/silverpeas/core/webapi/wopi/AbstractWopiFileResource.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) 2000 - 2020 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.webapi.wopi;
+
+import org.silverpeas.core.admin.user.model.User;
+import org.silverpeas.core.wopi.WopiFile;
+import org.silverpeas.core.wopi.WopiFileEditionManager;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.HttpMethod;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import static java.text.MessageFormat.format;
+import static java.util.Optional.empty;
+import static java.util.Optional.of;
+import static org.silverpeas.core.wopi.WopiLogger.logger;
+
+/**
+ * @author silveryocha
+ */
+public abstract class AbstractWopiFileResource implements WopiProtectedWebResource {
+
+  @PathParam("fileId")
+  private String fileId;
+
+  private WopiFileEditionContext editionContext;
+
+  @Inject
+  private WopiRequestContext requestContext;
+
+  @Inject
+  private WopiFileEditionManager editionManager;
+
+  @Context
+  private HttpServletRequest httpRequest;
+
+  @Context
+  private HttpServletResponse httpResponse;
+
+  @PostConstruct
+  protected void initContext() {
+    requestContext.init(httpRequest, httpResponse);
+  }
+
+  @Override
+  public WopiRequestContext getSilverpeasContext() {
+    return requestContext;
+  }
+
+  /**
+   * Processes the given supplier after authorization checking
+   * @param supplier the supplier of response.
+   * @return the response given by supplier.
+   */
+  protected Response process(Supplier<Response> supplier) {
+    try {
+      final String accessToken = requestContext.getAccessToken();
+      editionContext = getEditionManager().getEditionContextFrom(fileId, accessToken,
+          (u, f) -> new WopiFileEditionContext(u.orElse(null), f.orElse(null)));
+      final Optional<Response> errorResponse = checkEditionContext();
+      return errorResponse.orElseGet(supplier);
+    } catch (WopiResponseError e) {
+      return e.getResponse();
+    } catch (Exception e) {
+      logger().error(e);
+      return Response.status(Response.Status.INTERNAL_SERVER_ERROR).build();
+    }
+  }
+
+  private Optional<Response> checkEditionContext() {
+    if (editionContext.getUser() == null) {
+      return of(Response.status(Response.Status.UNAUTHORIZED).build());
+    }
+    final User user = editionContext.getUser().asSilverpeas();
+    final WopiFile wopiFile = editionContext.getFile();
+    if (wopiFile == null) {
+      return of(Response.status(Response.Status.NOT_FOUND).build());
+    }
+    if (HttpMethod.GET.equals(httpRequest.getMethod()) && !wopiFile.canBeAccessedBy(user)) {
+      final String error = format("User {0} can not access the file {1}", user.getId(), wopiFile);
+      logger().error(error);
+      return of(Response.status(Response.Status.UNAUTHORIZED).build());
+    } else if (!HttpMethod.GET.equals(httpRequest.getMethod()) && !wopiFile.canBeModifiedBy(user)){
+      final String error = format("User {0} can not modify the file {1}", user.getId(), wopiFile);
+      logger().error(error);
+      return of(Response.status(Response.Status.UNAUTHORIZED).build());
+    }
+    return empty();
+  }
+
+  protected WopiFileEditionContext getEditionContext() {
+    return editionContext;
+  }
+
+  protected WopiFileEditionManager getEditionManager() {
+    return editionManager;
+  }
+}

--- a/core-web/src/main/java/org/silverpeas/core/webapi/wopi/WebWopiFileEdition.java
+++ b/core-web/src/main/java/org/silverpeas/core/webapi/wopi/WebWopiFileEdition.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2000 - 2020 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.webapi.wopi;
+
+import org.silverpeas.core.annotation.Bean;
+import org.silverpeas.core.security.session.SessionInfo;
+import org.silverpeas.core.util.ServiceProvider;
+import org.silverpeas.core.wopi.WopiFile;
+import org.silverpeas.core.wopi.WopiFileEditionManager;
+import org.silverpeas.core.wopi.WopiUser;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.core.UriBuilder;
+import java.util.Optional;
+
+import static java.text.MessageFormat.format;
+import static java.util.Optional.of;
+import static javax.ws.rs.core.UriBuilder.fromUri;
+import static org.silverpeas.core.security.session.SessionManagementProvider.getSessionManagement;
+import static org.silverpeas.core.wopi.WopiLogger.logger;
+import static org.silverpeas.core.wopi.WopiSettings.getWopiHostServiceBaseUrl;
+
+/**
+ * In charge of the management of WOPI contexts.
+ * <p>
+ * The exposed signatures permits to caller to initialize a WOPI edition.
+ * </p>
+ * <p>
+ * WOPI services can use directly the implementation of this interface in order to get more
+ * functionality.
+ * </p>
+ * @author silveryocha
+ */
+@Bean
+public class WebWopiFileEdition {
+
+  private static final String WOPI_SRC_PARAM = "WOPISrc";
+  private static final String ACCESS_TOKEN_PARAM = "access_token";
+
+  public static WebWopiFileEdition get() {
+    return ServiceProvider.getService(WebWopiFileEdition.class);
+  }
+
+  protected WebWopiFileEdition() {
+  }
+
+  /**
+   * Initializing a WOPI edition from given data.
+   * @param request the current request from which the edition is started.
+   * @param file a Silverpeas's WOPI file.
+   * @return an optional URL of the Silverpeas's editor page.
+   */
+  public Optional<String> initializeWith(final HttpServletRequest request, final WopiFile file) {
+    final String userSessionId = request.getSession(false).getId();
+    final SessionInfo sessionInfo = getSessionManagement().getSessionInfo(userSessionId);
+    return WopiFileEditionManager.get().prepareEditionWith(sessionInfo, file).flatMap(e -> {
+      final WopiUser editionUser = e.getUser();
+      final WopiFile editionFile = e.getFile();
+      final String fileId = editionFile.id();
+      final UriBuilder hostUriBuilder = fromUri(getWopiHostServiceBaseUrl()).path(fileId);
+      final UriBuilder uriBuilder = fromUri(e.getClientBaseUrl())
+          .queryParam(WOPI_SRC_PARAM, hostUriBuilder.build())
+          .queryParam(ACCESS_TOKEN_PARAM, editionUser.getAccessToken());
+      final String clientUrl = uriBuilder.build().toString();
+      logger().debug(() -> format(
+          "from {0} initializing WOPI edition for {1} and for user {2} with WOPI client URL {3}",
+          userSessionId, editionFile, editionUser, clientUrl));
+      return of(clientUrl).map(u -> {
+        request.setAttribute("WopiClientUrl", u);
+        request.setAttribute("WopiUser", editionUser);
+        request.setAttribute("WopiFile", editionFile);
+        return "/media/jsp/wopi/editor.jsp";
+      });
+    });
+  }
+}

--- a/core-web/src/main/java/org/silverpeas/core/webapi/wopi/WopiFileEditionContext.java
+++ b/core-web/src/main/java/org/silverpeas/core/webapi/wopi/WopiFileEditionContext.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2000 - 2020 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.webapi.wopi;
+
+import org.silverpeas.core.admin.user.model.User;
+import org.silverpeas.core.wopi.WopiFile;
+import org.silverpeas.core.wopi.WopiUser;
+
+import java.util.StringJoiner;
+
+/**
+ * Handles the edition context of a file.
+ * @author silveryocha
+ */
+public class WopiFileEditionContext {
+
+  private final WopiUser user;
+
+  private final WopiFileWrapper file;
+
+  protected WopiFileEditionContext(final WopiUser user, final WopiFile file) {
+    this.user = user;
+    this.file = file != null ? new WopiFileWrapper(file) : null;
+  }
+
+  /**
+   * Gets the initiator of the edition
+   * @return a {@link User} representing the initiator of the edition.
+   */
+  protected WopiUser getUser() {
+    return user;
+  }
+
+  /**
+   * Gets the WOPI file the context is linked to.
+   * @return a {@link WopiFile} instance.
+   */
+  public WopiFile getFile() {
+    return file;
+  }
+
+  @Override
+  public String toString() {
+    return new StringJoiner(", ", WopiFileEditionContext.class.getSimpleName() + "[", "]")
+        .add("user=" + user).add("file=" + file).toString();
+  }
+}

--- a/core-web/src/main/java/org/silverpeas/core/webapi/wopi/WopiFileResource.java
+++ b/core-web/src/main/java/org/silverpeas/core/webapi/wopi/WopiFileResource.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright (C) 2000 - 2020 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.webapi.wopi;
+
+import org.silverpeas.core.admin.user.model.User;
+import org.silverpeas.core.annotation.WebService;
+import org.silverpeas.core.util.JSONCodec;
+import org.silverpeas.core.util.StringUtil;
+import org.silverpeas.core.webapi.base.annotation.Authenticated;
+import org.silverpeas.core.wopi.WopiFile;
+import org.silverpeas.core.wopi.WopiUser;
+
+import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.StreamingOutput;
+import java.io.IOException;
+import java.time.OffsetDateTime;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static java.text.MessageFormat.format;
+import static java.time.OffsetDateTime.parse;
+import static java.util.Optional.*;
+import static javax.ws.rs.core.MediaType.APPLICATION_OCTET_STREAM;
+import static javax.ws.rs.core.Response.Status.CONFLICT;
+import static org.silverpeas.core.date.TemporalFormatter.toIso8601;
+import static org.silverpeas.core.util.StringUtil.*;
+import static org.silverpeas.core.util.URLUtil.getFullApplicationURL;
+import static org.silverpeas.core.util.URLUtil.getServerURL;
+import static org.silverpeas.core.util.file.FileServerUtils.getImageURL;
+import static org.silverpeas.core.webapi.wopi.WopiResourceURIs.WOPI_FILE_BASE_URI;
+import static org.silverpeas.core.wopi.WopiLogger.logger;
+import static org.silverpeas.core.wopi.WopiSettings.*;
+
+/**
+ * @author silveryocha
+ */
+@WebService
+@Path(WOPI_FILE_BASE_URI)
+@Authenticated
+public class WopiFileResource extends AbstractWopiFileResource {
+
+  private static final String WOPI_OVERRIDE_HEADER = "X-WOPI-Override";
+  private static final String WOPI_USER_IDS_HEADER = "X-WOPI-ViewUserIds";
+  static final String WOPI_LOCK_HEADER = "X-WOPI-Lock";
+
+  private static final String LAST_MODIFIED_TIME_FIELD = "LastModifiedTime";
+
+  @Inject
+  private WopiLockResponseManager lockManager;
+
+  /**
+   * @see
+   * <a href="https://wopi.readthedocs.io/projects/wopirest/en/latest/endpoints.html#files-endpoint"> WOPI spec,
+   * files endpoint</a>
+   */
+  @GET
+  public Response sendFileData() {
+    return process(() -> {
+      final WopiFileEditionContext context = getEditionContext();
+      final WopiFile file = context.getFile();
+      final WopiUser user = context.getUser();
+      final String json = JSONCodec.encodeObject(o -> {
+        final User spUser = user.asSilverpeas();
+        final boolean canBeModifiedBy = file.canBeModifiedBy(spUser);
+        final boolean webViewOnly = false;
+        final HttpServletRequest request = getSilverpeasContext().getRequest();
+        return o
+            // File
+            .put("OwnerId", getWopiUserIdPrefix() + file.owner())
+            .put("BaseFileName", file.name())
+            .put("Size", file.size())
+            .put("UserId", user.getId())
+            .put("Version", file.version())
+            .put(LAST_MODIFIED_TIME_FIELD, toIso8601(file.lastModificationDate(), true))
+            // Host capabilities
+            .put("SupportsContainers", false)
+            .put("SupportsDeleteFile", false)
+            .put("SupportsEcosystem", false)
+            .put("SupportsExtendedLockLength", false)
+            .put("SupportsFolders", false)
+            .put("SupportsGetLock", lockManager.isEnabled())
+            .put("SupportsLocks", lockManager.isEnabled())
+            .put("SupportsRename", false)
+            .put("SupportsUpdate", false)
+            .put("SupportsUserInfo", false)
+            // UI
+            .put("PostMessageOrigin", getServerURL(request))
+            .put("ClosePostMessage", true)
+            // User
+            .put("UserFriendlyName", spUser.getDisplayedName())
+            .putJSONObject("UserExtraInfo", e ->
+                e.put("avatar", getFullApplicationURL(request) + getImageURL(spUser.getAvatar(), "30x")))
+            // User Permissions
+            .put("ReadOnly", !canBeModifiedBy)
+            .put("DisablePrint", webViewOnly)
+            .put("DisableExport", webViewOnly)
+            .put("RestrictedWebViewOnly", webViewOnly)
+            .put("UserCanAttend", false)
+            .put("UserCanNotWriteRelative", true)
+            .put("UserCanPresent", false)
+            .put("UserCanRename", false)
+            .put("UserCanWrite", canBeModifiedBy);
+        }
+      );
+      return Response.ok().type(MediaType.APPLICATION_JSON).entity(json).build();
+    });
+  }
+
+  /**
+   * @see
+   * <a href="https://wopi.readthedocs.io/projects/wopirest/en/latest/endpoints.html#files-endpoint"> WOPI spec,
+   * files endpoint</a>
+   */
+  @POST
+  public Response receiveFileData() {
+    return process(() -> {
+      final HttpServletRequest request = getSilverpeasContext().getRequest();
+      final String action = defaultStringIfNotDefined(request.getHeader(WOPI_OVERRIDE_HEADER));
+      final WopiFile file = getEditionContext().getFile();
+      final Optional<Response> response;
+      if ("SP_CURRENT_USERS".equals(action)) {
+        final Set<String> userIds = Stream
+            .of(ofNullable(request.getHeader(WOPI_USER_IDS_HEADER)).orElse("").split("[, ;]"))
+            .filter(StringUtil::isDefined)
+            .map(String::trim)
+            .collect(Collectors.toSet());
+        getEditionManager().notifyEditionWith(file, userIds);
+        response = of(Response.ok().build());
+      } else if (action.contains("LOCK")) {
+        response = lockManager.manage(request, action, file);
+      } else {
+        response = empty();
+      }
+      return response.orElseGet(() -> Response.status(Response.Status.NOT_IMPLEMENTED).build());
+    });
+  }
+
+  /**
+   * @see
+   * <a href="https://wopi.readthedocs.io/projects/wopirest/en/latest/endpoints.html#file-contents-endpoint"> WOPI spec,
+   * file contents endpoint</a>
+   */
+  @GET
+  @Path("contents")
+  public Response sendFileContentData() {
+    return process(() -> {
+      final WopiFileEditionContext context = getEditionContext();
+      final StreamingOutput streamingOutput = o -> context.getFile().loadInto(o);
+      return Response.ok(streamingOutput, APPLICATION_OCTET_STREAM).build();
+    });
+  }
+
+  /**
+   * @see
+   * <a href="https://wopi.readthedocs.io/projects/wopirest/en/latest/endpoints.html#file-contents-endpoint"> WOPI spec,
+   * file contents endpoint</a>
+   */
+  @POST
+  @Path("contents")
+  public Response receiveFileContentData() {
+    return process(() -> {
+      final HttpServletRequest request = getSilverpeasContext().getRequest();
+      final WopiFileEditionContext context = getEditionContext();
+      final WopiFile file = context.getFile();
+      of(isLockCapabilityEnabled())
+          .filter(b -> b)
+          .map(b -> request.getHeader(WOPI_LOCK_HEADER))
+          .filter(l -> (isDefined(l) && !file.lock().exists()) || !file.lock().id().equals(l))
+          .ifPresent(l -> {
+            logger().debug(() -> format("WRITE CONFLICT because of not corresponding LOCK {0} on file {1}", l, file));
+            throw new WopiResponseError(Response.status(CONFLICT)
+                .header(WOPI_LOCK_HEADER, file.lock().id())
+                .build());
+          });
+      getTimestampVerificationElements().ifPresent(e -> {
+        final String timestampHeaderValue = request.getHeader(e.getFirst());
+        if (isDefined(timestampHeaderValue)) {
+          final OffsetDateTime timestampToVerify = parse(timestampHeaderValue);
+          logger().debug(() -> format("timestamp {0} verified on file {1}", timestampToVerify, file));
+          if (!timestampToVerify.isEqual(file.lastModificationDate())) {
+            logger().debug(() -> format("WRITE CONFLICT because of not corresponding timestamp {0} on file {1}", timestampToVerify, file));
+            throw new WopiResponseError(Response.status(CONFLICT)
+                .type(MediaType.APPLICATION_JSON).entity(e.getSecond())
+                .build());
+          }
+        } else {
+          logger().debug(() -> format("no timestamp verification on file {0}", file));
+        }
+      });
+      try {
+        file.updateFrom(getSilverpeasContext().getRequest().getInputStream());
+      } catch (IOException e) {
+        throw new WebApplicationException(e, Response.Status.NOT_FOUND);
+      }
+      getExitFieldNameDetection()
+          .filter(f -> getBooleanValue(request.getHeader(f)))
+          .ifPresent(f -> getEditionManager().revokeFile(file));
+      final String json = JSONCodec.encodeObject(
+          o -> o.put(LAST_MODIFIED_TIME_FIELD, toIso8601(file.lastModificationDate(), true)));
+      return Response.ok().type(MediaType.APPLICATION_JSON).entity(json).build();
+    });
+  }
+}

--- a/core-web/src/main/java/org/silverpeas/core/webapi/wopi/WopiFileWrapper.java
+++ b/core-web/src/main/java/org/silverpeas/core/webapi/wopi/WopiFileWrapper.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (C) 2000 - 2020 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.webapi.wopi;
+
+import org.silverpeas.core.ResourceReference;
+import org.silverpeas.core.admin.user.model.User;
+import org.silverpeas.core.wopi.WopiFile;
+import org.silverpeas.core.wopi.WopiFileLock;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.time.OffsetDateTime;
+import java.util.Optional;
+
+import static java.time.ZoneOffset.UTC;
+
+/**
+ * This WRAPPER is used by WOPI host and gives the possibility to add functionality
+ * contextualized to a WopiFile.
+ * @author silveryocha
+ */
+public class WopiFileWrapper extends WopiFile {
+
+  private final WopiFile wopiFile;
+
+  WopiFileWrapper(final WopiFile wopiFile) {
+    this.wopiFile = wopiFile;
+  }
+
+  @Override
+  public Optional<ResourceReference> linkedToResource() {
+    return wopiFile.linkedToResource();
+  }
+
+  @Override
+  public String silverpeasId() {
+    return wopiFile.silverpeasId();
+  }
+
+  @Override
+  public String id() {
+    return wopiFile.id();
+  }
+
+  @Override
+  public User owner() {
+    return wopiFile.owner();
+  }
+
+  @Override
+  public String name() {
+    return wopiFile.name();
+  }
+
+  @Override
+  public String ext() {
+    return wopiFile.ext();
+  }
+
+  @Override
+  public String mimeType() {
+    return wopiFile.mimeType();
+  }
+
+  @Override
+  public long size() {
+    return wopiFile.size();
+  }
+
+  /**
+   * Gets the last modification date with second precision.
+   * @return an {@link OffsetDateTime} with cleared milliseconds.
+   */
+  @Override
+  public OffsetDateTime lastModificationDate() {
+    return wopiFile.lastModificationDate().withNano(0).withOffsetSameInstant(UTC);
+  }
+
+  @Override
+  public String version() {
+    return wopiFile.version();
+  }
+
+  @Override
+  public void updateFrom(final InputStream input) throws IOException {
+    wopiFile.updateFrom(input);
+  }
+
+  @Override
+  public void loadInto(final OutputStream output) throws IOException {
+    wopiFile.loadInto(output);
+  }
+
+  @Override
+  public WopiFileLock lock() {
+    return wopiFile.lock();
+  }
+
+  @Override
+  public String toString() {
+    return wopiFile.toString();
+  }
+
+  @Override
+  public boolean canBeAccessedBy(final User user) {
+    return wopiFile.canBeAccessedBy(user);
+  }
+
+  @Override
+  public boolean canBeModifiedBy(final User user) {
+    return wopiFile.canBeModifiedBy(user);
+  }
+
+  @Override
+  public boolean canBeDeletedBy(final User user) {
+    return wopiFile.canBeDeletedBy(user);
+  }
+}

--- a/core-web/src/main/java/org/silverpeas/core/webapi/wopi/WopiLockResponseManager.java
+++ b/core-web/src/main/java/org/silverpeas/core/webapi/wopi/WopiLockResponseManager.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (C) 2000 - 2020 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.webapi.wopi;
+
+import org.silverpeas.core.annotation.Service;
+import org.silverpeas.core.wopi.WopiFile;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.core.Response;
+import java.util.Optional;
+
+import static java.text.MessageFormat.format;
+import static javax.ws.rs.core.Response.Status.CONFLICT;
+import static org.apache.commons.lang3.StringUtils.EMPTY;
+import static org.silverpeas.core.util.StringUtil.isDefined;
+import static org.silverpeas.core.webapi.wopi.WopiFileResource.WOPI_LOCK_HEADER;
+import static org.silverpeas.core.wopi.WopiLogger.logger;
+import static org.silverpeas.core.wopi.WopiSettings.isLockCapabilityEnabled;
+
+/**
+ * @author silveryocha
+ */
+@Service
+public class WopiLockResponseManager {
+
+  private static final String WOPI_OLD_LOCK_HEADER = "X-WOPI-OldLock";
+
+  protected WopiLockResponseManager() {
+  }
+
+  /**
+   * Indicates if lock manager is enabled.
+   * @return true of enabled, false otherwise.
+   */
+  protected boolean isEnabled() {
+    return isLockCapabilityEnabled();
+  }
+
+  /**
+   * Manages a file lock.
+   * @param request the current request.
+   * @param lockAction the lock action.
+   * @param file the current file to manage.
+   * @return an optional HTTP response.
+   */
+  protected Optional<Response> manage(final HttpServletRequest request, final String lockAction,
+      final WopiFile file) {
+    final Response response;
+    if (!isEnabled()) {
+      response = null;
+    } else if (currentLockIsNotWopiOne(file)) {
+      logger().debug(() -> format("EXTERNAL LOCK CONFLICT on file {0}", file));
+      response = Response.status(CONFLICT).header(WOPI_LOCK_HEADER, EMPTY).build();
+    } else if ("LOCK".equals(lockAction)) {
+      response = lock(request, file);
+    } else if ("GET_LOCK".equals(lockAction)) {
+      response = getLock(file);
+    } else if ("REFRESH_LOCK".equals(lockAction)) {
+      response = refreshLock(request, file);
+    } else if ("UNLOCK".equals(lockAction)) {
+      response = unlock(request, file);
+    } else {
+      response = null;
+    }
+    return Optional.ofNullable(response);
+  }
+
+  private Response lock(final HttpServletRequest request, final WopiFile file) {
+    final String lockId = request.getHeader(WOPI_LOCK_HEADER);
+    final String oldLockId = request.getHeader(WOPI_OLD_LOCK_HEADER);
+    if (isDefined(oldLockId)) {
+      // unlock and relock case
+      if (!file.lock().exists() || !file.lock().id().equals(oldLockId)) {
+        logger().debug(() -> format("RELOCK CONFLICT with old lock {0} on file {1}", oldLockId, file));
+        return Response.status(CONFLICT)
+            .header(WOPI_LOCK_HEADER, file.lock().id())
+            .build();
+      }
+      logger().debug(() -> format("RELOCK with new lock {0} on file {1}", lockId, file));
+    } else {
+      // new lock case
+      if (file.lock().exists() && !file.lock().id().equals(lockId)) {
+        logger().debug(() -> format("LOCK CONFLICT with new lock {0} on file {1}", lockId, file));
+        return Response.status(CONFLICT)
+            .header(WOPI_LOCK_HEADER, file.lock().id())
+            .build();
+      }
+      logger().debug(() -> format("LOCK with new lock {0} on file {1}", lockId, file));
+    }
+    file.lock().setId(lockId);
+    return Response.ok().header(WOPI_LOCK_HEADER, file.lock().id()).build();
+  }
+
+  private Response getLock(final WopiFile file) {
+    logger().debug(() -> format("GET LOCK on file {0}", file));
+    return Response.ok().header(WOPI_LOCK_HEADER, file.lock().id()).build();
+  }
+
+  private Response refreshLock(final HttpServletRequest request, final WopiFile file) {
+    final String lockId = request.getHeader(WOPI_LOCK_HEADER);
+    if (!file.lock().exists() || !file.lock().id().equals(lockId)) {
+      logger().debug(() -> format("REFRESH LOCK CONFLICT with new lock {0} on file {1}", lockId, file));
+      return Response.status(CONFLICT)
+          .header(WOPI_LOCK_HEADER, file.lock().id())
+          .build();
+    }
+    logger().debug(() -> format("REFRESH LOCK with new lock {0} on file {1}", lockId, file));
+    file.lock().setId(lockId);
+    return Response.ok().header(WOPI_LOCK_HEADER, file.lock().id()).build();
+  }
+
+  private Response unlock(final HttpServletRequest request, final WopiFile file) {
+    final String lockId = request.getHeader(WOPI_LOCK_HEADER);
+    if (!file.lock().exists() || !file.lock().id().equals(lockId)) {
+      logger().debug(() -> format("UNLOCK CONFLICT with lock {0} on file {1}", lockId, file));
+      return Response.status(CONFLICT)
+          .header(WOPI_LOCK_HEADER, file.lock().id())
+          .build();
+    }
+    logger().debug(() -> format("UNLOCK on file {0}", file));
+    file.lock().clear();
+    return Response.ok().build();
+  }
+
+  private boolean currentLockIsNotWopiOne(final WopiFile file) {
+    return file.lock().exists() && file.lock().id().length() > 1024;
+  }
+}

--- a/core-web/src/main/java/org/silverpeas/core/webapi/wopi/WopiProtectedWebResource.java
+++ b/core-web/src/main/java/org/silverpeas/core/webapi/wopi/WopiProtectedWebResource.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2000 - 2020 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.webapi.wopi;
+
+import org.silverpeas.core.util.StringUtil;
+import org.silverpeas.core.web.WebResourceUri;
+import org.silverpeas.core.webapi.base.ProtectedWebResource;
+import org.silverpeas.core.webapi.base.UserPrivilegeValidation;
+
+import javax.servlet.http.HttpServletRequest;
+
+import static org.silverpeas.core.util.StringUtil.defaultStringIfNotDefined;
+import static org.silverpeas.core.webapi.base.UserPrivilegeValidation.HTTP_ACCESS_TOKEN;
+import static org.silverpeas.core.webapi.base.UserPrivilegeValidation.HTTP_AUTHORIZATION;
+
+/**
+ * <p>
+ * All WEB services handling the WOPI host requests must implement this interface.
+ * </p>
+ * @author silveryocha
+ */
+public interface WopiProtectedWebResource extends ProtectedWebResource {
+
+  @Override
+  WopiRequestContext getSilverpeasContext();
+
+  @Override
+  default void validateUserAuthentication(final UserPrivilegeValidation validation) {
+    final HttpServletRequest request = getSilverpeasContext().getRequest();
+    final String authorizationValue = request.getHeader(HTTP_AUTHORIZATION);
+    final String accessToken;
+    if (StringUtil.isDefined(authorizationValue)) {
+      accessToken = authorizationValue.substring("Bearer ".length());
+    } else {
+      accessToken = defaultStringIfNotDefined(request.getHeader(HTTP_ACCESS_TOKEN),
+          request.getParameter(HTTP_ACCESS_TOKEN));
+    }
+    getSilverpeasContext().setAccessToken(accessToken);
+  }
+
+  @Override
+  default HttpServletRequest getHttpRequest() {
+    return getSilverpeasContext().getRequest();
+  }
+
+  @Override
+  default WebResourceUri getUri() {
+    return null;
+  }
+
+  @Override
+  default String getComponentId() {
+    return null;
+  }
+}

--- a/core-web/src/main/java/org/silverpeas/core/webapi/wopi/WopiRequestContext.java
+++ b/core-web/src/main/java/org/silverpeas/core/webapi/wopi/WopiRequestContext.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2000 - 2019 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.webapi.wopi;
+
+import org.silverpeas.core.webapi.base.SilverpeasRequestContext;
+
+import javax.enterprise.context.RequestScoped;
+
+import static org.silverpeas.core.util.StringUtil.defaultStringIfNotDefined;
+
+/**
+ * The WOPI host request context which handles the domain identifier data in addition to the data
+ * handled by  {@link SilverpeasRequestContext}.
+ * @author silveryocha
+ */
+@RequestScoped
+class WopiRequestContext extends SilverpeasRequestContext {
+
+  private String accessToken;
+
+  String getAccessToken() {
+    return defaultStringIfNotDefined(accessToken);
+  }
+
+  void setAccessToken(final String accessToken) {
+    this.accessToken = accessToken;
+  }
+}

--- a/core-web/src/main/java/org/silverpeas/core/webapi/wopi/WopiResourceURIs.java
+++ b/core-web/src/main/java/org/silverpeas/core/webapi/wopi/WopiResourceURIs.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2000 - 2019 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.webapi.wopi;
+
+
+/**
+ * Base URIs from which the REST-based resources representing WOPI exchange.
+ * @author silveryocha
+ */
+final class WopiResourceURIs {
+
+  static final String WOPI_FILE_BASE_URI = "wopi/files/{fileId}";
+
+  private WopiResourceURIs() {
+    throw new IllegalStateException("Utility class");
+  }
+}

--- a/core-web/src/main/java/org/silverpeas/core/webapi/wopi/WopiResponseError.java
+++ b/core-web/src/main/java/org/silverpeas/core/webapi/wopi/WopiResponseError.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2000 - 2020 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.webapi.wopi;
+
+import javax.ws.rs.core.Response;
+
+/**
+ * @author silveryocha
+ */
+class WopiResponseError extends RuntimeException {
+  private static final long serialVersionUID = 863867838952254729L;
+
+  private final transient Response response;
+
+  WopiResponseError(final Response response) {
+    super("conflict");
+    this.response = response;
+  }
+
+  Response getResponse() {
+    return response;
+  }
+}

--- a/core-web/src/main/java/org/silverpeas/core/webapi/wopi/WopiServerFilter.java
+++ b/core-web/src/main/java/org/silverpeas/core/webapi/wopi/WopiServerFilter.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2000 - 2020 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.webapi.wopi;
+
+import org.silverpeas.core.util.logging.Level;
+import org.silverpeas.core.web.http.HttpRequest;
+import org.silverpeas.core.web.session.UserSessionEvent;
+import org.silverpeas.core.wopi.DefaultWopiUser;
+import org.silverpeas.core.wopi.WopiFileEditionManager;
+import org.silverpeas.core.wopi.WopiUser;
+
+import javax.enterprise.event.Observes;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Enumeration;
+
+import static javax.ws.rs.core.Response.Status.fromStatusCode;
+import static org.silverpeas.core.wopi.WopiLogger.logger;
+
+/**
+ * This filter is today design to log HTTP exchanges between Silverpeas (WOPI Host) and the WOPI
+ * client. The logging is enabled at the DEBUG logging level which can be set from Silverpeas's
+ * administration.
+ * <p>
+ *   Errors are always logged whatever the logging level set.
+ * </p>
+ * @author silveryocha
+ */
+public class WopiServerFilter implements Filter {
+
+  @Override
+  public void doFilter(final ServletRequest request, final ServletResponse response,
+      final FilterChain chain) throws IOException, ServletException {
+    if (response instanceof HttpServletResponse) {
+      final HttpServletResponse httpResponse = (HttpServletResponse) response;
+      final boolean debug = logger().isLoggable(Level.DEBUG);
+      if (debug) {
+        final HttpRequest httpRequest = HttpRequest.decorate(request);
+        final Enumeration<String> headerNames = httpRequest.getHeaderNames();
+        final StringBuilder sb = new StringBuilder();
+        while (headerNames.hasMoreElements()) {
+          final String headerName = headerNames.nextElement();
+          sb.append(headerName).append("=").append(httpRequest.getHeader(headerName)).append("\n");
+        }
+        final Enumeration<String> parameterNames = httpRequest.getParameterNames();
+        while (parameterNames.hasMoreElements()) {
+          final String parameterName = parameterNames.nextElement();
+          sb.append(parameterName).append("=").append(httpRequest.getParameter(parameterName)).append("\n");
+        }
+        logger().debug("handling {0} on {1} from WOPI host {2}:{3}", httpRequest.getMethod(),
+            httpRequest.getRequestURI(), httpRequest.getRemoteHost(),
+            String.valueOf(httpRequest.getRemotePort()));
+        logger().debug("with headers and parameters:\n{0}", sb);
+      }
+      chain.doFilter(request, response);
+      if (httpResponse.getStatus() >= 400) {
+        logger().error("error {0} - {1}", httpResponse.getStatus(), fromStatusCode(httpResponse.getStatus()));
+      } else if (debug) {
+        logger().debug("status {0} - {1}", httpResponse.getStatus(), fromStatusCode(httpResponse.getStatus()));
+      }
+      return;
+    }
+    chain.doFilter(request, response);
+  }
+
+  @Override
+  public void init(final FilterConfig filterConfig) {
+    // Nothing to do.
+  }
+
+  @Override
+  public void destroy() {
+    // Nothing to do.
+  }
+
+  /**
+   * On session ending, cleaning the cache of users.
+   * @param userSessionEvent the user session event.
+   */
+  public void onEvent(@Observes final UserSessionEvent userSessionEvent) {
+    if (userSessionEvent.isClosing()) {
+      final WopiUser user = new DefaultWopiUser(userSessionEvent.getSessionInfo());
+      WopiFileEditionManager.get().revokeUser(user);
+    }
+  }
+}


### PR DESCRIPTION
Silverpeas implements its own WOPI host in order to ensure the exchanges between the online editor and Silverpeas's services.

WOPI setting file permits to specify the necessary data to make the WOPI world working well and it also permits to enable or not the feature.

WOPI API has its own logging configuration file.

At Silverpeas's server start, the setting data are read in order to indicate to the security API the base URL to authorized on UI.

At first WOPI file edition, WOPI discovery is performed in order to get the online editor capabilities. It permits to Silverpeas to construct a mapping of handled mime-types.

WEBDAV API has been updated in order to use the new WOPI features.

The Silverpeas's administration has a new entry "WOPI" under tools category.

Using the new HttpClient and HttpRequest API provided by Java 11.

Linked to PR https://github.com/Silverpeas/Silverpeas-Components/pull/712