### PR TITLE
Bug #12398

### DIFF
--- a/core-library/src/integration-test/java/org/silverpeas/core/contribution/publication/service/PublicationDAOIT.java
+++ b/core-library/src/integration-test/java/org/silverpeas/core/contribution/publication/service/PublicationDAOIT.java
@@ -102,14 +102,19 @@ public class PublicationDAOIT {
         }
       }
       String keywords = buffer.toString();
-      PublicationDetail detail = new PublicationDetail(pk, name, description, now.getTime(),
-          beginDate.
-          getTime(),
-          endDate.getTime(),
-          creatorId, importance, version, keywords, contenu);
-      detail.setBeginHour(DateUtil.formatTime(beginDate));
-      detail.setEndHour(DateUtil.formatTime(endDate));
+      PublicationDetail detail = PublicationDetail.builder()
+          .setPk(pk)
+          .setNameAndDescription(name, description)
+          .created(now.getTime(), creatorId)
+          .setBeginDateTime(beginDate.getTime(), DateUtil.formatTime(beginDate))
+          .setEndDateTime(endDate.getTime(), DateUtil.formatTime(endDate))
+          .setImportance(importance)
+          .setVersion(version)
+          .setKeywords(keywords)
+          .setContentPagePath(contenu)
+          .build();
       PublicationDAO.insertRow(con, detail);
+
       PublicationDetail result = PublicationDAO.loadRow(con, pk);
       detail.setUpdateDate(now.getTime());
       detail.setUpdaterId(creatorId);

--- a/core-library/src/integration-test/java/org/silverpeas/core/contribution/tracking/ContributionModificationTrackingIT.java
+++ b/core-library/src/integration-test/java/org/silverpeas/core/contribution/tracking/ContributionModificationTrackingIT.java
@@ -37,8 +37,6 @@ import org.silverpeas.core.admin.component.WAComponentRegistry;
 import org.silverpeas.core.admin.user.model.User;
 import org.silverpeas.core.cache.service.CacheServiceProvider;
 import org.silverpeas.core.contribution.ContributionEventProcessor;
-import org.silverpeas.core.contribution.ContributionModificationContextHandler;
-import org.silverpeas.core.contribution.ContributionOperationContextPropertyHandler;
 import org.silverpeas.core.contribution.publication.model.PublicationDetail;
 import org.silverpeas.core.contribution.publication.model.PublicationPK;
 import org.silverpeas.core.contribution.publication.service.PublicationService;
