### PR TITLE
Bug #12446

### DIFF
--- a/core-api/src/main/java/org/silverpeas/core/date/Period.java
+++ b/core-api/src/main/java/org/silverpeas/core/date/Period.java
@@ -387,6 +387,16 @@ public class Period implements Serializable {
   }
 
   /**
+   * Is this period an indefinite one? That is to say a period ranging over an indefinite range
+   * of time meaning that whatever any event, it occurs during this period. In Silverpeas, an
+   * indefinite period starts at {@link LocalDate#MIN} and ends at {@link LocalDate#MAX}.
+   * @return true if this period is an indefinite one. False otherwise.
+   */
+  public boolean isIndefinite() {
+    return startsAtMinDate() && endsAtMaxDate();
+  }
+
+  /**
    * Is this period starts at the the minimum supported date/datetime in Java?
    * @return true if this period starts at the minimum date/datetime supported by Java. False
    * otherwise.

--- a/core-api/src/main/java/org/silverpeas/core/date/TemporalConverter.java
+++ b/core-api/src/main/java/org/silverpeas/core/date/TemporalConverter.java
@@ -283,7 +283,15 @@ public class TemporalConverter {
     Objects.requireNonNull(temporal);
     Instant instant = applyByType(temporal, LOCAL_DATE_TO_INSTANT, LOCAL_DATE_TIME_TO_INSTANT,
         OFFSET_DATE_TIME_TO_INSTANT, ZONED_DATE_TIME_TO_INSTANT, INSTANT_TO_INSTANT);
-    return Date.from(instant);
+    Date date;
+    if (instant == Instant.MIN) {
+      date = new Date(Long.MIN_VALUE);
+    } else if (instant == Instant.MAX) {
+      date = new Date(Long.MAX_VALUE);
+    } else {
+      date = Date.from(instant);
+    }
+    return date;
   }
 
   private static final Conversion<Instant, Instant> INSTANT_TO_INSTANT =

--- a/core-api/src/main/java/org/silverpeas/core/variables/Variable.java
+++ b/core-api/src/main/java/org/silverpeas/core/variables/Variable.java
@@ -34,7 +34,6 @@ import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
-import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
@@ -50,9 +49,8 @@ import java.util.Set;
  */
 @Entity
 @Table(name = "sb_variables_variable")
