### PR TITLE
Bug #12443

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,25 +29,7 @@ mvn clean install -Pdeployment -Djava.awt.headless=true -Dcontext=ci
     stage('Quality Analysis') {
       steps {
         script {
-          // quality analyse with our SonarQube service is performed only for PR against our main
-          // repository
-          if (env.BRANCH_NAME.startsWith('PR') &&
-              env.CHANGE_URL?.startsWith('https://github.com/Silverpeas')) {
-            withSonarQubeEnv {
-              sh """
-mvn ${SONAR_MAVEN_GOAL} -Dsonar.projectKey=Silverpeas_Silverpeas-Core \\
-    -Dsonar.organization=silverpeas \\
-    -Dsonar.pullrequest.branch=${env.BRANCH_NAME} \\
-    -Dsonar.pullrequest.key=${env.CHANGE_ID} \\
-    -Dsonar.pullrequest.base=master \\
-    -Dsonar.pullrequest.provider=github \\
-    -Dsonar.host.url=${SONAR_HOST_URL} \\
-    -Dsonar.login=${SONAR_AUTH_TOKEN}
-"""
-            }
-          } else {
-            echo "It isn't a PR validation for the Silverpeas organization. Nothing to analyse."
-          }
+          echo "No quality analyse for 6.1.x because it is built with Java 8 and SonarQube requires Java 11"
         }
       }
     }

