### PR TITLE
Bug #11964: avoiding getting errors on file encrypted content during the indexation.

### DIFF
--- a/core-configuration/src/main/config/properties/org/silverpeas/index/indexing/IndexEngine.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/index/indexing/IndexEngine.properties
@@ -72,6 +72,12 @@ TimeOutParameter = 30000
 #activate "did you mean" Indexing
 enableDymIndexing = false
 
+# A file can induces indexation errors because of an un-parsable content.
+# This parameters permits to ignore the content of a such file by checking a REGEXP pattern on its mimetype.
+# If the pattern matches, then the file content is ignored.
+# If empty, the default pattern "(?i).*(protected|encrypted).*" is applied.
+index.file.content.mimetype.ignore.pattern =
+
 # server name to identify origin of indexed documents
 server.name = Silverpeas
 

--- a/core-library/src/main/java/org/silverpeas/core/contribution/publication/service/DefaultPublicationService.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/publication/service/DefaultPublicationService.java
@@ -330,7 +330,7 @@ public class DefaultPublicationService implements PublicationService, ComponentI
         }
       }
 
-      if (indexOperation == IndexManager.ADD || indexOperation == IndexManager.READD) {
+      if (indexOperation == IndexManager.ADD || indexOperation == IndexManager.ADD_AGAIN) {
         createIndex(detail.getPK(), true, indexOperation);
       } else if (indexOperation == IndexManager.REMOVE) {
         deleteIndex(detail.getPK());
@@ -954,7 +954,7 @@ public class DefaultPublicationService implements PublicationService, ComponentI
 
   private void createIndex(PublicationDetail pubDetail, boolean processContent) {
     if (pubDetail.getIndexOperation() == IndexManager.ADD ||
-        pubDetail.getIndexOperation() == IndexManager.READD) {
+        pubDetail.getIndexOperation() == IndexManager.ADD_AGAIN) {
       try {
         FullIndexEntry indexEntry = getFullIndexEntry(pubDetail, processContent);
         IndexEngineProxy.addIndexEntry(indexEntry);
@@ -985,7 +985,7 @@ public class DefaultPublicationService implements PublicationService, ComponentI
 
   private void createIndex(PublicationPK pubPK, boolean processContent, int indexOperation) {
 
-    if (indexOperation == IndexManager.ADD || indexOperation == IndexManager.READD) {
+    if (indexOperation == IndexManager.ADD || indexOperation == IndexManager.ADD_AGAIN) {
 
       try {
         PublicationDetail pubDetail = getDetail(pubPK);
@@ -1181,7 +1181,7 @@ public class DefaultPublicationService implements PublicationService, ComponentI
     });
 
     for (Map.Entry<IndexEntryKey, List<String>> entry : pathsByIndex.entrySet()) {
-      final FullIndexEntry aliasIndexEntry = index.clone();
+      final FullIndexEntry aliasIndexEntry = index.getCopy();
       final IndexEntryKey indexEntryKey = entry.getKey();
       aliasIndexEntry.setPK(indexEntryKey);
       aliasIndexEntry.setPaths(entry.getValue());

--- a/core-library/src/main/java/org/silverpeas/core/index/indexing/IndexingLogger.java
+++ b/core-library/src/main/java/org/silverpeas/core/index/indexing/IndexingLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2000 - 2020 Silverpeas
+ * Copyright (C) 2000 - 2021 Silverpeas
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -21,25 +21,27 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.silverpeas.core.notification.sse;
+package org.silverpeas.core.index.indexing;
 
+import org.silverpeas.core.annotation.Service;
 import org.silverpeas.core.initialization.Initialization;
 import org.silverpeas.core.util.logging.SilverLogger;
 
 /**
- * @author Yohann Chastagnier
+ * @author silveryocha
  */
-public class SseLogger implements Initialization {
+@Service
+public class IndexingLogger implements Initialization {
 
   private static SilverLogger silverLogger;
 
   static void initLogger() {
     if (silverLogger == null) {
-      silverLogger = SilverLogger.getLogger(SseLogger.class);
+      silverLogger = SilverLogger.getLogger(IndexingLogger.class);
     }
   }
 
-  public static SilverLogger get() {
+  public static SilverLogger indexingLogger() {
     return silverLogger;
   }
 

--- a/core-library/src/main/java/org/silverpeas/core/index/indexing/model/DidYouMeanIndexer.java
+++ b/core-library/src/main/java/org/silverpeas/core/index/indexing/model/DidYouMeanIndexer.java
@@ -27,10 +27,11 @@ import org.apache.lucene.search.spell.SpellChecker;
 import org.apache.lucene.store.FSDirectory;
 import org.silverpeas.core.i18n.I18NHelper;
 import org.silverpeas.core.util.StringUtil;
-import org.silverpeas.core.util.logging.SilverLogger;
 
 import java.io.File;
 import java.io.IOException;
+
+import static org.silverpeas.core.index.indexing.IndexingLogger.indexingLogger;
 
 /**
  * This class allows to manage the specific index of "did you mean" functionality. <br>
@@ -65,8 +66,7 @@ public class DidYouMeanIndexer {
     // stop the process if method parameters is null or empty
     if (!StringUtil.isDefined(field) || !StringUtil.isDefined(originalIndexDirectory) ||
         !StringUtil.isDefined(spellIndexDirectory)) {
-      SilverLogger.getLogger(DidYouMeanIndexer.class)
-          .error("Invalid argument passed to create a spell index");
+      indexingLogger().error("Invalid argument passed to create a spell index");
       return;
     }
   }
@@ -104,7 +104,7 @@ public class DidYouMeanIndexer {
             spell.clearIndex();
             isCleared = true;
         } catch (IOException e) {
-          SilverLogger.getLogger(DidYouMeanIndexer.class).error(e);
+          indexingLogger().error(e);
         }
       }
     return isCleared;

--- a/core-library/src/main/java/org/silverpeas/core/index/indexing/model/FullIndexEntry.java
+++ b/core-library/src/main/java/org/silverpeas/core/index/indexing/model/FullIndexEntry.java
@@ -37,8 +37,7 @@ import java.util.Set;
  * (mainly all the data contents which must be indexed but which is useless at retrieve time). This
  * extra-content is indexed but not stored in the index.
  */
-public class FullIndexEntry extends IndexEntry implements Serializable, Cloneable {
-
+public class FullIndexEntry extends IndexEntry implements Serializable {
   private static final long serialVersionUID = -4955524385769457730L;
 
   /**
@@ -57,6 +56,15 @@ public class FullIndexEntry extends IndexEntry implements Serializable, Cloneabl
 
   public FullIndexEntry(IndexEntryKey pk) {
     super(pk);
+  }
+
+  FullIndexEntry(final FullIndexEntry other) {
+    super(other);
+    this.textList = other.textList != null ? new ArrayList<>(other.textList) : null;
+    this.fileList = other.fileList != null ? new ArrayList<>(other.fileList) : null;
+    this.linkedFileList = other.linkedFileList != null ? new ArrayList<>(other.linkedFileList) : null;
+    this.fields = other.fields != null ? new ArrayList<>(other.fields) : null;
+    this.linkedFileIdsList = other.linkedFileIdsList != null ? new HashSet<>(other.linkedFileIdsList) : null;
   }
 
   /**
@@ -193,8 +201,7 @@ public class FullIndexEntry extends IndexEntry implements Serializable, Cloneabl
     return fields;
   }
 
-  @Override
-  public FullIndexEntry clone() {
-    return (FullIndexEntry) super.clone();
+  public FullIndexEntry getCopy() {
+    return new FullIndexEntry(this);
   }
 }

--- a/core-library/src/main/java/org/silverpeas/core/index/indexing/model/IndexEntry.java
+++ b/core-library/src/main/java/org/silverpeas/core/index/indexing/model/IndexEntry.java
@@ -26,10 +26,10 @@ package org.silverpeas.core.index.indexing.model;
 import org.silverpeas.core.i18n.I18NHelper;
 import org.silverpeas.core.util.DateUtil;
 import org.silverpeas.core.util.StringUtil;
-import org.silverpeas.core.util.logging.SilverLogger;
 
 import java.io.Serializable;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -42,7 +42,7 @@ import java.util.Set;
  * IndexEntry is created by a Silverpeas component when it creates a new element or document. This
  * IndexEntry will be returned later when the document matches a query.
  */
-public class IndexEntry implements Serializable, Cloneable {
+public class IndexEntry implements Serializable {
 
   private static final long serialVersionUID = -4817004188601716658L;
 
@@ -87,6 +87,28 @@ public class IndexEntry implements Serializable, Cloneable {
    */
   public IndexEntry(IndexEntryKey pk) {
     this.pk = pk;
+  }
+
+  IndexEntry(final IndexEntry other) {
+    this.pk = new IndexEntryKey(other.pk);
+    this.lang = other.lang;
+    this.creationDate = other.creationDate;
+    this.creationUser = other.creationUser;
+    this.lastModificationDate = other.lastModificationDate;
+    this.lastModificationUser = other.lastModificationUser;
+    this.startDate = other.startDate;
+    this.endDate = other.endDate;
+    this.indexId = other.indexId;
+    this.thumbnail = other.thumbnail;
+    this.thumbnailMimeType = other.thumbnailMimeType;
+    this.thumbnailDirectory = other.thumbnailDirectory;
+    this.titles = other.titles != null ? new HashMap<>(other.titles) : null;
+    this.previews = other.previews != null ? new HashMap<>(other.previews) : null;
+    this.keywordsI18N = other.keywordsI18N != null ? new HashMap<>(other.keywordsI18N) : null;
+    this.serverName = other.serverName;
+    this.filename = other.filename;
+    this.paths = other.paths != null ? new ArrayList<>(other.paths) : null;
+    this.alias = other.alias;
   }
 
   /**
@@ -396,14 +418,14 @@ public class IndexEntry implements Serializable, Cloneable {
 
   private Map<String, String> getTitles() {
     if (titles == null) {
-      titles = new HashMap<String, String>();
+      titles = new HashMap<>();
     }
     return titles;
   }
 
   private Map<String, String> getPreviews() {
     if (previews == null) {
-      previews = new HashMap<String, String>();
+      previews = new HashMap<>();
     }
     return previews;
   }
@@ -493,18 +515,6 @@ public class IndexEntry implements Serializable, Cloneable {
 
   public void setAlias(boolean alias) {
     this.alias = alias;
-  }
-
-  @Override
-  public IndexEntry clone() {
-    IndexEntry clone;
-    try {
-      clone = (IndexEntry) super.clone();
-    } catch (final CloneNotSupportedException e) {
-      SilverLogger.getLogger(this).error(e);
-      clone = null;
-    }
-    return clone;
   }
 
   private String getDate(Date date) {

--- a/core-library/src/main/java/org/silverpeas/core/index/indexing/model/IndexEntryKey.java
+++ b/core-library/src/main/java/org/silverpeas/core/index/indexing/model/IndexEntryKey.java
@@ -63,6 +63,12 @@ public final class IndexEntryKey implements Serializable {
     this.objectId = objectId;
   }
 
+  IndexEntryKey(final IndexEntryKey other) {
+    this.component = other.component;
+    this.objectType = other.objectType;
+    this.objectId = other.objectId;
+  }
+
   /**
    * Create a new IndexEntry from s. We must have :
    * <PRE>

--- a/core-library/src/main/java/org/silverpeas/core/index/indexing/model/IndexManager.java
+++ b/core-library/src/main/java/org/silverpeas/core/index/indexing/model/IndexManager.java
@@ -59,8 +59,14 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
+import static java.lang.System.currentTimeMillis;
+import static java.text.MessageFormat.format;
+import static java.util.Optional.ofNullable;
+import static org.apache.commons.lang3.time.DurationFormatUtils.formatDurationHMS;
+import static org.silverpeas.core.index.indexing.IndexingLogger.indexingLogger;
 import static org.silverpeas.core.index.indexing.model.IndexProcessor.doFlush;
 import static org.silverpeas.core.index.indexing.model.IndexProcessor.doRemoveAll;
 
@@ -105,10 +111,12 @@ public class IndexManager {
   public static final int NONE = -1;
   public static final int ADD = 0;
   public static final int REMOVE = 1;
-  public static final int READD = 2;
+  public static final int ADD_AGAIN = 2;
   private static final String ATTACHMENT_PREFIX = "Attachment";
   private static final int DEFAULT_MAX_FIELD_LENGTH = 10000;
   private static final int DEFAULT_MERGE_FACTOR_VALUE = 10;
+  private static final SettingBundle settings =
+      ResourceLocator.getSettingBundle("org.silverpeas.index.indexing.IndexEngine");
   /*
    * The lucene index engine parameters.
    */
@@ -119,25 +127,7 @@ public class IndexManager {
   // enable the "Did you mean " indexing
   private static boolean enableDymIndexing = false;
   private static String serverName = null;
-
-  static {
-    // Reads and set the index engine parameters from the given properties file
-    SettingBundle settings =
-        ResourceLocator.getSettingBundle("org.silverpeas.index.indexing.IndexEngine");
-    maxFieldLength = settings.getInteger("lucene.maxFieldLength", maxFieldLength);
-    mergeFactor = settings.getInteger("lucene.mergeFactor", mergeFactor);
-    maxMergeDocs = settings.getInteger("lucene.maxMergeDocs", maxMergeDocs);
-
-    String stringValue = settings.getString("lucene.RAMBufferSizeMB", Double.toString(
-        IndexWriterConfig.DEFAULT_RAM_BUFFER_SIZE_MB));
-    defaultRamBufferSizeMb = Double.parseDouble(stringValue);
-
-    enableDymIndexing = settings.getBoolean("enableDymIndexing", false);
-    serverName = settings.getString("server.name", "Silverpeas");
-  }
-
-  private Map<String, IndexWriter> indexWriters = new LinkedHashMap<>();
-
+  private final Map<String, IndexWriter> indexWriters = new LinkedHashMap<>();
   @Inject
   private ParserManager parserManager;
 
@@ -158,11 +148,17 @@ public class IndexManager {
    * @param indexEntry
    */
   void addIndexEntry(FullIndexEntry indexEntry) {
-    indexEntry.setServerName(serverName);
-    String indexPath = getIndexDirectoryPath(indexEntry);
-    IndexWriter writer = getIndexWriter(indexPath, indexEntry.getLang());
-    removeIndexEntry(writer, indexEntry.getPK());
-    index(writer, indexEntry);
+    final long start = currentTimeMillis();
+    try {
+      indexEntry.setServerName(serverName);
+      String indexPath = getIndexDirectoryPath(indexEntry);
+      IndexWriter writer = getIndexWriter(indexPath, indexEntry.getLang());
+      removeIndexEntry(writer, indexEntry.getPK());
+      index(writer, indexEntry);
+    } finally {
+      indexingLogger().debug(() ->
+          format("addIndexEntry {0} in {1}", indexEntry.getPK(), formatDurationHMS(currentTimeMillis() - start)));
+    }
   }
 
   /**
@@ -170,7 +166,7 @@ public class IndexManager {
    */
   public void flush() {
     doFlush(() -> {
-      final SilverLogger logger = SilverLogger.getLogger(this);
+      final SilverLogger logger = indexingLogger();
       final List<String> pathProcessed = new ArrayList<>(indexWriters.size());
       final Iterator<Map.Entry<String, IndexWriter>> it = indexWriters.entrySet().iterator();
       logger.debug("flushing manager of indexation about {0} writer(s)", indexWriters.size());
@@ -183,7 +179,7 @@ public class IndexManager {
         try {
           writer.close();
         } catch (IOException e) {
-          SilverLogger.getLogger(this).error("Cannot close index " + path, e);
+          indexingLogger().error("Cannot close index " + path, e);
         }
         // update the spelling index
         if (enableDymIndexing) {
@@ -201,7 +197,7 @@ public class IndexManager {
       // removing document according to indexEntryPK
       writer.deleteDocuments(term);
     } catch (IOException e) {
-      SilverLogger.getLogger(this).error("Index deletion failure: " + indexEntryKey.toString(), e);
+      indexingLogger().error("Index deletion failure: " + indexEntryKey.toString(), e);
     }
   }
 
@@ -224,7 +220,7 @@ public class IndexManager {
       // removing documents according to SCOPE term
       writer.deleteDocuments(term);
     } catch (IOException e) {
-      SilverLogger.getLogger(this).error("Index deletion failure for scope : " + scope, e);
+      indexingLogger().error("Index deletion failure for scope : " + scope, e);
     }
   }
 
@@ -294,19 +290,38 @@ public class IndexManager {
   }
 
   /**
-   * Get the reader specific of the file described by the file description
-   *
-   * @param file
-   * @return the reader specific of the file described by the file description
+   * @param file a file description
+   * @return the optional {@link Reader} specific of the file described by the file description
    */
-  private Reader getReader(FileDescription file) {
-    Reader reader = null;
-    Parser parser = parserManager.getParser(file.getFormat());
+  private Optional<Reader> getReader(FileDescription file) {
+    final String filePath = file.getPath();
+    return ofNullable(file.getFormat())
+        .map(f -> hasMimetypeToBeIgnored(filePath, f) ? null : f)
+        .flatMap(parserManager::getParser)
+        .map(p -> p.getContext(filePath, file.getEncoding()))
+        .filter(c -> !c.getMetadata().getValue("Content-Type")
+            .map(t -> hasMimetypeToBeIgnored(filePath, t))
+            .filter(Boolean.TRUE::equals)
+            .isPresent())
+        .map(Parser.Context::getReader);
+  }
 
-    if (parser != null) {
-      reader = parser.getReader(file.getPath(), file.getEncoding());
+  /**
+   * Indicates if the given mime-type has to be ignored.
+   * <p>
+   * File path is used for logging purpose.
+   * </p>
+   * @param filePath a file path.
+   * @param mimeType the according mime type.
+   * @return true if mime type is protected, false otherwise.
+   */
+  private boolean hasMimetypeToBeIgnored(final String filePath, final String mimeType) {
+    final String pattern = settings.getString("index.file.content.mimetype.ignore.pattern", "(?i).*(protected|encrypted).*");
+    final boolean hasToBeIgnored = mimeType.matches(pattern);
+    if (hasToBeIgnored) {
+      indexingLogger().warn("Mimetype {0} must be ignored, removing from indexation the content of file {1}", mimeType, filePath);
     }
-    return reader;
+    return hasToBeIgnored;
   }
 
   /**
@@ -334,7 +349,7 @@ public class IndexManager {
                 .setMergePolicy(policy);
         return new IndexWriter(FSDirectory.open(file.toPath()), configuration);
       } catch (IOException e) {
-        SilverLogger.getLogger(this).error("Unknown index file " + path, e);
+        indexingLogger().error("Unknown index file " + path, e);
       }
       // The map is not filled
       return null;
@@ -352,7 +367,7 @@ public class IndexManager {
       Term key = new Term(KEY, indexEntry.getPK().toString());
       writer.updateDocument(key, makeDocument(indexEntry));
     } catch (Exception e) {
-      SilverLogger.getLogger(this).error(e.getMessage(), e);
+      indexingLogger().error(e.getMessage(), e);
     }
   }
 
@@ -614,14 +629,26 @@ public class IndexManager {
       return;
     }
     try {
-      Reader reader = getReader(fileDescription);
-      if (reader != null) {
-        Field field = new Field(getFieldName(CONTENT, fileDescription.getLang()), reader,
-            TextField.TYPE_NOT_STORED);
+      getReader(fileDescription).ifPresent(r -> {
+        final Field field = new Field(getFieldName(CONTENT, fileDescription.getLang()), r, TextField.TYPE_NOT_STORED);
         doc.add(field);
-      }
+      });
     } catch (RuntimeException e) {
-      SilverLogger.getLogger(this).error("Failed to parse file " + fileDescription.getPath(), e);
+      indexingLogger().error("Failed to parse file " + fileDescription.getPath(), e);
     }
+  }
+
+  static {
+    // Reads and set the index engine parameters from the given properties file
+    maxFieldLength = settings.getInteger("lucene.maxFieldLength", maxFieldLength);
+    mergeFactor = settings.getInteger("lucene.mergeFactor", mergeFactor);
+    maxMergeDocs = settings.getInteger("lucene.maxMergeDocs", maxMergeDocs);
+
+    String stringValue = settings.getString("lucene.RAMBufferSizeMB", Double.toString(
+        IndexWriterConfig.DEFAULT_RAM_BUFFER_SIZE_MB));
+    defaultRamBufferSizeMb = Double.parseDouble(stringValue);
+
+    enableDymIndexing = settings.getBoolean("enableDymIndexing", false);
+    serverName = settings.getString("server.name", "Silverpeas");
   }
 }

--- a/core-library/src/main/java/org/silverpeas/core/index/indexing/model/IndexProcessor.java
+++ b/core-library/src/main/java/org/silverpeas/core/index/indexing/model/IndexProcessor.java
@@ -35,6 +35,8 @@ import java.util.List;
 import java.util.concurrent.locks.StampedLock;
 import java.util.function.Supplier;
 
+import static org.silverpeas.core.index.indexing.IndexingLogger.indexingLogger;
+
 /**
  * @author silveryocha
  */
@@ -53,7 +55,7 @@ public class IndexProcessor {
   }
 
   public static <R> R doSearch(SearchIndexProcess<R> searchIndexProcess, Supplier<R> defaultReturn) throws ParseException {
-    final SilverLogger logger = SilverLogger.getLogger(IndexProcessor.class);
+    final SilverLogger logger = indexingLogger();
     final long stamp;
     synchronized (MUTEX) {
       stamp = SEARCH_LOCK.tryReadLock();
@@ -93,7 +95,7 @@ public class IndexProcessor {
 
   static void doRemoveAll(RemoveAllIndexesProcess removeAllIndexesProcess) {
     final long stamp = SEARCH_LOCK.writeLock();
-    final SilverLogger logger = SilverLogger.getLogger(IndexProcessor.class);
+    final SilverLogger logger = indexingLogger();
     logger.debug("starting remove of all index entries");
     try {
       logger.debug("closing all index readers");
@@ -108,7 +110,7 @@ public class IndexProcessor {
   }
 
   private static void closeIndexReaders() {
-    final SilverLogger logger = SilverLogger.getLogger(IndexProcessor.class);
+    final SilverLogger logger = indexingLogger();
     if (SEARCH_LOCK.getReadLockCount() == 0) {
       synchronized (UPDATED_MUTEX) {
         if (searchSettings.getBoolean("index.reader.closeAfterLastSearch", false)) {

--- a/core-library/src/main/java/org/silverpeas/core/index/indexing/model/IndexReadersCache.java
+++ b/core-library/src/main/java/org/silverpeas/core/index/indexing/model/IndexReadersCache.java
@@ -35,11 +35,13 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.BiConsumer;
 
+import static org.silverpeas.core.index.indexing.IndexingLogger.indexingLogger;
+
 public class IndexReadersCache {
   private static final Object READER_MUTEX = new Object();
   private static final Map<String, IndexReader> INDEX_READERS = new HashMap<>();
   private static final BiConsumer<String, IndexReader> CLOSE_INDEX_CONSUMER = (s, r) -> {
-    final SilverLogger logger = SilverLogger.getLogger(IndexReadersCache.class);
+    final SilverLogger logger = indexingLogger();
     try {
       logger.debug("closing reader of path {0}", s);
       r.close();
@@ -71,16 +73,14 @@ public class IndexReadersCache {
           indexReader = DirectoryReader.open(FSDirectory.open(rootPath.toPath()));
           INDEX_READERS.put(path, indexReader);
         } catch (Exception e) {
-          SilverLogger.getLogger(IndexReadersCache.class).warn(e);
+          indexingLogger().warn(e);
         }
       } else if (indexReader != null && !validRootPath) {
-        SilverLogger.getLogger(IndexReadersCache.class).warn(
-            "index reader exists in cache but no index path is existing! ({0})", path);
+        indexingLogger().warn("index reader exists in cache but no index path is existing! ({0})", path);
         closeIndexReader(path);
         indexReader = null;
       } else if (!validRootPath) {
-        SilverLogger.getLogger(IndexReadersCache.class)
-            .debug("index reader for path {0} can not be open as there is no index data", path);
+        indexingLogger().debug("index reader for path {0} can not be open as there is no index data", path);
       }
       return indexReader;
     }

--- a/core-library/src/main/java/org/silverpeas/core/index/indexing/model/RepositoryIndexer.java
+++ b/core-library/src/main/java/org/silverpeas/core/index/indexing/model/RepositoryIndexer.java
@@ -25,7 +25,6 @@ package org.silverpeas.core.index.indexing.model;
 
 import org.apache.commons.io.FilenameUtils;
 import org.silverpeas.core.util.file.FileUtil;
-import org.silverpeas.core.util.logging.SilverLogger;
 
 import java.io.File;
 import java.nio.file.Files;
@@ -33,6 +32,8 @@ import java.nio.file.Path;
 import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.List;
+
+import static org.silverpeas.core.index.indexing.IndexingLogger.indexingLogger;
 
 /**
  * An RepositoryIndexer allow to index files in a whole repository except the directories
@@ -83,7 +84,7 @@ public class RepositoryIndexer {
    */
   private void processFileList(Path dir, LocalDate creationDate, String creatorId, String action) {
     if (count % 10000 == 0) {
-      SilverLogger.getLogger(this).debug("# of indexed documents = {0}", count);
+      indexingLogger().debug("# of indexed documents = {0}", count);
     }
 
     File[] dirs = dir.toFile().listFiles(DirectorySPFilter.getInstance());

--- a/core-library/src/main/java/org/silverpeas/core/index/indexing/parser/Parser.java
+++ b/core-library/src/main/java/org/silverpeas/core/index/indexing/parser/Parser.java
@@ -24,13 +24,41 @@
 package org.silverpeas.core.index.indexing.parser;
 
 import java.io.Reader;
+import java.util.Optional;
 
 /**
  * A parser is used to retrieve the text content of a file.
  */
 public interface Parser {
+
+  interface Metadata {
+    Optional<String> getValue(final String key);
+  }
+
   /**
-   * Returns a Reader giving only the text content of the file.
+   * The paser context ensures to provide a {@link Reader} instance with also {@link Metadata}.
    */
-  Reader getReader(String path, String encoding);
+  class Context {
+    private final Reader reader;
+    private final Metadata metadata;
+
+    public Context(final Reader reader, final Metadata metadata) {
+      this.reader = reader;
+      this.metadata = metadata;
+    }
+
+    public Reader getReader() {
+      return reader;
+    }
+
+    public Metadata getMetadata() {
+      return metadata;
+    }
+  }
+
+  /**
+   * @return a {@link Context} instance providing a {@link Reader} and {@link Metadata} about the
+   * file.
+   */
+  Context getContext(String path, String encoding);
 }

--- a/core-library/src/main/java/org/silverpeas/core/index/indexing/parser/ParserManager.java
+++ b/core-library/src/main/java/org/silverpeas/core/index/indexing/parser/ParserManager.java
@@ -26,7 +26,6 @@ package org.silverpeas.core.index.indexing.parser;
 import org.silverpeas.core.util.ResourceLocator;
 import org.silverpeas.core.util.ServiceProvider;
 import org.silverpeas.core.util.SettingBundle;
-import org.silverpeas.core.util.logging.SilverLogger;
 
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
@@ -34,7 +33,11 @@ import javax.inject.Singleton;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.MissingResourceException;
+import java.util.Optional;
 import java.util.Set;
+
+import static java.util.Optional.ofNullable;
+import static org.silverpeas.core.index.indexing.IndexingLogger.indexingLogger;
 
 /**
  * The ParserManager class manages all the parsers which will be used to parse the indexed files.
@@ -73,29 +76,23 @@ public final class ParserManager {
           Parser parser = ServiceProvider.getService(parserName);
           parserMap.put(mimeType, parser);
         } catch (IllegalStateException e) {
-          SilverLogger.getLogger(this)
-              .error("No parser found in silverpeas for {0}: {1}", mimeType, parserName);
+          indexingLogger().error("No parser found in silverpeas for {0}: {1}", mimeType, parserName);
         } catch (Exception e) {
-          SilverLogger.getLogger(this).error(e.getMessage(), e);
+          indexingLogger().error(e.getMessage(), e);
         }
       }
     } catch (MissingResourceException e) {
-      SilverLogger.getLogger(this).error(e.getMessage(), e);
+      indexingLogger().error(e.getMessage(), e);
     }
   }
 
   /**
    * Get the parser for a given file format.
-   *
-   * @param format
-   * @return
+   * @param format a file format.
+   * @return an optional {@link Parser} instance.
    */
-  public Parser getParser(String format) {
-    Parser parser = parserMap.get(format);
-    if (parser == null) {
-      return defaultParser;
-    }
-    return parser;
+  public Optional<Parser> getParser(String format) {
+    return ofNullable(parserMap.getOrDefault(format, defaultParser));
   }
 
 }

--- a/core-library/src/main/java/org/silverpeas/core/index/indexing/parser/tika/TikaInitialization.java
+++ b/core-library/src/main/java/org/silverpeas/core/index/indexing/parser/tika/TikaInitialization.java
@@ -29,7 +29,8 @@ import org.apache.tika.utils.XMLReaderUtils;
 import org.silverpeas.core.initialization.Initialization;
 import org.silverpeas.core.util.ResourceLocator;
 import org.silverpeas.core.util.SettingBundle;
-import org.silverpeas.core.util.logging.SilverLogger;
+
+import static org.silverpeas.core.index.indexing.IndexingLogger.indexingLogger;
 
 /**
  * Initialization of some of the Tika properties.
@@ -46,11 +47,10 @@ public class TikaInitialization implements Initialization {
     try {
       XMLReaderUtils.setPoolSize(poolSize);
     } catch (TikaException e) {
-      SilverLogger.getLogger(this)
+      indexingLogger()
           .error("Failure while setting the size of the SAX parsers pool to " + poolSize +
               ". Rollback to the default pool size (" + XMLReaderUtils.DEFAULT_POOL_SIZE + ")", e);
       XMLReaderUtils.setPoolSize(XMLReaderUtils.DEFAULT_POOL_SIZE);
     }
   }
 }
-  

--- a/core-library/src/main/java/org/silverpeas/core/index/indexing/parser/tika/TikaParser.java
+++ b/core-library/src/main/java/org/silverpeas/core/index/indexing/parser/tika/TikaParser.java
@@ -26,7 +26,7 @@ package org.silverpeas.core.index.indexing.parser.tika;
 import org.apache.tika.Tika;
 import org.silverpeas.core.index.indexing.parser.DefaultParser;
 import org.silverpeas.core.index.indexing.parser.Parser;
-import org.silverpeas.core.util.logging.SilverLogger;
+import org.silverpeas.core.util.StringUtil;
 
 import javax.annotation.PostConstruct;
 import javax.inject.Named;
@@ -34,6 +34,11 @@ import java.io.File;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
+import java.util.Optional;
+
+import static java.util.Optional.empty;
+import static java.util.Optional.ofNullable;
+import static org.silverpeas.core.index.indexing.IndexingLogger.indexingLogger;
 
 @Named("tikaParser")
 @DefaultParser
@@ -47,12 +52,29 @@ public class TikaParser implements Parser {
   }
 
   @Override
-  public Reader getReader(String path, String encoding) {
+  public Context getContext(String path, String encoding) {
     try {
-      return tika.parse(new File(path));
+      final org.apache.tika.metadata.Metadata metadata = new org.apache.tika.metadata.Metadata();
+      final Reader reader = tika.parse(new File(path), metadata);
+      return new Context(reader, new TikaMetadata(metadata));
     } catch (IOException ex) {
-      SilverLogger.getLogger(this).error(ex.getMessage(), ex);
+      indexingLogger().error(ex.getMessage(), ex);
     }
-    return new StringReader("");
+    return new Context(new StringReader(""), new TikaMetadata(null));
+  }
+
+  private static class TikaMetadata implements Metadata {
+    private final org.apache.tika.metadata.Metadata metadata;
+
+    private TikaMetadata(final org.apache.tika.metadata.Metadata metadata) {
+      this.metadata = metadata;
+    }
+
+    @Override
+    public Optional<String> getValue(final String key) {
+      return metadata == null
+          ? empty()
+          : ofNullable(metadata.get(key)).filter(StringUtil::isDefined);
+    }
   }
 }


### PR DESCRIPTION
Some of the modifications:
- modifying the indexing file parser in order to provide meta data of files
- avoiding to parse files with mime-type matching a parametrized reg exp pattern
- refactoring clone method to a getCopy one for FullIndexEntry
- centralizing a logger for indexing package (IndexingLogger)
- fixing some sonar feedback