-@NamedQueries({
-    @NamedQuery(name = "allVariables", query = "select v from Variable v order by v.label ASC"),
-    @NamedQuery(name = "currentVariables", query = "select distinct v from Variable v join v.values vv where vv.startDate <= :today and :today <= vv.endDate order by v.label ASC")})
+@NamedQuery(name = "allVariables", query = "select v from Variable v order by v.label ASC")
+@NamedQuery(name = "currentVariables", query = "select distinct v from Variable v join v.values vv where vv.startDate <= :today and :today <= vv.endDate order by v.label ASC")
 public class Variable extends SilverpeasJpaEntity<Variable, UuidIdentifier> implements
     Securable {
 
@@ -64,7 +62,7 @@ public class Variable extends SilverpeasJpaEntity<Variable, UuidIdentifier> impl
 
   @OneToMany(mappedBy = "variable", fetch = FetchType.EAGER, cascade = CascadeType.ALL,
       orphanRemoval = true)
-  private Set<VariableScheduledValue> values = new HashSet<>();
+  private final Set<VariableScheduledValue> values = new HashSet<>();
 
   protected Variable() {
     // default constructor for the persistence engine

--- a/core-api/src/test/java/org/silverpeas/core/variables/VariableScheduledValueTest.java
+++ b/core-api/src/test/java/org/silverpeas/core/variables/VariableScheduledValueTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2000 - 2021 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Lib
+ * Open Source Software ("FLOSS") applications as described in Silverpeas
+ * FLOSS exception. You should have received a copy of the text describin
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public Licen
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.silverpeas.core.variables;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.silverpeas.core.date.Period;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class VariableScheduledValueTest {
+
+  @Test
+  @DisplayName("A variable's value is defined in a given period of days")
+  void createAValueScheduledInADefinedDaysPeriod() {
+    LocalDate yesterday = LocalDate.now().minusDays(1);
+    LocalDate tomorrow = LocalDate.now().plusDays(1);
+    VariableScheduledValue value =
+        new VariableScheduledValue("value", Period.between(yesterday, tomorrow));
+
+    assertThat(value.getValue(), is("value"));
+    assertThat(value.getPeriod().getStartDate(), is(yesterday));
+    assertThat(value.getPeriod().getEndDate(), is(tomorrow));
+  }
+
+  @Test
+  @DisplayName("A variable's value is defined in a given period of time")
+  void createAValueScheduledInADefinedDatetimePeriod() {
+    OffsetDateTime yesterday = OffsetDateTime.now().minusDays(1);
+    OffsetDateTime tomorrow = OffsetDateTime.now().plusDays(1);
+    VariableScheduledValue value =
+        new VariableScheduledValue("value", Period.between(yesterday, tomorrow));
+
+    assertThat(value.getValue(), is("value"));
+    assertThat(value.getPeriod().getStartDate(), is(yesterday.toLocalDate()));
+    assertThat(value.getPeriod().getEndDate(), is(tomorrow.toLocalDate()));
+  }
+
+  @Test
+  @DisplayName("A variable's value is defined forever")
+  void createAValueScheduledForever() {
+    VariableScheduledValue value = new VariableScheduledValue("value", Period.indefinite());
+
+    assertThat(value.getValue(), is("value"));
+    assertThat(value.getPeriod().isIndefinite(), is(true));
+    assertThat(value.getPeriod().getStartDate(), is(LocalDate.MIN));
+    assertThat(value.getPeriod().getEndDate(), is(LocalDate.MAX));
+  }
+}

--- a/core-api/src/test/java/org/silverpeas/core/variables/VariableTest.java
+++ b/core-api/src/test/java/org/silverpeas/core/variables/VariableTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2000 - 2021 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Lib
+ * Open Source Software ("FLOSS") applications as described in Silverpeas
+ * FLOSS exception. You should have received a copy of the text describin
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public Licen
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.silverpeas.core.variables;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.silverpeas.core.admin.user.model.User;
+import org.silverpeas.core.date.Period;
+import org.silverpeas.core.persistence.Transaction;
+import org.silverpeas.core.test.TestBeanContainer;
+import org.silverpeas.core.test.extension.EnableSilverTestEnv;
+import org.silverpeas.core.test.extension.RequesterProvider;
+import org.silverpeas.core.test.extension.TestManagedMock;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.*;
+
+@EnableSilverTestEnv
+class VariableTest {
+
+  @TestManagedMock
+  VariableScheduledValueRepository valuesRepository;
+
+  @TestManagedMock
+  VariablesRepository variablesRepository;
+
+  @RequesterProvider
+  User getCurrentUser() {
+    User user = mock(User.class);
+    when(user.getId()).thenReturn("1");
+    when(user.getFirstName()).thenReturn("John");
+    when(user.getLastName()).thenReturn("Doo");
+    return user;
+  }
+
+  @BeforeEach
+  void setUpMocks() {
+    Transaction transaction = new Transaction();
+    when(TestBeanContainer.getMockedBeanContainer()
+        .getBeanByType(Transaction.class)).thenReturn(transaction);
+  }
+
+  @Test
+  void propertiesOfAVariableWithoutValueAreCorrectlySet() {
+    Variable variable = new Variable("Var1", "My variable var1");
+    assertThat(variable.getLabel(), is("Var1"));
+    assertThat(variable.getDescription(), is("My variable var1"));
+    assertThat(variable.getNumberOfValues(), is(0));
+    assertThat(variable.getVariableValues().isEmpty(), is(true));
+  }
+
+  @Test
+  void propertiesOfAVariableWithTwoValuesAreCorrectlySet() {
+    Variable variable = new Variable("Var1", "My variable var1");
+    VariableScheduledValue value1 = new VariableScheduledValue("value1", Period.indefinite());
+    VariableScheduledValue value2 = new VariableScheduledValue("value2", Period.indefinite());
+    variable.getVariableValues().add(value1);
+    variable.getVariableValues().add(value2);
+
+    assertThat(variable.getLabel(), is("Var1"));
+    assertThat(variable.getDescription(), is("My variable var1"));
+    assertThat(variable.getNumberOfValues(), is(2));
+    assertThat(variable.getVariableValues().size(), is(2));
+    assertThat(variable.getVariableValues().contains(value1), is(true));
+    assertThat(variable.getVariableValues().contains(value2), is(true));
+  }
+
+  @Test
+  void saveAVariableWithoutAnyValue() {
+    Variable variable = new Variable("Var1", "My variable var1");
+    variable.save();
+    verify(variablesRepository).save(variable);
+  }
+
+  @Test
+  void saveAVariableWithValue() {
+    Variable variable = new Variable("Var1", "My variable var1");
+    VariableScheduledValue value = new VariableScheduledValue("value", Period.indefinite());
+    variable.getVariableValues().add(value);
+    variable.save();
+    verify(variablesRepository).save(variable);
+  }
+
+  @Test
+  void saveExplicitlyAValueOfAVariable() {
+    Variable variable = new Variable("Var1", "My variable var1");
+    VariableScheduledValue value = new VariableScheduledValue("value", Period.indefinite());
+    variable.getVariableValues().addAndSave(value);
+    verify(valuesRepository).save(value);
+  }
+}

--- a/core-war/src/main/java/org/silverpeas/web/variables/VariableUIEntity.java
+++ b/core-war/src/main/java/org/silverpeas/web/variables/VariableUIEntity.java
@@ -25,7 +25,7 @@ public class VariableUIEntity extends SelectableUIEntity<Variable> {
     super(data, selectedIds);
   }
 
-  private Supplier<VariableScheduledValue> defaultValue =
+  private final Supplier<VariableScheduledValue> defaultValue =
       () -> new VariableScheduledValue("", Period.between(LocalDate.MIN, LocalDate.MAX));
 
   @Override


### PR DESCRIPTION
Fix the conversion from an Instant to a Date object. Java doesn't
correctly take into account the conversion of MIN and MAX values of the
different types of date and datetime, so we have to take ourselves in
charge of these.