### PR TITLE
Bug #12581: fixing the subscription validation popin which was not displayed in some cases when it was supposed to

### DIFF
--- a/core-library/src/integration-test/java/org/silverpeas/core/subscription/ResourceSubscriptionProviderIT.java
+++ b/core-library/src/integration-test/java/org/silverpeas/core/subscription/ResourceSubscriptionProviderIT.java
@@ -87,7 +87,7 @@ public class ResourceSubscriptionProviderIT extends AbstractCommonSubscriptionIn
     @Override
     public SubscriptionSubscriberList getSubscribersOfComponentAndTypedResource(
         final String componentInstanceId, final SubscriptionResourceType resourceType,
-        final String resourceId) {
+        final String resourceId, final SubscriberDirective... directives) {
       SubscriptionSubscriberList result = new SubscriptionSubscriberList();
       result
           .add(UserSubscriptionSubscriber.from("userIdFromTestKmeliaResourceSubscriptionService"));

--- a/core-library/src/main/java/org/silverpeas/core/calendar/subscription/AbstractCalendarSubscriptionService.java
+++ b/core-library/src/main/java/org/silverpeas/core/calendar/subscription/AbstractCalendarSubscriptionService.java
@@ -25,6 +25,7 @@ package org.silverpeas.core.calendar.subscription;
 
 import org.silverpeas.core.ResourceReference;
 import org.silverpeas.core.calendar.Calendar;
+import org.silverpeas.core.subscription.SubscriberDirective;
 import org.silverpeas.core.subscription.SubscriptionFactory;
 import org.silverpeas.core.subscription.SubscriptionResourceType;
 import org.silverpeas.core.subscription.SubscriptionSubscriber;
@@ -57,7 +58,7 @@ public abstract class AbstractCalendarSubscriptionService extends AbstractResour
   @Override
   public SubscriptionSubscriberList getSubscribersOfComponentAndTypedResource(
       final String componentInstanceId, final SubscriptionResourceType resourceType,
-      final String resourceId) {
+      final String resourceId, final SubscriberDirective... directives) {
     final Collection<SubscriptionSubscriber> subscribers = new HashSet<>();
     SubscriptionResourceType nextTypeToHandle = resourceType;
     if (nextTypeToHandle == CALENDAR) {

--- a/core-library/src/main/java/org/silverpeas/core/contribution/publication/subscription/LocationFilterDirective.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/publication/subscription/LocationFilterDirective.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2000 - 2021 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.contribution.publication.subscription;
+
+import org.silverpeas.core.contribution.publication.model.Location;
+import org.silverpeas.core.subscription.SubscriberDirective;
+
+import java.util.function.Predicate;
+
+/**
+ * This directive permits to apply a location filtering, known by the caller, when searching for
+ * subscribers about a publication.
+ * @author silveryocha
+ */
+public class LocationFilterDirective implements SubscriberDirective {
+  private final Predicate<Location> filter;
+
+  private LocationFilterDirective(final Predicate<Location> filter) {
+    this.filter = filter;
+  }
+
+  public static LocationFilterDirective withLocationFilter(final Predicate<Location> filter) {
+    return new LocationFilterDirective(filter);
+  }
+
+  public Predicate<Location> getFilter() {
+    return filter;
+  }
+}

--- a/core-library/src/main/java/org/silverpeas/core/contribution/publication/subscription/OnLocationDirective.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/publication/subscription/OnLocationDirective.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2000 - 2021 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.contribution.publication.subscription;
+
+import org.silverpeas.core.subscription.SubscriberDirective;
+
+/**
+ * This directive permits to communicate the location identifier to handle the subscriber search
+ * for on a publication ALIAS.
+ * @author silveryocha
+ */
+public class OnLocationDirective implements SubscriberDirective {
+  private final String locationId;
+
+  private OnLocationDirective(final String locationId) {
+    this.locationId = locationId;
+  }
+
+  public static OnLocationDirective onLocationId(final String locationId) {
+    return new OnLocationDirective(locationId);
+  }
+
+  public String getLocationId() {
+    return locationId;
+  }
+}

--- a/core-library/src/main/java/org/silverpeas/core/subscription/ResourceSubscriptionService.java
+++ b/core-library/src/main/java/org/silverpeas/core/subscription/ResourceSubscriptionService.java
@@ -68,29 +68,13 @@ public interface ResourceSubscriptionService {
    * @param componentInstanceId the identifier of the component instance from which subscription
    * are requested.
    * @param resourceType the type of the aimed resource.
-   * @param resourceId the identifier of the aime resource.
+   * @param resourceId the identifier of the aimed resource.
+   * @param directives some directive to apply when it is necessary.
    * @return an instance of {@link SubscriptionSubscriberList} that
    * represents a collection of {@link SubscriptionSubscriber} decorated with useful tool methods.
    */
   SubscriptionSubscriberList getSubscribersOfComponentAndTypedResource(String componentInstanceId,
-      SubscriptionResourceType resourceType, String resourceId);
-
-  /**
-   * Gets all subscribers concerned by a specified resource represented by the
-   * given resource type and identifier.<br>
-   * The inheritance of subscription is handled by this method. So if the aimed subscription
-   * resource has a parent subscription resource, subscribers of both of them are returned.
-   * @param componentInstanceId the identifier of the component instance from which subscription
-   * are requested.
-   * @param resourceType the type of the aimed resource.
-   * @param resourceId the identifier of the aimed resource.
-   * @param locationId the optional identifier of the location of the aimed resource.
-   * @return an instance of {@link SubscriptionSubscriberList} that
-   * represents a collection of {@link SubscriptionSubscriber} decorated with useful tool methods.
-   */
-  SubscriptionSubscriberList getSubscribersOfComponentAndTypedResourceOnLocation(
-      String componentInstanceId, SubscriptionResourceType resourceType, String resourceId,
-      String locationId);
+      SubscriptionResourceType resourceType, String resourceId, SubscriberDirective... directives);
 
   /**
    * Gets all subscribers concerned by a specified subscription resource.<br>
@@ -101,17 +85,5 @@ public interface ResourceSubscriptionService {
    * represents a collection of {@link SubscriptionSubscriber} decorated with useful tool methods.
    */
   SubscriptionSubscriberList getSubscribersOfSubscriptionResource(
-      SubscriptionResource subscriptionResource);
-
-  /**
-   * Gets all subscribers concerned by a specified subscription resource.<br>
-   * The inheritance of subscription is handled by this method. So if the aimed subscription
-   * resource has a parent subscription resource, subscribers of both of them are returned.
-   * @param subscriptionResource the instance of subscription resource.
-   * @param locationId the optional identifier of the location of the aimed subscription resource.
-   * @return an instance of {@link SubscriptionSubscriberList} that
-   * represents a collection of {@link SubscriptionSubscriber} decorated with useful tool methods.
-   */
-  SubscriptionSubscriberList getSubscribersOfSubscriptionResourceOnLocation(
-      SubscriptionResource subscriptionResource, String locationId);
+      SubscriptionResource subscriptionResource, SubscriberDirective... directives);
 }

--- a/core-library/src/main/java/org/silverpeas/core/subscription/SubscriberDirective.java
+++ b/core-library/src/main/java/org/silverpeas/core/subscription/SubscriberDirective.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2000 - 2021 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.silverpeas.core.subscription;
+
+/**
+ * Definition of directive to apply on subscriber search for.
+ * @author silveryocha
+ */
+public interface SubscriberDirective {
+}

--- a/core-library/src/main/java/org/silverpeas/core/subscription/service/AbstractResourceSubscriptionService.java
+++ b/core-library/src/main/java/org/silverpeas/core/subscription/service/AbstractResourceSubscriptionService.java
@@ -23,13 +23,13 @@
  */
 package org.silverpeas.core.subscription.service;
 
-import org.silverpeas.core.NotSupportedException;
 import org.silverpeas.core.initialization.Initialization;
 import org.silverpeas.core.node.model.NodeDetail;
 import org.silverpeas.core.node.model.NodePK;
 import org.silverpeas.core.node.model.NodePath;
 import org.silverpeas.core.node.service.NodeService;
 import org.silverpeas.core.subscription.ResourceSubscriptionService;
+import org.silverpeas.core.subscription.SubscriberDirective;
 import org.silverpeas.core.subscription.SubscriptionResource;
 import org.silverpeas.core.subscription.SubscriptionResourceType;
 import org.silverpeas.core.subscription.SubscriptionSubscriber;
@@ -41,7 +41,6 @@ import java.util.HashSet;
 import static org.silverpeas.core.subscription.SubscriptionServiceProvider.getSubscribeService;
 import static org.silverpeas.core.subscription.constant.CommonSubscriptionResourceConstants.COMPONENT;
 import static org.silverpeas.core.subscription.constant.CommonSubscriptionResourceConstants.NODE;
-import static org.silverpeas.core.util.StringUtil.isDefined;
 
 /**
  * @author Yohann Chastagnier
@@ -67,15 +66,15 @@ public abstract class AbstractResourceSubscriptionService implements ResourceSub
 
   @Override
   public SubscriptionSubscriberList getSubscribersOfSubscriptionResource(
-      final SubscriptionResource subscriptionResource) {
+      final SubscriptionResource subscriptionResource, final SubscriberDirective... directives) {
     return getSubscribersOfComponentAndTypedResource(subscriptionResource.getInstanceId(),
-        subscriptionResource.getType(), subscriptionResource.getId());
+        subscriptionResource.getType(), subscriptionResource.getId(), directives);
   }
 
   @Override
   public SubscriptionSubscriberList getSubscribersOfComponentAndTypedResource(
       final String componentInstanceId, final SubscriptionResourceType resourceType,
-      final String resourceId) {
+      final String resourceId, final SubscriberDirective... directives) {
     final Collection<SubscriptionSubscriber> subscribers = new HashSet<>();
     if (NODE == resourceType) {
       final NodePath path = !"kmax".equals(componentInstanceId) ? getNodeService()
@@ -88,23 +87,6 @@ public abstract class AbstractResourceSubscriptionService implements ResourceSub
       // nothing is done here about other types, explicit component implementation MUST exist.
     }
     return new SubscriptionSubscriberList(subscribers);
-  }
-
-  @Override
-  public SubscriptionSubscriberList getSubscribersOfSubscriptionResourceOnLocation(
-      final SubscriptionResource subscriptionResource, final String locationId) {
-    return getSubscribersOfComponentAndTypedResourceOnLocation(subscriptionResource.getInstanceId(),
-        subscriptionResource.getType(), subscriptionResource.getId(), locationId);
-  }
-
-  @Override
-  public SubscriptionSubscriberList getSubscribersOfComponentAndTypedResourceOnLocation(
-      final String componentInstanceId, final SubscriptionResourceType resourceType,
-      final String resourceId, final String locationId) {
-    if (isDefined(locationId)) {
-      throw new NotSupportedException("location is not supported");
-    }
-    return getSubscribersOfComponentAndTypedResource(componentInstanceId, resourceType, resourceId);
   }
 
   private void addAllSubscribersAboutComponentInstance(final String componentInstanceId,

--- a/core-library/src/main/java/org/silverpeas/core/subscription/service/ResourceSubscriptionProvider.java
+++ b/core-library/src/main/java/org/silverpeas/core/subscription/service/ResourceSubscriptionProvider.java
@@ -26,6 +26,7 @@ package org.silverpeas.core.subscription.service;
 import org.silverpeas.core.admin.component.model.SilverpeasComponentInstance;
 import org.silverpeas.core.admin.service.OrganizationController;
 import org.silverpeas.core.subscription.ResourceSubscriptionService;
+import org.silverpeas.core.subscription.SubscriberDirective;
 import org.silverpeas.core.subscription.SubscriptionResource;
 import org.silverpeas.core.subscription.SubscriptionResourceType;
 import org.silverpeas.core.subscription.SubscriptionSubscriber;
@@ -87,35 +88,16 @@ public class ResourceSubscriptionProvider {
    * are requested.
    * @param resourceType the type of the aimed resource.
    * @param resourceId the identifier of the aime resource.
+   * @param directives some directive to apply when it is necessary.
    * @return an instance of {@link SubscriptionSubscriberList} that
    * represents a collection of {@link SubscriptionSubscriber} decorated
    * with useful tool methods.
    */
   public static SubscriptionSubscriberList getSubscribersOfComponentAndTypedResource(
-      String componentInstanceId, SubscriptionResourceType resourceType, String resourceId) {
-    return getService(componentInstanceId)
-        .getSubscribersOfComponentAndTypedResource(componentInstanceId, resourceType, resourceId);
-  }
-
-  /**
-   * Gets all subscribers concerned by a specified resource represented by the
-   * given resource type and identifier.<br>
-   * The inheritance of subscription is handled by this method. So if the aimed subscription
-   * resource has a parent subscription resource, subscribers of both of them are returned.
-   * @param componentInstanceId the identifier of the component instance from which subscription
-   * are requested.
-   * @param resourceType the type of the aimed resource.
-   * @param resourceId the identifier of the aime resource.
-   * @param locationId the identifier of the location the resource is currently checked.
-   * @return an instance of {@link SubscriptionSubscriberList} that
-   * represents a collection of {@link SubscriptionSubscriber} decorated
-   * with useful tool methods.
-   */
-  public static SubscriptionSubscriberList getSubscribersOfComponentAndTypedResourceOnLocation(
       String componentInstanceId, SubscriptionResourceType resourceType, String resourceId,
-      final String locationId) {
-    return getService(componentInstanceId).getSubscribersOfComponentAndTypedResourceOnLocation(
-        componentInstanceId, resourceType, resourceId, locationId);
+      SubscriberDirective... directives) {
+    return getService(componentInstanceId).getSubscribersOfComponentAndTypedResource(
+        componentInstanceId, resourceType, resourceId, directives);
   }
 
   /**
@@ -123,31 +105,15 @@ public class ResourceSubscriptionProvider {
    * The inheritance of subscription is handled by this method. So if the aimed subscription
    * resource has a parent subscription resource, subscribers of both of them are returned.
    * @param subscriptionResource the instance of subscription resource.
+   * @param directives some directive to apply when it is necessary.
    * @return an instance of {@link SubscriptionSubscriberList} that
    * represents a collection of {@link SubscriptionSubscriber} decorated
    * with useful tool methods.
    */
   public static SubscriptionSubscriberList getSubscribersOfSubscriptionResource(
-      SubscriptionResource subscriptionResource) {
+      SubscriptionResource subscriptionResource, SubscriberDirective... directives) {
     return getService(subscriptionResource.getInstanceId())
-        .getSubscribersOfSubscriptionResource(subscriptionResource);
-  }
-
-  /**
-   * Gets all subscribers concerned by a specified subscription resource.<br>
-   * The inheritance of subscription is handled by this method. So if the aimed subscription
-   * resource has a parent subscription resource, subscribers of both of them are returned.
-   * @param subscriptionResource the instance of subscription resource.
-   * @param locationId the identifier of the location the resource is currently checked.
-   * @return an instance of {@link SubscriptionSubscriberList} that
-   * represents a collection of {@link SubscriptionSubscriber} decorated
-   * with useful tool methods.
-   */
-  public static SubscriptionSubscriberList getSubscribersOfSubscriptionResourceOnLocation(
-      SubscriptionResource subscriptionResource, String locationId) {
-    return getService(
-        subscriptionResource.getInstanceId()).getSubscribersOfSubscriptionResourceOnLocation(
-        subscriptionResource, locationId);
+        .getSubscribersOfSubscriptionResource(subscriptionResource, directives);
   }
 
   /**

--- a/core-web/src/main/java/org/silverpeas/core/webapi/subscribe/SubscriptionResource.java
+++ b/core-web/src/main/java/org/silverpeas/core/webapi/subscribe/SubscriptionResource.java
@@ -27,6 +27,7 @@ import org.silverpeas.core.admin.user.model.User;
 import org.silverpeas.core.admin.user.model.UserDetail;
 import org.silverpeas.core.annotation.WebService;
 import org.silverpeas.core.comment.CommentRuntimeException;
+import org.silverpeas.core.subscription.SubscriberDirective;
 import org.silverpeas.core.subscription.Subscription;
 import org.silverpeas.core.subscription.SubscriptionResourceType;
 import org.silverpeas.core.subscription.SubscriptionSubscriber;
@@ -50,6 +51,7 @@ import javax.ws.rs.core.Response.Status;
 import java.util.ArrayList;
 import java.util.Collection;
 
+import static org.silverpeas.core.contribution.publication.subscription.OnLocationDirective.onLocationId;
 import static org.silverpeas.core.subscription.SubscriptionServiceProvider.getSubscribeService;
 import static org.silverpeas.core.subscription.constant.CommonSubscriptionResourceConstants.COMPONENT;
 import static org.silverpeas.core.subscription.constant.CommonSubscriptionResourceConstants.UNKNOWN;
@@ -218,9 +220,12 @@ public class SubscriptionResource extends AbstractSubscriptionResource {
           StringUtil.isNotDefined(resourceId)) {
         throw new WebApplicationException(Status.NOT_FOUND);
       }
-      SubscriptionSubscriberList subscribers = ResourceSubscriptionProvider
-          .getSubscribersOfComponentAndTypedResourceOnLocation(getComponentId(),
-              parsedSubscriptionResourceType, resourceId, locationId);
+      final SubscriberDirective[] directives = isDefined(locationId) ?
+          new SubscriberDirective[]{onLocationId(locationId)} :
+          new SubscriberDirective[0];
+      SubscriptionSubscriberList subscribers =
+          ResourceSubscriptionProvider.getSubscribersOfComponentAndTypedResource(
+          getComponentId(), parsedSubscriptionResourceType, resourceId, directives);
       if (existenceIndicatorOnly) {
         return Response
             .ok(String.valueOf(!subscribers.getAllUserIds().isEmpty()), MediaType.APPLICATION_JSON)


### PR DESCRIPTION
Refactoring centralized services in order to introduce the ability to apply different kinds of directive in the searching for subscribers.
According to the context of the search for subscribers, it is possible to apply a directive that will precise the result.

Linked to PR https://github.com/Silverpeas/Silverpeas-Components/pull/752