@@ -258,10 +256,10 @@ public class ContributionModificationTrackingIT {
 
     Mutable<PublicationPK> pk = Mutable.empty();
     withinTransaction(() -> {
-      PublicationDetail publication = new PublicationDetail();
-      publication.setPk(new PublicationPK(PublicationPK.UNKNOWN_ID, TestContext.KMELIA_ID));
-      publication.setName("A new publication");
-      publication.setDescription("A new publication for testing purpose");
+      PublicationDetail publication = PublicationDetail.builder()
+          .setPk(new PublicationPK(PublicationPK.UNKNOWN_ID, TestContext.KMELIA_ID))
+          .setNameAndDescription("A new publication", "A new publication for testing purpose")
+          .build();
       publication.setCreatorId(User.getCurrentRequester().getId());
       publication.setCreationDate(new Date());
       publication.setAuthor(publication.getCreatorId());
@@ -281,10 +279,10 @@ public class ContributionModificationTrackingIT {
 
     Mutable<PublicationPK> pk = Mutable.empty();
     withinTransaction(() -> {
-      PublicationDetail publication = new PublicationDetail();
-      publication.setPk(new PublicationPK(PublicationPK.UNKNOWN_ID, TestContext.KMELIA_ID));
-      publication.setName("A new publication");
-      publication.setDescription("A new publication for testing purpose");
+      PublicationDetail publication = PublicationDetail.builder()
+          .setPk(new PublicationPK(PublicationPK.UNKNOWN_ID, TestContext.KMELIA_ID))
+          .setNameAndDescription("A new publication", "A new publication for testing purpose")
+          .build();
       publication.setCreatorId("-3");
       publication.setCreationDate(new Date());
       publication.setAuthor(publication.getCreatorId());

--- a/core-library/src/main/java/org/silverpeas/core/contribution/publication/dao/PublicationDAO.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/publication/dao/PublicationDAO.java
@@ -436,18 +436,25 @@ public class PublicationDAO extends AbstractDAO {
       if (getSort) {
         order = rs.getInt("pubOrder");
       }
-      pub =
-          new PublicationDetail(pk, name, description, creationDate, beginDate, endDate, creatorId,
-              importance, version, keywords, content, status, updateDate, updaterId, validateDate,
-              validatorId, author);
-
+      pub = PublicationDetail.builder(lang)
+          .setPk(pk)
+          .setNameAndDescription(name, description)
+          .created(creationDate, creatorId)
+          .updated(updateDate, updaterId)
+          .validated(validateDate, validatorId)
+          .setBeginDateTime(beginDate, beginHour)
+          .setEndDateTime(endDate, endHour)
+          .setImportance(importance)
+          .setVersion(version)
+          .setKeywords(keywords)
+          .setContentPagePath(content)
+          .build();
+      pub.setStatus(status);
+      pub.setAuthor(author);
       pub.setInfoId(infoId);
-      pub.setBeginHour(beginHour);
-      pub.setEndHour(endHour);
       pub.setTargetValidatorId(targetValidatorId);
       pub.setCloneId(Integer.toString(tempPubId));
       pub.setCloneStatus(cloneStatus);
-      pub.setLanguage(lang);
       pub.setDraftOutDate(draftOutDate);
       pub.setExplicitRank(order);
     } catch (ParseException e) {
@@ -735,8 +742,7 @@ public class PublicationDAO extends AbstractDAO {
         .executeWith(con, r -> {
           final PublicationPK pk = new PublicationPK(Integer.toString(r.getInt(1)), r.getString(2));
           if (indexedPubPks.containsKey(pk)) {
-            final PublicationDetail pubDetail = new PublicationDetail();
-            pubDetail.setPk(pk);
+            final PublicationDetail pubDetail = PublicationDetail.builder().setPk(pk).build();
             pubDetail.setStatus(r.getString(3));
             pubDetail.setCloneId(Integer.toString(r.getInt(4)));
             pubDetail.setCloneStatus(r.getString(5));

--- a/core-library/src/main/java/org/silverpeas/core/contribution/publication/model/PublicationDetail.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/publication/model/PublicationDetail.java
@@ -23,6 +23,7 @@
  */
 package org.silverpeas.core.contribution.publication.model;
 
+import org.silverpeas.core.ResourceReference;
 import org.silverpeas.core.admin.user.model.User;
 import org.silverpeas.core.admin.user.model.UserDetail;
 import org.silverpeas.core.contribution.ContributionModificationContextHandler;
@@ -63,6 +64,7 @@ import org.silverpeas.core.contribution.tracking.ModificationTracked;
 import org.silverpeas.core.date.Period;
 import org.silverpeas.core.i18n.AbstractI18NBean;
 import org.silverpeas.core.i18n.I18NHelper;
+import org.silverpeas.core.i18n.I18n;
 import org.silverpeas.core.index.indexing.model.IndexManager;
 import org.silverpeas.core.io.media.image.thumbnail.control.ThumbnailController;
 import org.silverpeas.core.io.media.image.thumbnail.model.ThumbnailDetail;
@@ -112,31 +114,32 @@ public class PublicationDetail extends AbstractI18NBean<PublicationI18N>
     Serializable, WithAttachment, WithThumbnail, WithReminder {
   private static final long serialVersionUID = 9199848912262605680L;
 
+  private static final String EXCHANGE_NAMESPACE = "http://www.silverpeas.org/exchange";
   public static final String DELAYED_VISIBILITY_AT_MODEL_PROPERTY = "DELAYED_VISIBILITY_AT";
 
   private PublicationPK pk;
   private String infoId;
-  @XmlElement(name = "creationDate", namespace = "http://www.silverpeas.org/exchange")
+  @XmlElement(name = "creationDate", namespace = EXCHANGE_NAMESPACE)
   @XmlJavaTypeAdapter(DateAdapter.class)
   private Date creationDate;
-  @XmlElement(name = "beginDate", namespace = "http://www.silverpeas.org/exchange")
+  @XmlElement(name = "beginDate", namespace = EXCHANGE_NAMESPACE)
   @XmlJavaTypeAdapter(DateAdapter.class)
   private Date beginDate;
-  @XmlElement(name = "endDate", namespace = "http://www.silverpeas.org/exchange")
+  @XmlElement(name = "endDate", namespace = EXCHANGE_NAMESPACE)
   @XmlJavaTypeAdapter(DateAdapter.class)
   private Date endDate;
-  @XmlElement(name = "creatorId", namespace = "http://www.silverpeas.org/exchange")
+  @XmlElement(name = "creatorId", namespace = EXCHANGE_NAMESPACE)
   private String creatorId;
-  @XmlElement(name = "creatorName", namespace = "http://www.silverpeas.org/exchange")
+  @XmlElement(name = "creatorName", namespace = EXCHANGE_NAMESPACE)
   private String creatorName;
-  @XmlElement(name = "importance", namespace = "http://www.silverpeas.org/exchange")
+  @XmlElement(name = "importance", namespace = EXCHANGE_NAMESPACE)
   private int importance;
-  @XmlElement(name = "version", namespace = "http://www.silverpeas.org/exchange")
+  @XmlElement(name = "version", namespace = EXCHANGE_NAMESPACE)
   private String version;
-  @XmlElement(name = "keywords", namespace = "http://www.silverpeas.org/exchange")
+  @XmlElement(name = "keywords", namespace = EXCHANGE_NAMESPACE)
   private String keywords;
   private String content;
-  @XmlElement(name = "status", namespace = "http://www.silverpeas.org/exchange")
+  @XmlElement(name = "status", namespace = EXCHANGE_NAMESPACE)
   private String status;
   private Date updateDate;
   private String updaterId;
@@ -176,6 +179,26 @@ public class PublicationDetail extends AbstractI18NBean<PublicationI18N>
 
   private ContributionRating contributionRating;
 
+  /**
+   * Gets a builder of {@link PublicationDetail} instances for the default language as defined in
+   * {@link I18n#getDefaultLanguage()}. All the textual properties (name, description and keywords)
+   * will be related to this language.
+   * @return a {@link Builder} instance
+   */
+  public static Builder builder() {
+    return new Builder(I18n.get().getDefaultLanguage());
+  }
+
+  /**
+   * Gets a builder of {@link PublicationDetail} instances for the specified language. All the
+   * textual properties (name, description and keywords) will be related to this language.
+   * @param language a ISO 639-1 code of a supported language.
+   * @return a {@link Builder} instance
+   */
+  public static Builder builder(final String language) {
+    return new Builder(language);
+  }
+
   @Override
   protected Class<PublicationI18N> getTranslationType() {
     return PublicationI18N.class;
@@ -184,332 +207,8 @@ public class PublicationDetail extends AbstractI18NBean<PublicationI18N>
   /**
    * Default contructor, required for JAXB mapping in importExport.
    */
-  public PublicationDetail() {
+  protected PublicationDetail() {
     // Nothing to do
-  }
-
-  public PublicationDetail(String name, String description, Period visibilityPeriod,
-      String creatorId, String componentId) {
-    this.pk = new PublicationPK("unknown", componentId);
-    setName(name);
-    setDescription(description);
-    setVisibilityPeriod(visibilityPeriod);
-    this.creatorId = creatorId;
-  }
-
-  public PublicationDetail(PublicationPK pk, String name, String description, Date creationDate,
-      Date beginDate, Date endDate, String creatorId, int importance, String version,
-      String keywords, String content) {
-    this.pk = pk;
-    setName(name);
-    setDescription(description);
-    this.creationDate = creationDate;
-    this.beginDate = beginDate;
-    this.endDate = endDate;
-    this.creatorId = creatorId;
-    this.importance = importance;
-    this.version = version;
-    this.keywords = keywords;
-    this.content = content;
-  }
-
-  /**
-   * @param id
-   * @param name
-   * @param description
-   * @param creationDate
-   * @param beginDate
-   * @param endDate
-   * @param creatorId
-   * @param importance
-   * @param version
-   * @param keywords
-   * @param content
-   */
-  public PublicationDetail(String id, String name, String description, Date creationDate,
-      Date beginDate, Date endDate, String creatorId, String importance, String version,
-      String keywords, String content) {
-    this.pk = new PublicationPK(id);
-    setName(name);
-    setDescription(description);
-    this.creationDate = creationDate;
-    this.beginDate = beginDate;
-    this.endDate = endDate;
-    this.creatorId = creatorId;
-    this.importance = Integer.parseInt(importance);
-    this.version = version;
-    this.keywords = keywords;
-    this.content = content;
-  }
-
-  public PublicationDetail(PublicationPK pk, String name, String description, Date creationDate,
-      Date beginDate, Date endDate, String creatorId, int importance, String version,
-      String keywords, String content, String status) {
-    this.pk = pk;
-    setName(name);
-    setDescription(description);
-    this.creationDate = creationDate;
-    this.beginDate = beginDate;
-    this.endDate = endDate;
-    this.creatorId = creatorId;
-    this.importance = importance;
-    this.version = version;
-    this.keywords = keywords;
-    this.content = content;
-    this.status = status;
-  }
-
-  public PublicationDetail(PublicationPK pk, String name, String description, Date creationDate,
-      Date beginDate, Date endDate, String creatorId, int importance, String version,
-      String keywords, String content, String status, Date updateDate) {
-    this.pk = pk;
-    setName(name);
-    setDescription(description);
-    this.creationDate = creationDate;
-    this.beginDate = beginDate;
-    this.endDate = endDate;
-    this.creatorId = creatorId;
-    this.importance = importance;
-    this.version = version;
-    this.keywords = keywords;
-    this.content = content;
-    this.status = status;
-    this.updateDate = updateDate;
-  }
-
-  /**
-   * @param name
-   * @param description
-   * @param creationDate
-   * @param beginDate
-   * @param endDate
-   * @param creatorId
-   * @param importance
-   * @param version
-   * @param keywords
-   * @param content
-   * @param status
-   * @param updateDate
-   * @param updaterId
-   * @deprecated @param pk
-   */
-  @Deprecated
-  public PublicationDetail(PublicationPK pk, String name, String description, Date creationDate,
-      Date beginDate, Date endDate, String creatorId, int importance, String version,
-      String keywords, String content, String status, Date updateDate, String updaterId) {
-    this.pk = pk;
-    setName(name);
-    setDescription(description);
-    this.creationDate = creationDate;
-    this.beginDate = beginDate;
-    this.endDate = endDate;
-    this.creatorId = creatorId;
-    this.importance = importance;
-    this.version = version;
-    this.keywords = keywords;
-    this.content = content;
-    this.status = status;
-    this.updateDate = updateDate;
-    this.updaterId = updaterId;
-  }
-
-  public PublicationDetail(PublicationPK pk, String name, String description, Date creationDate,
-      Date beginDate, Date endDate, String creatorId, int importance, String version,
-      String keywords, String content, String status, Date updateDate, String updaterId,
-      String author) {
-    this.pk = pk;
-    setName(name);
-    setDescription(description);
-    this.creationDate = creationDate;
-    this.beginDate = beginDate;
-    this.endDate = endDate;
-    this.creatorId = creatorId;
-    this.importance = importance;
-    this.version = version;
-    this.keywords = keywords;
-    this.content = content;
-    this.status = status;
-    this.updateDate = updateDate;
-    this.updaterId = updaterId;
-    this.author = author;
-  }
-
-  /**
-   * @param name
-   * @param description
-   * @param creationDate
-   * @param beginDate
-   * @param endDate
-   * @param creatorId
-   * @param importance
-   * @param version
-   * @param keywords
-   * @param content
-   * @param status
-   * @deprecated @param id
-   */
-  @Deprecated
-  public PublicationDetail(String id, String name, String description, Date creationDate,
-      Date beginDate, Date endDate, String creatorId, String importance, String version,
-      String keywords, String content, String status) {
-    this.pk = new PublicationPK(id);
-    setName(name);
-    setDescription(description);
-    this.creationDate = creationDate;
-    this.beginDate = beginDate;
-    this.endDate = endDate;
-    this.creatorId = creatorId;
-    this.importance = Integer.parseInt(importance);
-    this.version = version;
-    this.keywords = keywords;
-    this.content = content;
-    this.status = status;
-  }
-
-  public PublicationDetail(String id, String name, String description, Date creationDate,
-      Date beginDate, Date endDate, String creatorId, String importance, String version,
-      String keywords, String content, String status, String updaterId, String author) {
-    this.pk = new PublicationPK(id);
-    setName(name);
-    setDescription(description);
-    this.creationDate = creationDate;
-    this.beginDate = beginDate;
-    this.endDate = endDate;
-    this.creatorId = creatorId;
-    this.importance = Integer.parseInt(importance);
-    this.version = version;
-    this.keywords = keywords;
-    this.content = content;
-    this.status = status;
-    this.updaterId = updaterId;
-    this.author = author;
-  }
-
-  public PublicationDetail(String id, String name, String description, Date creationDate,
-      Date beginDate, Date endDate, String creatorId, String importance, String version,
-      String keywords, String content, String status, Date updateDate) {
-    this.pk = new PublicationPK(id);
-    setName(name);
-    setDescription(description);
-    this.creationDate = creationDate;
-    this.beginDate = beginDate;
-    this.endDate = endDate;
-    this.creatorId = creatorId;
-    this.importance = Integer.parseInt(importance);
-    this.version = version;
-    this.keywords = keywords;
-    this.content = content;
-    this.status = status;
-    this.updateDate = updateDate;
-  }
-
-  public PublicationDetail(String id, String name, String description, Date creationDate,
-      Date beginDate, Date endDate, String creatorId, String importance, String version,
-      String keywords, String content, String status, Date updateDate, String updaterId) {
-    this.pk = new PublicationPK(id);
-    setName(name);
-    setDescription(description);
-    this.creationDate = creationDate;
-    this.beginDate = beginDate;
-    this.endDate = endDate;
-    this.creatorId = creatorId;
-    this.importance = Integer.parseInt(importance);
-    this.version = version;
-    this.keywords = keywords;
-    this.content = content;
-    this.status = status;
-    this.updateDate = updateDate;
-    this.updaterId = updaterId;
-  }
-
-  public PublicationDetail(String id, String name, String description, Date creationDate,
-      Date beginDate, Date endDate, String creatorId, String importance, String version,
-      String keywords, String content, String status, Date updateDate, String updaterId,
-      Date validateDate, String validatorId) {
-    this.pk = new PublicationPK(id);
-    setName(name);
-    setDescription(description);
-    this.creationDate = creationDate;
-    this.beginDate = beginDate;
-    this.endDate = endDate;
-    this.creatorId = creatorId;
-    this.importance = Integer.parseInt(importance);
-    this.version = version;
-    this.keywords = keywords;
-    this.content = content;
-    this.status = status;
-    this.updateDate = updateDate;
-    this.updaterId = updaterId;
-    this.validateDate = validateDate;
-    this.validatorId = validatorId;
-
-  }
-
-  /**
-   * @param pk
-   * @param name
-   * @param description
-   * @param creationDate
-   * @param beginDate
-   * @param endDate
-   * @param creatorId
-   * @param importance
-   * @param version
-   * @param keywords
-   * @param content
-   * @param status
-   * @param updateDate
-   * @param updaterId
-   * @param validateDate
-   * @param validatorId
-   * @deprecated
-   */
-  @Deprecated
-  public PublicationDetail(PublicationPK pk, String name, String description, Date creationDate,
-      Date beginDate, Date endDate, String creatorId, int importance, String version,
-      String keywords, String content, String status, Date updateDate, String updaterId,
-      Date validateDate, String validatorId) {
-    this.pk = pk;
-    setName(name);
-    setDescription(description);
-    this.creationDate = creationDate;
-    this.beginDate = beginDate;
-    this.endDate = endDate;
-    this.creatorId = creatorId;
-    this.importance = importance;
-    this.version = version;
-    this.keywords = keywords;
-    this.content = content;
-    this.status = status;
-    this.updateDate = updateDate;
-    this.updaterId = updaterId;
-    this.validateDate = validateDate;
-    this.validatorId = validatorId;
-
-  }
-
-  public PublicationDetail(PublicationPK pk, String name, String description, Date creationDate,
-      Date beginDate, Date endDate, String creatorId, int importance, String version,
-      String keywords, String content, String status, Date updateDate, String updaterId,
-      Date validateDate, String validatorId, String author) {
-    this.pk = pk;
-    setName(name);
-    setDescription(description);
-    this.creationDate = creationDate;
-    this.beginDate = beginDate;
-    this.endDate = endDate;
-    this.creatorId = creatorId;
-    this.importance = importance;
-    this.version = version;
-    this.keywords = keywords;
-    this.content = content;
-    this.status = status;
-    this.updateDate = updateDate;
-    this.updaterId = updaterId;
-    this.validateDate = validateDate;
-    this.validatorId = validatorId;
-    this.author = author;
-
   }
 
   public PublicationPK getPK() {
@@ -1003,6 +702,9 @@ public class PublicationDetail extends AbstractI18NBean<PublicationI18N>
 
   public void setKeywords(String keywords) {
     this.keywords = keywords;
+    String lang = getLanguage();
+    PublicationI18N translation = getTranslation(lang);
+    translation.setKeywords(keywords);
   }
 
   public void setVersion(String version) {
@@ -1104,6 +806,7 @@ public class PublicationDetail extends AbstractI18NBean<PublicationI18N>
 
   public PublicationDetail copy() {
     PublicationDetail clone = new PublicationDetail();
+    clone.setLanguage(getLanguage());
     clone.setAuthor(author);
     clone.setBeginDate(beginDate);
     clone.setBeginHour(beginHour);
@@ -1374,5 +1077,152 @@ public class PublicationDetail extends AbstractI18NBean<PublicationI18N>
       userId = getCreatorId();
     }
     return userId;
+  }
+
+  /**
+   * A builder of a {@link PublicationDetail} instance by setting some of its properties.
+   */
+  public static class Builder {
+
+    private final PublicationDetail publication = new PublicationDetail();
+
+    Builder(final String language) {
+      publication.setLanguage(language);
+    }
+
+    /**
+     * Builds a {@link PublicationDetail} instance from the properties that were previously set
+     * with this builder.
+     * @return a {@link PublicationDetail} instance.
+     */
+    public PublicationDetail build() {
+      if (publication.getPK() == null) {
+        publication.setPk(new PublicationPK(ResourceReference.UNKNOWN_ID));
+      }
+      return publication;
+    }
+
+    /**
+     * Sets the unique identifier of the {@link PublicationDetail} instance to build.
+     * @param pk a unique identifier of a publication.
+     * @return itself.
+     */
+    public Builder setPk(final PublicationPK pk) {
+      publication.setPk(pk);
+      return this;
+    }
+
+    /**
+     * Sets the creation properties of the {@link PublicationDetail} instance to build.
+     * @param creationDate the date at which the publication was created.
+     * @param creatorId the identifier of the user that created the publication.
+     * @return itself.
+     */
+    public Builder created(final Date creationDate, final String creatorId) {
+      publication.creationDate = creationDate;
+      publication.creatorId = creatorId;
+      return this;
+    }
+
+    /**
+     * Sets the update properties of the {@link PublicationDetail} instance to build.
+     * @param updateDate the date at which the publication was lastly updated.
+     * @param updaterId the identifier of the user that lastly updated the publication.
+     * @return itself.
+     */
+    public Builder updated(final Date updateDate, final String updaterId) {
+      publication.updateDate = updateDate;
+      publication.updaterId = updaterId;
+      return this;
+    }
+
+    /**
+     * Sets the validation properties of the {@link PublicationDetail} instance to build.
+     * @param validateDate the date at which the publication was validated.
+     * @param validatorId the identifier of the user that validated the publication.
+     * @return itself.
+     */
+    public Builder validated(final Date validateDate, final String validatorId) {
+      publication.validateDate = validateDate;
+      publication.validatorId = validatorId;
+      return this;
+    }
+
+    /**
+     * Sets the visibility begin date properties of the {@link PublicationDetail} instance to build.
+     * @param date the day at which the publication begins to be visible.
+     * @param hour the hour at which the publication begins to be visible.
+     * @return itself.
+     */
+    public Builder setBeginDateTime(final Date date, final String hour) {
+      publication.beginDate = date;
+      publication.beginHour = hour;
+      return this;
+    }
+
+    /**
+     * Sets the visibility end date properties of the {@link PublicationDetail} instance to build.
+     * @param date the day at which the publication ends to be visible.
+     * @param hour the hour at which the publication ends to be visible.
+     * @return itself.
+     */
+    public Builder setEndDateTime(final Date date, final String hour) {
+      publication.endDate = date;
+      publication.endHour = hour;
+      return this;
+    }
+
+    /**
+     * Sets the importance of the {@link PublicationDetail} instance to build.
+     * @param importance the importance of the publication. Lower value means more importance.
+     * @return itself.
+     */
+    public Builder setImportance(final int importance) {
+      publication.importance = importance;
+      return this;
+    }
+
+    /**
+     * Sets the keywords of the {@link PublicationDetail} instance to build.
+     * @param keywords the keywords of the publication.
+     * @return itself.
+     */
+    public Builder setKeywords(final String keywords) {
+      publication.keywords = keywords;
+      return this;
+    }
+
+    /**
+     * Sets the URL path where is located the content of the {@link PublicationDetail} instance
+     * to build.
+     * @param contentPagePath the path of the content of the publication.
+     * @return itself.
+     */
+    public Builder setContentPagePath(final String contentPagePath) {
+      publication.content = contentPagePath;
+      return this;
+    }
+
+    /**
+     * Sets the version of the {@link PublicationDetail} instance to build.
+     * @param version the version of the publication.
+     * @return itself.
+     */
+    public Builder setVersion(final String version) {
+      publication.version = version;
+      return this;
+    }
+
+    /**
+     * Sets in the default language the given name and description of the publication to build.
+     * @param name the name of the publication.
+     * @param description the description of the publication.
+     * @return itself.
+     */
+    public Builder setNameAndDescription(final String name, final String description) {
+      publication.setName(name);
+      publication.setDescription(description);
+      return this;
+    }
   }
 }

--- a/core-library/src/main/java/org/silverpeas/core/i18n/BeanTranslation.java
+++ b/core-library/src/main/java/org/silverpeas/core/i18n/BeanTranslation.java
@@ -51,6 +51,7 @@ public class BeanTranslation implements ResourceTranslation, Serializable {
    * @param translation the bean translation to copy.
    */
   protected BeanTranslation(final BeanTranslation translation) {
+    id = translation.id;
     objectId = translation.objectId;
     language = translation.language;
     name = translation.name;

--- a/core-library/src/test/java/org/silverpeas/core/contribution/tracking/ContributionTrackingTestContext.java
+++ b/core-library/src/test/java/org/silverpeas/core/contribution/tracking/ContributionTrackingTestContext.java
@@ -77,10 +77,10 @@ public class ContributionTrackingTestContext {
   }
 
   PublicationDetail getPublication(final String instanceId) {
-    PublicationDetail publi = new PublicationDetail();
-    publi.setPk(new PublicationPK("23", instanceId));
-    publi.setName("My publi");
-    publi.setDescription("A description");
+    PublicationDetail publi = PublicationDetail.builder()
+        .setPk(new PublicationPK("23", instanceId))
+        .setNameAndDescription("My publi", "A description")
+        .build();
     publi.setCreationDate(Date.from(YESTERDAY.toInstant()));
     publi.setCreatorId("1");
     publi.setUpdateDate(publi.getCreationDate());

--- a/core-library/src/test/java/org/silverpeas/core/security/authorization/TestPublicationAccessController.java
+++ b/core-library/src/test/java/org/silverpeas/core/security/authorization/TestPublicationAccessController.java
@@ -3823,8 +3823,7 @@ public class TestPublicationAccessController {
     }
 
     private PublicationDetail newPublicationWith(final PublicationPK pubPk) {
-      PublicationDetail publi = new PublicationDetail();
-      publi.setPk(pubPk);
+      PublicationDetail publi = PublicationDetail.builder().setPk(pubPk).build();
       publi.setStatus(testContext.pubStatus);
       publi.setCreatorId(testContext.isUserThePublicationAuthor ? USER_ID : "otherUserId");
       if (!testContext.isPubVisible) {

--- a/core-library/src/test/java/org/silverpeas/core/security/authorization/TestSimpleDocumentAccessController.java
+++ b/core-library/src/test/java/org/silverpeas/core/security/authorization/TestSimpleDocumentAccessController.java
@@ -76,6 +76,7 @@ public class TestSimpleDocumentAccessController {
 
   @Rule
   public LibCoreCommonAPIRule commonAPIRule = new LibCoreCommonAPIRule();
+
   @Before
   public void setup() {
     user = mock(User.class);
@@ -95,15 +96,13 @@ public class TestSimpleDocumentAccessController {
   public void testIsUserAuthorizedOnSomethingOtherThanGED() {
     // User has no right on component
     testContext.clear();
-    testContext.results()
-        .verifyCallOfComponentAccessControllerGetUserRoles();
+    testContext.results().verifyCallOfComponentAccessControllerGetUserRoles();
     assertIsUserAuthorized(false);
 
     // User has USER role on component
     testContext.clear();
     testContext.withComponentUserRoles(SilverpeasRole.USER);
-    testContext.results()
-        .verifyCallOfComponentAccessControllerGetUserRoles();
+    testContext.results().verifyCallOfComponentAccessControllerGetUserRoles();
     assertIsUserAuthorized(true);
 
     // User has PUBLISHER role on component
@@ -111,8 +110,7 @@ public class TestSimpleDocumentAccessController {
     testContext.clear();
     testContext.withComponentUserRoles(SilverpeasRole.PUBLISHER)
         .onOperationsOf(AccessControlOperation.SHARING);
-    testContext.results()
-        .verifyCallOfComponentAccessControllerGetUserRoles();
+    testContext.results().verifyCallOfComponentAccessControllerGetUserRoles();
     assertIsUserAuthorized(false);
 
     // User has ADMIN role on component
@@ -120,26 +118,25 @@ public class TestSimpleDocumentAccessController {
     testContext.clear();
     testContext.withComponentUserRoles(SilverpeasRole.ADMIN)
         .onOperationsOf(AccessControlOperation.SHARING);
-    testContext.results()
-        .verifyCallOfComponentAccessControllerGetUserRoles();
+    testContext.results().verifyCallOfComponentAccessControllerGetUserRoles();
     assertIsUserAuthorized(false);
 
     // User has PUBLISHER role on component
     // User rights are verified for sharing action on the document, sharing is enabled
     testContext.clear();
     testContext.withComponentUserRoles(SilverpeasRole.PUBLISHER)
-        .onOperationsOf(AccessControlOperation.SHARING).enableFileSharingRole(SilverpeasRole.ADMIN);
-    testContext.results()
-        .verifyCallOfComponentAccessControllerGetUserRoles();
+        .onOperationsOf(AccessControlOperation.SHARING)
+        .enableFileSharingRole(SilverpeasRole.ADMIN);
+    testContext.results().verifyCallOfComponentAccessControllerGetUserRoles();
     assertIsUserAuthorized(false);
 
     // User has ADMIN role on component
     // User rights are verified for sharing action on the document, sharing is enabled
     testContext.clear();
     testContext.withComponentUserRoles(SilverpeasRole.ADMIN)
-        .onOperationsOf(AccessControlOperation.SHARING).enableFileSharingRole(SilverpeasRole.ADMIN);
-    testContext.results()
-        .verifyCallOfComponentAccessControllerGetUserRoles();
+        .onOperationsOf(AccessControlOperation.SHARING)
+        .enableFileSharingRole(SilverpeasRole.ADMIN);
+    testContext.results().verifyCallOfComponentAccessControllerGetUserRoles();
     assertIsUserAuthorized(false);
 
     // User has USER role on component
@@ -147,8 +144,7 @@ public class TestSimpleDocumentAccessController {
     testContext.clear();
     testContext.withComponentUserRoles(SilverpeasRole.USER)
         .onOperationsOf(AccessControlOperation.DOWNLOAD);
-    testContext.results()
-        .verifyCallOfComponentAccessControllerGetUserRoles();
+    testContext.results().verifyCallOfComponentAccessControllerGetUserRoles();
     assertIsUserAuthorized(true);
 
     // User has PUBLISHER role on component
@@ -156,8 +152,7 @@ public class TestSimpleDocumentAccessController {
     testContext.clear();
     testContext.withComponentUserRoles(SilverpeasRole.PUBLISHER)
         .onOperationsOf(AccessControlOperation.DOWNLOAD);
-    testContext.results()
-        .verifyCallOfComponentAccessControllerGetUserRoles();
+    testContext.results().verifyCallOfComponentAccessControllerGetUserRoles();
     assertIsUserAuthorized(true);
 
     // User has WRITER role on component
@@ -165,35 +160,34 @@ public class TestSimpleDocumentAccessController {
     testContext.clear();
     testContext.withComponentUserRoles(SilverpeasRole.WRITER)
         .onOperationsOf(AccessControlOperation.DOWNLOAD);
-    testContext.results()
-        .verifyCallOfComponentAccessControllerGetUserRoles();
+    testContext.results().verifyCallOfComponentAccessControllerGetUserRoles();
     assertIsUserAuthorized(true);
 
     // User has USER role on component
     // User is going to download the document (download is forbidden for readers)
     testContext.clear();
     testContext.withComponentUserRoles(SilverpeasRole.USER)
-        .onOperationsOf(AccessControlOperation.DOWNLOAD).forbidDownloadForReaders();
-    testContext.results()
-        .verifyCallOfComponentAccessControllerGetUserRoles();
+        .onOperationsOf(AccessControlOperation.DOWNLOAD)
+        .forbidDownloadForReaders();
+    testContext.results().verifyCallOfComponentAccessControllerGetUserRoles();
     assertIsUserAuthorized(false);
 
     // User has PUBLISHER role on component
     // User is going to download the document (download is forbidden for readers)
     testContext.clear();
     testContext.withComponentUserRoles(SilverpeasRole.PUBLISHER)
-        .onOperationsOf(AccessControlOperation.DOWNLOAD).forbidDownloadForReaders();
-    testContext.results()
-        .verifyCallOfComponentAccessControllerGetUserRoles();
+        .onOperationsOf(AccessControlOperation.DOWNLOAD)
+        .forbidDownloadForReaders();
+    testContext.results().verifyCallOfComponentAccessControllerGetUserRoles();
     assertIsUserAuthorized(true);
 
     // User has WRITER role on component
     // User is going to download the document (download is forbidden for readers)
     testContext.clear();
     testContext.withComponentUserRoles(SilverpeasRole.WRITER)
-        .onOperationsOf(AccessControlOperation.DOWNLOAD).forbidDownloadForReaders();
-    testContext.results()
-        .verifyCallOfComponentAccessControllerGetUserRoles();
+        .onOperationsOf(AccessControlOperation.DOWNLOAD)
+        .forbidDownloadForReaders();
+    testContext.results().verifyCallOfComponentAccessControllerGetUserRoles();
     assertIsUserAuthorized(true);
 
     // User has USER role on component
@@ -201,8 +195,7 @@ public class TestSimpleDocumentAccessController {
     testContext.clear();
     testContext.withComponentUserRoles(SilverpeasRole.USER)
         .onOperationsOf(AccessControlOperation.PERSIST_ACTIONS.iterator().next());
-    testContext.results()
-        .verifyCallOfComponentAccessControllerGetUserRoles();
+    testContext.results().verifyCallOfComponentAccessControllerGetUserRoles();
     assertIsUserAuthorized(false);
 
     // User has PUBLISHER role on component
@@ -210,8 +203,7 @@ public class TestSimpleDocumentAccessController {
     testContext.clear();
     testContext.withComponentUserRoles(SilverpeasRole.PUBLISHER)
         .onOperationsOf(AccessControlOperation.PERSIST_ACTIONS.iterator().next());
-    testContext.results()
-        .verifyCallOfComponentAccessControllerGetUserRoles();
+    testContext.results().verifyCallOfComponentAccessControllerGetUserRoles();
     assertIsUserAuthorized(true);
 
     // User has WRITER role on component
@@ -219,8 +211,7 @@ public class TestSimpleDocumentAccessController {
     testContext.clear();
     testContext.withComponentUserRoles(SilverpeasRole.WRITER)
         .onOperationsOf(AccessControlOperation.PERSIST_ACTIONS.iterator().next());
-    testContext.results()
-        .verifyCallOfComponentAccessControllerGetUserRoles();
+    testContext.results().verifyCallOfComponentAccessControllerGetUserRoles();
     assertIsUserAuthorized(true);
   }
 
@@ -245,7 +236,8 @@ public class TestSimpleDocumentAccessController {
     // User has PUBLISHER role on component
     // User rights are verified for sharing action on the document, but sharing is not enabled
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.PUBLISHER).onGEDComponent()
+    testContext.withComponentUserRoles(SilverpeasRole.PUBLISHER)
+        .onGEDComponent()
         .onOperationsOf(AccessControlOperation.SHARING);
     testContext.results()
         .verifyCallOfComponentAccessControllerGetUserRoles()
@@ -255,7 +247,8 @@ public class TestSimpleDocumentAccessController {
     // User has ADMIN role on component
     // User rights are verified for sharing action on the document, but sharing is not enabled
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.ADMIN).onGEDComponent()
+    testContext.withComponentUserRoles(SilverpeasRole.ADMIN)
+        .onGEDComponent()
         .onOperationsOf(AccessControlOperation.SHARING);
     testContext.results()
         .verifyCallOfComponentAccessControllerGetUserRoles()
@@ -265,8 +258,10 @@ public class TestSimpleDocumentAccessController {
     // User has PUBLISHER role on component
     // User rights are verified for sharing action on the document, sharing is enabled
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.PUBLISHER).onGEDComponent()
-        .onOperationsOf(AccessControlOperation.SHARING).enableFileSharingRole(SilverpeasRole.ADMIN);
+    testContext.withComponentUserRoles(SilverpeasRole.PUBLISHER)
+        .onGEDComponent()
+        .onOperationsOf(AccessControlOperation.SHARING)
+        .enableFileSharingRole(SilverpeasRole.ADMIN);
     testContext.results()
         .verifyCallOfComponentAccessControllerGetUserRoles()
         .verifyTwoCallsOfComponentAccessControllerIsUserAuthorized();
@@ -275,8 +270,10 @@ public class TestSimpleDocumentAccessController {
     // User has ADMIN role on component
     // User rights are verified for sharing action on the document, sharing is enabled
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.ADMIN).onGEDComponent()
-        .onOperationsOf(AccessControlOperation.SHARING).enableFileSharingRole(SilverpeasRole.ADMIN);
+    testContext.withComponentUserRoles(SilverpeasRole.ADMIN)
+        .onGEDComponent()
+        .onOperationsOf(AccessControlOperation.SHARING)
+        .enableFileSharingRole(SilverpeasRole.ADMIN);
     testContext.results()
         .verifyCallOfComponentAccessControllerGetUserRoles()
         .verifyTwoCallsOfComponentAccessControllerIsUserAuthorized();
@@ -285,7 +282,8 @@ public class TestSimpleDocumentAccessController {
     // User has USER role on component
     // User is going to download the document (but no download restriction on the document)
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.USER).onGEDComponent()
+    testContext.withComponentUserRoles(SilverpeasRole.USER)
+        .onGEDComponent()
         .onOperationsOf(AccessControlOperation.DOWNLOAD);
     testContext.results()
         .verifyCallOfComponentAccessControllerGetUserRoles()
@@ -295,7 +293,8 @@ public class TestSimpleDocumentAccessController {
     // User has PUBLISHER role on component
     // User is going to download the document (but no download restriction on the document)
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.PUBLISHER).onGEDComponent()
+    testContext.withComponentUserRoles(SilverpeasRole.PUBLISHER)
+        .onGEDComponent()
         .onOperationsOf(AccessControlOperation.DOWNLOAD);
     testContext.results()
         .verifyCallOfComponentAccessControllerGetUserRoles()
@@ -305,7 +304,8 @@ public class TestSimpleDocumentAccessController {
     // User has WRITER role on component
     // User is going to download the document (but no download restriction on the document)
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.WRITER).onGEDComponent()
+    testContext.withComponentUserRoles(SilverpeasRole.WRITER)
+        .onGEDComponent()
         .onOperationsOf(AccessControlOperation.DOWNLOAD);
     testContext.results()
         .verifyCallOfComponentAccessControllerGetUserRoles()
@@ -315,8 +315,10 @@ public class TestSimpleDocumentAccessController {
     // User has USER role on component
     // User is going to download the document (download is forbidden for readers)
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.USER).onGEDComponent()
-        .onOperationsOf(AccessControlOperation.DOWNLOAD).forbidDownloadForReaders();
+    testContext.withComponentUserRoles(SilverpeasRole.USER)
+        .onGEDComponent()
+        .onOperationsOf(AccessControlOperation.DOWNLOAD)
+        .forbidDownloadForReaders();
     testContext.results()
         .verifyCallOfComponentAccessControllerGetUserRoles()
         .verifyTwoCallsOfComponentAccessControllerIsUserAuthorized();
@@ -325,8 +327,10 @@ public class TestSimpleDocumentAccessController {
     // User has PUBLISHER role on component
     // User is going to download the document (download is forbidden for readers)
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.PUBLISHER).onGEDComponent()
-        .onOperationsOf(AccessControlOperation.DOWNLOAD).forbidDownloadForReaders();
+    testContext.withComponentUserRoles(SilverpeasRole.PUBLISHER)
+        .onGEDComponent()
+        .onOperationsOf(AccessControlOperation.DOWNLOAD)
+        .forbidDownloadForReaders();
     testContext.results()
         .verifyCallOfComponentAccessControllerGetUserRoles()
         .verifyTwoCallsOfComponentAccessControllerIsUserAuthorized();
@@ -335,8 +339,10 @@ public class TestSimpleDocumentAccessController {
     // User has WRITER role on component
     // User is going to download the document (download is forbidden for readers)
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.WRITER).onGEDComponent()
-        .onOperationsOf(AccessControlOperation.DOWNLOAD).forbidDownloadForReaders();
+    testContext.withComponentUserRoles(SilverpeasRole.WRITER)
+        .onGEDComponent()
+        .onOperationsOf(AccessControlOperation.DOWNLOAD)
+        .forbidDownloadForReaders();
     testContext.results()
         .verifyCallOfComponentAccessControllerGetUserRoles()
         .verifyTwoCallsOfComponentAccessControllerIsUserAuthorized();
@@ -345,7 +351,8 @@ public class TestSimpleDocumentAccessController {
     // User has USER role on component
     // User is going to modify the document
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.USER).onGEDComponent()
+    testContext.withComponentUserRoles(SilverpeasRole.USER)
+        .onGEDComponent()
         .onOperationsOf(AccessControlOperation.PERSIST_ACTIONS.iterator().next());
     testContext.results()
         .verifyCallOfComponentAccessControllerGetUserRoles()
@@ -355,7 +362,8 @@ public class TestSimpleDocumentAccessController {
     // User has PUBLISHER role on component
     // User is going to modify the document
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.PUBLISHER).onGEDComponent()
+    testContext.withComponentUserRoles(SilverpeasRole.PUBLISHER)
+        .onGEDComponent()
         .onOperationsOf(AccessControlOperation.PERSIST_ACTIONS.iterator().next());
     testContext.results()
         .verifyCallOfComponentAccessControllerGetUserRoles()
@@ -365,7 +373,8 @@ public class TestSimpleDocumentAccessController {
     // User has WRITER role on component
     // User is going to modify the document
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.WRITER).onGEDComponent()
+    testContext.withComponentUserRoles(SilverpeasRole.WRITER)
+        .onGEDComponent()
         .onOperationsOf(AccessControlOperation.PERSIST_ACTIONS.iterator().next());
     testContext.results()
         .verifyCallOfComponentAccessControllerGetUserRoles()
@@ -378,151 +387,160 @@ public class TestSimpleDocumentAccessController {
     // User has no right on component
     testContext.clear();
     testContext.onGEDComponent().documentAttachedToDirectory();
-    testContext.results()
-        .verifyCallOfNodeAccessControllerGetUserRoles();
+    testContext.results().verifyCallOfNodeAccessControllerGetUserRoles();
     assertIsUserAuthorized(false);
 
     // User has USER role on component
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.USER).onGEDComponent()
+    testContext.withComponentUserRoles(SilverpeasRole.USER)
+        .onGEDComponent()
         .documentAttachedToDirectory();
-    testContext.results()
-        .verifyCallOfNodeAccessControllerGetUserRoles();
+    testContext.results().verifyCallOfNodeAccessControllerGetUserRoles();
     assertIsUserAuthorized(true);
 
     // User has PUBLISHER role on component
     // User rights are verified for sharing action on the document, but sharing is not enabled
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.PUBLISHER).onGEDComponent()
-        .documentAttachedToDirectory().onOperationsOf(AccessControlOperation.SHARING);
-    testContext.results()
-        .verifyCallOfNodeAccessControllerGetUserRoles();
+    testContext.withComponentUserRoles(SilverpeasRole.PUBLISHER)
+        .onGEDComponent()
+        .documentAttachedToDirectory()
+        .onOperationsOf(AccessControlOperation.SHARING);
+    testContext.results().verifyCallOfNodeAccessControllerGetUserRoles();
     assertIsUserAuthorized(false);
 
     // User has ADMIN role on component
     // User rights are verified for sharing action on the document, but sharing is not enabled
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.ADMIN).onGEDComponent()
-        .documentAttachedToDirectory().onOperationsOf(AccessControlOperation.SHARING);
-    testContext.results()
-        .verifyCallOfNodeAccessControllerGetUserRoles();
+    testContext.withComponentUserRoles(SilverpeasRole.ADMIN)
+        .onGEDComponent()
+        .documentAttachedToDirectory()
+        .onOperationsOf(AccessControlOperation.SHARING);
+    testContext.results().verifyCallOfNodeAccessControllerGetUserRoles();
     assertIsUserAuthorized(false);
 
     // User has PUBLISHER role on component
     // User rights are verified for sharing action on the document, sharing is enabled
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.PUBLISHER).onGEDComponent()
-        .documentAttachedToDirectory().onOperationsOf(AccessControlOperation.SHARING)
+    testContext.withComponentUserRoles(SilverpeasRole.PUBLISHER)
+        .onGEDComponent()
+        .documentAttachedToDirectory()
+        .onOperationsOf(AccessControlOperation.SHARING)
         .enableFileSharingRole(SilverpeasRole.ADMIN);
-    testContext.results()
-        .verifyCallOfNodeAccessControllerGetUserRoles();
+    testContext.results().verifyCallOfNodeAccessControllerGetUserRoles();
     assertIsUserAuthorized(false);
 
     // User has ADMIN role on component
     // User rights are verified for sharing action on the document, sharing is enabled
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.ADMIN).onGEDComponent()
-        .documentAttachedToDirectory().onOperationsOf(AccessControlOperation.SHARING)
+    testContext.withComponentUserRoles(SilverpeasRole.ADMIN)
+        .onGEDComponent()
+        .documentAttachedToDirectory()
+        .onOperationsOf(AccessControlOperation.SHARING)
         .enableFileSharingRole(SilverpeasRole.ADMIN);
-    testContext.results()
-        .verifyCallOfNodeAccessControllerGetUserRoles();
+    testContext.results().verifyCallOfNodeAccessControllerGetUserRoles();
     assertIsUserAuthorized(true);
 
     // User has USER role on component
     // User is going to download the document (but no download restriction on the document)
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.USER).onGEDComponent()
-        .documentAttachedToDirectory().onOperationsOf(AccessControlOperation.DOWNLOAD);
-    testContext.results()
-        .verifyCallOfNodeAccessControllerGetUserRoles();
+    testContext.withComponentUserRoles(SilverpeasRole.USER)
+        .onGEDComponent()
+        .documentAttachedToDirectory()
+        .onOperationsOf(AccessControlOperation.DOWNLOAD);
+    testContext.results().verifyCallOfNodeAccessControllerGetUserRoles();
     assertIsUserAuthorized(true);
 
     // User has PUBLISHER role on component
     // User is going to download the document (but no download restriction on the document)
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.PUBLISHER).onGEDComponent()
-        .documentAttachedToDirectory().onOperationsOf(AccessControlOperation.DOWNLOAD);
-    testContext.results()
-        .verifyCallOfNodeAccessControllerGetUserRoles();
+    testContext.withComponentUserRoles(SilverpeasRole.PUBLISHER)
+        .onGEDComponent()
+        .documentAttachedToDirectory()
+        .onOperationsOf(AccessControlOperation.DOWNLOAD);
+    testContext.results().verifyCallOfNodeAccessControllerGetUserRoles();
     assertIsUserAuthorized(true);
 
     // User has WRITER role on component
     // User is going to download the document (but no download restriction on the document)
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.WRITER).onGEDComponent()
-        .documentAttachedToDirectory().onOperationsOf(AccessControlOperation.DOWNLOAD);
-    testContext.results()
-        .verifyCallOfNodeAccessControllerGetUserRoles();
+    testContext.withComponentUserRoles(SilverpeasRole.WRITER)
+        .onGEDComponent()
+        .documentAttachedToDirectory()
+        .onOperationsOf(AccessControlOperation.DOWNLOAD);
+    testContext.results().verifyCallOfNodeAccessControllerGetUserRoles();
     assertIsUserAuthorized(true);
 
     // User has USER role on component
     // User is going to download the document (download is forbidden for readers)
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.USER).onGEDComponent()
-        .documentAttachedToDirectory().onOperationsOf(AccessControlOperation.DOWNLOAD)
+    testContext.withComponentUserRoles(SilverpeasRole.USER)
+        .onGEDComponent()
+        .documentAttachedToDirectory()
+        .onOperationsOf(AccessControlOperation.DOWNLOAD)
         .forbidDownloadForReaders();
-    testContext.results()
-        .verifyCallOfNodeAccessControllerGetUserRoles();
+    testContext.results().verifyCallOfNodeAccessControllerGetUserRoles();
     assertIsUserAuthorized(false);
 
     // User has PUBLISHER role on component
     // User is going to download the document (download is forbidden for readers)
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.PUBLISHER).onGEDComponent()
-        .documentAttachedToDirectory().onOperationsOf(AccessControlOperation.DOWNLOAD)
+    testContext.withComponentUserRoles(SilverpeasRole.PUBLISHER)
+        .onGEDComponent()
+        .documentAttachedToDirectory()
+        .onOperationsOf(AccessControlOperation.DOWNLOAD)
         .forbidDownloadForReaders();
-    testContext.results()
-        .verifyCallOfNodeAccessControllerGetUserRoles();
+    testContext.results().verifyCallOfNodeAccessControllerGetUserRoles();
     assertIsUserAuthorized(true);
 
     // User has WRITER role on component
     // User is going to download the document (download is forbidden for readers)
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.WRITER).onGEDComponent()
-        .documentAttachedToDirectory().onOperationsOf(AccessControlOperation.DOWNLOAD)
+    testContext.withComponentUserRoles(SilverpeasRole.WRITER)
+        .onGEDComponent()
+        .documentAttachedToDirectory()
+        .onOperationsOf(AccessControlOperation.DOWNLOAD)
         .forbidDownloadForReaders();
-    testContext.results()
-        .verifyCallOfNodeAccessControllerGetUserRoles();
+    testContext.results().verifyCallOfNodeAccessControllerGetUserRoles();
     assertIsUserAuthorized(false);
 
     // User has USER role on component
     // User is going to modify the document
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.USER).onGEDComponent()
+    testContext.withComponentUserRoles(SilverpeasRole.USER)
+        .onGEDComponent()
         .documentAttachedToDirectory()
         .onOperationsOf(AccessControlOperation.PERSIST_ACTIONS.iterator().next());
-    testContext.results()
-        .verifyCallOfNodeAccessControllerGetUserRoles();
+    testContext.results().verifyCallOfNodeAccessControllerGetUserRoles();
     assertIsUserAuthorized(false);
 
     // User has PUBLISHER role on component
     // User is going to modify the document
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.PUBLISHER).onGEDComponent()
+    testContext.withComponentUserRoles(SilverpeasRole.PUBLISHER)
+        .onGEDComponent()
         .documentAttachedToDirectory()
         .onOperationsOf(AccessControlOperation.PERSIST_ACTIONS.iterator().next());
-    testContext.results()
-        .verifyCallOfNodeAccessControllerGetUserRoles();
+    testContext.results().verifyCallOfNodeAccessControllerGetUserRoles();
     assertIsUserAuthorized(false);
 
     // User has WRITER role on component
     // User is going to modify the document
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.WRITER).onGEDComponent()
+    testContext.withComponentUserRoles(SilverpeasRole.WRITER)
+        .onGEDComponent()
         .documentAttachedToDirectory()
         .onOperationsOf(AccessControlOperation.PERSIST_ACTIONS.iterator().next());
-    testContext.results()
-        .verifyCallOfNodeAccessControllerGetUserRoles();
+    testContext.results().verifyCallOfNodeAccessControllerGetUserRoles();
     assertIsUserAuthorized(false);
 
     // User has ADMIN role on component
     // User is going to modify the document
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.ADMIN).onGEDComponent()
+    testContext.withComponentUserRoles(SilverpeasRole.ADMIN)
+        .onGEDComponent()
         .documentAttachedToDirectory()
         .onOperationsOf(AccessControlOperation.PERSIST_ACTIONS.iterator().next());
-    testContext.results()
-        .verifyCallOfNodeAccessControllerGetUserRoles();
+    testContext.results().verifyCallOfNodeAccessControllerGetUserRoles();
     assertIsUserAuthorized(true);
   }
 
@@ -539,7 +557,8 @@ public class TestSimpleDocumentAccessController {
 
     // User has USER role on component
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.USER).onGEDComponent()
+    testContext.withComponentUserRoles(SilverpeasRole.USER)
+        .onGEDComponent()
         .documentAttachedToPublication();
     testContext.results()
         .verifyCallOfNodeAccessControllerGetUserRoles()
@@ -549,8 +568,10 @@ public class TestSimpleDocumentAccessController {
     // User has PUBLISHER role on component
     // User rights are verified for sharing action on the document, but sharing is not enabled
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.PUBLISHER).onGEDComponent()
-        .documentAttachedToPublication().onOperationsOf(AccessControlOperation.SHARING);
+    testContext.withComponentUserRoles(SilverpeasRole.PUBLISHER)
+        .onGEDComponent()
+        .documentAttachedToPublication()
+        .onOperationsOf(AccessControlOperation.SHARING);
     testContext.results()
         .verifyCallOfNodeAccessControllerGetUserRoles()
         .verifyCallOfPublicationBmGetDetail();
@@ -559,8 +580,10 @@ public class TestSimpleDocumentAccessController {
     // User has ADMIN role on component
     // User rights are verified for sharing action on the document, but sharing is not enabled
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.ADMIN).onGEDComponent()
-        .documentAttachedToPublication().onOperationsOf(AccessControlOperation.SHARING);
+    testContext.withComponentUserRoles(SilverpeasRole.ADMIN)
+        .onGEDComponent()
+        .documentAttachedToPublication()
+        .onOperationsOf(AccessControlOperation.SHARING);
     testContext.results()
         .verifyCallOfNodeAccessControllerGetUserRoles()
         .verifyCallOfPublicationBmGetDetail();
@@ -569,8 +592,10 @@ public class TestSimpleDocumentAccessController {
     // User has PUBLISHER role on component
     // User rights are verified for sharing action on the document, sharing is enabled
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.PUBLISHER).onGEDComponent()
-        .documentAttachedToPublication().onOperationsOf(AccessControlOperation.SHARING)
+    testContext.withComponentUserRoles(SilverpeasRole.PUBLISHER)
+        .onGEDComponent()
+        .documentAttachedToPublication()
+        .onOperationsOf(AccessControlOperation.SHARING)
         .enableFileSharingRole(SilverpeasRole.ADMIN);
     testContext.results()
         .verifyCallOfNodeAccessControllerGetUserRoles()
@@ -580,8 +605,10 @@ public class TestSimpleDocumentAccessController {
     // User has ADMIN role on component
     // User rights are verified for sharing action on the document, sharing is enabled
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.ADMIN).onGEDComponent()
-        .documentAttachedToPublication().onOperationsOf(AccessControlOperation.SHARING)
+    testContext.withComponentUserRoles(SilverpeasRole.ADMIN)
+        .onGEDComponent()
+        .documentAttachedToPublication()
+        .onOperationsOf(AccessControlOperation.SHARING)
         .enableFileSharingRole(SilverpeasRole.ADMIN);
     testContext.results()
         .verifyCallOfNodeAccessControllerGetUserRoles()
@@ -591,8 +618,10 @@ public class TestSimpleDocumentAccessController {
     // User has USER role on component
     // User is going to download the document (but no download restriction on the document)
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.USER).onGEDComponent()
-        .documentAttachedToPublication().onOperationsOf(AccessControlOperation.DOWNLOAD);
+    testContext.withComponentUserRoles(SilverpeasRole.USER)
+        .onGEDComponent()
+        .documentAttachedToPublication()
+        .onOperationsOf(AccessControlOperation.DOWNLOAD);
     testContext.results()
         .verifyCallOfNodeAccessControllerGetUserRoles()
         .verifyCallOfPublicationBmGetDetail();
@@ -601,8 +630,10 @@ public class TestSimpleDocumentAccessController {
     // User has PUBLISHER role on component
     // User is going to download the document (but no download restriction on the document)
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.PUBLISHER).onGEDComponent()
-        .documentAttachedToPublication().onOperationsOf(AccessControlOperation.DOWNLOAD);
+    testContext.withComponentUserRoles(SilverpeasRole.PUBLISHER)
+        .onGEDComponent()
+        .documentAttachedToPublication()
+        .onOperationsOf(AccessControlOperation.DOWNLOAD);
     testContext.results()
         .verifyCallOfNodeAccessControllerGetUserRoles()
         .verifyCallOfPublicationBmGetDetail();
@@ -611,8 +642,10 @@ public class TestSimpleDocumentAccessController {
     // User has WRITER role on component
     // User is going to download the document (but no download restriction on the document)
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.WRITER).onGEDComponent()
-        .documentAttachedToPublication().onOperationsOf(AccessControlOperation.DOWNLOAD);
+    testContext.withComponentUserRoles(SilverpeasRole.WRITER)
+        .onGEDComponent()
+        .documentAttachedToPublication()
+        .onOperationsOf(AccessControlOperation.DOWNLOAD);
     testContext.results()
         .verifyCallOfNodeAccessControllerGetUserRoles()
         .verifyCallOfPublicationBmGetDetail();
@@ -621,8 +654,10 @@ public class TestSimpleDocumentAccessController {
     // User has USER role on component
     // User is going to download the document (download is forbidden for readers)
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.USER).onGEDComponent()
-        .documentAttachedToPublication().onOperationsOf(AccessControlOperation.DOWNLOAD)
+    testContext.withComponentUserRoles(SilverpeasRole.USER)
+        .onGEDComponent()
+        .documentAttachedToPublication()
+        .onOperationsOf(AccessControlOperation.DOWNLOAD)
         .forbidDownloadForReaders();
     testContext.results()
         .verifyCallOfNodeAccessControllerGetUserRoles()
@@ -632,8 +667,10 @@ public class TestSimpleDocumentAccessController {
     // User has PUBLISHER role on component
     // User is going to download the document (download is forbidden for readers)
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.PUBLISHER).onGEDComponent()
-        .documentAttachedToPublication().onOperationsOf(AccessControlOperation.DOWNLOAD)
+    testContext.withComponentUserRoles(SilverpeasRole.PUBLISHER)
+        .onGEDComponent()
+        .documentAttachedToPublication()
+        .onOperationsOf(AccessControlOperation.DOWNLOAD)
         .forbidDownloadForReaders();
     testContext.results()
         .verifyCallOfNodeAccessControllerGetUserRoles()
@@ -643,8 +680,10 @@ public class TestSimpleDocumentAccessController {
     // User has WRITER role on component
     // User is going to download the document (download is forbidden for readers)
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.WRITER).onGEDComponent()
-        .documentAttachedToPublication().onOperationsOf(AccessControlOperation.DOWNLOAD)
+    testContext.withComponentUserRoles(SilverpeasRole.WRITER)
+        .onGEDComponent()
+        .documentAttachedToPublication()
+        .onOperationsOf(AccessControlOperation.DOWNLOAD)
         .forbidDownloadForReaders();
     testContext.results()
         .verifyCallOfNodeAccessControllerGetUserRoles()
@@ -654,8 +693,11 @@ public class TestSimpleDocumentAccessController {
     // User has WRITER role on component (cowriting enabled)
     // User is going to download the document (download is forbidden for readers)
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.WRITER).onGEDComponent().enableCoWriting()
-        .documentAttachedToPublication().onOperationsOf(AccessControlOperation.DOWNLOAD)
+    testContext.withComponentUserRoles(SilverpeasRole.WRITER)
+        .onGEDComponent()
+        .enableCoWriting()
+        .documentAttachedToPublication()
+        .onOperationsOf(AccessControlOperation.DOWNLOAD)
         .forbidDownloadForReaders();
     testContext.results()
         .verifyCallOfNodeAccessControllerGetUserRoles()
@@ -665,7 +707,8 @@ public class TestSimpleDocumentAccessController {
     // User has USER role on component
     // User is going to modify the document
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.USER).onGEDComponent()
+    testContext.withComponentUserRoles(SilverpeasRole.USER)
+        .onGEDComponent()
         .documentAttachedToPublication()
         .onOperationsOf(AccessControlOperation.PERSIST_ACTIONS.iterator().next());
     testContext.results()
@@ -676,7 +719,8 @@ public class TestSimpleDocumentAccessController {
     // User has PUBLISHER role on component
     // User is going to modify the document
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.PUBLISHER).onGEDComponent()
+    testContext.withComponentUserRoles(SilverpeasRole.PUBLISHER)
+        .onGEDComponent()
         .documentAttachedToPublication()
         .onOperationsOf(AccessControlOperation.PERSIST_ACTIONS.iterator().next());
     testContext.results()
@@ -687,7 +731,8 @@ public class TestSimpleDocumentAccessController {
     // User has WRITER role on component
     // User is going to modify the document
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.WRITER).onGEDComponent()
+    testContext.withComponentUserRoles(SilverpeasRole.WRITER)
+        .onGEDComponent()
         .documentAttachedToPublication()
         .onOperationsOf(AccessControlOperation.PERSIST_ACTIONS.iterator().next());
     testContext.results()
@@ -698,7 +743,9 @@ public class TestSimpleDocumentAccessController {
     // User has WRITER role on component
     // User is going to modify the document (cowriting enabled)
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.WRITER).onGEDComponent().enableCoWriting()
+    testContext.withComponentUserRoles(SilverpeasRole.WRITER)
+        .onGEDComponent()
+        .enableCoWriting()
         .documentAttachedToPublication()
         .onOperationsOf(AccessControlOperation.PERSIST_ACTIONS.iterator().next());
     testContext.results()
@@ -708,8 +755,7 @@ public class TestSimpleDocumentAccessController {
   }
 
   @Test
-  public void
-  testIsUserAuthorizedOnGEDAndForeignIdIsPublicationAndUserIsThePublicationAuthorAndNoRightOnDirectories() {
+  public void testIsUserAuthorizedOnGEDAndForeignIdIsPublicationAndUserIsThePublicationAuthorAndNoRightOnDirectories() {
     // User has no right on component
     testContext.clear();
     testContext.onGEDComponent().documentAttachedToPublication().userIsThePublicationAuthor();
@@ -721,8 +767,10 @@ public class TestSimpleDocumentAccessController {
 
     // User has USER role on component
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.USER).onGEDComponent()
-        .documentAttachedToPublication().userIsThePublicationAuthor();
+    testContext.withComponentUserRoles(SilverpeasRole.USER)
+        .onGEDComponent()
+        .documentAttachedToPublication()
+        .userIsThePublicationAuthor();
     testContext.results()
         .verifyCallOfNodeAccessControllerGetUserRoles()
         .verifyCallOfPublicationBmGetDetail();
@@ -731,8 +779,10 @@ public class TestSimpleDocumentAccessController {
     // User has PUBLISHER role on component
     // User rights are verified for sharing action on the document, but sharing is not enabled
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.PUBLISHER).onGEDComponent()
-        .documentAttachedToPublication().userIsThePublicationAuthor()
+    testContext.withComponentUserRoles(SilverpeasRole.PUBLISHER)
+        .onGEDComponent()
+        .documentAttachedToPublication()
+        .userIsThePublicationAuthor()
         .onOperationsOf(AccessControlOperation.SHARING);
     testContext.results()
         .verifyCallOfNodeAccessControllerGetUserRoles()
@@ -742,8 +792,10 @@ public class TestSimpleDocumentAccessController {
     // User has ADMIN role on component
     // User rights are verified for sharing action on the document, but sharing is not enabled
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.ADMIN).onGEDComponent()
-        .documentAttachedToPublication().userIsThePublicationAuthor()
+    testContext.withComponentUserRoles(SilverpeasRole.ADMIN)
+        .onGEDComponent()
+        .documentAttachedToPublication()
+        .userIsThePublicationAuthor()
         .onOperationsOf(AccessControlOperation.SHARING);
     testContext.results()
         .verifyCallOfNodeAccessControllerGetUserRoles()
@@ -753,9 +805,12 @@ public class TestSimpleDocumentAccessController {
     // User has PUBLISHER role on component
     // User rights are verified for sharing action on the document, sharing is enabled
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.PUBLISHER).onGEDComponent()
-        .documentAttachedToPublication().userIsThePublicationAuthor()
-        .onOperationsOf(AccessControlOperation.SHARING).enableFileSharingRole(SilverpeasRole.ADMIN);
+    testContext.withComponentUserRoles(SilverpeasRole.PUBLISHER)
+        .onGEDComponent()
+        .documentAttachedToPublication()
+        .userIsThePublicationAuthor()
+        .onOperationsOf(AccessControlOperation.SHARING)
+        .enableFileSharingRole(SilverpeasRole.ADMIN);
     testContext.results()
         .verifyCallOfNodeAccessControllerGetUserRoles()
         .verifyCallOfPublicationBmGetDetail();
@@ -764,9 +819,12 @@ public class TestSimpleDocumentAccessController {
     // User has ADMIN role on component
     // User rights are verified for sharing action on the document, sharing is enabled
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.ADMIN).onGEDComponent()
-        .documentAttachedToPublication().userIsThePublicationAuthor()
-        .onOperationsOf(AccessControlOperation.SHARING).enableFileSharingRole(SilverpeasRole.ADMIN);
+    testContext.withComponentUserRoles(SilverpeasRole.ADMIN)
+        .onGEDComponent()
+        .documentAttachedToPublication()
+        .userIsThePublicationAuthor()
+        .onOperationsOf(AccessControlOperation.SHARING)
+        .enableFileSharingRole(SilverpeasRole.ADMIN);
     testContext.results()
         .verifyCallOfNodeAccessControllerGetUserRoles()
         .verifyCallOfPublicationBmGetDetail();
@@ -775,8 +833,10 @@ public class TestSimpleDocumentAccessController {
     // User has USER role on component
     // User is going to download the document (but no download restriction on the document)
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.USER).onGEDComponent()
-        .documentAttachedToPublication().userIsThePublicationAuthor()
+    testContext.withComponentUserRoles(SilverpeasRole.USER)
+        .onGEDComponent()
+        .documentAttachedToPublication()
+        .userIsThePublicationAuthor()
         .onOperationsOf(AccessControlOperation.DOWNLOAD);
     testContext.results()
         .verifyCallOfNodeAccessControllerGetUserRoles()
@@ -786,8 +846,10 @@ public class TestSimpleDocumentAccessController {
     // User has PUBLISHER role on component
     // User is going to download the document (but no download restriction on the document)
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.PUBLISHER).onGEDComponent()
-        .documentAttachedToPublication().userIsThePublicationAuthor()
+    testContext.withComponentUserRoles(SilverpeasRole.PUBLISHER)
+        .onGEDComponent()
+        .documentAttachedToPublication()
+        .userIsThePublicationAuthor()
         .onOperationsOf(AccessControlOperation.DOWNLOAD);
     testContext.results()
         .verifyCallOfNodeAccessControllerGetUserRoles()
@@ -797,8 +859,10 @@ public class TestSimpleDocumentAccessController {
     // User has WRITER role on component
     // User is going to download the document (but no download restriction on the document)
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.WRITER).onGEDComponent()
-        .documentAttachedToPublication().userIsThePublicationAuthor()
+    testContext.withComponentUserRoles(SilverpeasRole.WRITER)
+        .onGEDComponent()
+        .documentAttachedToPublication()
+        .userIsThePublicationAuthor()
         .onOperationsOf(AccessControlOperation.DOWNLOAD);
     testContext.results()
         .verifyCallOfNodeAccessControllerGetUserRoles()
@@ -808,9 +872,12 @@ public class TestSimpleDocumentAccessController {
     // User has USER role on component
     // User is going to download the document (download is forbidden for readers)
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.USER).onGEDComponent()
-        .documentAttachedToPublication().userIsThePublicationAuthor()
-        .onOperationsOf(AccessControlOperation.DOWNLOAD).forbidDownloadForReaders();
+    testContext.withComponentUserRoles(SilverpeasRole.USER)
+        .onGEDComponent()
+        .documentAttachedToPublication()
+        .userIsThePublicationAuthor()
+        .onOperationsOf(AccessControlOperation.DOWNLOAD)
+        .forbidDownloadForReaders();
     testContext.results()
         .verifyCallOfNodeAccessControllerGetUserRoles()
         .verifyCallOfPublicationBmGetDetail();
@@ -819,9 +886,12 @@ public class TestSimpleDocumentAccessController {
     // User has PUBLISHER role on component
     // User is going to download the document (download is forbidden for readers)
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.PUBLISHER).onGEDComponent()
-        .documentAttachedToPublication().userIsThePublicationAuthor()
-        .onOperationsOf(AccessControlOperation.DOWNLOAD).forbidDownloadForReaders();
+    testContext.withComponentUserRoles(SilverpeasRole.PUBLISHER)
+        .onGEDComponent()
+        .documentAttachedToPublication()
+        .userIsThePublicationAuthor()
+        .onOperationsOf(AccessControlOperation.DOWNLOAD)
+        .forbidDownloadForReaders();
     testContext.results()
         .verifyCallOfNodeAccessControllerGetUserRoles()
         .verifyCallOfPublicationBmGetDetail();
@@ -830,9 +900,12 @@ public class TestSimpleDocumentAccessController {
     // User has WRITER role on component
     // User is going to download the document (download is forbidden for readers)
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.WRITER).onGEDComponent()
-        .documentAttachedToPublication().userIsThePublicationAuthor()
-        .onOperationsOf(AccessControlOperation.DOWNLOAD).forbidDownloadForReaders();
+    testContext.withComponentUserRoles(SilverpeasRole.WRITER)
+        .onGEDComponent()
+        .documentAttachedToPublication()
+        .userIsThePublicationAuthor()
+        .onOperationsOf(AccessControlOperation.DOWNLOAD)
+        .forbidDownloadForReaders();
     testContext.results()
         .verifyCallOfNodeAccessControllerGetUserRoles()
         .verifyCallOfPublicationBmGetDetail();
@@ -841,8 +914,10 @@ public class TestSimpleDocumentAccessController {
     // User has USER role on component
     // User is going to modify the document
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.USER).onGEDComponent()
-        .documentAttachedToPublication().userIsThePublicationAuthor()
+    testContext.withComponentUserRoles(SilverpeasRole.USER)
+        .onGEDComponent()
+        .documentAttachedToPublication()
+        .userIsThePublicationAuthor()
         .onOperationsOf(AccessControlOperation.PERSIST_ACTIONS.iterator().next());
     testContext.results()
         .verifyCallOfNodeAccessControllerGetUserRoles()
@@ -852,8 +927,10 @@ public class TestSimpleDocumentAccessController {
     // User has PUBLISHER role on component
     // User is going to modify the document
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.PUBLISHER).onGEDComponent()
-        .documentAttachedToPublication().userIsThePublicationAuthor()
+    testContext.withComponentUserRoles(SilverpeasRole.PUBLISHER)
+        .onGEDComponent()
+        .documentAttachedToPublication()
+        .userIsThePublicationAuthor()
         .onOperationsOf(AccessControlOperation.PERSIST_ACTIONS.iterator().next());
     testContext.results()
         .verifyCallOfNodeAccessControllerGetUserRoles()
@@ -863,8 +940,10 @@ public class TestSimpleDocumentAccessController {
     // User has WRITER role on component
     // User is going to modify the document
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.WRITER).onGEDComponent()
-        .documentAttachedToPublication().userIsThePublicationAuthor()
+    testContext.withComponentUserRoles(SilverpeasRole.WRITER)
+        .onGEDComponent()
+        .documentAttachedToPublication()
+        .userIsThePublicationAuthor()
         .onOperationsOf(AccessControlOperation.PERSIST_ACTIONS.iterator().next());
     testContext.results()
         .verifyCallOfNodeAccessControllerGetUserRoles()
@@ -873,12 +952,14 @@ public class TestSimpleDocumentAccessController {
   }
 
   @Test
-  public void
-  testIsUserAuthorizedOnGEDAndForeignIdIsPublicationOnRootDirectoryAndUserIsThePublicationAuthorAndRightsOnDirectories() {
+  public void testIsUserAuthorizedOnGEDAndForeignIdIsPublicationOnRootDirectoryAndUserIsThePublicationAuthorAndRightsOnDirectories() {
     // User has no right on component
     testContext.clear();
-    testContext.onGEDComponent().documentAttachedToPublication().publicationOnRootDirectory()
-        .withRightsActivatedOnDirectory().userIsThePublicationAuthor();
+    testContext.onGEDComponent()
+        .documentAttachedToPublication()
+        .publicationOnRootDirectory()
+        .withRightsActivatedOnDirectory()
+        .userIsThePublicationAuthor();
     testContext.results()
         .verifyCallOfPublicationBmGetDetail()
         .verifyCallOfPublicationBmGetDetailAndGetAllAliases()
@@ -887,9 +968,12 @@ public class TestSimpleDocumentAccessController {
 
     // User has USER role on component
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.USER).onGEDComponent()
-        .documentAttachedToPublication().publicationOnRootDirectory()
-        .withRightsActivatedOnDirectory().userIsThePublicationAuthor();
+    testContext.withComponentUserRoles(SilverpeasRole.USER)
+        .onGEDComponent()
+        .documentAttachedToPublication()
+        .publicationOnRootDirectory()
+        .withRightsActivatedOnDirectory()
+        .userIsThePublicationAuthor();
     testContext.results()
         .verifyCallOfPublicationBmGetDetail()
         .verifyCallOfPublicationBmGetMainLocation()
@@ -899,9 +983,12 @@ public class TestSimpleDocumentAccessController {
     // User has USER role on component
     // User rights are verified for sharing action on the document, sharing is enabled
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.USER).onGEDComponent()
-        .documentAttachedToPublication().publicationOnRootDirectory()
-        .withRightsActivatedOnDirectory().userIsThePublicationAuthor()
+    testContext.withComponentUserRoles(SilverpeasRole.USER)
+        .onGEDComponent()
+        .documentAttachedToPublication()
+        .publicationOnRootDirectory()
+        .withRightsActivatedOnDirectory()
+        .userIsThePublicationAuthor()
         .onOperationsOf(AccessControlOperation.SHARING)
         .enableFileSharingRole(SilverpeasRole.READER);
     testContext.results()
@@ -913,10 +1000,13 @@ public class TestSimpleDocumentAccessController {
     // User has USER role on component but it is anonymous
     // User rights are verified for sharing action on the document, sharing is enabled
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.USER).onGEDComponent()
+    testContext.withComponentUserRoles(SilverpeasRole.USER)
+        .onGEDComponent()
         .userIsAnonymous()
-        .documentAttachedToPublication().publicationOnRootDirectory()
-        .withRightsActivatedOnDirectory().userIsThePublicationAuthor()
+        .documentAttachedToPublication()
+        .publicationOnRootDirectory()
+        .withRightsActivatedOnDirectory()
+        .userIsThePublicationAuthor()
         .onOperationsOf(AccessControlOperation.SHARING)
         .enableFileSharingRole(SilverpeasRole.READER);
     testContext.results()
@@ -928,9 +1018,12 @@ public class TestSimpleDocumentAccessController {
     // User has PUBLISHER role on component
     // User rights are verified for sharing action on the document, but sharing is not enabled
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.PUBLISHER).onGEDComponent()
-        .documentAttachedToPublication().publicationOnRootDirectory()
-        .withRightsActivatedOnDirectory().userIsThePublicationAuthor()
+    testContext.withComponentUserRoles(SilverpeasRole.PUBLISHER)
+        .onGEDComponent()
+        .documentAttachedToPublication()
+        .publicationOnRootDirectory()
+        .withRightsActivatedOnDirectory()
+        .userIsThePublicationAuthor()
         .onOperationsOf(AccessControlOperation.SHARING);
     testContext.results()
         .verifyCallOfPublicationBmGetDetail()
@@ -941,9 +1034,12 @@ public class TestSimpleDocumentAccessController {
     // User has ADMIN role on component
     // User rights are verified for sharing action on the document, but sharing is not enabled
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.ADMIN).onGEDComponent()
-        .documentAttachedToPublication().publicationOnRootDirectory()
-        .withRightsActivatedOnDirectory().userIsThePublicationAuthor()
+    testContext.withComponentUserRoles(SilverpeasRole.ADMIN)
+        .onGEDComponent()
+        .documentAttachedToPublication()
+        .publicationOnRootDirectory()
+        .withRightsActivatedOnDirectory()
+        .userIsThePublicationAuthor()
         .onOperationsOf(AccessControlOperation.SHARING);
     testContext.results()
         .verifyCallOfPublicationBmGetDetail()
@@ -954,10 +1050,14 @@ public class TestSimpleDocumentAccessController {
     // User has PUBLISHER role on component
     // User rights are verified for sharing action on the document, sharing is enabled
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.PUBLISHER).onGEDComponent()
-        .documentAttachedToPublication().publicationOnRootDirectory()
-        .withRightsActivatedOnDirectory().userIsThePublicationAuthor()
-        .onOperationsOf(AccessControlOperation.SHARING).enableFileSharingRole(SilverpeasRole.ADMIN);
+    testContext.withComponentUserRoles(SilverpeasRole.PUBLISHER)
+        .onGEDComponent()
+        .documentAttachedToPublication()
+        .publicationOnRootDirectory()
+        .withRightsActivatedOnDirectory()
+        .userIsThePublicationAuthor()
+        .onOperationsOf(AccessControlOperation.SHARING)
+        .enableFileSharingRole(SilverpeasRole.ADMIN);
     testContext.results()
         .verifyCallOfPublicationBmGetDetail()
         .verifyCallOfPublicationBmGetMainLocation()
@@ -967,10 +1067,14 @@ public class TestSimpleDocumentAccessController {
     // User has PUBLISHER role on component
     // User rights are verified for sharing action on the document, sharing is enabled
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.PUBLISHER).onGEDComponent()
-        .documentAttachedToPublication().publicationOnRootDirectory()
-        .withRightsActivatedOnDirectory().userIsThePublicationAuthor()
-        .onOperationsOf(AccessControlOperation.SHARING).enableFileSharingRole(SilverpeasRole.READER);
+    testContext.withComponentUserRoles(SilverpeasRole.PUBLISHER)
+        .onGEDComponent()
+        .documentAttachedToPublication()
+        .publicationOnRootDirectory()
+        .withRightsActivatedOnDirectory()
+        .userIsThePublicationAuthor()
+        .onOperationsOf(AccessControlOperation.SHARING)
+        .enableFileSharingRole(SilverpeasRole.READER);
     testContext.results()
         .verifyCallOfPublicationBmGetDetail()
         .verifyCallOfPublicationBmGetMainLocation()
@@ -980,10 +1084,14 @@ public class TestSimpleDocumentAccessController {
     // User has ADMIN role on component
     // User rights are verified for sharing action on the document, sharing is enabled
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.ADMIN).onGEDComponent()
-        .documentAttachedToPublication().publicationOnRootDirectory()
-        .withRightsActivatedOnDirectory().userIsThePublicationAuthor()
-        .onOperationsOf(AccessControlOperation.SHARING).enableFileSharingRole(SilverpeasRole.ADMIN);
+    testContext.withComponentUserRoles(SilverpeasRole.ADMIN)
+        .onGEDComponent()
+        .documentAttachedToPublication()
+        .publicationOnRootDirectory()
+        .withRightsActivatedOnDirectory()
+        .userIsThePublicationAuthor()
+        .onOperationsOf(AccessControlOperation.SHARING)
+        .enableFileSharingRole(SilverpeasRole.ADMIN);
     testContext.results()
         .verifyCallOfPublicationBmGetDetail()
         .verifyCallOfPublicationBmGetMainLocation()
@@ -993,9 +1101,12 @@ public class TestSimpleDocumentAccessController {
     // User has USER role on component
     // User is going to download the document (but no download restriction on the document)
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.USER).onGEDComponent()
-        .documentAttachedToPublication().publicationOnRootDirectory()
-        .withRightsActivatedOnDirectory().userIsThePublicationAuthor()
+    testContext.withComponentUserRoles(SilverpeasRole.USER)
+        .onGEDComponent()
+        .documentAttachedToPublication()
+        .publicationOnRootDirectory()
+        .withRightsActivatedOnDirectory()
+        .userIsThePublicationAuthor()
         .onOperationsOf(AccessControlOperation.DOWNLOAD);
     testContext.results()
         .verifyCallOfPublicationBmGetDetail()
@@ -1006,9 +1117,12 @@ public class TestSimpleDocumentAccessController {
     // User has PUBLISHER role on component
     // User is going to download the document (but no download restriction on the document)
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.PUBLISHER).onGEDComponent()
-        .documentAttachedToPublication().publicationOnRootDirectory()
-        .withRightsActivatedOnDirectory().userIsThePublicationAuthor()
+    testContext.withComponentUserRoles(SilverpeasRole.PUBLISHER)
+        .onGEDComponent()
+        .documentAttachedToPublication()
+        .publicationOnRootDirectory()
+        .withRightsActivatedOnDirectory()
+        .userIsThePublicationAuthor()
         .onOperationsOf(AccessControlOperation.DOWNLOAD);
     testContext.results()
         .verifyCallOfPublicationBmGetDetail()
@@ -1019,9 +1133,12 @@ public class TestSimpleDocumentAccessController {
     // User has WRITER role on component
     // User is going to download the document (but no download restriction on the document)
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.WRITER).onGEDComponent()
-        .documentAttachedToPublication().publicationOnRootDirectory()
-        .withRightsActivatedOnDirectory().userIsThePublicationAuthor()
+    testContext.withComponentUserRoles(SilverpeasRole.WRITER)
+        .onGEDComponent()
+        .documentAttachedToPublication()
+        .publicationOnRootDirectory()
+        .withRightsActivatedOnDirectory()
+        .userIsThePublicationAuthor()
         .onOperationsOf(AccessControlOperation.DOWNLOAD);
     testContext.results()
         .verifyCallOfPublicationBmGetDetail()
@@ -1032,10 +1149,14 @@ public class TestSimpleDocumentAccessController {
     // User has USER role on component
     // User is going to download the document (download is forbidden for readers)
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.USER).onGEDComponent()
-        .documentAttachedToPublication().publicationOnRootDirectory()
-        .withRightsActivatedOnDirectory().userIsThePublicationAuthor()
-        .onOperationsOf(AccessControlOperation.DOWNLOAD).forbidDownloadForReaders();
+    testContext.withComponentUserRoles(SilverpeasRole.USER)
+        .onGEDComponent()
+        .documentAttachedToPublication()
+        .publicationOnRootDirectory()
+        .withRightsActivatedOnDirectory()
+        .userIsThePublicationAuthor()
+        .onOperationsOf(AccessControlOperation.DOWNLOAD)
+        .forbidDownloadForReaders();
     testContext.results()
         .verifyCallOfPublicationBmGetDetail()
         .verifyCallOfPublicationBmGetMainLocation()
@@ -1045,10 +1166,14 @@ public class TestSimpleDocumentAccessController {
     // User has PUBLISHER role on component
     // User is going to download the document (download is forbidden for readers)
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.PUBLISHER).onGEDComponent()
-        .documentAttachedToPublication().publicationOnRootDirectory()
-        .withRightsActivatedOnDirectory().userIsThePublicationAuthor()
-        .onOperationsOf(AccessControlOperation.DOWNLOAD).forbidDownloadForReaders();
+    testContext.withComponentUserRoles(SilverpeasRole.PUBLISHER)
+        .onGEDComponent()
+        .documentAttachedToPublication()
+        .publicationOnRootDirectory()
+        .withRightsActivatedOnDirectory()
+        .userIsThePublicationAuthor()
+        .onOperationsOf(AccessControlOperation.DOWNLOAD)
+        .forbidDownloadForReaders();
     testContext.results()
         .verifyCallOfPublicationBmGetDetail()
         .verifyCallOfPublicationBmGetMainLocation()
@@ -1058,10 +1183,14 @@ public class TestSimpleDocumentAccessController {
     // User has WRITER role on component
     // User is going to download the document (download is forbidden for readers)
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.WRITER).onGEDComponent()
-        .documentAttachedToPublication().publicationOnRootDirectory()
-        .withRightsActivatedOnDirectory().userIsThePublicationAuthor()
-        .onOperationsOf(AccessControlOperation.DOWNLOAD).forbidDownloadForReaders();
+    testContext.withComponentUserRoles(SilverpeasRole.WRITER)
+        .onGEDComponent()
+        .documentAttachedToPublication()
+        .publicationOnRootDirectory()
+        .withRightsActivatedOnDirectory()
+        .userIsThePublicationAuthor()
+        .onOperationsOf(AccessControlOperation.DOWNLOAD)
+        .forbidDownloadForReaders();
     testContext.results()
         .verifyCallOfPublicationBmGetDetail()
         .verifyCallOfPublicationBmGetMainLocation()
@@ -1071,9 +1200,12 @@ public class TestSimpleDocumentAccessController {
     // User has USER role on component
     // User is going to modify the document
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.USER).onGEDComponent()
-        .documentAttachedToPublication().publicationOnRootDirectory()
-        .withRightsActivatedOnDirectory().userIsThePublicationAuthor()
+    testContext.withComponentUserRoles(SilverpeasRole.USER)
+        .onGEDComponent()
+        .documentAttachedToPublication()
+        .publicationOnRootDirectory()
+        .withRightsActivatedOnDirectory()
+        .userIsThePublicationAuthor()
         .onOperationsOf(AccessControlOperation.PERSIST_ACTIONS.iterator().next());
     testContext.results()
         .verifyCallOfPublicationBmGetDetail()
@@ -1084,9 +1216,12 @@ public class TestSimpleDocumentAccessController {
     // User has PUBLISHER role on component
     // User is going to modify the document
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.PUBLISHER).onGEDComponent()
-        .documentAttachedToPublication().publicationOnRootDirectory()
-        .withRightsActivatedOnDirectory().userIsThePublicationAuthor()
+    testContext.withComponentUserRoles(SilverpeasRole.PUBLISHER)
+        .onGEDComponent()
+        .documentAttachedToPublication()
+        .publicationOnRootDirectory()
+        .withRightsActivatedOnDirectory()
+        .userIsThePublicationAuthor()
         .onOperationsOf(AccessControlOperation.PERSIST_ACTIONS.iterator().next());
     testContext.results()
         .verifyCallOfPublicationBmGetDetail()
@@ -1097,9 +1232,12 @@ public class TestSimpleDocumentAccessController {
     // User has WRITER role on component
     // User is going to modify the document
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.WRITER).onGEDComponent()
-        .documentAttachedToPublication().publicationOnRootDirectory()
-        .withRightsActivatedOnDirectory().userIsThePublicationAuthor()
+    testContext.withComponentUserRoles(SilverpeasRole.WRITER)
+        .onGEDComponent()
+        .documentAttachedToPublication()
+        .publicationOnRootDirectory()
+        .withRightsActivatedOnDirectory()
+        .userIsThePublicationAuthor()
         .onOperationsOf(AccessControlOperation.PERSIST_ACTIONS.iterator().next());
     testContext.results()
         .verifyCallOfPublicationBmGetDetail()
@@ -1122,8 +1260,11 @@ public class TestSimpleDocumentAccessController {
     // User has USER role on component
     // User has no role on directory
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.USER).onGEDComponent()
-        .documentAttachedToPublication().withRightsActivatedOnDirectory().withNodeUserRoles();
+    testContext.withComponentUserRoles(SilverpeasRole.USER)
+        .onGEDComponent()
+        .documentAttachedToPublication()
+        .withRightsActivatedOnDirectory()
+        .withNodeUserRoles();
     testContext.results()
         .verifyCallOfNodeAccessControllerGetUserRoles()
         .verifyCallOfPublicationBmGetDetail()
@@ -1135,9 +1276,13 @@ public class TestSimpleDocumentAccessController {
     // User has no role on directory
     // User rights are verified for sharing action on the document, sharing is enabled
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.ADMIN).onGEDComponent()
-        .documentAttachedToPublication().withRightsActivatedOnDirectory().withNodeUserRoles()
-        .onOperationsOf(AccessControlOperation.SHARING).enableFileSharingRole(SilverpeasRole.ADMIN);
+    testContext.withComponentUserRoles(SilverpeasRole.ADMIN)
+        .onGEDComponent()
+        .documentAttachedToPublication()
+        .withRightsActivatedOnDirectory()
+        .withNodeUserRoles()
+        .onOperationsOf(AccessControlOperation.SHARING)
+        .enableFileSharingRole(SilverpeasRole.ADMIN);
     testContext.results()
         .verifyCallOfNodeAccessControllerGetUserRoles()
         .verifyCallOfPublicationBmGetDetail()
@@ -1149,9 +1294,12 @@ public class TestSimpleDocumentAccessController {
     // User has PUBLISHER role on directory
     // User rights are verified for sharing action on the document, but sharing is not enabled
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.USER).onGEDComponent()
-        .documentAttachedToPublication().withRightsActivatedOnDirectory()
-        .withNodeUserRoles(SilverpeasRole.PUBLISHER).onOperationsOf(AccessControlOperation.SHARING);
+    testContext.withComponentUserRoles(SilverpeasRole.USER)
+        .onGEDComponent()
+        .documentAttachedToPublication()
+        .withRightsActivatedOnDirectory()
+        .withNodeUserRoles(SilverpeasRole.PUBLISHER)
+        .onOperationsOf(AccessControlOperation.SHARING);
     testContext.results()
         .verifyCallOfNodeAccessControllerGetUserRoles()
         .verifyCallOfPublicationBmGetDetail()
@@ -1163,9 +1311,12 @@ public class TestSimpleDocumentAccessController {
     // User has ADMIN role on directory
     // User rights are verified for sharing action on the document, but sharing is not enabled
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.USER).onGEDComponent()
-        .documentAttachedToPublication().withRightsActivatedOnDirectory()
-        .withNodeUserRoles(SilverpeasRole.ADMIN).onOperationsOf(AccessControlOperation.SHARING);
+    testContext.withComponentUserRoles(SilverpeasRole.USER)
+        .onGEDComponent()
+        .documentAttachedToPublication()
+        .withRightsActivatedOnDirectory()
+        .withNodeUserRoles(SilverpeasRole.ADMIN)
+        .onOperationsOf(AccessControlOperation.SHARING);
     testContext.results()
         .verifyCallOfNodeAccessControllerGetUserRoles()
         .verifyCallOfPublicationBmGetDetail()
@@ -1177,9 +1328,12 @@ public class TestSimpleDocumentAccessController {
     // User has PUBLISHER role on directory
     // User rights are verified for sharing action on the document, sharing is enabled
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.USER).onGEDComponent()
-        .documentAttachedToPublication().withRightsActivatedOnDirectory()
-        .withNodeUserRoles(SilverpeasRole.PUBLISHER).onOperationsOf(AccessControlOperation.SHARING)
+    testContext.withComponentUserRoles(SilverpeasRole.USER)
+        .onGEDComponent()
+        .documentAttachedToPublication()
+        .withRightsActivatedOnDirectory()
+        .withNodeUserRoles(SilverpeasRole.PUBLISHER)
+        .onOperationsOf(AccessControlOperation.SHARING)
         .enableFileSharingRole(SilverpeasRole.ADMIN);
     testContext.results()
         .verifyCallOfNodeAccessControllerGetUserRoles()
@@ -1192,9 +1346,12 @@ public class TestSimpleDocumentAccessController {
     // User has ADMIN role on directory
     // User rights are verified for sharing action on the document, sharing is enabled
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.USER).onGEDComponent()
-        .documentAttachedToPublication().withRightsActivatedOnDirectory()
-        .withNodeUserRoles(SilverpeasRole.ADMIN).onOperationsOf(AccessControlOperation.SHARING)
+    testContext.withComponentUserRoles(SilverpeasRole.USER)
+        .onGEDComponent()
+        .documentAttachedToPublication()
+        .withRightsActivatedOnDirectory()
+        .withNodeUserRoles(SilverpeasRole.ADMIN)
+        .onOperationsOf(AccessControlOperation.SHARING)
         .enableFileSharingRole(SilverpeasRole.ADMIN);
     testContext.results()
         .verifyCallOfNodeAccessControllerGetUserRoles()
@@ -1207,9 +1364,12 @@ public class TestSimpleDocumentAccessController {
     // User has USER role on directory
     // User is going to download the document (but no download restriction on the document)
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.USER).onGEDComponent()
-        .documentAttachedToPublication().withRightsActivatedOnDirectory()
-        .withNodeUserRoles(SilverpeasRole.USER).onOperationsOf(AccessControlOperation.DOWNLOAD);
+    testContext.withComponentUserRoles(SilverpeasRole.USER)
+        .onGEDComponent()
+        .documentAttachedToPublication()
+        .withRightsActivatedOnDirectory()
+        .withNodeUserRoles(SilverpeasRole.USER)
+        .onOperationsOf(AccessControlOperation.DOWNLOAD);
     testContext.results()
         .verifyCallOfNodeAccessControllerGetUserRoles()
         .verifyCallOfPublicationBmGetDetail()
@@ -1221,8 +1381,10 @@ public class TestSimpleDocumentAccessController {
     // User has PUBLISHER role on directory
     // User is going to download the document (but no download restriction on the document)
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.USER).onGEDComponent()
-        .documentAttachedToPublication().withRightsActivatedOnDirectory()
+    testContext.withComponentUserRoles(SilverpeasRole.USER)
+        .onGEDComponent()
+        .documentAttachedToPublication()
+        .withRightsActivatedOnDirectory()
         .withNodeUserRoles(SilverpeasRole.PUBLISHER)
         .onOperationsOf(AccessControlOperation.DOWNLOAD);
     testContext.results()
@@ -1236,9 +1398,12 @@ public class TestSimpleDocumentAccessController {
     // User has WRITER role on directory
     // User is going to download the document (but no download restriction on the document)
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.USER).onGEDComponent()
-        .documentAttachedToPublication().withRightsActivatedOnDirectory()
-        .withNodeUserRoles(SilverpeasRole.WRITER).onOperationsOf(AccessControlOperation.DOWNLOAD);
+    testContext.withComponentUserRoles(SilverpeasRole.USER)
+        .onGEDComponent()
+        .documentAttachedToPublication()
+        .withRightsActivatedOnDirectory()
+        .withNodeUserRoles(SilverpeasRole.WRITER)
+        .onOperationsOf(AccessControlOperation.DOWNLOAD);
     testContext.results()
         .verifyCallOfNodeAccessControllerGetUserRoles()
         .verifyCallOfPublicationBmGetDetail()
@@ -1250,9 +1415,12 @@ public class TestSimpleDocumentAccessController {
     // User has USER role on directory
     // User is going to download the document (download is forbidden for readers)
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.USER).onGEDComponent()
-        .documentAttachedToPublication().withRightsActivatedOnDirectory()
-        .withNodeUserRoles(SilverpeasRole.USER).onOperationsOf(AccessControlOperation.DOWNLOAD)
+    testContext.withComponentUserRoles(SilverpeasRole.USER)
+        .onGEDComponent()
+        .documentAttachedToPublication()
+        .withRightsActivatedOnDirectory()
+        .withNodeUserRoles(SilverpeasRole.USER)
+        .onOperationsOf(AccessControlOperation.DOWNLOAD)
         .forbidDownloadForReaders();
     testContext.results()
         .verifyCallOfNodeAccessControllerGetUserRoles()
@@ -1265,9 +1433,12 @@ public class TestSimpleDocumentAccessController {
     // User has PUBLISHER role on directory
     // User is going to download the document (download is forbidden for readers)
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.USER).onGEDComponent()
-        .documentAttachedToPublication().withRightsActivatedOnDirectory()
-        .withNodeUserRoles(SilverpeasRole.PUBLISHER).onOperationsOf(AccessControlOperation.DOWNLOAD)
+    testContext.withComponentUserRoles(SilverpeasRole.USER)
+        .onGEDComponent()
+        .documentAttachedToPublication()
+        .withRightsActivatedOnDirectory()
+        .withNodeUserRoles(SilverpeasRole.PUBLISHER)
+        .onOperationsOf(AccessControlOperation.DOWNLOAD)
         .forbidDownloadForReaders();
     testContext.results()
         .verifyCallOfNodeAccessControllerGetUserRoles()
@@ -1280,9 +1451,12 @@ public class TestSimpleDocumentAccessController {
     // User has WRITER role on directory
     // User is going to download the document (download is forbidden for readers)
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.USER).onGEDComponent()
-        .documentAttachedToPublication().withRightsActivatedOnDirectory()
-        .withNodeUserRoles(SilverpeasRole.WRITER).onOperationsOf(AccessControlOperation.DOWNLOAD)
+    testContext.withComponentUserRoles(SilverpeasRole.USER)
+        .onGEDComponent()
+        .documentAttachedToPublication()
+        .withRightsActivatedOnDirectory()
+        .withNodeUserRoles(SilverpeasRole.WRITER)
+        .onOperationsOf(AccessControlOperation.DOWNLOAD)
         .forbidDownloadForReaders();
     testContext.results()
         .verifyCallOfNodeAccessControllerGetUserRoles()
@@ -1295,9 +1469,13 @@ public class TestSimpleDocumentAccessController {
     // User has WRITER role on directory
     // User is going to download the document (download is forbidden for readers)
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.USER).onGEDComponent().enableCoWriting()
-        .documentAttachedToPublication().withRightsActivatedOnDirectory()
-        .withNodeUserRoles(SilverpeasRole.WRITER).onOperationsOf(AccessControlOperation.DOWNLOAD)
+    testContext.withComponentUserRoles(SilverpeasRole.USER)
+        .onGEDComponent()
+        .enableCoWriting()
+        .documentAttachedToPublication()
+        .withRightsActivatedOnDirectory()
+        .withNodeUserRoles(SilverpeasRole.WRITER)
+        .onOperationsOf(AccessControlOperation.DOWNLOAD)
         .forbidDownloadForReaders();
     testContext.results()
         .verifyCallOfNodeAccessControllerGetUserRoles()
@@ -1310,8 +1488,10 @@ public class TestSimpleDocumentAccessController {
     // User has USER role on directory
     // User is going to modify the document
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.USER).onGEDComponent()
-        .documentAttachedToPublication().withRightsActivatedOnDirectory()
+    testContext.withComponentUserRoles(SilverpeasRole.USER)
+        .onGEDComponent()
+        .documentAttachedToPublication()
+        .withRightsActivatedOnDirectory()
         .withNodeUserRoles(SilverpeasRole.USER)
         .onOperationsOf(AccessControlOperation.PERSIST_ACTIONS.iterator().next());
     testContext.results()
@@ -1325,8 +1505,10 @@ public class TestSimpleDocumentAccessController {
     // User has PUBLISHER role on directory
     // User is going to modify the document
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.USER).onGEDComponent()
-        .documentAttachedToPublication().withRightsActivatedOnDirectory()
+    testContext.withComponentUserRoles(SilverpeasRole.USER)
+        .onGEDComponent()
+        .documentAttachedToPublication()
+        .withRightsActivatedOnDirectory()
         .withNodeUserRoles(SilverpeasRole.PUBLISHER)
         .onOperationsOf(AccessControlOperation.PERSIST_ACTIONS.iterator().next());
     testContext.results()
@@ -1340,8 +1522,10 @@ public class TestSimpleDocumentAccessController {
     // User has WRITER role on directory
     // User is going to modify the document
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.USER).onGEDComponent()
-        .documentAttachedToPublication().withRightsActivatedOnDirectory()
+    testContext.withComponentUserRoles(SilverpeasRole.USER)
+        .onGEDComponent()
+        .documentAttachedToPublication()
+        .withRightsActivatedOnDirectory()
         .withNodeUserRoles(SilverpeasRole.WRITER)
         .onOperationsOf(AccessControlOperation.PERSIST_ACTIONS.iterator().next());
     testContext.results()
@@ -1355,8 +1539,11 @@ public class TestSimpleDocumentAccessController {
     // User has WRITER role on directory
     // User is going to modify the document
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.USER).onGEDComponent().enableCoWriting()
-        .documentAttachedToPublication().withRightsActivatedOnDirectory()
+    testContext.withComponentUserRoles(SilverpeasRole.USER)
+        .onGEDComponent()
+        .enableCoWriting()
+        .documentAttachedToPublication()
+        .withRightsActivatedOnDirectory()
         .withNodeUserRoles(SilverpeasRole.WRITER)
         .onOperationsOf(AccessControlOperation.PERSIST_ACTIONS.iterator().next());
     testContext.results()
@@ -1368,11 +1555,12 @@ public class TestSimpleDocumentAccessController {
   }
 
   @Test
-  public void
-  testIsUserAuthorizedOnGEDAndForeignIdIsPublicationAndUserIsThePublicationAuthorAndUserHasRightsOnDirectories() {
+  public void testIsUserAuthorizedOnGEDAndForeignIdIsPublicationAndUserIsThePublicationAuthorAndUserHasRightsOnDirectories() {
     // User has no right on component
     testContext.clear();
-    testContext.onGEDComponent().documentAttachedToPublication().withRightsActivatedOnDirectory()
+    testContext.onGEDComponent()
+        .documentAttachedToPublication()
+        .withRightsActivatedOnDirectory()
         .userIsThePublicationAuthor();
     testContext.results()
         .verifyCallOfNodeAccessControllerGetUserRoles()
@@ -1383,8 +1571,11 @@ public class TestSimpleDocumentAccessController {
     // User has USER role on component
     // User has no role on directory
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.USER).onGEDComponent()
-        .documentAttachedToPublication().withRightsActivatedOnDirectory().withNodeUserRoles()
+    testContext.withComponentUserRoles(SilverpeasRole.USER)
+        .onGEDComponent()
+        .documentAttachedToPublication()
+        .withRightsActivatedOnDirectory()
+        .withNodeUserRoles()
         .userIsThePublicationAuthor();
     testContext.results()
         .verifyCallOfNodeAccessControllerGetUserRoles()
@@ -1398,9 +1589,13 @@ public class TestSimpleDocumentAccessController {
     // User has no role on directory
     // User rights are verified for sharing action on the document, sharing is enabled
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.ADMIN).onGEDComponent()
-        .documentAttachedToPublication().withRightsActivatedOnDirectory().withNodeUserRoles()
-        .userIsThePublicationAuthor().onOperationsOf(AccessControlOperation.SHARING)
+    testContext.withComponentUserRoles(SilverpeasRole.ADMIN)
+        .onGEDComponent()
+        .documentAttachedToPublication()
+        .withRightsActivatedOnDirectory()
+        .withNodeUserRoles()
+        .userIsThePublicationAuthor()
+        .onOperationsOf(AccessControlOperation.SHARING)
         .enableFileSharingRole(SilverpeasRole.ADMIN);
     testContext.results()
         .verifyCallOfNodeAccessControllerGetUserRoles()
@@ -1414,9 +1609,12 @@ public class TestSimpleDocumentAccessController {
     // User has PUBLISHER role on directory
     // User rights are verified for sharing action on the document, but sharing is not enabled
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.USER).onGEDComponent()
-        .documentAttachedToPublication().withRightsActivatedOnDirectory()
-        .withNodeUserRoles(SilverpeasRole.PUBLISHER).userIsThePublicationAuthor()
+    testContext.withComponentUserRoles(SilverpeasRole.USER)
+        .onGEDComponent()
+        .documentAttachedToPublication()
+        .withRightsActivatedOnDirectory()
+        .withNodeUserRoles(SilverpeasRole.PUBLISHER)
+        .userIsThePublicationAuthor()
         .onOperationsOf(AccessControlOperation.SHARING);
     testContext.results()
         .verifyCallOfNodeAccessControllerGetUserRoles()
@@ -1429,9 +1627,12 @@ public class TestSimpleDocumentAccessController {
     // User has ADMIN role on directory
     // User rights are verified for sharing action on the document, but sharing is not enabled
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.USER).onGEDComponent()
-        .documentAttachedToPublication().withRightsActivatedOnDirectory()
-        .withNodeUserRoles(SilverpeasRole.ADMIN).userIsThePublicationAuthor()
+    testContext.withComponentUserRoles(SilverpeasRole.USER)
+        .onGEDComponent()
+        .documentAttachedToPublication()
+        .withRightsActivatedOnDirectory()
+        .withNodeUserRoles(SilverpeasRole.ADMIN)
+        .userIsThePublicationAuthor()
         .onOperationsOf(AccessControlOperation.SHARING);
     testContext.results()
         .verifyCallOfNodeAccessControllerGetUserRoles()
@@ -1444,10 +1645,14 @@ public class TestSimpleDocumentAccessController {
     // User has PUBLISHER role on directory
     // User rights are verified for sharing action on the document, sharing is enabled
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.USER).onGEDComponent()
-        .documentAttachedToPublication().withRightsActivatedOnDirectory()
-        .withNodeUserRoles(SilverpeasRole.PUBLISHER).userIsThePublicationAuthor()
-        .onOperationsOf(AccessControlOperation.SHARING).enableFileSharingRole(SilverpeasRole.ADMIN);
+    testContext.withComponentUserRoles(SilverpeasRole.USER)
+        .onGEDComponent()
+        .documentAttachedToPublication()
+        .withRightsActivatedOnDirectory()
+        .withNodeUserRoles(SilverpeasRole.PUBLISHER)
+        .userIsThePublicationAuthor()
+        .onOperationsOf(AccessControlOperation.SHARING)
+        .enableFileSharingRole(SilverpeasRole.ADMIN);
     testContext.results()
         .verifyCallOfNodeAccessControllerGetUserRoles()
         .verifyCallOfPublicationBmGetDetail()
@@ -1459,10 +1664,14 @@ public class TestSimpleDocumentAccessController {
     // User has ADMIN role on directory
     // User rights are verified for sharing action on the document, sharing is enabled
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.USER).onGEDComponent()
-        .documentAttachedToPublication().withRightsActivatedOnDirectory()
-        .withNodeUserRoles(SilverpeasRole.ADMIN).userIsThePublicationAuthor()
-        .onOperationsOf(AccessControlOperation.SHARING).enableFileSharingRole(SilverpeasRole.ADMIN);
+    testContext.withComponentUserRoles(SilverpeasRole.USER)
+        .onGEDComponent()
+        .documentAttachedToPublication()
+        .withRightsActivatedOnDirectory()
+        .withNodeUserRoles(SilverpeasRole.ADMIN)
+        .userIsThePublicationAuthor()
+        .onOperationsOf(AccessControlOperation.SHARING)
+        .enableFileSharingRole(SilverpeasRole.ADMIN);
     testContext.results()
         .verifyCallOfNodeAccessControllerGetUserRoles()
         .verifyCallOfPublicationBmGetDetail()
@@ -1474,9 +1683,12 @@ public class TestSimpleDocumentAccessController {
     // User has USER role on directory
     // User is going to download the document (but no download restriction on the document)
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.USER).onGEDComponent()
-        .documentAttachedToPublication().withRightsActivatedOnDirectory()
-        .withNodeUserRoles(SilverpeasRole.USER).userIsThePublicationAuthor()
+    testContext.withComponentUserRoles(SilverpeasRole.USER)
+        .onGEDComponent()
+        .documentAttachedToPublication()
+        .withRightsActivatedOnDirectory()
+        .withNodeUserRoles(SilverpeasRole.USER)
+        .userIsThePublicationAuthor()
         .onOperationsOf(AccessControlOperation.DOWNLOAD);
     testContext.results()
         .verifyCallOfNodeAccessControllerGetUserRoles()
@@ -1489,9 +1701,12 @@ public class TestSimpleDocumentAccessController {
     // User has PUBLISHER role on directory
     // User is going to download the document (but no download restriction on the document)
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.USER).onGEDComponent()
-        .documentAttachedToPublication().withRightsActivatedOnDirectory()
-        .withNodeUserRoles(SilverpeasRole.PUBLISHER).userIsThePublicationAuthor()
+    testContext.withComponentUserRoles(SilverpeasRole.USER)
+        .onGEDComponent()
+        .documentAttachedToPublication()
+        .withRightsActivatedOnDirectory()
+        .withNodeUserRoles(SilverpeasRole.PUBLISHER)
+        .userIsThePublicationAuthor()
         .onOperationsOf(AccessControlOperation.DOWNLOAD);
     testContext.results()
         .verifyCallOfNodeAccessControllerGetUserRoles()
@@ -1504,9 +1719,12 @@ public class TestSimpleDocumentAccessController {
     // User has WRITER role on directory
     // User is going to download the document (but no download restriction on the document)
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.USER).onGEDComponent()
-        .documentAttachedToPublication().withRightsActivatedOnDirectory()
-        .withNodeUserRoles(SilverpeasRole.WRITER).userIsThePublicationAuthor()
+    testContext.withComponentUserRoles(SilverpeasRole.USER)
+        .onGEDComponent()
+        .documentAttachedToPublication()
+        .withRightsActivatedOnDirectory()
+        .withNodeUserRoles(SilverpeasRole.WRITER)
+        .userIsThePublicationAuthor()
         .onOperationsOf(AccessControlOperation.DOWNLOAD);
     testContext.results()
         .verifyCallOfNodeAccessControllerGetUserRoles()
@@ -1519,10 +1737,14 @@ public class TestSimpleDocumentAccessController {
     // User has USER role on directory
     // User is going to download the document (download is forbidden for readers)
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.USER).onGEDComponent()
-        .documentAttachedToPublication().withRightsActivatedOnDirectory()
-        .withNodeUserRoles(SilverpeasRole.USER).userIsThePublicationAuthor()
-        .onOperationsOf(AccessControlOperation.DOWNLOAD).forbidDownloadForReaders();
+    testContext.withComponentUserRoles(SilverpeasRole.USER)
+        .onGEDComponent()
+        .documentAttachedToPublication()
+        .withRightsActivatedOnDirectory()
+        .withNodeUserRoles(SilverpeasRole.USER)
+        .userIsThePublicationAuthor()
+        .onOperationsOf(AccessControlOperation.DOWNLOAD)
+        .forbidDownloadForReaders();
     testContext.results()
         .verifyCallOfNodeAccessControllerGetUserRoles()
         .verifyCallOfPublicationBmGetDetail()
@@ -1534,10 +1756,14 @@ public class TestSimpleDocumentAccessController {
     // User has PUBLISHER role on directory
     // User is going to download the document (download is forbidden for readers)
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.USER).onGEDComponent()
-        .documentAttachedToPublication().withRightsActivatedOnDirectory()
-        .withNodeUserRoles(SilverpeasRole.PUBLISHER).userIsThePublicationAuthor()
-        .onOperationsOf(AccessControlOperation.DOWNLOAD).forbidDownloadForReaders();
+    testContext.withComponentUserRoles(SilverpeasRole.USER)
+        .onGEDComponent()
+        .documentAttachedToPublication()
+        .withRightsActivatedOnDirectory()
+        .withNodeUserRoles(SilverpeasRole.PUBLISHER)
+        .userIsThePublicationAuthor()
+        .onOperationsOf(AccessControlOperation.DOWNLOAD)
+        .forbidDownloadForReaders();
     testContext.results()
         .verifyCallOfNodeAccessControllerGetUserRoles()
         .verifyCallOfPublicationBmGetDetail()
@@ -1549,10 +1775,14 @@ public class TestSimpleDocumentAccessController {
     // User has WRITER role on directory
     // User is going to download the document (download is forbidden for readers)
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.USER).onGEDComponent()
-        .documentAttachedToPublication().withRightsActivatedOnDirectory()
-        .withNodeUserRoles(SilverpeasRole.WRITER).userIsThePublicationAuthor()
-        .onOperationsOf(AccessControlOperation.DOWNLOAD).forbidDownloadForReaders();
+    testContext.withComponentUserRoles(SilverpeasRole.USER)
+        .onGEDComponent()
+        .documentAttachedToPublication()
+        .withRightsActivatedOnDirectory()
+        .withNodeUserRoles(SilverpeasRole.WRITER)
+        .userIsThePublicationAuthor()
+        .onOperationsOf(AccessControlOperation.DOWNLOAD)
+        .forbidDownloadForReaders();
     testContext.results()
         .verifyCallOfNodeAccessControllerGetUserRoles()
         .verifyCallOfPublicationBmGetDetail()
@@ -1564,9 +1794,12 @@ public class TestSimpleDocumentAccessController {
     // User has USER role on directory
     // User is going to modify the document
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.USER).onGEDComponent()
-        .documentAttachedToPublication().withRightsActivatedOnDirectory()
-        .withNodeUserRoles(SilverpeasRole.USER).userIsThePublicationAuthor()
+    testContext.withComponentUserRoles(SilverpeasRole.USER)
+        .onGEDComponent()
+        .documentAttachedToPublication()
+        .withRightsActivatedOnDirectory()
+        .withNodeUserRoles(SilverpeasRole.USER)
+        .userIsThePublicationAuthor()
         .onOperationsOf(AccessControlOperation.PERSIST_ACTIONS.iterator().next());
     testContext.results()
         .verifyCallOfNodeAccessControllerGetUserRoles()
@@ -1579,9 +1812,12 @@ public class TestSimpleDocumentAccessController {
     // User has PUBLISHER role on directory
     // User is going to modify the document
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.USER).onGEDComponent()
-        .documentAttachedToPublication().withRightsActivatedOnDirectory()
-        .withNodeUserRoles(SilverpeasRole.PUBLISHER).userIsThePublicationAuthor()
+    testContext.withComponentUserRoles(SilverpeasRole.USER)
+        .onGEDComponent()
+        .documentAttachedToPublication()
+        .withRightsActivatedOnDirectory()
+        .withNodeUserRoles(SilverpeasRole.PUBLISHER)
+        .userIsThePublicationAuthor()
         .onOperationsOf(AccessControlOperation.PERSIST_ACTIONS.iterator().next());
     testContext.results()
         .verifyCallOfNodeAccessControllerGetUserRoles()
@@ -1594,9 +1830,12 @@ public class TestSimpleDocumentAccessController {
     // User has WRITER role on directory
     // User is going to modify the document
     testContext.clear();
-    testContext.withComponentUserRoles(SilverpeasRole.USER).onGEDComponent()
-        .documentAttachedToPublication().withRightsActivatedOnDirectory()
-        .withNodeUserRoles(SilverpeasRole.WRITER).userIsThePublicationAuthor()
+    testContext.withComponentUserRoles(SilverpeasRole.USER)
+        .onGEDComponent()
+        .documentAttachedToPublication()
+        .withRightsActivatedOnDirectory()
+        .withNodeUserRoles(SilverpeasRole.WRITER)
+        .userIsThePublicationAuthor()
         .onOperationsOf(AccessControlOperation.PERSIST_ACTIONS.iterator().next());
     testContext.results()
         .verifyCallOfNodeAccessControllerGetUserRoles()
@@ -1613,9 +1852,10 @@ public class TestSimpleDocumentAccessController {
   private void assertIsUserAuthorized(boolean expectedUserAuthorization) {
     testContext.setup();
     SimpleDocument document = new SimpleDocument();
-    document
-        .setPK(new SimpleDocumentPK("dummyUuid", testContext.isGED ? GED_INSTANCE_ID : "yellowpages38"));
-    document.setForeignId(testContext.isDocumentAttachedToDirectory ? "Node_26" :
+    document.setPK(
+        new SimpleDocumentPK("dummyUuid", testContext.isGED ? GED_INSTANCE_ID : "yellowpages38"));
+    document.setForeignId(testContext.isDocumentAttachedToDirectory ?
+        "Node_26" :
         (testContext.isDocumentAttachedToPublication ? "26" : "dummyId"));
     if (!testContext.isDownloadAllowedForReaders) {
       document.addRolesForWhichDownloadIsForbidden(SilverpeasRole.READER_ROLES);
@@ -1644,9 +1884,13 @@ public class TestSimpleDocumentAccessController {
 
     public void clear() {
       CacheServiceProvider.clearAllThreadCaches();
-      reset(user, componentAccessController, organizationController, nodeAccessController, publicationService);
-      final PublicationAccessControl publicationAccessController = new PublicationAccessController(componentAccessController, nodeAccessController);
-      testInstance = new SimpleDocumentAccessController(componentAccessController, nodeAccessController, publicationAccessController);
+      reset(user, componentAccessController, organizationController, nodeAccessController,
+          publicationService);
+      final PublicationAccessControl publicationAccessController =
+          new PublicationAccessController(componentAccessController, nodeAccessController);
+      testInstance =
+          new SimpleDocumentAccessController(componentAccessController, nodeAccessController,
+              publicationAccessController);
       userIsAnonymous = false;
       isGED = false;
       isCoWriting = false;
@@ -1739,47 +1983,47 @@ public class TestSimpleDocumentAccessController {
     public void setup() {
       when(user.getId()).thenReturn(USER_ID);
       when(user.isAnonymous()).thenReturn(userIsAnonymous);
-      when(componentAccessController
-          .getUserRoles(anyString(), anyString(), any(AccessControlContext.class)))
-          .then(new Returns(componentUserRoles));
-      when(componentAccessController.isUserAuthorized(any(EnumSet.class)))
-          .then(new Returns(!componentUserRoles.isEmpty()));
-      when(organizationController.getComponentInstance(anyString()))
-          .thenAnswer(a -> {
-            final String i = a.getArgument(0);
-            final SilverpeasComponentInstance instance = mock(SilverpeasComponentInstance.class);
-            when(instance.isTopicTracker()).then(new Returns(i.startsWith("kmelia") || i.startsWith("kmax") || i.startsWith("toolbox")));
-            return Optional.of(instance);
-          });
-      when(organizationController.getComponentParameterValue(anyString(), eq("rightsOnTopics")))
-          .then(new Returns(Boolean.toString(isRightsOnDirectories)));
-      when(organizationController.getComponentParameterValue(anyString(), eq("coWriting")))
-          .then(new Returns(Boolean.toString(isCoWriting)));
-      when(organizationController.getComponentParameterValue(anyString(), eq("useFileSharing")))
-          .thenAnswer((Answer<String>) invocationOnMock -> {
-            if (fileSharingRole != null) {
-              if (fileSharingRole.equals(SilverpeasRole.ADMIN)) {
-                return "1";
-              } else if (fileSharingRole.equals(SilverpeasRole.WRITER)) {
-                return "2";
-              } else {
-                return "3";
-              }
-            }
-            return null;
-          });
-      when(nodeAccessController
-          .getUserRoles(anyString(), any(NodePK.class), any(AccessControlContext.class))).then(m -> {
+      when(componentAccessController.getUserRoles(anyString(), anyString(),
+          any(AccessControlContext.class))).then(new Returns(componentUserRoles));
+      when(componentAccessController.isUserAuthorized(any(EnumSet.class))).then(
+          new Returns(!componentUserRoles.isEmpty()));
+      when(organizationController.getComponentInstance(anyString())).thenAnswer(a -> {
+        final String i = a.getArgument(0);
+        final SilverpeasComponentInstance instance = mock(SilverpeasComponentInstance.class);
+        when(instance.isTopicTracker()).then(
+            new Returns(i.startsWith("kmelia") || i.startsWith("kmax") || i.startsWith("toolbox")));
+        return Optional.of(instance);
+      });
+      when(organizationController.getComponentParameterValue(anyString(),
+          eq("rightsOnTopics"))).then(new Returns(Boolean.toString(isRightsOnDirectories)));
+      when(organizationController.getComponentParameterValue(anyString(), eq("coWriting"))).then(
+          new Returns(Boolean.toString(isCoWriting)));
+      when(organizationController.getComponentParameterValue(anyString(),
+          eq("useFileSharing"))).thenAnswer((Answer<String>) invocationOnMock -> {
+        if (fileSharingRole != null) {
+          if (fileSharingRole.equals(SilverpeasRole.ADMIN)) {
+            return "1";
+          } else if (fileSharingRole.equals(SilverpeasRole.WRITER)) {
+            return "2";
+          } else {
+            return "3";
+          }
+        }
+        return null;
+      });
+      when(nodeAccessController.getUserRoles(anyString(), any(NodePK.class),
+          any(AccessControlContext.class))).then(m -> {
         if (isRightsOnDirectories) {
           return nodeNotInheritedUserRoles == null ? componentUserRoles : nodeNotInheritedUserRoles;
         }
-        return componentUserRoles;   
+        return componentUserRoles;
       });
-      when(nodeAccessController.isUserAuthorized(any(EnumSet.class)))
-          .then(invocation -> CollectionUtil.isNotEmpty((EnumSet) invocation.getArguments()[0]));
+      when(nodeAccessController.isUserAuthorized(any(EnumSet.class))).then(
+          invocation -> CollectionUtil.isNotEmpty((EnumSet) invocation.getArguments()[0]));
       when(publicationService.getMinimalDataByIds(any(Collection.class))).then(invocation -> {
-        PublicationDetail publi = new PublicationDetail();
-        publi.setPk(((Collection<PublicationPK>) invocation.getArguments()[0]).iterator().next());
+        PublicationPK pk =
+            ((Collection<PublicationPK>) invocation.getArguments()[0]).iterator().next();
+        PublicationDetail publi = PublicationDetail.builder().setPk(pk).build();
         publi.setStatus(PublicationDetail.VALID_STATUS);
         publi.setCreatorId(testContext.isUserThePublicationAuthor ? USER_ID : "otherUserId");
         return singletonList(publi);
@@ -1841,24 +2085,26 @@ public class TestSimpleDocumentAccessController {
 
     @SuppressWarnings("unchecked")
     public void verifyMethodCalls() {
-      verify(componentAccessController, times(nbCallOfComponentAccessControllerGetUserRoles))
-          .getUserRoles(anyString(), anyString(), any(AccessControlContext.class));
-      verify(componentAccessController, times(0))
-          .isUserAuthorized(anyString(), anyString(), any(AccessControlContext.class));
-      verify(componentAccessController, times(nbCallOfComponentAccessControllerIsUserAuthorized))
-          .isUserAuthorized(any(EnumSet.class));
-      final ComponentAccessController.DataManager dataManager = ComponentAccessController.getDataManager(testContext.accessControlContext);
-      verify(nodeAccessController, times(nbCallOfNodeAccessControllerGetUserRoles))
-          .getUserRoles(anyString(), any(NodePK.class), any(AccessControlContext.class));
-      verify(nodeAccessController, times(nbCallOfNodeAccessControllerIsUserAuthorized))
-          .isUserAuthorized(any(EnumSet.class));
-      verify(publicationService, times(nbCallOfPublicationBmGetDetail))
-          .getMinimalDataByIds(any(Collection.class));
-      verify(publicationService, times(0))
-          .getMainLocation(any(PublicationPK.class));
-      verify(publicationService, times(0))
-          .getAllAliases(any(PublicationPK.class));
-      verify(publicationService, times(Math.max(nbCallOfPublicationBmGetMainLocation, nbCallOfPublicationBmGetAllAliases)))
+      verify(componentAccessController,
+          times(nbCallOfComponentAccessControllerGetUserRoles)).getUserRoles(anyString(),
+          anyString(), any(AccessControlContext.class));
+      verify(componentAccessController, times(0)).isUserAuthorized(anyString(), anyString(),
+          any(AccessControlContext.class));
+      verify(componentAccessController,
+          times(nbCallOfComponentAccessControllerIsUserAuthorized)).isUserAuthorized(
+          any(EnumSet.class));
+      final ComponentAccessController.DataManager dataManager =
+          ComponentAccessController.getDataManager(testContext.accessControlContext);
+      verify(nodeAccessController, times(nbCallOfNodeAccessControllerGetUserRoles)).getUserRoles(
+          anyString(), any(NodePK.class), any(AccessControlContext.class));
+      verify(nodeAccessController,
+          times(nbCallOfNodeAccessControllerIsUserAuthorized)).isUserAuthorized(any(EnumSet.class));
+      verify(publicationService, times(nbCallOfPublicationBmGetDetail)).getMinimalDataByIds(
+          any(Collection.class));
+      verify(publicationService, times(0)).getMainLocation(any(PublicationPK.class));
+      verify(publicationService, times(0)).getAllAliases(any(PublicationPK.class));
+      verify(publicationService,
+          times(Math.max(nbCallOfPublicationBmGetMainLocation, nbCallOfPublicationBmGetAllAliases)))
           .getAllLocations(any(PublicationPK.class));
     }
   }

--- a/core-services/importExport/src/main/java/org/silverpeas/core/importexport/control/ImportSettings.java
+++ b/core-services/importExport/src/main/java/org/silverpeas/core/importexport/control/ImportSettings.java
@@ -50,7 +50,7 @@ public class ImportSettings implements Cloneable {
   private int method;
   private String contentLanguage;
   private String targetValidatorIds;
-  private PublicationDetail publicationForAllFiles = new PublicationDetail();
+  private PublicationDetail publicationForAllFiles = PublicationDetail.builder().build();
 
   public ImportSettings(String pathToImport, UserDetail user, String componentId, String folderId,
       boolean draftUsed, boolean poiUsed, int method) {

--- a/core-services/importExport/src/main/java/org/silverpeas/core/importexport/control/PublicationImportExport.java
+++ b/core-services/importExport/src/main/java/org/silverpeas/core/importexport/control/PublicationImportExport.java
@@ -142,11 +142,17 @@ public class PublicationImportExport {
       motsClefs = settings.getPublicationForAllFiles().getKeywords();
       content = settings.getPublicationForAllFiles().getContentPagePath();
     }
-    PublicationDetail publication =
-        new PublicationDetail("unknown", nomPub, description, creationDate, new Date(), null,
-            settings.getUser().getId(), "1", null, motsClefs, content);
+
+    PublicationDetail publication = PublicationDetail.builder(settings.getContentLanguage())
+        .setNameAndDescription(nomPub, description)
+        .created(creationDate, settings.getUser().getId())
+        .setBeginDateTime(new Date(), null)
+        .setImportance(1)
+        .setKeywords(motsClefs)
+        .setContentPagePath(content)
+        .build();
+
     publication.setTargetValidatorId(settings.getTargetValidatorIds());
-    publication.setLanguage(settings.getContentLanguage());
     if (lastModificationDate != null) {
       publication.setUpdateDate(lastModificationDate);
       publication.setUpdateDataMustBeSet(true);

--- a/core-services/importExport/src/main/java/org/silverpeas/core/importexport/control/PublicationsTypeManager.java
+++ b/core-services/importExport/src/main/java/org/silverpeas/core/importexport/control/PublicationsTypeManager.java
@@ -601,13 +601,16 @@ public class PublicationsTypeManager {
               pubDetailToCreate =
                   PublicationImportExport.convertFileInfoToPublicationDetail(file, settings);
             } else {/* TODO: jeter exception ou trouver une autre solution de nommage */
-              pubDetailToCreate = new PublicationDetail("unknown", "pub temp", "description",
-                  new Date(),
-                  new Date(), null, userDetail.getId(), "1", null, null, null);
+              pubDetailToCreate = PublicationDetail.builder()
+                  .setNameAndDescription("pub temp", "description")
+                  .created(new Date(), userDetail.getId())
+                  .setImportance(1)
+                  .setBeginDateTime(new Date(), "")
+                  .build();
             }
           } else {
             // C'est une publication à mettre à jour par id
-            pubDetailToCreate = new PublicationDetail();
+            pubDetailToCreate = PublicationDetail.builder().build();
           }
         }
         if (pubDetailToCreate != null) {

--- a/core-services/pdc/src/main/java/org/silverpeas/core/pdc/tree/model/TreeNodeI18N.java
+++ b/core-services/pdc/src/main/java/org/silverpeas/core/pdc/tree/model/TreeNodeI18N.java
@@ -53,6 +53,5 @@ public class TreeNodeI18N extends BeanTranslation implements java.io.Serializabl
    */
   public TreeNodeI18N(final AxisHeaderI18N otherTranslation) {
     super(otherTranslation);
-    setId(otherTranslation.getId());
   }
 }

--- a/core-test/src/main/java/org/silverpeas/core/test/extention/SilverTestEnv.java
+++ b/core-test/src/main/java/org/silverpeas/core/test/extention/SilverTestEnv.java
@@ -37,6 +37,7 @@ import org.silverpeas.core.admin.user.model.User;
 import org.silverpeas.core.admin.user.service.GroupProvider;
 import org.silverpeas.core.admin.user.service.UserProvider;
 import org.silverpeas.core.cache.service.CacheServiceProvider;
+import org.silverpeas.core.i18n.I18n;
 import org.silverpeas.core.test.TestBeanContainer;
 import org.silverpeas.core.test.util.MavenTestEnv;
 import org.silverpeas.core.test.util.lang.TestSystemWrapper;
@@ -78,7 +79,7 @@ import static org.mockito.Mockito.*;
  * Prepares the environment specific to Silverpeas to run unit tests.
  * <p>Firstly, it mocks the container of beans and set ups it for the tests with some of the
  * common beans in Silverpeas: {@link UserProvider}, {@link GroupProvider}, {@link SystemWrapper},
- * {@link ManagedThreadPool}, and the logging system.
+ * {@link I18n}, {@link ManagedThreadPool}, and the logging system.
  * </p>
  * <p>
  * Secondly it scans for fields and parameters annotated with {@link TestManagedBean} and
@@ -385,11 +386,19 @@ public class SilverTestEnv implements TestInstancePostProcessor, ParameterResolv
   }
 
   private void mockCommonBeans(final Object testInstance) {
+    mockI18n();
     mockUserProvider();
     mockGroupProvider();
     mockSystemWrapper(testInstance);
     mockLoggingSystem();
     mockManagedThreadFactory();
+  }
+
+  private void mockI18n() {
+    I18n i18n = mock(I18n.class);
+    when(i18n.getDefaultLanguage()).thenReturn("fr");
+    when(i18n.getSupportedLanguages()).thenReturn(Set.of("fr", "en", "de"));
+    when(TestBeanContainer.getMockedBeanContainer().getBeanByType(I18n.class)).thenReturn(i18n);
   }
 
   private void mockUserProvider() {

--- a/core-war/src/test/java/org/silverpeas/cmis/SilverpeasObjectsTree.java
+++ b/core-war/src/test/java/org/silverpeas/cmis/SilverpeasObjectsTree.java
@@ -164,8 +164,16 @@ public class SilverpeasObjectsTree {
     ContributionIdentifier folder = ContributionIdentifier.decode(folderId);
     PublicationPK pk = new PublicationPK(String.valueOf(localId), folder.getComponentInstanceId());
     Date today = new Date();
-    PublicationDetail pub =
-        new PublicationDetail(pk, name, description, today, today, null, "0", 1, null, "", "");
+    PublicationDetail pub = PublicationDetail.builder(LANGUAGE)
+        .setPk(pk)
+        .setNameAndDescription(name, description)
+        .created(today, "0")
+        .setImportance(1)
+        .setBeginDateTime(today, null)
+        .setKeywords("")
+        .setContentPagePath("")
+        .build();
+
     pub.setStatus(PublicationDetail.VALID_STATUS);
     pub.setUpdaterId(pub.getCreatorId());
     pub.setUpdateDate(pub.getCreationDate());

--- a/core-web/src/main/java/org/silverpeas/core/webapi/publication/PublicationEntity.java
+++ b/core-web/src/main/java/org/silverpeas/core/webapi/publication/PublicationEntity.java
@@ -243,12 +243,12 @@ public class PublicationEntity implements WebEntity {
   }
 
   public PublicationDetail toPublicationDetail() {
-    PublicationDetail publication = new PublicationDetail();
-    publication.setPk(new PublicationPK(id, componentId));
-    publication.setName(name);
-    publication.setDescription(description);
-    publication.setKeywords(keywords);
-    publication.setImportance(importance);
+    PublicationDetail publication = PublicationDetail.builder()
+        .setPk(new PublicationPK(id, componentId))
+        .setNameAndDescription(name, description)
+        .setKeywords(keywords)
+        .setImportance(importance)
+        .build();
     publication.setCreatorId(creator.getId());
     if (lastUpdater != null) {
       publication.setUpdaterId(lastUpdater.getId());


### PR DESCRIPTION
Add a PublicationDetail builder to control the way the instances are
created by taking care of the language in which the textual properties
are written (name, description and keywords).

Don't forget to merge also PR https://github.com/Silverpeas/Silverpeas-Components/pull/739