--- a/core-library/src/integration-test/java/org/silverpeas/core/contribution/attachment/AttachmentServiceIT.java
+++ b/core-library/src/integration-test/java/org/silverpeas/core/contribution/attachment/AttachmentServiceIT.java
@@ -1146,7 +1146,7 @@ public class AttachmentServiceIT extends JcrIntegrationIT {
   @Test
   public void testUpdateAttachmentForbidRoles() {
     SimpleDocument documentUpdated = instance.searchDocumentById(existingFrDoc, null);
-    assertThat(documentUpdated.getForbiddenDownloadForRoles(), nullValue());
+    assertThat(documentUpdated.getForbiddenDownloadForRoles(), is(empty()));
 
     // Adding roles that adds technically the downloadable mixin to the SimpleDocument node
     documentUpdated
@@ -1169,7 +1169,7 @@ public class AttachmentServiceIT extends JcrIntegrationIT {
     documentUpdated.addRolesForWhichDownloadIsAllowed(SilverpeasRole.reader);
     instance.updateAttachment(documentUpdated, false, false);
     result = instance.searchDocumentById(existingFrDoc, null);
-    assertThat(result.getForbiddenDownloadForRoles(), nullValue());
+    assertThat(result.getForbiddenDownloadForRoles(), empty());
   }
 
   /**
@@ -1178,7 +1178,7 @@ public class AttachmentServiceIT extends JcrIntegrationIT {
   @Test
   public void testSwitchAllowingDownloadForReaders() {
     SimpleDocument documentUpdated = instance.searchDocumentById(existingFrDoc, null);
-    assertThat(documentUpdated.getForbiddenDownloadForRoles(), nullValue());
+    assertThat(documentUpdated.getForbiddenDownloadForRoles(), empty());
 
     // Forbid download for readers
     instance.switchAllowingDownloadForReaders(documentUpdated.getPk(), false);
@@ -1192,7 +1192,7 @@ public class AttachmentServiceIT extends JcrIntegrationIT {
     // Allow download for readers
     instance.switchAllowingDownloadForReaders(documentUpdated.getPk(), true);
     result = instance.searchDocumentById(existingFrDoc, null);
-    assertThat(result.getForbiddenDownloadForRoles(), nullValue());
+    assertThat(result.getForbiddenDownloadForRoles(), empty());
   }
 
   /**

--- a/core-library/src/integration-test/java/org/silverpeas/core/contribution/attachment/HistorisedAttachmentServiceIT.java
+++ b/core-library/src/integration-test/java/org/silverpeas/core/contribution/attachment/HistorisedAttachmentServiceIT.java
@@ -691,13 +691,13 @@ public class HistorisedAttachmentServiceIT extends JcrIntegrationIT {
       assertThat(result, notNullValue());
       assertThat(result, hasSize(1));
       SimpleDocument documentOfResult = result.get(0);
-      assertThat(documentOfResult.getForbiddenDownloadForRoles(), nullValue());
+      assertThat(documentOfResult.getForbiddenDownloadForRoles(), empty());
 
       // Allowing readers (but nothing is saved in JCR)
       instance.switchAllowingDownloadForReaders(documentPK, true);
       documentOfResult = instance.searchDocumentById(documentPK, "fr");
       assertThat(documentOfResult, notNullValue());
-      assertThat(documentOfResult.getForbiddenDownloadForRoles(), nullValue());
+      assertThat(documentOfResult.getForbiddenDownloadForRoles(), empty());
 
       // Forbidding readers
       instance.switchAllowingDownloadForReaders(documentPK, false);
@@ -717,7 +717,7 @@ public class HistorisedAttachmentServiceIT extends JcrIntegrationIT {
       instance.switchAllowingDownloadForReaders(documentPK, true);
       documentOfResult = instance.searchDocumentById(documentPK, "fr");
       assertThat(documentOfResult, notNullValue());
-      assertThat(documentOfResult.getForbiddenDownloadForRoles(), nullValue());
+      assertThat(documentOfResult.getForbiddenDownloadForRoles(), empty());
 
     }
   }

--- a/core-library/src/integration-test/java/org/silverpeas/core/contribution/attachment/repository/DocumentRepositoryIT.java
+++ b/core-library/src/integration-test/java/org/silverpeas/core/contribution/attachment/repository/DocumentRepositoryIT.java
@@ -260,7 +260,7 @@ public class DocumentRepositoryIT extends JcrIntegrationIT {
       assertThat(doc, is(notNullValue()));
       assertThat(doc.getOldSilverpeasId(), is(not(0L)));
       assertThat(doc.getCreated(), is(creationDate));
-      assertThat(doc.getForbiddenDownloadForRoles(), nullValue());
+      assertThat(doc.getForbiddenDownloadForRoles(), empty());
       checkEnglishSimpleDocument(doc);
     }
   }
@@ -523,7 +523,7 @@ public class DocumentRepositoryIT extends JcrIntegrationIT {
       documentRepository.storeContent(document, content);
       SimpleDocumentPK expResult = new SimpleDocumentPK(result.getId(), instanceId);
       assertThat(result, is(expResult));
-      assertThat(document.getForbiddenDownloadForRoles(), nullValue());
+      assertThat(document.getForbiddenDownloadForRoles(), empty());
       attachment = createFrenchSimpleAttachment();
       document = new SimpleDocument(emptyId, foreignId, 15, false, attachment);
       document.addRolesForWhichDownloadIsForbidden(SilverpeasRole.reader);
@@ -555,7 +555,7 @@ public class DocumentRepositoryIT extends JcrIntegrationIT {
       documentRepository.storeContent(document, content);
       SimpleDocumentPK expResult = new SimpleDocumentPK(result.getId(), instanceId);
       assertThat(result, is(expResult));
-      assertThat(document.getForbiddenDownloadForRoles(), nullValue());
+      assertThat(document.getForbiddenDownloadForRoles(), empty());
       attachment = createFrenchSimpleAttachment();
       document = new SimpleDocument(emptyId, foreignId, 15, false, attachment);
       document.addRolesForWhichDownloadIsForbidden(SilverpeasRole.reader);

--- a/core-library/src/integration-test/java/org/silverpeas/core/contribution/attachment/repository/HistorisedDocumentRepositoryIT.java
+++ b/core-library/src/integration-test/java/org/silverpeas/core/contribution/attachment/repository/HistorisedDocumentRepositoryIT.java
@@ -3404,7 +3404,7 @@ public class HistorisedDocumentRepositoryIT extends JcrIntegrationIT {
       SimpleDocumentPK result = createVersionedDocument(session, document, content);
       SimpleDocumentPK expResult = new SimpleDocumentPK(result.getId(), instanceId);
       assertThat(result, is(expResult));
-      assertThat(document.getForbiddenDownloadForRoles(), nullValue());
+      assertThat(document.getForbiddenDownloadForRoles(), empty());
       HistorisedDocument docCreated =
           (HistorisedDocument) documentRepository.findDocumentById(session, result, "fr");
       assertThat(docCreated, is(notNullValue()));
@@ -3517,9 +3517,9 @@ public class HistorisedDocumentRepositoryIT extends JcrIntegrationIT {
       assertThat(doc.getMinorVersion(), is(1));
       assertThat(doc.getVersionIndex(), is(4));
       assertThat(doc.getVersionIndex(), is(doc.getVersionMaster().getVersionIndex()));
-      assertThat(doc.getForbiddenDownloadForRoles(), nullValue());
+      assertThat(doc.getForbiddenDownloadForRoles(), empty());
       for (SimpleDocumentVersion version : doc.getHistory()) {
-        assertThat(version.getForbiddenDownloadForRoles(), nullValue());
+        assertThat(version.getForbiddenDownloadForRoles(), empty());
       }
     }
   }
@@ -3687,7 +3687,7 @@ public class HistorisedDocumentRepositoryIT extends JcrIntegrationIT {
       SimpleDocumentPK result = createVersionedDocument(session, document, content);
       SimpleDocumentPK expResult = new SimpleDocumentPK(result.getId(), instanceId);
       assertThat(result, is(expResult));
-      assertThat(document.getForbiddenDownloadForRoles(), nullValue());
+      assertThat(document.getForbiddenDownloadForRoles(), empty());
       HistorisedDocument docCreated =
           (HistorisedDocument) documentRepository.findDocumentById(session, result, "fr");
       assertThat(docCreated, is(notNullValue()));

--- a/core-library/src/main/java/org/silverpeas/core/contribution/attachment/SimpleDocumentService.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/attachment/SimpleDocumentService.java
@@ -741,8 +741,7 @@ public class SimpleDocumentService
       SimpleDocument document = repository
           .findDocumentById(session, new SimpleDocumentPK(context.getAttachmentId()),
               contentLanguage);
-      SimpleDocument docBeforeUpdate =
-          repository.findDocumentById(session, document.getPk(), contentLanguage);
+      SimpleDocument docBeforeUpdate = new SimpleDocument(document);
       contentLanguage = document.getLanguage();
       boolean updateOfficeContentFromWebDav =
           document.isOpenOfficeCompatible() && !context.isUpload() && context.isWebdav();
@@ -803,7 +802,7 @@ public class SimpleDocumentService
   private boolean prepareDocumentForUnlocking(final UnlockContext context,
       final SimpleDocument document, final boolean updateOfficeContentFromWebDav) {
     boolean notify = false;
-    if (context.isWebdav() || context.isUpload()) {
+    if (context.isWebdav() && StringUtil.isDefined(document.getEditedBy())) {
       String workerId = document.getEditedBy();
       document.setUpdated(new Date());
       document.setUpdatedBy(workerId);

--- a/core-library/src/main/java/org/silverpeas/core/contribution/attachment/model/SimpleAttachment.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/attachment/model/SimpleAttachment.java
@@ -63,6 +63,20 @@ public class SimpleAttachment implements Serializable {
   public SimpleAttachment() {
   }
 
+  public SimpleAttachment(final SimpleAttachment attachment) {
+    this.filename = attachment.filename;
+    this.language = attachment.language;
+    this.title = attachment.title;
+    this.description = attachment.description;
+    this.size = attachment.size;
+    this.contentType = attachment.contentType;
+    this.createdBy = attachment.createdBy;
+    this.created = attachment.created;
+    this.updatedBy = attachment.updatedBy;
+    this.updated = attachment.updated;
+    this.xmlFormId = attachment.xmlFormId;
+  }
+
   public String getNodeName() {
     return SimpleDocument.FILE_PREFIX + getLanguage();
   }

--- a/core-library/src/main/java/org/silverpeas/core/contribution/attachment/model/SimpleDocument.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/attachment/model/SimpleDocument.java
@@ -94,7 +94,7 @@ public class SimpleDocument implements Serializable, Securable {
   private String nodeName;
   private String comment;
   private DocumentType documentType = DocumentType.attachment;
-  private Set<SilverpeasRole> forbiddenDownloadForRoles = null;
+  private Set<SilverpeasRole> forbiddenDownloadForRoles = EnumSet.noneOf(SilverpeasRole.class);
   private SimpleAttachment attachment;
   private boolean displayableAsContent = true;
 
@@ -157,7 +157,7 @@ public class SimpleDocument implements Serializable, Securable {
     this.repositoryPath = simpleDocument.getRepositoryPath();
     this.versionMaster = simpleDocument.getVersionMaster();
     this.versionIndex = simpleDocument.getVersionIndex();
-    this.pk = simpleDocument.getPk();
+    this.pk = simpleDocument.getPk().clone();
     this.foreignId = simpleDocument.getForeignId();
     this.order = simpleDocument.getOrder();
     this.versioned = simpleDocument.isVersioned();
@@ -173,8 +173,8 @@ public class SimpleDocument implements Serializable, Securable {
     this.nodeName = simpleDocument.getNodeName();
     this.comment = simpleDocument.getComment();
     this.documentType = simpleDocument.getDocumentType();
-    this.forbiddenDownloadForRoles = simpleDocument.forbiddenDownloadForRoles;
-    this.attachment = simpleDocument.getAttachment();
+    this.forbiddenDownloadForRoles = EnumSet.copyOf(simpleDocument.forbiddenDownloadForRoles);
+    this.attachment = new SimpleAttachment(simpleDocument.getAttachment());
     this.displayableAsContent = simpleDocument.displayableAsContent;
   }
 
@@ -847,8 +847,8 @@ public class SimpleDocument implements Serializable, Securable {
     }
 
     if (CollectionUtil.isEmpty(getVersionMaster().forbiddenDownloadForRoles)) {
-      // In that case, there is no reason to verify user role informations because it doesn't
-      // exists any restriction for downloading.
+      // In that case, there is no reason to verify user role information because it doesn't
+      // exist any restriction for downloading.
       return true;
     }
 
@@ -907,9 +907,6 @@ public class SimpleDocument implements Serializable, Securable {
   public boolean addRolesForWhichDownloadIsForbidden(
       final Collection<SilverpeasRole> forbiddenRoles) {
     if (CollectionUtil.isNotEmpty(forbiddenRoles)) {
-      if (getVersionMaster().forbiddenDownloadForRoles == null) {
-        getVersionMaster().forbiddenDownloadForRoles = EnumSet.noneOf(SilverpeasRole.class);
-      }
       return getVersionMaster().forbiddenDownloadForRoles.addAll(forbiddenRoles);
     }
     return false;
@@ -944,8 +941,7 @@ public class SimpleDocument implements Serializable, Securable {
    * @return
    */
   public Set<SilverpeasRole> getForbiddenDownloadForRoles() {
-    return (getVersionMaster().forbiddenDownloadForRoles != null) ?
-        Collections.unmodifiableSet(getVersionMaster().forbiddenDownloadForRoles) : null;
+    return Collections.unmodifiableSet(getVersionMaster().forbiddenDownloadForRoles);
   }
 
   /**

--- a/core-library/src/test/java/org/silverpeas/core/contribution/attachment/model/SimpleDocumentTest.java
+++ b/core-library/src/test/java/org/silverpeas/core/contribution/attachment/model/SimpleDocumentTest.java
@@ -419,7 +419,7 @@ public class SimpleDocumentTest {
     SimpleDocument instance = new SimpleDocument();
     SimpleDocumentPK pk = new SimpleDocumentPK("dummyId", instanceId);
     instance.setPK(pk);
-    assertThat(instance.getForbiddenDownloadForRoles(), nullValue());
+    assertThat(instance.getForbiddenDownloadForRoles(), empty());
 
     assertThat(isDownloadAllowedForRolesFrom(instance, null), is(false));
     assertThat(isDownloadAllowedForRolesFrom(instance, new UserDetailWithRoles()), is(false));
@@ -430,7 +430,7 @@ public class SimpleDocumentTest {
 
     // Forbid empty
     instance.addRolesForWhichDownloadIsForbidden();
-    assertThat(instance.getForbiddenDownloadForRoles(), nullValue());
+    assertThat(instance.getForbiddenDownloadForRoles(), empty());
 
     // Forbid writers
     instance.addRolesForWhichDownloadIsForbidden(SilverpeasRole.writer);


### PR DESCRIPTION
Fix the bug that came from a double system notification about the update
of the attachment: one from the update of the file itself, the other
from the document unlocking. Such a notification is listening by the
publication update module that updates the last modification data of the
publication to which the document is attached.
The fix is to avoid such notification in the case of an update by
upload.

Add also a copy constructor to SimpleDocument and to SimpleAttachment
classes.

Don't forget to merge also PR https://github.com/Silverpeas/Silverpeas-Components/pull/742