### PR TITLE
Feature #12035: wiring the modification popins on massive publication update.

### DIFF
--- a/core-configuration/src/main/config/properties/org/silverpeas/contribution/multilang/contribution.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/contribution/multilang/contribution.properties
@@ -24,9 +24,10 @@
 
 contribution.CalendarEvent.ui.message.label = l''\u00e9v\u00e9nement <b>{0}</b>
 contribution.CalendarEventOccurrence.ui.message.label=l''\u00e9v\u00e9nement <b>{0}</b>
-contribution.modification.minor.help=Dans le cas o\u00f9 elles ne le sont pas, la date et l'auteur des modifications resteront inchang\u00e9s. Ainsi, cette contribution n'appara\u00eetra pas parmi les nouveaut\u00e9s.
+contribution.modification.minor.help=Dans le cas o\u00f9 elles ne le sont pas, la date et l''auteur des modifications resteront inchang\u00e9s. Ainsi, {0,choice, 1#cette contribution n''appara\u00eetra| 1<ces contributions n''appara\u00eetront} pas parmi les nouveaut\u00e9s.
 contribution.modification.minor.importants=Oui, mes modifications sont importantes
 contribution.modification.minor.question=Vos modifications sont-elles importantes ?
 contribution.News.modification.context.dialog.title=Concernant l'actualit\u00e9
 contribution.blogPublication.modification.context.dialog.title=Concernant le billet
 contribution.Publication.modification.context.dialog.title=Concernant la publication
+contribution.Publication.several.modification.context.dialog.title=Concernant les publications

--- a/core-configuration/src/main/config/properties/org/silverpeas/contribution/multilang/contribution_de.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/contribution/multilang/contribution_de.properties
@@ -24,9 +24,10 @@
 
 contribution.CalendarEvent.ui.message.label = the event <b>{0}</b>
 contribution.CalendarEventOccurrence.ui.message.label=the event <b>{0}</b>
-contribution.modification.minor.help=If they are not, the date and the author of the update will remain unchanged. Thus, this contribution will not appear among the novelties.
+contribution.modification.minor.help=If they are not, the date and the author of the update will remain unchanged. Thus, {0,choice, 1#this contribution| 1<these contributions} will not appear among the novelties.
 contribution.modification.minor.importants=Yes, they are important
 contribution.modification.minor.question=Are your changes major?
 contribution.News.modification.context.dialog.title=About the news
 contribution.blogPublication.modification.context.dialog.title=About the post
 contribution.Publication.modification.context.dialog.title=About the publication
+contribution.Publication.several.modification.context.dialog.title=About the publications

--- a/core-configuration/src/main/config/properties/org/silverpeas/contribution/multilang/contribution_en.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/contribution/multilang/contribution_en.properties
@@ -24,9 +24,10 @@
 
 contribution.CalendarEvent.ui.message.label = the event <b>{0}</b>
 contribution.CalendarEventOccurrence.ui.message.label=the event <b>{0}</b>
-contribution.modification.minor.help=If they are not, the date and the author of the update will remain unchanged. Thus, this contribution will not appear among the novelties.
+contribution.modification.minor.help=If they are not, the date and the author of the update will remain unchanged. Thus, {0,choice, 1#this contribution| 1<these contributions} will not appear among the novelties.
 contribution.modification.minor.importants=Yes, they are important
 contribution.modification.minor.question=Are your changes major?
 contribution.News.modification.context.dialog.title=About the news
 contribution.blogPublication.modification.context.dialog.title=About the post
 contribution.Publication.modification.context.dialog.title=About the publication
+contribution.Publication.several.modification.context.dialog.title=About the publications

--- a/core-configuration/src/main/config/properties/org/silverpeas/contribution/multilang/contribution_fr.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/contribution/multilang/contribution_fr.properties
@@ -24,9 +24,10 @@
 
 contribution.CalendarEvent.ui.message.label = l''\u00e9v\u00e9nement <b>{0}</b>
 contribution.CalendarEventOccurrence.ui.message.label = l''\u00e9v\u00e9nement <b>{0}</b>
-contribution.modification.minor.help=Dans le cas o\u00f9 elles ne le sont pas, la date et l'auteur des modifications resteront inchang\u00e9s. Ainsi, cette contribution n'appara\u00eetra pas parmi les nouveaut\u00e9s.
+contribution.modification.minor.help=Dans le cas o\u00f9 elles ne le sont pas, la date et l''auteur des modifications resteront inchang\u00e9s. Ainsi, {0,choice, 1#cette contribution n''appara\u00eetra| 1<ces contributions n''appara\u00eetront} pas parmi les nouveaut\u00e9s.
 contribution.modification.minor.importants=Oui, mes modifications sont importantes
 contribution.modification.minor.question=Vos modifications sont-elles importantes ?
 contribution.News.modification.context.dialog.title=Concernant l'actualit\u00e9
 contribution.blogPublication.modification.context.dialog.title=Concernant le billet
 contribution.Publication.modification.context.dialog.title=Concernant la publication
+contribution.Publication.several.modification.context.dialog.title=Concernant les publications

--- a/core-library/src/main/java/org/silverpeas/core/contribution/content/form/displayers/ImageFieldDisplayer.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/content/form/displayers/ImageFieldDisplayer.java
@@ -23,6 +23,10 @@
  */
 package org.silverpeas.core.contribution.content.form.displayers;
 
+import org.silverpeas.core.admin.component.model.ComponentInstLight;
+import org.silverpeas.core.contribution.attachment.AttachmentServiceProvider;
+import org.silverpeas.core.contribution.attachment.model.SimpleDocument;
+import org.silverpeas.core.contribution.attachment.model.SimpleDocumentPK;
 import org.silverpeas.core.contribution.content.form.Field;
 import org.silverpeas.core.contribution.content.form.FieldDisplayer;
 import org.silverpeas.core.contribution.content.form.FieldTemplate;
@@ -30,24 +34,21 @@ import org.silverpeas.core.contribution.content.form.Form;
 import org.silverpeas.core.contribution.content.form.FormException;
 import org.silverpeas.core.contribution.content.form.GalleryHelper;
 import org.silverpeas.core.contribution.content.form.PagesContext;
-import org.silverpeas.core.contribution.content.form.RenderingContext;
 import org.silverpeas.core.contribution.content.form.Util;
 import org.silverpeas.core.contribution.content.form.field.FileField;
+import org.silverpeas.core.contribution.content.wysiwyg.service.WysiwygController;
 import org.silverpeas.core.util.CollectionUtil;
-import org.silverpeas.core.util.URLUtil;
-import org.silverpeas.core.admin.component.model.ComponentInstLight;
-import org.silverpeas.core.contribution.attachment.AttachmentServiceProvider;
-import org.silverpeas.core.contribution.attachment.model.SimpleDocument;
-import org.silverpeas.core.contribution.attachment.model.SimpleDocumentPK;
-import org.silverpeas.core.util.file.FileServerUtils;
 import org.silverpeas.core.util.ResourceLocator;
 import org.silverpeas.core.util.SettingBundle;
 import org.silverpeas.core.util.StringUtil;
-import org.silverpeas.core.contribution.content.wysiwyg.service.WysiwygController;
+import org.silverpeas.core.util.URLUtil;
+import org.silverpeas.core.util.file.FileServerUtils;
 
 import java.io.PrintWriter;
 import java.util.List;
 import java.util.Map;
+
+import static org.silverpeas.core.util.StringUtil.defaultStringIfNotDefined;
 
 /**
  * A ImageFieldDisplayer is an object which can display an image in HTML and can retrieve via HTTP
@@ -129,12 +130,12 @@ public class ImageFieldDisplayer extends AbstractFileFieldDisplayer {
         if (imageURL != null) {
           thumbnailURL = FileServerUtils.getImageURL(imageURL, size);
         } else {
-          thumbnailURL = "#";
+          thumbnailURL = "/util/viewgenerator/icons/px.gif";
         }
 
         out.println("<div id=\"" + fieldName + "ThumbnailArea\" class=\"thumbnailArea\" style=\"" +
             displayCSS + "\">");
-        out.println("<a id=\"" + fieldName + "ThumbnailLink\" href=\"" + imageURL +
+        out.println("<a id=\"" + fieldName + "ThumbnailLink\" href=\"" + defaultStringIfNotDefined(imageURL, "javascript:void(0)") +
             "\" target=\"_blank\">");
         out.println("<img alt=\"\" align=\"top\" src=\"" + thumbnailURL + "\" id=\"" + fieldName +
             "Thumbnail\"/>&nbsp;");

--- a/core-library/src/main/java/org/silverpeas/core/contribution/publication/model/PublicationDetail.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/publication/model/PublicationDetail.java
@@ -27,6 +27,7 @@ import org.silverpeas.core.ResourceReference;
 import org.silverpeas.core.admin.user.model.User;
 import org.silverpeas.core.admin.user.model.UserDetail;
 import org.silverpeas.core.contribution.ContributionModificationContextHandler;
+import org.silverpeas.core.contribution.ContributionStatus;
 import org.silverpeas.core.contribution.ContributionWithVisibility;
 import org.silverpeas.core.contribution.attachment.AttachmentServiceProvider;
 import org.silverpeas.core.contribution.attachment.model.SimpleDocument;
@@ -338,6 +339,22 @@ public class PublicationDetail extends AbstractI18NBean<PublicationI18N>
 
   public String getStatus() {
     return status;
+  }
+
+  public ContributionStatus getContributionStatus() {
+    final ContributionStatus contributionStatus;
+    if (DRAFT_STATUS.equalsIgnoreCase(status)) {
+      contributionStatus = ContributionStatus.DRAFT;
+    } else if (VALID_STATUS.equalsIgnoreCase(status)) {
+      contributionStatus = ContributionStatus.VALIDATED;
+    } else if (TO_VALIDATE_STATUS.equalsIgnoreCase(status)) {
+      contributionStatus = ContributionStatus.PENDING_VALIDATION;
+    } else if (REFUSED_STATUS.equalsIgnoreCase(status)) {
+      contributionStatus = ContributionStatus.REFUSED;
+    } else {
+      contributionStatus = ContributionStatus.UNKNOWN;
+    }
+    return contributionStatus;
   }
 
   public String getImage() {

--- a/core-library/src/main/java/org/silverpeas/core/contribution/publication/subscription/AbstractPublicationSubscriptionService.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/publication/subscription/AbstractPublicationSubscriptionService.java
@@ -44,6 +44,7 @@ import static org.silverpeas.core.subscription.SubscriptionServiceProvider.getSu
 import static org.silverpeas.core.subscription.constant.CommonSubscriptionResourceConstants.COMPONENT;
 import static org.silverpeas.core.subscription.constant.CommonSubscriptionResourceConstants.NODE;
 import static org.silverpeas.core.util.Mutable.of;
+import static org.silverpeas.core.util.StringUtil.isDefined;
 
 /**
  * As the class is implementing {@link org.silverpeas.core.initialization.Initialization}, no
@@ -68,6 +69,14 @@ public abstract class AbstractPublicationSubscriptionService extends AbstractRes
   public SubscriptionSubscriberList getSubscribersOfComponentAndTypedResource(
       final String componentInstanceId, final SubscriptionResourceType resourceType,
       final String resourceId) {
+    return getSubscribersOfComponentAndTypedResourceOnLocation(componentInstanceId,
+        resourceType, resourceId, null);
+  }
+
+  @Override
+  public SubscriptionSubscriberList getSubscribersOfComponentAndTypedResourceOnLocation(
+      final String componentInstanceId, final SubscriptionResourceType resourceType,
+      final String resourceId, final String locationId) {
     final Collection<SubscriptionSubscriber> subscribers = new HashSet<>();
     final Mutable<Pair<SubscriptionResourceType, String>> reference = of(Pair.of(resourceType, resourceId));
     if (reference.get().getFirst() == PUBLICATION_ALIAS) {
@@ -76,6 +85,9 @@ public abstract class AbstractPublicationSubscriptionService extends AbstractRes
       final PublicationPK publicationPK = new PublicationPK(resourceId, componentInstanceId);
       subscribers.addAll(getSubscribeService().getSubscribers(
           PublicationAliasSubscriptionResource.from(publicationPK)));
+      if (isDefined(locationId)) {
+        reference.set(Pair.of(NODE, locationId));
+      }
     }
     if (reference.get().getFirst() == PUBLICATION) {
       // In that case, subscribers of publication must be verified.

--- a/core-library/src/main/java/org/silverpeas/core/contribution/util/ContributionBatchManagementContext.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/util/ContributionBatchManagementContext.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (C) 2000 - 2021 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.silverpeas.core.contribution.util;
+
+import org.silverpeas.core.ActionType;
+import org.silverpeas.core.contribution.ContributionStatus;
+import org.silverpeas.core.contribution.model.Contribution;
+import org.silverpeas.core.contribution.publication.model.Location;
+import org.silverpeas.core.subscription.SubscriptionResource;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This class permits to specify a context into which a batch of contribution has to be managed.
+ * For example, it permits to define the context on the save action of batch modification of
+ * publications.
+ * @author silveryocha
+ */
+public class ContributionBatchManagementContext {
+  private final List<ContributionContext> contributionContexts = new ArrayList<>();
+  private ActionType entityPersistenceAction = ActionType.READ;
+
+  /**
+   * Initializes a context by specifying the contribution handled by this context.
+   * @return a new instance of {@link ContributionBatchManagementContext}.
+   */
+  public static ContributionBatchManagementContext initialize() {
+    return new ContributionBatchManagementContext();
+  }
+
+  /**
+   * Hidden constructor.
+   */
+  private ContributionBatchManagementContext() {
+  }
+
+
+  /**
+   * Setup the finest subscription resource linked to the entity that is handled.
+   * <p>
+   * This method can be called several times in order to constitute a list of
+   * {@link SubscriptionResource} to handle.
+   * </p>
+   * @param contribution the concerned contribution.
+   * @param contributionStatus the status of the concerned contribution.
+   * @param location an optional location.
+   * @param linkedSubscriptionResource the finest subscription resource (the resource on which
+   * subscriptions are registered) linked to the entity that is handled.
+   * @return itself.
+   */
+  public ContributionBatchManagementContext addContributionContext(final Contribution contribution,
+      final ContributionStatus contributionStatus, final Location location,
+      final SubscriptionResource linkedSubscriptionResource) {
+    this.contributionContexts.add(
+        new ContributionContext(contribution, contributionStatus, location,
+            linkedSubscriptionResource));
+    return this;
+  }
+
+  /**
+   * Gets the contribution contexts.
+   * @return list of {@link ContributionContext} instance.
+   */
+  public List<ContributionContext> getContributionContexts() {
+    return contributionContexts;
+  }
+
+  /**
+   * Sets the context of persistence action performed on the entity.
+   * @param entityPersistenceAction the type of persistence action performed on the persisted
+   * entity.
+   * @return the instance of the current completed context.
+   */
+  public ContributionBatchManagementContext forPersistenceAction(
+      ActionType entityPersistenceAction) {
+    this.entityPersistenceAction = entityPersistenceAction;
+    return this;
+  }
+
+  /**
+   * Gets the persistence (or validation) action that is performed on the entity.
+   * @return the persistence (or validation) action that is performed on the entity.
+   */
+  public ActionType getEntityPersistenceAction() {
+    return entityPersistenceAction;
+  }
+
+  public static class ContributionContext {
+    private final Contribution contribution;
+    private final ContributionStatus contributionStatus;
+    private final Location location;
+    private final SubscriptionResource linkedSubscriptionResource;
+
+    private ContributionContext(final Contribution contribution,
+        final ContributionStatus contributionStatus, final Location location, final SubscriptionResource linkedSubscriptionResource) {
+      this.contribution = contribution;
+      this.contributionStatus = contributionStatus;
+      this.location = location;
+      this.linkedSubscriptionResource = linkedSubscriptionResource;
+    }
+
+    public Contribution getContribution() {
+      return contribution;
+    }
+
+    public ContributionStatus getContributionStatus() {
+      return contributionStatus;
+    }
+
+    public Location getLocation() {
+      return location;
+    }
+
+    public SubscriptionResource getLinkedSubscriptionResource() {
+      return linkedSubscriptionResource;
+    }
+  }
+}

--- a/core-library/src/main/java/org/silverpeas/core/contribution/util/ContributionManagementContext.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/util/ContributionManagementContext.java
@@ -27,6 +27,7 @@ import org.silverpeas.core.ActionType;
 import org.silverpeas.core.contribution.ContributionStatus;
 import org.silverpeas.core.contribution.model.Contribution;
 import org.silverpeas.core.contribution.model.ContributionIdentifier;
+import org.silverpeas.core.contribution.publication.model.Location;
 import org.silverpeas.core.subscription.SubscriptionResource;
 
 /**
@@ -38,6 +39,7 @@ import org.silverpeas.core.subscription.SubscriptionResource;
 public class ContributionManagementContext {
   private final ContributionIdentifier contributionId;
   private SubscriptionResource linkedSubscriptionResource;
+  private Location location;
   private ActionType entityPersistenceAction = ActionType.READ;
   private ContributionStatus entityStatusBeforePersistAction = ContributionStatus.UNKNOWN;
   private ContributionStatus entityStatusAfterPersistAction = ContributionStatus.UNKNOWN;
@@ -77,6 +79,16 @@ public class ContributionManagementContext {
   public ContributionManagementContext aboutSubscriptionResource(
       final SubscriptionResource linkedSubscriptionResource) {
     this.linkedSubscriptionResource = linkedSubscriptionResource;
+    return this;
+  }
+
+  /**
+   * Setup the location at which the subscription resource is aimed.
+   * @param location a {@link Location} instance from which MUST contribution is handled.
+   * @return itself.
+   */
+  public ContributionManagementContext atLocation(final Location location) {
+    this.location = location;
     return this;
   }
 
@@ -137,5 +149,13 @@ public class ContributionManagementContext {
    */
   public ContributionStatus getEntityStatusAfterPersistAction() {
     return entityStatusAfterPersistAction;
+  }
+
+  /**
+   * Gets the optional location of the contribution from which it is managed.
+   * @return a {@link Location} if any, null otherwise.
+   */
+  public Location getLocation() {
+    return location;
   }
 }

--- a/core-library/src/main/java/org/silverpeas/core/subscription/ResourceSubscriptionService.java
+++ b/core-library/src/main/java/org/silverpeas/core/subscription/ResourceSubscriptionService.java
@@ -76,6 +76,23 @@ public interface ResourceSubscriptionService {
       SubscriptionResourceType resourceType, String resourceId);
 
   /**
+   * Gets all subscribers concerned by a specified resource represented by the
+   * given resource type and identifier.<br>
+   * The inheritance of subscription is handled by this method. So if the aimed subscription
+   * resource has a parent subscription resource, subscribers of both of them are returned.
+   * @param componentInstanceId the identifier of the component instance from which subscription
+   * are requested.
+   * @param resourceType the type of the aimed resource.
+   * @param resourceId the identifier of the aimed resource.
+   * @param locationId the optional identifier of the location of the aimed resource.
+   * @return an instance of {@link SubscriptionSubscriberList} that
+   * represents a collection of {@link SubscriptionSubscriber} decorated with useful tool methods.
+   */
+  SubscriptionSubscriberList getSubscribersOfComponentAndTypedResourceOnLocation(
+      String componentInstanceId, SubscriptionResourceType resourceType, String resourceId,
+      String locationId);
+
+  /**
    * Gets all subscribers concerned by a specified subscription resource.<br>
    * The inheritance of subscription is handled by this method. So if the aimed subscription
    * resource has a parent subscription resource, subscribers of both of them are returned.
@@ -85,4 +102,16 @@ public interface ResourceSubscriptionService {
    */
   SubscriptionSubscriberList getSubscribersOfSubscriptionResource(
       SubscriptionResource subscriptionResource);
+
+  /**
+   * Gets all subscribers concerned by a specified subscription resource.<br>
+   * The inheritance of subscription is handled by this method. So if the aimed subscription
+   * resource has a parent subscription resource, subscribers of both of them are returned.
+   * @param subscriptionResource the instance of subscription resource.
+   * @param locationId the optional identifier of the location of the aimed subscription resource.
+   * @return an instance of {@link SubscriptionSubscriberList} that
+   * represents a collection of {@link SubscriptionSubscriber} decorated with useful tool methods.
+   */
+  SubscriptionSubscriberList getSubscribersOfSubscriptionResourceOnLocation(
+      SubscriptionResource subscriptionResource, String locationId);
 }

--- a/core-library/src/main/java/org/silverpeas/core/subscription/service/AbstractResourceSubscriptionService.java
+++ b/core-library/src/main/java/org/silverpeas/core/subscription/service/AbstractResourceSubscriptionService.java
@@ -23,6 +23,7 @@
  */
 package org.silverpeas.core.subscription.service;
 
+import org.silverpeas.core.NotSupportedException;
 import org.silverpeas.core.initialization.Initialization;
 import org.silverpeas.core.node.model.NodeDetail;
 import org.silverpeas.core.node.model.NodePK;
@@ -40,6 +41,7 @@ import java.util.HashSet;
 import static org.silverpeas.core.subscription.SubscriptionServiceProvider.getSubscribeService;
 import static org.silverpeas.core.subscription.constant.CommonSubscriptionResourceConstants.COMPONENT;
 import static org.silverpeas.core.subscription.constant.CommonSubscriptionResourceConstants.NODE;
+import static org.silverpeas.core.util.StringUtil.isDefined;
 
 /**
  * @author Yohann Chastagnier
@@ -86,6 +88,23 @@ public abstract class AbstractResourceSubscriptionService implements ResourceSub
       // nothing is done here about other types, explicit component implementation MUST exist.
     }
     return new SubscriptionSubscriberList(subscribers);
+  }
+
+  @Override
+  public SubscriptionSubscriberList getSubscribersOfSubscriptionResourceOnLocation(
+      final SubscriptionResource subscriptionResource, final String locationId) {
+    return getSubscribersOfComponentAndTypedResourceOnLocation(subscriptionResource.getInstanceId(),
+        subscriptionResource.getType(), subscriptionResource.getId(), locationId);
+  }
+
+  @Override
+  public SubscriptionSubscriberList getSubscribersOfComponentAndTypedResourceOnLocation(
+      final String componentInstanceId, final SubscriptionResourceType resourceType,
+      final String resourceId, final String locationId) {
+    if (isDefined(locationId)) {
+      throw new NotSupportedException("location is not supported");
+    }
+    return getSubscribersOfComponentAndTypedResource(componentInstanceId, resourceType, resourceId);
   }
 
   private void addAllSubscribersAboutComponentInstance(final String componentInstanceId,

--- a/core-library/src/main/java/org/silverpeas/core/subscription/service/ResourceSubscriptionProvider.java
+++ b/core-library/src/main/java/org/silverpeas/core/subscription/service/ResourceSubscriptionProvider.java
@@ -98,6 +98,27 @@ public class ResourceSubscriptionProvider {
   }
 
   /**
+   * Gets all subscribers concerned by a specified resource represented by the
+   * given resource type and identifier.<br>
+   * The inheritance of subscription is handled by this method. So if the aimed subscription
+   * resource has a parent subscription resource, subscribers of both of them are returned.
+   * @param componentInstanceId the identifier of the component instance from which subscription
+   * are requested.
+   * @param resourceType the type of the aimed resource.
+   * @param resourceId the identifier of the aime resource.
+   * @param locationId the identifier of the location the resource is currently checked.
+   * @return an instance of {@link SubscriptionSubscriberList} that
+   * represents a collection of {@link SubscriptionSubscriber} decorated
+   * with useful tool methods.
+   */
+  public static SubscriptionSubscriberList getSubscribersOfComponentAndTypedResourceOnLocation(
+      String componentInstanceId, SubscriptionResourceType resourceType, String resourceId,
+      final String locationId) {
+    return getService(componentInstanceId).getSubscribersOfComponentAndTypedResourceOnLocation(
+        componentInstanceId, resourceType, resourceId, locationId);
+  }
+
+  /**
    * Gets all subscribers concerned by a specified subscription resource.<br>
    * The inheritance of subscription is handled by this method. So if the aimed subscription
    * resource has a parent subscription resource, subscribers of both of them are returned.
@@ -110,6 +131,23 @@ public class ResourceSubscriptionProvider {
       SubscriptionResource subscriptionResource) {
     return getService(subscriptionResource.getInstanceId())
         .getSubscribersOfSubscriptionResource(subscriptionResource);
+  }
+
+  /**
+   * Gets all subscribers concerned by a specified subscription resource.<br>
+   * The inheritance of subscription is handled by this method. So if the aimed subscription
+   * resource has a parent subscription resource, subscribers of both of them are returned.
+   * @param subscriptionResource the instance of subscription resource.
+   * @param locationId the identifier of the location the resource is currently checked.
+   * @return an instance of {@link SubscriptionSubscriberList} that
+   * represents a collection of {@link SubscriptionSubscriber} decorated
+   * with useful tool methods.
+   */
+  public static SubscriptionSubscriberList getSubscribersOfSubscriptionResourceOnLocation(
+      SubscriptionResource subscriptionResource, String locationId) {
+    return getService(
+        subscriptionResource.getInstanceId()).getSubscribersOfSubscriptionResourceOnLocation(
+        subscriptionResource, locationId);
   }
 
   /**

--- a/core-war/src/main/webapp/WEB-INF/tags/silverpeas/util/attachmentDragAndDrop.tag
+++ b/core-war/src/main/webapp/WEB-INF/tags/silverpeas/util/attachmentDragAndDrop.tag
@@ -75,7 +75,10 @@
               description="The the subscription notification type to manage, if any." %>
 <%@ attribute name="handledSubscriptionResourceId" required="false"
               type="java.lang.String"
-              description="The the resource id of subscription notification to manage, if any." %>
+              description="The resource id of subscription notification to manage, if any." %>
+<%@ attribute name="handledSubscriptionLocationId" required="false"
+              type="java.lang.String"
+              description="The location id of location the subscription notification is managed, if any." %>
 <c:if test="${isHandledModificationContext == null}">
   <c:set var="isHandledModificationContext" value="${false}"/>
 </c:if>
@@ -197,11 +200,17 @@
         <c:when test="${isHandledSubscriptionConfirmation}">
         let rejectOnClose = true;
         $.subscription.confirmNotificationSendingOnUpdate({
+          contribution : {
+            contributionId : {
+              componentInstanceId : '${componentInstanceId}',
+              localId : '${resourceId}',
+              type : '${resourceType}'
+            },
+            locationId : '${handledSubscriptionLocationId}',
+            indexable : ${hasToBeIndexed}
+          },
           comment : {
-            saveNote : ${silfn:booleanValue(commentActivated)},
-            contributionLocalId : '${resourceId}',
-            contributionType : '${resourceType}',
-            contributionIndexable : ${hasToBeIndexed}
+            saveNote : ${silfn:booleanValue(commentActivated)}
           },
           subscription : {
             componentInstanceId : '${componentInstanceId}',

--- a/core-war/src/main/webapp/WEB-INF/tags/silverpeas/util/displayAttachments.tag
+++ b/core-war/src/main/webapp/WEB-INF/tags/silverpeas/util/displayAttachments.tag
@@ -80,6 +80,7 @@
 <c:set var="isHandledContributionModificationContext" value="${false}"/>
 <c:set var="_paramHandledSubscriptionType" value=""/>
 <c:set var="_paramHandledSubscriptionResourceId" value=""/>
+<c:set var="_paramHandledSubscriptionLocationId" value=""/>
 <c:if test="${not empty contributionManagementContext}">
   <c:if test="${contributionManagementContext.entityStatusBeforePersistAction.validated
               and contributionManagementContext.entityStatusAfterPersistAction.validated
@@ -87,6 +88,9 @@
     <c:set var="isHandledContributionModificationContext" value="${true}"/>
     <c:set var="_paramHandledSubscriptionType" value="${contributionManagementContext.linkedSubscriptionResource.type.name}"/>
     <c:set var="_paramHandledSubscriptionResourceId" value="${contributionManagementContext.linkedSubscriptionResource.id}"/>
+    <c:if test="${contributionManagementContext.location != null}">
+      <c:set var="_paramHandledSubscriptionLocationId" value="${contributionManagementContext.location.id}"/>
+    </c:if>
   </c:if>
 </c:if>
 <c:set var="isHandledSubscriptionConfirmation"
@@ -129,4 +133,5 @@
   <c:param name="HandledContributionModificationContext" value="${isHandledContributionModificationContext}"/>
   <c:param name="HandledSubscriptionType" value="${_paramHandledSubscriptionType}"/>
   <c:param name="HandledSubscriptionResourceId" value="${_paramHandledSubscriptionResourceId}"/>
+  <c:param name="HandledSubscriptionLocationId" value="${_paramHandledSubscriptionLocationId}"/>
 </c:import>

--- a/core-war/src/main/webapp/attachment/jsp/displayAttachedFiles.jsp
+++ b/core-war/src/main/webapp/attachment/jsp/displayAttachedFiles.jsp
@@ -90,6 +90,7 @@
 
   <c:set var="handledSubscriptionType" value="${param.HandledSubscriptionType}"/>
   <c:set var="handledSubscriptionResourceId" value="${param.HandledSubscriptionResourceId}"/>
+  <c:set var="handledSubscriptionLocationId" value="${param.HandledSubscriptionLocationId}"/>
   <c:set var="isHandledSubscriptionConfirmation"
          value="${not empty handledSubscriptionType and not empty handledSubscriptionResourceId}"/>
   <c:set var="isHandledModificationContext"
@@ -764,11 +765,17 @@
       var checkInWebDav = typeof params.checkInWebDav === 'undefined' || params.checkInWebDav;
       if (verifyVersionType(params.versionTypeDomRadioSelector) === 'public' && checkInWebDav) {
         $.subscription.confirmNotificationSendingOnUpdate({
+          contribution : {
+            contributionId : {
+              componentInstanceId : '${componentId}',
+              localId : '${param.Id}',
+              type : '${param.Type}'
+            },
+            locationId : '${handledSubscriptionLocationId}',
+            indexable : ${indexIt}
+          },
           comment : {
-            saveNote : ${silfn:booleanValue(commentActivated)},
-            contributionLocalId : '${param.Id}',
-            contributionType : '${param.Type}',
-            contributionIndexable : ${indexIt}
+            saveNote : ${silfn:booleanValue(commentActivated)}
           },
           subscription : {
             componentInstanceId : '${componentId}',
@@ -1508,5 +1515,6 @@
                                   documentType="${param.Context}"
                                   isHandledModificationContext="${isHandledModificationContext}"
                                   handledSubscriptionType="${handledSubscriptionType}"
-                                  handledSubscriptionResourceId="${handledSubscriptionResourceId}"/>
+                                  handledSubscriptionResourceId="${handledSubscriptionResourceId}"
+                                  handledSubscriptionLocationId="${handledSubscriptionLocationId}"/>
 </c:if>

--- a/core-war/src/main/webapp/contribution/jsp/messages/modificationContext.jsp
+++ b/core-war/src/main/webapp/contribution/jsp/messages/modificationContext.jsp
@@ -31,8 +31,11 @@
 <view:setBundle basename="org.silverpeas.contribution.multilang.contribution"/>
 
 <c:set var="isMinorModificationBahavior" value="${silfn:booleanValue(param.minorBehavior)}"/>
+<c:set var="isSeveralContributions" value="${silfn:booleanValue(param.several)}"/>
 <fmt:message var="minorQuestionLabel" key="contribution.modification.minor.question"/>
-<fmt:message var="minorHelpMessage" key="contribution.modification.minor.help"/>
+<fmt:message var="minorHelpMessage" key="contribution.modification.minor.help">
+  <fmt:param value="${isSeveralContributions ? 2 : 1}"/>
+</fmt:message>
 <fmt:message var="minorImportantsLabel" key="contribution.modification.minor.importants"/>
 
 <div class="contribution-modification-context">

--- a/core-war/src/main/webapp/wysiwyg/jsp/htmlEditor.jsp
+++ b/core-war/src/main/webapp/wysiwyg/jsp/htmlEditor.jsp
@@ -251,6 +251,7 @@
 <c:set var="isHtmlLoadingContext" value="${actionWysiwyg eq 'Load' or actionWysiwyg eq 'Refresh'}"/>
 <c:set var="handledSubscriptionType" value="${param.handledSubscriptionType}"/>
 <c:set var="handledSubscriptionResourceId" value="${param.handledSubscriptionResourceId}"/>
+<c:set var="handledSubscriptionLocationId" value=""/>
 <c:set var="contributionManagementContext" value="${requestScope.contributionManagementContext}"/>
 <c:set var="wysiwygTextValue" value="<%=wysiwygTextValue%>"/>
 <c:set var="isModificationContextEnabled" value="${false}"/>
@@ -262,6 +263,9 @@
     <c:set var="isModificationContextEnabled" value="${true}"/>
     <c:set var="handledSubscriptionType" value="${contributionManagementContext.linkedSubscriptionResource.type.name}"/>
     <c:set var="handledSubscriptionResourceId" value="${contributionManagementContext.linkedSubscriptionResource.id}"/>
+    <c:if test="${contributionManagementContext.location != null}">
+      <c:set var="handledSubscriptionLocationId" value="${contributionManagementContext.location.id}"/>
+    </c:if>
   </c:if>
 </c:if>
 <c:set var="isHandledSubscriptionConfirmation"
@@ -423,11 +427,13 @@
             <c:choose>
             <c:when test="${silfn:isDefined(wysiwygTextValue) and isHandledSubscriptionConfirmation}">
             jQuery.subscription.confirmNotificationSendingOnUpdate({
+              contribution : {
+                contributionId : contributionId,
+                indexable : <%=indexIt%>,
+                locationId : '${handledSubscriptionLocationId}'
+              },
               comment : {
-                saveNote : ${silfn:booleanValue(commentActivated)},
-                contributionLocalId : contributionId.localId,
-                contributionType : contributionId.type,
-                contributionIndexable : <%=indexIt%>
+                saveNote : ${silfn:booleanValue(commentActivated)}
               },
               subscription : {
                 componentInstanceId : '<%=componentId%>',

--- a/core-web/src/main/java/org/silverpeas/core/web/util/viewgenerator/html/buttons/AbstractContributionManagementContextTag.java
+++ b/core-web/src/main/java/org/silverpeas/core/web/util/viewgenerator/html/buttons/AbstractContributionManagementContextTag.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright (C) 2000 - 2021 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.silverpeas.core.web.util.viewgenerator.html.buttons;
+
+import org.apache.ecs.ElementContainer;
+import org.apache.ecs.xhtml.script;
+import org.silverpeas.core.admin.service.OrganizationController;
+import org.silverpeas.core.contribution.ContributionStatus;
+import org.silverpeas.core.contribution.model.ContributionIdentifier;
+import org.silverpeas.core.contribution.publication.model.Location;
+import org.silverpeas.core.html.SupportedWebPlugins;
+import org.silverpeas.core.html.WebPlugin;
+import org.silverpeas.core.subscription.SubscriptionResourceType;
+import org.silverpeas.core.util.StringUtil;
+import org.silverpeas.core.web.http.HttpRequest;
+import org.silverpeas.core.web.util.viewgenerator.html.GraphicElementFactory;
+
+import javax.servlet.jsp.JspException;
+import javax.servlet.jsp.tagext.TagSupport;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static java.util.Optional.ofNullable;
+import static org.silverpeas.core.subscription.constant.CommonSubscriptionResourceConstants.COMPONENT;
+import static org.silverpeas.core.web.util.viewgenerator.html.JavascriptPluginInclusion.getDynamicSubscriptionJavascriptLoadContent;
+
+
+abstract class AbstractContributionManagementContextTag extends TagSupport {
+  private static final long serialVersionUID = 317414465687842654L;
+
+  public abstract String getJsValidationCallbackMethodName();
+  abstract List<Item> getItems();
+
+  public AbstractContributionManagementContextTag() {
+    this.init();
+  }
+
+  @Override
+  public void release() {
+    super.release();
+    this.init();
+  }
+
+  abstract void init();
+
+  @Override
+  public int doEndTag() throws JspException {
+    ButtonTag buttonTag = (ButtonTag) findAncestorWithClass(this, ButtonTag.class);
+    if (buttonTag != null) {
+      buttonTag.setActionPreProcessing("");
+      ElementContainer xhtml = new ElementContainer();
+      xhtml.addElement(WebPlugin.get()
+          .getHtml(SupportedWebPlugins.CONTRIBUTIONMODICTX, getRequest().getUserLanguage()));
+      xhtml.addElement(new script().setType("text/javascript")
+          .addElement(getDynamicSubscriptionJavascriptLoadContent(null)));
+      xhtml.output(pageContext.getOut());
+      buttonTag.setActionPreProcessing(renderJs());
+      return EVAL_PAGE;
+    } else {
+      throw new JspException(this.getClass().getSimpleName() + " must be wrapped by " +
+          ButtonTag.class.getSimpleName());
+    }
+  }
+
+  @Override
+  public int doStartTag() throws JspException {
+    return EVAL_BODY_INCLUDE;
+  }
+
+  protected HttpRequest getRequest() {
+    return (HttpRequest) pageContext.getRequest();
+  }
+
+  protected String renderJs() {
+    final List<Item> items = getItems();
+    final StringBuilder sb = new StringBuilder();
+    sb.append("jQuery.contributionModificationContext.validateOnUpdate({");
+    sb.append("  items:[");
+    sb.append(items.stream()
+        .map(this::renderContributionObject)
+        .collect(Collectors.joining(",")));
+    sb.append("  ]");
+    sb.append("  ,callback: function() {");
+    sb.append(renderSubscriptionJs(items));
+    sb.append("  }");
+    if (StringUtil.isDefined(getJsValidationCallbackMethodName())) {
+      sb.append("  ,validationCallback:").append(getJsValidationCallbackMethodName());
+    }
+    sb.append("});");
+    return sb.toString();
+  }
+
+  protected String renderContributionObject(final Item item) {
+    final ContributionIdentifier cId = ofNullable(item.contributionId).orElseGet(() -> {
+      GraphicElementFactory gef = (GraphicElementFactory) pageContext.getSession()
+          .getAttribute(GraphicElementFactory.GE_FACTORY_SESSION_ATT);
+      final String componentId = gef.getComponentIdOfCurrentRequest();
+      return ContributionIdentifier.from(componentId, componentId, "UNKNOWN");
+    });
+    final String status = item.contributionStatus != null ?
+        String.format("'%s'", item.contributionStatus) :
+        "undefined";
+    final String locationId = item.location != null &&
+        item.location.getComponentInstanceId().equals(item.contributionId.getComponentInstanceId()) ?
+        String.format("'%s'", item.location.getLocalId()) :
+        "undefined";
+    final String indexable = item.contributionIndexable != null ?
+        item.contributionIndexable.toString().toLowerCase() :
+        "true";
+    return String.format(
+        "{contributionId:{componentInstanceId:'%s',localId:'%s',type:'%s'},status:%s,locationId:%s,indexable:%s}",
+        cId.getComponentInstanceId(), cId.getLocalId(), cId.getType(), status, locationId, indexable);
+  }
+
+  protected String renderSubscriptionJs(final List<Item> items) {
+    GraphicElementFactory gef = (GraphicElementFactory) pageContext.getSession()
+        .getAttribute(GraphicElementFactory.GE_FACTORY_SESSION_ATT);
+
+    final String componentId = gef.getComponentIdOfCurrentRequest();
+    boolean tabComments = StringUtil.getBooleanValue(
+        OrganizationController.get().getComponentParameterValue(componentId, "tabComments"));
+    boolean comments = StringUtil.getBooleanValue(
+        OrganizationController.get().getComponentParameterValue(componentId, "comments"));
+
+    final StringBuilder sb = new StringBuilder();
+    sb.append("jQuery.subscription.confirmNotificationSendingOnUpdate({items:[");
+    sb.append(items.stream()
+        .map(i -> renderContributionSubscriptionItem(componentId, i, tabComments || comments))
+        .collect(Collectors.joining(",")));
+    sb.append("  ],callback: function() {");
+    sb.append("    {action};");
+    sb.append("  }");
+    if (StringUtil.isDefined(getJsValidationCallbackMethodName())) {
+      sb.append("  ,validationCallback:").append(getJsValidationCallbackMethodName());
+    }
+    sb.append("});");
+    return sb.toString();
+  }
+
+  protected String renderContributionSubscriptionItem(final String componentId, final Item item,
+      final boolean isComment) {
+    final StringBuilder sb = new StringBuilder();
+    sb.append("{contribution:").append(renderContributionObject(item));
+    sb.append(",subscription:{");
+    sb.append("  componentInstanceId:'").append(componentId).append("'");
+    final SubscriptionResourceType type = item.subscriptionResourceType;
+    sb.append("  ,type:").append("$.subscription.subscriptionType.").append(type.getName());
+    if (COMPONENT != type) {
+      sb.append("  ,resourceId:'").append(item.subscriptionResourceId).append("'");
+    }
+    sb.append("  }");
+    if (isComment) {
+      sb.append("  ,comment:{");
+      sb.append("saveNote : true");
+      sb.append("}");
+    }
+    return sb.append("}").toString();
+  }
+
+  static class Item {
+    ContributionIdentifier contributionId;
+    ContributionStatus contributionStatus;
+    Location location;
+    SubscriptionResourceType subscriptionResourceType = COMPONENT;
+    String subscriptionResourceId = null;
+    Boolean contributionIndexable = true;
+  }
+}

--- a/core-web/src/main/java/org/silverpeas/core/web/util/viewgenerator/html/buttons/ContributionBatchManagementContextTag.java
+++ b/core-web/src/main/java/org/silverpeas/core/web/util/viewgenerator/html/buttons/ContributionBatchManagementContextTag.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2000 - 2021 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.silverpeas.core.web.util.viewgenerator.html.buttons;
+
+import org.silverpeas.core.contribution.model.Contribution;
+import org.silverpeas.core.contribution.util.ContributionBatchManagementContext;
+import org.silverpeas.core.subscription.SubscriptionResource;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * This TAG can be called into a {@link ButtonTag}.<br>
+ * It permits to display a popups in order to ask to the user some validation and confirmations.
+ * <p>
+ *   For now, it asks:
+ *   <ul>
+ *     <li>for minor/major modifications</li>
+ *     <li>for user notification sending</li>
+ *   </ul>
+ * </p>
+ */
+public class ContributionBatchManagementContextTag extends AbstractContributionManagementContextTag {
+  private static final long serialVersionUID = -3652425520811693463L;
+
+  private transient ContributionBatchManagementContext context;
+  private String jsValidationCallbackMethodName;
+
+  public ContributionBatchManagementContext getContext() {
+    return context;
+  }
+
+  public ContributionBatchManagementContextTag() {
+    super();
+  }
+
+  public void setContext(final ContributionBatchManagementContext context) {
+    this.context = context;
+  }
+
+  @Override
+  public String getJsValidationCallbackMethodName() {
+    return jsValidationCallbackMethodName;
+  }
+
+  @Override
+  void init() {
+    context = null;
+    jsValidationCallbackMethodName = null;
+  }
+
+  @Override
+  List<Item> getItems() {
+    return getContext().getContributionContexts().stream().map(c -> {
+      final Item item = new Item();
+      final Contribution contribution = c.getContribution();
+      item.contributionId = contribution.getIdentifier();
+      item.contributionIndexable = contribution.isIndexable();
+      item.contributionStatus = c.getContributionStatus();
+      item.location = c.getLocation();
+      final SubscriptionResource subscriptionResource = c.getLinkedSubscriptionResource();
+      item.subscriptionResourceId = subscriptionResource.getId();
+      item.subscriptionResourceType = subscriptionResource.getType();
+      return item;
+    }).collect(Collectors.toList());
+  }
+
+  public void setJsValidationCallbackMethodName(final String jsValidationCallbackMethodName) {
+    this.jsValidationCallbackMethodName = jsValidationCallbackMethodName;
+  }
+}

--- a/core-web/src/main/java/org/silverpeas/core/web/util/viewgenerator/html/layout/BodyPartLayoutTag.java
+++ b/core-web/src/main/java/org/silverpeas/core/web/util/viewgenerator/html/layout/BodyPartLayoutTag.java
@@ -41,6 +41,10 @@ public class BodyPartLayoutTag extends SilverpeasLayout {
   private String cssClass;
   private String ngController;
 
+  public BodyPartLayoutTag() {
+    super();
+  }
+
   public void setOnLoad(final String onLoad) {
     this.onLoad = onLoad;
   }
@@ -51,6 +55,13 @@ public class BodyPartLayoutTag extends SilverpeasLayout {
 
   public void setNgController(final String ngController) {
     this.ngController = ngController;
+  }
+
+  @Override
+  void init() {
+    onLoad = null;
+    cssClass = null;
+    ngController = null;
   }
 
   @Override

--- a/core-web/src/main/java/org/silverpeas/core/web/util/viewgenerator/html/layout/HeadLayoutPartTag.java
+++ b/core-web/src/main/java/org/silverpeas/core/web/util/viewgenerator/html/layout/HeadLayoutPartTag.java
@@ -55,6 +55,10 @@ public class HeadLayoutPartTag extends SilverpeasLayout {
   private boolean withFieldsetStyle;
   private boolean withCheckFormScript;
 
+  public HeadLayoutPartTag() {
+    super();
+  }
+
   public void setAtTop(final String atTop) {
     this.atTop = atTop;
   }
@@ -77,6 +81,16 @@ public class HeadLayoutPartTag extends SilverpeasLayout {
 
   public void setWithFieldsetStyle(final boolean withFieldsetStyle) {
     this.withFieldsetStyle = withFieldsetStyle;
+  }
+
+  @Override
+  void init() {
+    atTop = null;
+    minimalSilverpeasScriptEnv = false;
+    noLookAndFeel = false;
+    lookContextManagerCallbackOnly = false;
+    withFieldsetStyle = false;
+    withCheckFormScript = false;
   }
 
   @Override

--- a/core-web/src/main/java/org/silverpeas/core/web/util/viewgenerator/html/layout/HtmlLayoutTag.java
+++ b/core-web/src/main/java/org/silverpeas/core/web/util/viewgenerator/html/layout/HtmlLayoutTag.java
@@ -54,6 +54,10 @@ public class HtmlLayoutTag extends SilverpeasLayout {
 
   private boolean angularJsAppInitializedManually;
 
+  public HtmlLayoutTag() {
+    super();
+  }
+
   public void setAngularJsAppName(final String angularJsAppName) {
     this.angularJsAppName = angularJsAppName;
   }
@@ -68,6 +72,12 @@ public class HtmlLayoutTag extends SilverpeasLayout {
 
   boolean isAngularJsAppInitializedManually() {
     return angularJsAppInitializedManually;
+  }
+
+  @Override
+  void init() {
+    this.angularJsAppName = null;
+    this.angularJsAppInitializedManually = false;
   }
 
   @Override

--- a/core-web/src/main/java/org/silverpeas/core/web/util/viewgenerator/html/layout/SilverpeasLayout.java
+++ b/core-web/src/main/java/org/silverpeas/core/web/util/viewgenerator/html/layout/SilverpeasLayout.java
@@ -44,8 +44,12 @@ import static org.silverpeas.core.web.mvc.controller.MainSessionController.MAIN_
  * Centralizing common data providing.
  * @author silveryocha
  */
-class SilverpeasLayout extends BodyTagSupport {
+abstract class SilverpeasLayout extends BodyTagSupport {
   private static final long serialVersionUID = -8485442477706985045L;
+
+  public SilverpeasLayout() {
+    this.init();
+  }
 
   private Optional<MainSessionController> getMainSessionController() {
     final HttpSession session = ((HttpServletRequest) pageContext.getRequest()).getSession(false);
@@ -80,4 +84,12 @@ class SilverpeasLayout extends BodyTagSupport {
         ? resources.getMultilangBundle()
         : getGeneralLocalizationBundle(getUserLanguage());
   }
+
+  @Override
+  public void release() {
+    super.release();
+    this.init();
+  }
+
+  abstract void init();
 }

--- a/core-web/src/main/java/org/silverpeas/core/webapi/subscribe/SubscriptionResource.java
+++ b/core-web/src/main/java/org/silverpeas/core/webapi/subscribe/SubscriptionResource.java
@@ -185,7 +185,7 @@ public class SubscriptionResource extends AbstractSubscriptionResource {
   public Response getComponentSubscribersWithInheritance(
       @PathParam("subscriptionType") String subscriptionType,
       @QueryParam("existenceIndicatorOnly") boolean existenceIndicatorOnly) {
-    return getSubscribersWithInheritance(subscriptionType, null, existenceIndicatorOnly);
+    return getSubscribersWithInheritance(subscriptionType, null, null, existenceIndicatorOnly);
   }
 
   /**
@@ -197,6 +197,7 @@ public class SubscriptionResource extends AbstractSubscriptionResource {
    * @param subscriptionType the type of subscription.
    * @param resourceId identifier of the aimed resource (NODE for now). When a new type of resource
    * will be managed, the resource type will have to be passed into URI
+   * @param locationId optional identifier of the current location of the requested resource.
    * @param existenceIndicatorOnly indicates if the return must only be true (if it exists at
    * least one subscriber) or false (no subscribers).
    * @return the response to the HTTP GET request with the JSON representation of the asked
@@ -206,6 +207,7 @@ public class SubscriptionResource extends AbstractSubscriptionResource {
   @Path("{subscriptionType}/" + SubscriptionResourceURIs.SUBSCRIPTION_SUBSCRIBER_URI_PART + "/inheritance/{id}")
   public Response getSubscribersWithInheritance(
       @PathParam("subscriptionType") String subscriptionType, @PathParam("id") String resourceId,
+      @QueryParam("locationId") String locationId,
       @QueryParam("existenceIndicatorOnly") boolean existenceIndicatorOnly) {
     try {
       final SubscriptionResourceType parsedSubscriptionResourceType = decodeSubscriptionResourceType(subscriptionType);
@@ -217,8 +219,8 @@ public class SubscriptionResource extends AbstractSubscriptionResource {
         throw new WebApplicationException(Status.NOT_FOUND);
       }
       SubscriptionSubscriberList subscribers = ResourceSubscriptionProvider
-          .getSubscribersOfComponentAndTypedResource(getComponentId(),
-              parsedSubscriptionResourceType, resourceId);
+          .getSubscribersOfComponentAndTypedResourceOnLocation(getComponentId(),
+              parsedSubscriptionResourceType, resourceId, locationId);
       if (existenceIndicatorOnly) {
         return Response
             .ok(String.valueOf(!subscribers.getAllUserIds().isEmpty()), MediaType.APPLICATION_JSON)

--- a/core-web/src/main/resources/META-INF/viewGenerator.tld
+++ b/core-web/src/main/resources/META-INF/viewGenerator.tld
@@ -884,6 +884,13 @@
       <type>java.lang.String</type>
     </attribute>
     <attribute>
+      <description>The optional location</description>
+      <name>location</name>
+      <required>false</required>
+      <rtexprvalue>true</rtexprvalue>
+      <type>org.silverpeas.core.contribution.publication.model.Location</type>
+    </attribute>
+    <attribute>
       <description>Specify the name of the method to call in order to validate the data filled by
         a user. The method must return true if data filled are ok, false otherwise.</description>
       <name>jsValidationCallbackMethodName</name>
@@ -899,6 +906,33 @@
       <required>false</required>
       <rtexprvalue>true</rtexprvalue>
       <type>java.lang.Boolean</type>
+    </attribute>
+  </tag>
+  <tag>
+    <description>This TAG must be called into body of Button TAG.
+      It permits to handle a user contribution batch context.
+    </description>
+    <name>handleContributionBatchManagementContext</name>
+    <tag-class>
+      org.silverpeas.core.web.util.viewgenerator.html.buttons.ContributionBatchManagementContextTag
+    </tag-class>
+    <body-content>JSP</body-content>
+    <attribute>
+      <description>
+        The instance of the batch context
+      </description>
+      <name>context</name>
+      <required>true</required>
+      <rtexprvalue>true</rtexprvalue>
+      <type>org.silverpeas.core.contribution.util.ContributionBatchManagementContext</type>
+    </attribute>
+    <attribute>
+      <description>Specify the name of the method to call in order to validate the data filled by
+        a user. The method must return true if data filled are ok, false otherwise.</description>
+      <name>jsValidationCallbackMethodName</name>
+      <required>false</required>
+      <rtexprvalue>true</rtexprvalue>
+      <type>java.lang.String</type>
     </attribute>
   </tag>
   <tag>


### PR DESCRIPTION
Making the transversal mechanism of popins on contribution modification working on a batch of resources instead of working only on a single one.
A new TAG has been implemented in order to manage a batch of contribution.

Adding the management of a location into mechanism which is checking existence of subscription. It is used for guessing rightly subscriptions into case of an alias.

Fixing a bad behavior on ImageFieldDisplayer which was playing the load of the HTML page as many times as it exists image field.

Cleaning rightly the transversal TAGs written in order to manage the build of a Silverpeas's HTML page.

The Javascript plugins can now working on a single resource or on a batch of resource.

Linked to PR: https://github.com/Silverpeas/Silverpeas-Components/pull/746