### PR TITLE
Feature #9047: it is now possible to specify from publication criteria to retrieve publications also from aliases data.

### DIFF
--- a/core-library/src/main/java/org/silverpeas/core/contribution/publication/dao/PublicationCriteria.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/publication/dao/PublicationCriteria.java
@@ -82,6 +82,7 @@ public class PublicationCriteria {
   private final Set<Integer> excludedNodeIds = new HashSet<>();
   private final List<QUERY_ORDER_BY> orderByList = new ArrayList<>();
   private boolean mustHaveAtLeastOneNodeFather = false;
+  private boolean takingAliasesIntoAccount = false;
   private OffsetDateTime visibilityDate = null;
   private OffsetDateTime lastUpdatedSince = null;
   private PaginationPage pagination;
@@ -158,8 +159,21 @@ public class PublicationCriteria {
     return this;
   }
 
+  /**
+   * Indicates that the publication MUST be linked to a node.
+   * @return itself.
+   */
   public PublicationCriteria mustHaveAtLeastOneNodeFather() {
     this.mustHaveAtLeastOneNodeFather = true;
+    return this;
+  }
+
+  /**
+   * Indicates that publications can be retrieved from the aliases data.
+   * @return itself.
+   */
+  public PublicationCriteria takingAliasesIntoAccount() {
+    this.takingAliasesIntoAccount = true;
     return this;
   }
 
@@ -272,10 +286,14 @@ public class PublicationCriteria {
   }
 
   boolean mustJoinOnNodeFatherTable() {
-    return mustHaveAtLeastOneNodeFather || !includedNodeIds.isEmpty() || !excludedNodeIds.isEmpty();
+    return takingAliasesIntoAccount || mustHaveAtLeastOneNodeFather || !includedNodeIds.isEmpty() || !excludedNodeIds.isEmpty();
   }
 
-  List<String> getComponentInstanceIds() {
+  public boolean isAliasesTakenIntoAccount() {
+    return takingAliasesIntoAccount;
+  }
+
+  public List<String> getComponentInstanceIds() {
     return componentInstanceIds;
   }
 

--- a/core-library/src/main/java/org/silverpeas/core/contribution/publication/dao/PublicationDAO.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/publication/dao/PublicationDAO.java
@@ -837,7 +837,9 @@ public class PublicationDAO {
       query.join(PUBLICATION_FATHER_TABLE_NAME + " F").on("F.pubId = P.pubId");
     }
     if (!criteria.getComponentInstanceIds().isEmpty()) {
-      query.join("ST_ComponentInstance I").on("P.instanceid = CONCAT(I.componentname , CAST(I.id AS VARCHAR(20)))");
+      final String instanceSelector = criteria.isAliasesTakenIntoAccount() ? "F" : "P";
+      query.join("ST_ComponentInstance I")
+           .on(instanceSelector + ".instanceid = CONCAT(I.componentname , CAST(I.id AS VARCHAR(20)))");
     }
   }
 

--- a/core-library/src/main/java/org/silverpeas/core/contribution/publication/dao/PublicationFatherDAO.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/publication/dao/PublicationFatherDAO.java
@@ -177,13 +177,12 @@ public class PublicationFatherDAO {
    *   This method is designed for process performance needs.
    * </p>
    * @param con the database connection.
-   * @param ids the instance ids aimed.
+   * @param pubIds the publication ids which are aimed.
    * @return a list of {@link Location} instances.
    * @throws SQLException on database error.
    */
   public static Map<String, List<Location>> getAllLocationsByPublicationIds(Connection con,
-      Collection<PublicationPK> ids) throws SQLException {
-    final List<String> pubIds = ids.stream().map(PublicationPK::getId).collect(Collectors.toList());
+      Collection<String> pubIds) throws SQLException {
     return JdbcSqlQuery.executeBySplittingOn(pubIds, (pubIdBatch, result) -> {
       final JdbcSqlQuery query = JdbcSqlQuery.createSelect(LOCATION_FIELDS + ", " + PUB_ID)
           .from(PUBLICATION_FATHER_TABLE_NAME)

--- a/core-library/src/main/java/org/silverpeas/core/contribution/publication/model/PublicationDetail.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/publication/model/PublicationDetail.java
@@ -168,6 +168,7 @@ public class PublicationDetail extends AbstractI18NBean<PublicationI18N>
   public static final String CLONE_STATUS = "Clone";
   public static final String TYPE = "Publication";
   private boolean alias = false;
+  private Location authorizedLocation = null;
   private transient ThumbnailDetail thumbnail = null;
 
   private ContributionRating contributionRating;
@@ -1280,6 +1281,34 @@ public class PublicationDetail extends AbstractI18NBean<PublicationI18N>
     return contributionRating;
   }
 
+  /**
+   * Sets an authorized location to the current instance.
+   * <p>
+   * A publication is linked or not to a node, depending the application functional context. This
+   * method should be used into the case of a publication linked to a node, located at a location
+   * in other words. Sometimes, a publication can be located at several locations (so linked to
+   * several nodes), in that case there is a main location and the others which are called
+   * "aliases". The caller of this method has verified which locations of a publication is
+   * authorized according to a context, that the publication detail instance does not know about,
+   * and set one of these authorized ones to the current instance. If the authorized location set
+   * defines an alias then some methods will take into account this information, like
+   * {@link #getPermalink()} for example.
+   * </p>
+   * <p>
+   *   Giving a null location means that alias data MUST be cleared.
+   * </p>
+   * @param location a {@link Location} instance.
+   */
+  public void setAuthorizedLocation(final Location location) {
+    if (location == null) {
+      alias = false;
+      authorizedLocation = null;
+    } else {
+      this.alias = location.isAlias();
+      this.authorizedLocation = alias ? location : null;
+    }
+  }
+
   public void setAlias(boolean alias) {
     this.alias = alias;
   }
@@ -1289,7 +1318,10 @@ public class PublicationDetail extends AbstractI18NBean<PublicationI18N>
   }
 
   public String getPermalink() {
-    return URLUtil.getSimpleURL(URLUtil.URL_PUBLI, getId());
+    return URLUtil.getSimpleURL(URLUtil.URL_PUBLI, getId(),
+        authorizedLocation != null && !authorizedLocation.getInstanceId().equals(getInstanceId())
+            ? authorizedLocation.getInstanceId()
+            : null);
   }
 
   public boolean isSharingAllowedForRolesFrom(final UserDetail user) {

--- a/core-library/src/main/java/org/silverpeas/core/contribution/publication/service/PublicationService.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/publication/service/PublicationService.java
@@ -180,7 +180,7 @@ public interface PublicationService {
    * @param ids the instance ids aimed.
    * @return a list of {@link Location} instances.
    */
-  Map<String, List<Location>> getAllLocationsByPublicationIds(Collection<PublicationPK> ids);
+  Map<String, List<Location>> getAllLocationsByPublicationIds(Collection<String> ids);
 
   /**
    * Gets all the locations of the specified publication whatever the component instance in which

--- a/core-library/src/main/java/org/silverpeas/core/security/authorization/NodeAccessController.java
+++ b/core-library/src/main/java/org/silverpeas/core/security/authorization/NodeAccessController.java
@@ -200,21 +200,13 @@ public class NodeAccessController extends AbstractAccessController<NodePK>
       nodeDetailCache = singletonMap(computeNodeCacheKey(nodeDetail.getNodePK()), nodeDetail);
     }
 
-    /**
-     * @return the identifiers of component instance for which data has been loaded (empty set if
-     * already loaded)
-     */
-    Set<String> loadCaches(final String userId, final Collection<String> instanceIds) {
-      if (userProfiles != null || instanceIds.isEmpty()) {
-        return emptySet();
+    void loadCaches(final String userId, final Collection<String> instanceIds) {
+      if (userProfiles == null && !instanceIds.isEmpty()) {
+        completeCaches(userId, instanceIds);
       }
-      return completeCaches(userId, instanceIds);
     }
 
-    /**
-     * @return the identifiers of component instance for which data has been loaded
-     */
-    Set<String> completeCaches(final String userId, final Collection<String> instanceIds) {
+    void completeCaches(final String userId, final Collection<String> instanceIds) {
       final ComponentAccessController.DataManager componentDataManager = ComponentAccessController.getDataManager(context);
       final boolean firstLoad = nodeDetailCache == null;
       if (firstLoad) {
@@ -241,7 +233,6 @@ public class NodeAccessController extends AbstractAccessController<NodePK>
         caches.getFirst().forEach((k, v) -> nodeDetailCache.put(k, v));
         caches.getSecond().forEach((k, v) -> userProfiles.put(k, v));
       }
-      return instanceIdsWithRightsOnTopic;
     }
 
     private Pair<Map<String, NodeDetail>, Map<Pair<String, Integer>, Set<String>>> loadNodesAndUserProfiles(

--- a/core-library/src/main/java/org/silverpeas/core/security/authorization/PublicationAccessController.java
+++ b/core-library/src/main/java/org/silverpeas/core/security/authorization/PublicationAccessController.java
@@ -361,23 +361,18 @@ public class PublicationAccessController extends AbstractAccessController<Public
           .map(PublicationPK::getInstanceId)
           .collect(Collectors.toSet());
       final NodeAccessController.DataManager nodeDataManager = NodeAccessController.getDataManager(context);
-      final Set<String> instanceIdsWithRightsOnTopic = nodeDataManager.loadCaches(userId, instanceIds);
-      if (instanceIdsWithRightsOnTopic.isEmpty()) {
-        locationsByPublicationCache = emptyMap();
-      } else {
-        final List<PublicationPK> pksForLocations = givenPublicationPks.stream()
-            .filter(p -> instanceIdsWithRightsOnTopic.contains(p.getInstanceId()))
-            .collect(Collectors.toList());
-        locationsByPublicationCache = publicationService
-            .getAllLocationsByPublicationIds(pksForLocations);
-        final Set<String> additionalInstanceIdsToLoad = locationsByPublicationCache.entrySet().stream()
-            .flatMap(e -> new ArrayList<>(e.getValue()).stream())
-            .map(Location::getInstanceId)
-            .filter(i -> ! instanceIds.contains(i))
-            .collect(Collectors.toSet());
-        if (!additionalInstanceIdsToLoad.isEmpty()) {
-          nodeDataManager.completeCaches(userId, additionalInstanceIdsToLoad);
-        }
+      nodeDataManager.loadCaches(userId, instanceIds);
+      final Set<String> pubIdsForLocations = givenPublicationPks.stream()
+          .map(PublicationPK::getId)
+          .collect(Collectors.toSet());
+      locationsByPublicationCache = publicationService.getAllLocationsByPublicationIds(pubIdsForLocations);
+      final Set<String> additionalInstanceIdsToLoad = locationsByPublicationCache.entrySet().stream()
+          .flatMap(e -> new ArrayList<>(e.getValue()).stream())
+          .map(Location::getInstanceId)
+          .filter(i -> !instanceIds.contains(i))
+          .collect(Collectors.toSet());
+      if (!additionalInstanceIdsToLoad.isEmpty()) {
+        nodeDataManager.completeCaches(userId, additionalInstanceIdsToLoad);
       }
       return this;
     }

--- a/core-library/src/test/java/org/silverpeas/core/security/authorization/TestPublicationAccessControllerFilter.java
+++ b/core-library/src/test/java/org/silverpeas/core/security/authorization/TestPublicationAccessControllerFilter.java
@@ -230,7 +230,7 @@ public class TestPublicationAccessControllerFilter {
     assertThat(publicationDataManager.givenPublicationPks, containsInAnyOrder(pksOfTest));
     final int publicationForTestPlusOneClone = ALL_PUBLICATIONS_FOR_TEST_WITH_ONE_CLONE.size() + 1;
     assertThat(publicationDataManager.publicationCache.size(), is(publicationForTestPlusOneClone));
-    assertThat(publicationDataManager.locationsByPublicationCache.keySet(), containsInAnyOrder("3", "4"));
+    assertThat(publicationDataManager.locationsByPublicationCache.keySet(), containsInAnyOrder("1", "2", "3", "4", "27"));
     // Publication level
     if (fromPks) {
       // One to load the publications, and an other one to load the master of clones
@@ -278,7 +278,7 @@ public class TestPublicationAccessControllerFilter {
     assertThat(publicationDataManager.givenPublicationPks, containsInAnyOrder(pksOfTest));
     final int publicationForTestPlusOneClone = ALL_PUBLICATIONS_FOR_TEST_ON_INHERITED_RIGHTS_WITH_ONE_CLONE.size() + 1;
     assertThat(publicationDataManager.publicationCache.size(), is(publicationForTestPlusOneClone));
-    assertThat(publicationDataManager.locationsByPublicationCache.keySet(), empty());
+    assertThat(publicationDataManager.locationsByPublicationCache.keySet(), containsInAnyOrder("1", "2", "27"));
     // Publication level
     if (fromPks) {
       // One to load the publications, and an other one to load the master of clones
@@ -287,7 +287,7 @@ public class TestPublicationAccessControllerFilter {
       // One to load the master of clones
       verify(publicationService, times(1)).getMinimalDataByIds(anyCollection());
     }
-    verify(publicationService, times(0)).getAllLocationsByPublicationIds(anyCollection());
+    verify(publicationService, times(1)).getAllLocationsByPublicationIds(anyCollection());
     // Node level
     verify(nodeService, times(0)).getMinimalDataByInstances(anyCollection());
     verify(organizationController, times(0))
@@ -373,7 +373,7 @@ public class TestPublicationAccessControllerFilter {
     assertThat(publicationDataManager.lotOfDataMode, is(true));
     assertThat(publicationDataManager.givenPublicationPks, containsInAnyOrder(pksOfTest));
     assertThat(publicationDataManager.publicationCache.size(), is(0));
-    assertThat(publicationDataManager.locationsByPublicationCache.keySet(), containsInAnyOrder("3", "4"));
+    assertThat(publicationDataManager.locationsByPublicationCache.keySet(), containsInAnyOrder("1", "2", "3", "4", "27"));
     // Publication level
     verify(publicationService, times(0)).getMinimalDataByIds(anyCollection());
     verify(publicationService, times(1)).getAllLocationsByPublicationIds(anyCollection());
@@ -417,7 +417,7 @@ public class TestPublicationAccessControllerFilter {
     assertThat(publicationDataManager.givenPublicationPks, containsInAnyOrder(pksOfTest));
     final int publicationForTestPlusOneClone = ALL_PUBLICATIONS_FOR_TEST_WITH_ONE_CLONE.size() + 1;
     assertThat(publicationDataManager.publicationCache.size(), is(publicationForTestPlusOneClone));
-    assertThat(publicationDataManager.locationsByPublicationCache.keySet(), containsInAnyOrder("3", "4"));
+    assertThat(publicationDataManager.locationsByPublicationCache.keySet(), containsInAnyOrder("1", "2", "3", "4", "27"));
     // Publication level
     if (fromPks) {
       // One to load the publications, and an other one to load the master of clones
@@ -557,8 +557,8 @@ public class TestPublicationAccessControllerFilter {
               .collect(Collectors.toList()));
       when(publicationService.getAllLocationsByPublicationIds(anyCollection())).then(a -> {
           final Map<String, Set<Location>> result = new HashMap<>();
-          ((Collection<PublicationPK>) a.getArgument(0)).stream()
-              .flatMap(p -> ALL_PUBLICATIONS.stream().filter(pu -> pu.getPK().equals(p)))
+          ((Collection<String>) a.getArgument(0)).stream()
+              .flatMap(p -> ALL_PUBLICATIONS.stream().filter(pu -> pu.getPK().getId().equals(p)))
               .forEach(pu -> result.put(pu.getId(), new HashSet<>(pu.getLocations())));
           return result;
       });


### PR DESCRIPTION
Modifications:
- adding the new criterion and using it on SQL query execution
- adding new attribute into PublicationDetail in order to specify an authorized location which is used for now to compute a right permalink
- taking into account publications aliases into publication service fetching the authorized publication according to given criteria
- fixing a problem around the filtering on authorized publication about caches partially loaded about publication locations
- modifying the service signature about querying of publication locations in order to be as clear as possible

Linked to PR: https://github.com/Silverpeas/Silverpeas-Components/pull/719