### PR TITLE
Bug #12411

### DIFF
--- a/core-library/src/main/java/org/silverpeas/core/security/session/SessionInfo.java
+++ b/core-library/src/main/java/org/silverpeas/core/security/session/SessionInfo.java
@@ -225,13 +225,23 @@ public class SessionInfo implements SilverpeasUserSession {
   }
 
   /**
-   * Is this session is defined? A session is defined if it's a session opened to a user in
+   * Is this session defined? A session is defined if it's a session opened to a user in
    * Silverpeas.
    *
    * @return true if this session is defined, false otherwise.
    */
   public boolean isDefined() {
     return this != NoneSession && this.getUserDetail() != null;
+  }
+
+  /**
+   * Is this session an anonymous one? A session is anonymous when no users are explicitly
+   * authenticated and then identified and the users uses Silverpeas under the cover of an
+   * anonymous user account.
+   * @return true if this session is a defined anonymous one, false otherwise.
+   */
+  public boolean isAnonymous() {
+    return this == AnonymousSession && this.getUserDetail().isAnonymous();
   }
 
   /**

--- a/core-web/src/main/java/org/silverpeas/core/web/mvc/SilverListener.java
+++ b/core-web/src/main/java/org/silverpeas/core/web/mvc/SilverListener.java
@@ -103,29 +103,36 @@ public class SilverListener
     if (httpSession == null) {
       return;
     }
+
     // Setting the context according to the Silverpeas session state
     SessionInfo sessionInfo = sessionManager.getSessionInfo(httpSession.getId());
     if (sessionInfo.isDefined()) {
-      if (sessionInfo instanceof HTTPSessionInfo && sessionInfo != SessionInfo.AnonymousSession) {
+      if (sessionInfo instanceof HTTPSessionInfo && !sessionInfo.isAnonymous()) {
+        // a non anonymous HTTP session
         ((HTTPSessionInfo) sessionInfo).setHttpSession(httpSession);
       }
-      ((SessionCacheService) CacheServiceProvider.getSessionCacheService())
-          .setCurrentSessionCache(sessionInfo.getCache());
     } else {
-      try {
-        // Anonymous management
-        MainSessionController mainSessionController = (MainSessionController) httpSession
-            .getAttribute(MainSessionController.MAIN_SESSION_CONTROLLER_ATT);
-        if (mainSessionController != null && mainSessionController.getCurrentUserDetail() != null &&
-            mainSessionController.getCurrentUserDetail().isAnonymous()) {
-          ((SessionCacheService) CacheServiceProvider.getSessionCacheService())
-              .newSessionCache(mainSessionController.getCurrentUserDetail());
-        }
-      } catch (IllegalStateException e) {
+      // Anonymous management
+      MainSessionController mainSessionController = MainSessionController.getInstance(httpSession);
+      if (mainSessionController != null && mainSessionController.getCurrentUserDetail() != null &&
+          mainSessionController.getCurrentUserDetail().isAnonymous()) {
+        sessionInfo = SessionInfo.AnonymousSession;
+      } else {
+        // shouldn't be executed
         SilverLogger.getLogger(this)
-            .warn("request ''{0}'' accessing attributes on closed session ({1})",
-                httpRequest.getRequestURI(), e.getMessage(), e);
+            .warn("No identified user session attached to request ''{0}'' ",
+                httpRequest.getRequestURI());
+        return;
       }
+    }
+    try {
+      SessionCacheService sessionCacheService =
+          (SessionCacheService) CacheServiceProvider.getSessionCacheService();
+      sessionCacheService.setCurrentSessionCache(sessionInfo.getCache());
+    } catch (IllegalStateException e) {
+      SilverLogger.getLogger(this)
+          .warn("request ''{0}'' accessing attributes on closed session ({1})",
+              httpRequest.getRequestURI(), e.getMessage(), e);
     }
   }
 

--- a/core-web/src/main/java/org/silverpeas/core/web/mvc/controller/MainSessionController.java
+++ b/core-web/src/main/java/org/silverpeas/core/web/mvc/controller/MainSessionController.java
@@ -95,6 +95,18 @@ public class MainSessionController implements Clipboard, SessionCloseable, Seria
   private transient List<GlobalSilverContent> lastResults = null;
   private boolean allowPasswordChange;
 
+  /**
+   * Gets the {@link MainSessionController} instance set in the current user session. If the session
+   * doesn't refer any identified user, then null is returned.
+   * @param session the current HTTP session
+   * @return the {@link MainSessionController} instance attached to the current user session or null
+   * if there is no identified user in the current HTTP session.
+   */
+  public static MainSessionController getInstance(final HttpSession session) {
+    return (MainSessionController) session.getAttribute(
+        MainSessionController.MAIN_SESSION_CONTROLLER_ATT);
+  }
+
   public static boolean isAppInMaintenance() {
     return appInMaintenance;
   }


### PR DESCRIPTION
For each incoming request, in the case the user behind it has no
attached Silverpeas session (SessionInfo object), check if he's
the anonymous user and in this case sets the session cache from his
anonymous predefined session.