### PR TITLE
Feature #12789: transversal external streaming player.

### DIFF
--- a/core-api/src/main/java/org/silverpeas/core/media/streaming/StreamingProvider.java
+++ b/core-api/src/main/java/org/silverpeas/core/media/streaming/StreamingProvider.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (C) 2000 - 2022 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.media.streaming;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Data defining a stream provider.
+ * @author silveryocha
+ */
+public class StreamingProvider implements Serializable {
+  private static final long serialVersionUID = 3725979193939989226L;
+
+  /**
+   * The name of the streaming provider.
+   * <p>
+   *   It can be considered as the identifier of the provider from point of view of Silverpeas's
+   *   server.
+   * </p>
+   */
+  private final String name;
+  /**
+   * For each streaming provider, some parameters MUST be defined and some CAN be optionally
+   * defined. Following parameter MUST be a regexp which permits extracting streaming identifier
+   * from a full URL of a streaming. Second regexp matching group is taken into account for the
+   * identifier extraction. The first group is just permitting to hit several URL cases.
+   */
+  private final Pattern urlIdExtractorRegexpPattern;
+  /**
+   * The <a href="https://oembed.com">oembed</a> URL pattern that permits to build the HTTP
+   * request to get standard oembed data from the concerned streaming provider.
+   */
+  private final String oembedUrlStringPattern;
+  /**
+   * Optional parameter in order to indicate if the data to inject into pattern defined by
+   * attribute {@link #oembedUrlStringPattern} MUST be the identifier of the streaming (by
+   * default) or the full URL of a streaming (false).
+   */
+  private final boolean justIdInOembedUrl;
+  /**
+   * List of all regexp patterns that permits to identify a provider from a full URL of streaming.
+   */
+  private final List<Pattern> regexpDetectionParts;
+
+  /**
+   * Constructor to initialize a streaming provider instance.
+   * @param name see {@link #name} attribute documentation.
+   * @param urlIdExtractorRegexpPattern see {@link #urlIdExtractorRegexpPattern} attribute documentation.
+   * @param oembedUrlStringPattern see {@link #oembedUrlStringPattern} attribute documentation.
+   * @param justIdInOembedUrl see {@link #justIdInOembedUrl} attribute documentation.
+   * @param regexpDetectionParts see {@link #regexpDetectionParts} attribute documentation.
+   */
+  public StreamingProvider(final String name, final Pattern urlIdExtractorRegexpPattern,
+      final String oembedUrlStringPattern, final boolean justIdInOembedUrl,
+      final List<Pattern> regexpDetectionParts) {
+    this.name = name;
+    this.urlIdExtractorRegexpPattern = urlIdExtractorRegexpPattern;
+    this.oembedUrlStringPattern = oembedUrlStringPattern;
+    this.justIdInOembedUrl = justIdInOembedUrl;
+    this.regexpDetectionParts = regexpDetectionParts;
+  }
+
+  /**
+   * @see #name
+   * @return a string.
+   */
+  public String getName() {
+    return name;
+  }
+
+  /**
+   * @see #oembedUrlStringPattern
+   * @return a regexp pattern as string.
+   */
+  String getOembedUrlStringPattern() {
+    return oembedUrlStringPattern;
+  }
+
+  /**
+   * Gets all regexp patterns that permits about a full URL of a streaming to indicate if it is
+   * one handled by the streaming provider.
+   * @return list of regexp pattern containing at least one element.
+   */
+  public List<Pattern> getRegexpDetectionParts() {
+    return regexpDetectionParts;
+  }
+
+  /**
+   * Gets the identifier of the streaming from its full url by using a REGEXP pattern defined by
+   * {@link #urlIdExtractorRegexpPattern}.
+   * @param url a full streaming URL
+   * @return an optional streaming identifier which permits handling the not found case.
+   */
+  Optional<String> extractStreamingId(String url) {
+    if (!justIdInOembedUrl) {
+      return Optional.of(url);
+    }
+    final int matchedGroup = 2;
+    Matcher matcher = urlIdExtractorRegexpPattern.matcher(url);
+    if (matcher.find()) {
+      return Optional.of(matcher.group(matchedGroup));
+    }
+    return Optional.empty();
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final StreamingProvider that = (StreamingProvider) o;
+    return Objects.equals(name, that.name);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name);
+  }
+}

--- a/core-api/src/main/java/org/silverpeas/core/media/streaming/StreamingProvidersRegistry.java
+++ b/core-api/src/main/java/org/silverpeas/core/media/streaming/StreamingProvidersRegistry.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright (C) 2000 - 2022 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.media.streaming;
+
+import org.silverpeas.core.util.ResourceLocator;
+import org.silverpeas.core.util.ServiceProvider;
+import org.silverpeas.core.util.SettingBundle;
+import org.silverpeas.core.util.StringUtil;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Singleton;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import static java.lang.String.format;
+import static java.util.Optional.ofNullable;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toUnmodifiableSet;
+import static java.util.stream.Stream.concat;
+import static java.util.stream.Stream.of;
+import static org.silverpeas.core.util.StringUtil.EMPTY;
+import static org.silverpeas.core.util.StringUtil.isDefined;
+
+/**
+ * Register of all streaming providers handled into Silverpeas.
+ * <p>
+ *   This permits also to control which streaming providers are allowed into Silverpeas.
+ * </p>
+ * @author silveryocha
+ */
+@Singleton
+public class StreamingProvidersRegistry {
+
+  private final Map<String, StreamingProvider> registry = new HashMap<>();
+
+  public static StreamingProvidersRegistry get() {
+    return ServiceProvider.getService(StreamingProvidersRegistry.class);
+  }
+
+  /**
+   * The registry is filled by default from 'org.silverpeas.media.streaming.properties' file definitions.
+   * <p>
+   *   In order to handle other streaming providers, the property file MUST be completed.
+   *   Or it is also possible to an additional library to add programmatically an other streaming provider.
+   * </p>
+   */
+  @PostConstruct
+  protected void setupDefaults() {
+    registry.clear();
+    final SettingBundle settings = ResourceLocator.getSettingBundle("org.silverpeas.media.streaming");
+    of(settings.getList("streaming.provider.handledIds", new String[0]))
+        .map(i -> {
+          final String urlIdExtractorRegexpPattern = settings.getString(
+              format("streaming.provider.%s.urlIdExtractorRegexpPattern", i), EMPTY);
+          final String oembedUrlStringPattern = settings.getString(
+              format("streaming.provider.%s.oembedUrlStringPattern", i), EMPTY);
+          final Stream<String> additionalRegexpDetectionParts = of(
+              settings.getList(format("streaming.provider.%s.additionalRegexpDetectionParts", i),
+                  new String[0]));
+          if (isDefined(urlIdExtractorRegexpPattern) && isDefined(oembedUrlStringPattern)) {
+            final List<Pattern> regexpDetectionParts = concat(of(i), additionalRegexpDetectionParts)
+                .map(Pattern::compile)
+                .collect(toList());
+            final boolean justIdInOembedUrl = settings.getBoolean(
+                format("streaming.provider.%s.justIdInOembedUrl", i), true);
+            return new StreamingProvider(i, Pattern.compile(urlIdExtractorRegexpPattern),
+                oembedUrlStringPattern, justIdInOembedUrl, regexpDetectionParts);
+          }
+          return null;
+        })
+        .filter(Objects::nonNull)
+        .forEach(this::add);
+  }
+
+  public Set<StreamingProvider> getAll() {
+    return registry.values().stream().collect(toUnmodifiableSet());
+  }
+
+  /**
+   * Gets by name (which is considered as the identifier) the registered
+   * {@link StreamingProvider} instance if any.
+   * @param name a Silverpeas's identifier of streaming provider which is represented the name of
+   * the streaming provider.
+   * @return the aimed {@link StreamingProvider} is any.
+   */
+  public Optional<StreamingProvider> getByName(final String name) {
+    return ofNullable(name).map(String::toLowerCase).map(registry::get);
+
+  }
+
+  /**
+   * Adds a {@link StreamingProvider} instance into registry.
+   * @param streaming the streaming provider definition.
+   */
+  public void add(final StreamingProvider streaming) {
+    registry.put(streaming.getName().toLowerCase(), streaming);
+  }
+
+  /**
+   * Gets the registered {@link StreamingProvider} instance matching with the given full URL of a
+   * streaming.
+   * @param streamingUrl the full URL of a streaming.
+   * @return a {@link StreamingProvider} instance if any guessed from the given URL.
+   */
+  public Optional<StreamingProvider> getFromUrl(String streamingUrl) {
+    return ofNullable(streamingUrl)
+        .filter(StringUtil::isDefined)
+        .map(String::toLowerCase)
+        .flatMap(u -> registry.values().stream()
+            .filter(s -> s.getRegexpDetectionParts()
+                .stream()
+                .map(p -> p.matcher(u))
+                .anyMatch(Matcher::find))
+            .findFirst());
+  }
+
+  /**
+   * Gets the <a href="https://oembed.com/">oembed</a> url from the full URL of a streaming.
+   * <p>
+   *   oEmbed is a format for allowing an embedded representation of a URL on third party sites.
+   *   The simple API allows a website to display embedded content (such as photos or videos)
+   *   when a user posts a link to that resource, without having to parse the resource directly.
+   * </p>
+   * <p>
+   *   All streaming providers implementing oembed services are listed here:
+   *   <a href="https://oembed.com/providers.json">https://oembed.com/providers.json</a>
+   * </p>
+   * @param streamingUrl the full url of a streaming.
+   * @return the oembed url as string.
+   */
+  public Optional<String> getOembedUrl(String streamingUrl) {
+    return getFromUrl(streamingUrl)
+        .flatMap(p -> p.extractStreamingId(streamingUrl)
+            .map(i -> format(p.getOembedUrlStringPattern(), i)));
+  }
+}

--- a/core-configuration/src/main/config/properties/org/silverpeas/media/streaming.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/media/streaming.properties
@@ -1,0 +1,67 @@
+#
+# Copyright (C) 2000 - 2022 Silverpeas
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# As a special exception to the terms and conditions of version 3.0 of
+# the GPL, you may redistribute this Program in connection with Free/Libre
+# Open Source Software ("FLOSS") applications as described in Silverpeas's
+# FLOSS exception.  You should have received a copy of the text describing
+# the FLOSS exception, and it is also available here:
+# "https://www.silverpeas.org/legal/floss_exception.html"
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+# Each streaming provider is referenced by an identifier.
+# This parameter lists the streaming provider identifiers each one separated by a comma.
+streaming.provider.handledIds = youtube,vimeo,dailymotion,soundcloud
+
+# For each streaming provider, some parameters MUST be defined and some CAN be optionally defined.
+# Following parameter MUST be a regexp which permits extracting streaming identifier from a full URL of a streaming.
+# Second regexp matching group is taken into account for the identifier extraction.
+# The first group is just permitting to hit several URL cases.
+# [providerId] parameter part MUST be an identifier referenced by 'streaming.provider.handledIds' parameter.
+streaming.provider.[providerId].urlIdExtractorRegexpPattern=
+# oembed (https://oembed.com) URL pattern that permits to build the HTTP request to get
+# standard oembed data from the concerned streaming provider.
+# The pattern format will be applied to java String#format method.
+# [providerId] parameter part MUST be an identifier referenced by 'streaming.provider.handledIds' parameter.
+streaming.provider.[providerId].oembedUrlStringPattern=
+# Optional parameter in order to indicate if the data to inject into pattern defined by parameter
+# 'streaming.provider.[providerId].oembedUrlStringPattern' MUST be the identifier of the streaming (by default)
+# or the full URL of a streaming (false).
+# [providerId] parameter part MUST be an identifier referenced by 'streaming.provider.handledIds' parameter.
+streaming.provider.[providerId].justIdInOembedUrl=
+# Optional parameter that permits to specify regexp to identify different kind of streaming URL of a provider.
+# This parameter MAY be defined if regexp group 1 of parameter 'streaming.provider.[providerId].urlIdExtractorRegexpPattern'
+# does not permit to identify all kinds of streaming URL of a streaming provider.
+# [providerId] parameter part MUST be an identifier referenced by 'streaming.provider.handledIds' parameter.
+streaming.provider.[providerId].additionalRegexpDetectionParts=
+
+# All URL MUST be specified with http protocol (and not https). The server will automatically change
+# the protocol against the platform environment.
+
+streaming.provider.youtube.urlIdExtractorRegexpPattern=(?i)([?]|[&])v=([a-z0-9]+)
+streaming.provider.youtube.oembedUrlStringPattern=http://www.youtube.com/oembed?url=%s&format=json
+streaming.provider.youtube.justIdInOembedUrl=false
+streaming.provider.youtube.additionalRegexpDetectionParts=youtu
+
+streaming.provider.vimeo.urlIdExtractorRegexpPattern=(?i)(/|=)([0-9]+)
+streaming.provider.vimeo.oembedUrlStringPattern=http://vimeo.com/api/oembed.json?url=http://vimeo.com/%s
+
+streaming.provider.dailymotion.urlIdExtractorRegexpPattern=(?i)(/video/|dai.ly/)([a-z0-9]+)
+streaming.provider.dailymotion.oembedUrlStringPattern=http://www.dailymotion.com/services/oembed?url=http://www.dailymotion.com/video/%s
+streaming.provider.dailymotion.additionalRegexpDetectionParts=dai.ly
+
+streaming.provider.soundcloud.urlIdExtractorRegexpPattern=(?i)(soundcloud.com/)(.+)
+streaming.provider.soundcloud.oembedUrlStringPattern=http://soundcloud.com/oembed?url=http://soundcloud.com/%s&format=json

--- a/core-library/src/test/java/org/silverpeas/core/media/streaming/StreamingProvidersRegistryTest.java
+++ b/core-library/src/test/java/org/silverpeas/core/media/streaming/StreamingProvidersRegistryTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 2000 - 2022 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.media.streaming;
+
+import org.junit.jupiter.api.Test;
+import org.silverpeas.core.media.streaming.StreamingProvider;
+import org.silverpeas.core.media.streaming.StreamingProvidersRegistry;
+import org.silverpeas.core.test.extention.EnableSilverTestEnv;
+import org.silverpeas.core.test.extention.TestedBean;
+
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * @author silveryocha
+ */
+@EnableSilverTestEnv
+class StreamingProvidersRegistryTest {
+
+  @TestedBean
+  private StreamingProvidersRegistry registry;
+
+  @Test
+  void testFrom() {
+    assertThat(registry.getAll(), hasSize(4));
+    assertThat(registry.getByName(null).isPresent(), is(false));
+    assertThat(registry.getByName("").isPresent(), is(false));
+    assertThat(registry.getByName(" ").isPresent(), is(false));
+    assertThat(registry.getByName(" youtube").isPresent(), is(false));
+    assertThat(registry.getByName("youtube")
+        .map(StreamingProvider::getName).orElse(null), is("youtube"));
+    assertThat(registry.getByName("vImeO")
+        .map(StreamingProvider::getName).orElse(null), is("vimeo"));
+    assertThat(registry.getByName("dAilyMotion")
+        .map(StreamingProvider::getName).orElse(null), is("dailymotion"));
+  }
+
+  @Test
+  void testFromUrl() {
+    assertThat(registry.getFromUrl(null).isPresent(), is(false));
+    assertThat(registry.getFromUrl("").isPresent(), is(false));
+    assertThat(registry.getFromUrl(" ").isPresent(), is(false));
+    assertThat(registry.getFromUrl(" youtube")
+        .map(StreamingProvider::getName).orElse(null), is("youtube"));
+    assertThat(registry.getFromUrl("youtube")
+        .map(StreamingProvider::getName).orElse(null), is("youtube"));
+    assertThat(registry.getFromUrl("vImeO")
+        .map(StreamingProvider::getName).orElse(null), is("vimeo"));
+    assertThat(registry.getFromUrl("http://vImeO.be/123456789")
+        .map(StreamingProvider::getName).orElse(null), is("vimeo"));
+    assertThat(registry.getFromUrl("http://www.dailymotion.com/video/x3fd843_bever")
+            .map(StreamingProvider::getName).orElse(null), is("dailymotion"));
+  }
+
+  @Test
+  void testExtractStreamingId() {
+    StreamingProvider provider = registry.getByName("dailymotion").orElse(null);
+    assertThat(provider, notNullValue());
+    assertThat(provider.extractStreamingId(
+        "http://www.dailymotion.com/video/x3fd843_beverly-piegee-par-l-incroyable-strategie-de" +
+            "-gilles_tv").orElse(null), is("x3fd843"));
+    provider = registry.getByName("soundcloud").orElse(null);
+    assertThat(provider, notNullValue());
+    assertThat(provider.extractStreamingId(
+            "https://soundcloud.com/empreinte-digiale/saison-1-01-la-lazy-company-jean-sebastien" +
+                "-vermalle?in=benjamin-roux-10/sets/lazy-compagny").orElse(null),
+        is("empreinte-digiale/saison-1-01-la-lazy-company-jean-sebastien-vermalle?in=benjamin" +
+            "-roux-10/sets/lazy-compagny"));
+  }
+
+  @Test
+  void getYoutubeOembedUrl() {
+    final Optional<String> oembedUrl = registry.getOembedUrl("https://youtu.be/6xN3hSEj21Q");
+    assertThat(oembedUrl.isPresent(), is(true));
+    assertThat(oembedUrl.get(), is("http://www.youtube.com/oembed?url=https://youtu.be/6xN3hSEj21Q&format=json"));
+  }
+
+  @Test
+  void getVimeoOembedUrl() {
+    final Optional<String> oembedUrl = registry.getOembedUrl("https://vimeo.com/21040307");
+    assertThat(oembedUrl.isPresent(), is(true));
+    assertThat(oembedUrl.get(), is("http://vimeo.com/api/oembed.json?url=http://vimeo.com/21040307"));
+  }
+
+  @Test
+  void getDailymotionOembedUrl() {
+    final Optional<String> oembedUrl = registry.getOembedUrl("https://www.dailymotion.com/video/x3fgyln_jeff-bezos-fait-atterrir-en-secret-la-premiere-fusee-reutilisable_tech");
+    assertThat(oembedUrl.isPresent(), is(true));
+    assertThat(oembedUrl.get(), is("http://www.dailymotion.com/services/oembed?url=http://www.dailymotion.com/video/x3fgyln"));
+  }
+
+  @Test
+  void getSoundCloudOembedUrl() {
+    final Optional<String> oembedUrl = registry.getOembedUrl("https://soundcloud.com/empreinte-digiale/saison-1-01-la-lazy-company-jean-sebastien-vermalle?in=benjamin-roux-10/sets/lazy-compagny");
+    assertThat(oembedUrl.isPresent(), is(true));
+    assertThat(oembedUrl.get(), is("http://soundcloud.com/oembed?url=http://soundcloud.com/empreinte-digiale/saison-1-01-la-lazy-company-jean-sebastien-vermalle?in=benjamin-roux-10/sets/lazy-compagny&format=json"));
+  }
+}

--- a/core-library/src/test/resources/org/silverpeas/media/streaming.properties
+++ b/core-library/src/test/resources/org/silverpeas/media/streaming.properties
@@ -1,0 +1,40 @@
+#
+# Copyright (C) 2000 - 2021 Silverpeas
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# As a special exception to the terms and conditions of version 3.0 of
+# the GPL, you may redistribute this Program in connection with Free/Libre
+# Open Source Software ("FLOSS") applications as described in Silverpeas's
+# FLOSS exception.  You should have received a copy of the text describing
+# the FLOSS exception, and it is also available here:
+# "https://www.silverpeas.org/legal/floss_exception.html"
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+streaming.provider.handledIds = youtube,vimeo,dailymotion,soundcloud
+
+streaming.provider.youtube.urlIdExtractorRegexpPattern=(?i)([?]|[&])v=([a-z0-9]+)
+streaming.provider.youtube.oembedUrlStringPattern=http://www.youtube.com/oembed?url=%s&format=json
+streaming.provider.youtube.justIdInOembedUrl=false
+streaming.provider.youtube.additionalRegexpDetectionParts=youtu
+
+streaming.provider.vimeo.urlIdExtractorRegexpPattern=(?i)(/|=)([0-9]+)
+streaming.provider.vimeo.oembedUrlStringPattern=http://vimeo.com/api/oembed.json?url=http://vimeo.com/%s
+
+streaming.provider.dailymotion.urlIdExtractorRegexpPattern=(?i)(/video/|dai.ly/)([a-z0-9]+)
+streaming.provider.dailymotion.oembedUrlStringPattern=http://www.dailymotion.com/services/oembed?url=http://www.dailymotion.com/video/%s
+streaming.provider.dailymotion.additionalRegexpDetectionParts=dai.ly
+
+streaming.provider.soundcloud.urlIdExtractorRegexpPattern=(?i)(soundcloud.com/)(.+)
+streaming.provider.soundcloud.oembedUrlStringPattern=http://soundcloud.com/oembed?url=http://soundcloud.com/%s&format=json

--- a/core-war/src/main/webapp/WEB-INF/tags/silverpeas/media/streamingLibrary.tag
+++ b/core-war/src/main/webapp/WEB-INF/tags/silverpeas/media/streamingLibrary.tag
@@ -1,0 +1,83 @@
+<%@ tag import="org.silverpeas.core.media.streaming.StreamingProvidersRegistry" %><%--
+  ~ Copyright (C) 2000 - 2021 Silverpeas
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as
+  ~ published by the Free Software Foundation, either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ As a special exception to the terms and conditions of version 3.0 of
+  ~ the GPL, you may redistribute this Program in connection with Free/Libre
+  ~ Open Source Software ("FLOSS") applications as described in Silverpeas's
+  ~ FLOSS exception.  You should have received a copy of the text describing
+  ~ the FLOSS exception, and it is also available here:
+  ~ "https://www.silverpeas.org/legal/floss_exception.html"
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  --%>
+<%@ tag language="java" pageEncoding="UTF-8" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn" %>
+<%@ taglib uri="http://www.silverpeas.com/tld/silverFunctions" prefix="silfn" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
+<%@ taglib uri="http://www.silverpeas.com/tld/viewGenerator" prefix="view" %>
+
+<%-- Set resource bundle --%>
+<fmt:setLocale value="${requestScope.resources.language}"/>
+<view:setBundle bundle="${requestScope.resources.multilangBundle}"/>
+
+<%-- Constants --%>
+<c:set var="supportedStreamingProviders" value="<%=StreamingProvidersRegistry.get().getAll()%>"/>
+
+<script type="text/javascript">
+
+  /**
+   * Returns {
+   *   title,
+   *   author,
+   *   embedHtml,
+   *   formattedDurationHMS,
+   *   definition : {
+   *     width,
+   *     height
+   *   }
+   * }
+   */
+  function getPromiseOfStreamingProviderData(streamingUrl) {
+    return sp.ajaxRequest(webContext + '/services/media/streaming/providerData')
+        .withParam('url', streamingUrl)
+        .sendAndPromiseJsonResponse();
+  }
+
+  /**
+   * Indicates if a supported streaming provider is detected from the specified streaming URL.
+   * @param streamingUrl
+   * @returns {boolean}
+   */
+  function detectSupportedStreamingProvider(streamingUrl) {
+    <c:if test="${not empty supportedStreamingProviders}">
+    <c:set var="supportedStreamingProviderRegExpr" value=""/>
+    <c:forEach var="supportedStreamingProvider" items="${supportedStreamingProviders}">
+    <c:forEach var="regexpDetectionPart" items="${supportedStreamingProvider.regexpDetectionParts}">
+    <c:if test="${not empty supportedStreamingProviderRegExpr}">
+    <c:set var="supportedStreamingProviderRegExpr" value="${supportedStreamingProviderRegExpr}|"/>
+    </c:if>
+    <c:set var="supportedStreamingProviderRegExpr" value="${supportedStreamingProviderRegExpr}${regexpDetectionPart}"/>
+    </c:forEach>
+    </c:forEach>
+    if (streamingUrl && streamingUrl.length > 0) {
+      const urlRegExprCheck = /http.?:\/\/.*(${supportedStreamingProviderRegExpr})/;
+      if (urlRegExprCheck.exec(streamingUrl.toLowerCase()) != null) {
+        return true;
+      }
+    }
+    </c:if>
+    return false;
+  }
+</script>

--- a/core-war/src/main/webapp/media/jsp/embedStreaming.jsp
+++ b/core-war/src/main/webapp/media/jsp/embedStreaming.jsp
@@ -1,0 +1,67 @@
+<%--
+
+    Copyright (C) 2000 - 2021 Silverpeas
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    As a special exception to the terms and conditions of version 3.0 of
+    the GPL, you may redistribute this Program in connection with Free/Libre
+    Open Source Software ("FLOSS") applications as described in Silverpeas's
+    FLOSS exception.  You should have received a copy of the text describing
+    the FLOSS exception, and it is also available here:
+    "https://www.silverpeas.org/legal/floss_exception.html"
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+--%>
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+<%@ taglib uri="http://www.silverpeas.com/tld/silverFunctions" prefix="silfn" %>
+<%@ taglib prefix="viewTags" tagdir="/WEB-INF/tags/silverpeas/util" %>
+<%@ taglib uri="http://www.silverpeas.com/tld/viewGenerator" prefix="view" %>
+
+<c:set var="entity" value="${requestScope.entity}"/>
+<c:set var="definition" value="${requestScope.definition}"/>
+
+<jsp:useBean id="entity" type="org.silverpeas.core.webapi.media.streaming.StreamingProviderDataEntity"/>
+<jsp:useBean id="definition" type="org.silverpeas.core.io.media.Definition"/>
+
+<view:sp-page>
+<view:sp-head-part noLookAndFeel="true">
+  <meta charset="utf-8">
+  <!-- optimize mobile versions -->
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <style type="text/css">
+    body,
+    html {
+      width: 100%;
+      height: 100%;
+      margin: 0;
+      overflow: hidden;
+    }
+  </style>
+</view:sp-head-part>
+<body>
+<div id="streamingContainer"></div>
+<c:set var="width" value="${(definition != null and definition.widthDefined) ? ''.concat(definition.width).concat('px') : '100%'}"/>
+<c:set var="height" value="${(definition != null and definition.heightDefined) ? ''.concat(definition.height).concat('px') : '100%'}"/>
+<script type="text/javascript">
+  const player = '${silfn:escapeJs(entity.embedHtml)}'
+      .replace(/width="[0-9]+"/i, 'width="${width}"')
+      .replace(/height="[0-9]+"/i, 'height="${height}"');
+  const $playerContainer = document.querySelector('#streamingContainer');
+  $playerContainer.style.width = '${width}';
+  $playerContainer.style.height = '${height}';
+  $playerContainer.innerHTML = player;
+</script>
+</body>
+</view:sp-page>

--- a/core-web/src/main/java/org/silverpeas/core/webapi/media/streaming/EmbedStreamingPlayerParams.java
+++ b/core-web/src/main/java/org/silverpeas/core/webapi/media/streaming/EmbedStreamingPlayerParams.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2000 - 2021 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.silverpeas.core.webapi.media.streaming;
+
+import org.silverpeas.core.io.media.Definition;
+import org.silverpeas.core.web.http.HttpRequest;
+import org.silverpeas.core.web.http.RequestParameterDecoder;
+
+import javax.ws.rs.FormParam;
+
+/**
+ * This class contains the parameter values of a streaming service request.<br>
+ * To get a loaded container, use {@link RequestParameterDecoder#decode(HttpRequest, Class)}.
+ * @author silveryocha
+ */
+class EmbedStreamingPlayerParams {
+
+  @FormParam("url")
+  private String url;
+
+  @FormParam("width")
+  private Integer width;
+
+  @FormParam("height")
+  private Integer height;
+
+  String getUrl() {
+    return url;
+  }
+
+  public Definition getDefinition() {
+    return width != null && height != null ? Definition.of(width, height) : Definition.NULL;
+  }
+}

--- a/core-web/src/main/java/org/silverpeas/core/webapi/media/streaming/OembedDataEntity.java
+++ b/core-web/src/main/java/org/silverpeas/core/webapi/media/streaming/OembedDataEntity.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright (C) 2000 - 2021 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.silverpeas.core.webapi.media.streaming;
+
+import org.silverpeas.core.io.media.Definition;
+import org.silverpeas.core.webapi.media.MediaDefinitionEntity;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * @author silveryocha
+ */
+@XmlRootElement
+@XmlAccessorType(XmlAccessType.FIELD)
+public class OembedDataEntity {
+
+  @XmlElement(name = "provider_name")
+  private String providerName;
+
+  @XmlElement
+  private String title;
+
+  @XmlElement(name = "author_name")
+  private String author;
+
+  @XmlElement
+  private String html;
+
+  @XmlElement
+  private String width;
+
+  @XmlElement
+  private String height;
+
+  @XmlElement
+  private String duration;
+
+  @XmlElement
+  private String version;
+
+  @XmlElement(name="thumbnail_url")
+  private String thumbnailUrl;
+
+  @XmlElement(name="thumbnail_width")
+  private String thumbnailWidth;
+
+  @XmlElement(name="thumbnail_height")
+  private String thumbnailHeight;
+
+  protected OembedDataEntity() {
+  }
+
+  public String getProviderName() {
+    return providerName;
+  }
+
+  public void setProviderName(final String providerName) {
+    this.providerName = providerName;
+  }
+
+  public String getTitle() {
+    return title;
+  }
+
+  public void setTitle(final String title) {
+    this.title = title;
+  }
+
+  public String getAuthor() {
+    return author;
+  }
+
+  public void setAuthor(final String author) {
+    this.author = author;
+  }
+
+  public MediaDefinitionEntity getDefinition() {
+    return MediaDefinitionEntity
+        .createFrom(Definition.of(Integer.parseInt(getWidth()), Integer.parseInt(getHeight())));
+  }
+
+  public String getHtml() {
+    return html;
+  }
+
+  public void setHtml(final String html) {
+    this.html = html;
+  }
+
+  public String getWidth() {
+    return width;
+  }
+
+  public void setWidth(final String width) {
+    this.width = width;
+  }
+
+  public String getHeight() {
+    return height;
+  }
+
+  public void setHeight(final String height) {
+    this.height = height;
+  }
+
+  public String getDuration() {
+    return duration;
+  }
+
+  public void setDuration(final String duration) {
+    this.duration = duration;
+  }
+
+  public String getVersion() {
+    return version;
+  }
+
+  public void setVersion(final String version) {
+    this.version = version;
+  }
+
+  public String getThumbnailUrl() {
+    return thumbnailUrl;
+  }
+
+  public void setThumbnailUrl(final String thumbnailUrl) {
+    this.thumbnailUrl = thumbnailUrl;
+  }
+
+  public String getThumbnailWidth() {
+    return thumbnailWidth;
+  }
+
+  public void setThumbnailWidth(final String thumbnailWidth) {
+    this.thumbnailWidth = thumbnailWidth;
+  }
+
+  public String getThumbnailHeight() {
+    return thumbnailHeight;
+  }
+
+  public void setThumbnailHeight(final String thumbnailHeight) {
+    this.thumbnailHeight = thumbnailHeight;
+  }
+}

--- a/core-web/src/main/java/org/silverpeas/core/webapi/media/streaming/StreamingPlayerResource.java
+++ b/core-web/src/main/java/org/silverpeas/core/webapi/media/streaming/StreamingPlayerResource.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (C) 2000 - 2021 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.silverpeas.core.webapi.media.streaming;
+
+import org.jboss.resteasy.plugins.providers.html.View;
+import org.silverpeas.core.annotation.WebService;
+import org.silverpeas.core.io.media.Definition;
+import org.silverpeas.core.web.rs.RESTWebService;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+import static org.silverpeas.core.util.StringUtil.isNotDefined;
+import static org.silverpeas.core.web.http.RequestParameterDecoder.decode;
+import static org.silverpeas.core.webapi.media.streaming.StreamingProviderDataEntity.from;
+
+/**
+ * A common service to play external streaming into an embed context.
+ * <p>
+ * This service provide also the possibility to get information from external streaming providers
+ * by using oembed mechanism.
+ * </p>
+ * @author silveryocha
+ */
+@WebService
+@Path(StreamingPlayerResource.PATH)
+public class StreamingPlayerResource extends RESTWebService {
+
+  static final String PATH = "media/streaming";
+
+  @Override
+  protected String getResourceBasePath() {
+    return PATH;
+  }
+
+  /**
+   * Gets the provider data of a streaming from its url. If it doesn't exist, a 404 HTTP code is
+   * returned. If the user isn't authenticated, a 401 HTTP code is returned. If a problem occurs
+   * when processing the request, a 503 HTTP code is returned.
+   * @return the response to the HTTP GET request content of the asked streaming.
+   */
+  @GET
+  @Path("providerData")
+  @Produces(MediaType.APPLICATION_JSON)
+  public StreamingProviderDataEntity getStreamingProviderDataFromUrl() {
+    final EmbedStreamingPlayerParams params = decode(getHttpServletRequest(), EmbedStreamingPlayerParams.class);
+    try {
+      checkMandatoryParams(params);
+      final String url = params.getUrl();
+      final StreamingProviderDataEntity entity = getHandledStreamingProvider(url);
+      return entity.withURI(getUri().getRequestUri());
+    } catch (final WebApplicationException ex) {
+      throw ex;
+    } catch (final Exception ex) {
+      throw new WebApplicationException(ex, Response.Status.SERVICE_UNAVAILABLE);
+    }
+  }
+
+  /**
+   * Gets a view on the content with the HTML that permits to play the streaming.
+   * @return a descriptor of the renderer to use to display the streaming content.
+   */
+  @Path("player")
+  @GET
+  public View getPlayerContent() {
+    final EmbedStreamingPlayerParams params = decode(getHttpServletRequest(), EmbedStreamingPlayerParams.class);
+    try {
+      checkMandatoryParams(params);
+      final String url = params.getUrl();
+      final Definition definition = params.getDefinition();
+      final StreamingProviderDataEntity streamingEntity = getHandledStreamingProvider(url);
+      getHttpServletRequest().setAttribute("entity", streamingEntity);
+      getHttpServletRequest().setAttribute("definition", definition);
+      return new View("/media/jsp/embedStreaming.jsp");
+    } catch (final WebApplicationException ex) {
+      throw ex;
+    } catch (final Exception ex) {
+      throw new WebApplicationException(ex, Response.Status.SERVICE_UNAVAILABLE);
+    }
+  }
+
+  private StreamingProviderDataEntity getHandledStreamingProvider(final String url) {
+    final StreamingProviderDataEntity streamingEntity = from(url).orElseThrow(
+        () -> new WebApplicationException(String.format("Streaming URL '%s' is not Handled", url)));
+    if (getHttpRequest().isSecure()) {
+      // Replacing HTTP scheme by HTTPS one
+      streamingEntity.forceSecureEmbedUrl();
+    }
+    return streamingEntity;
+  }
+
+  @Override
+  public String getComponentId() {
+    return null;
+  }
+
+  /**
+   * Checks mandatory parameters.
+   * @param params the parameters.
+   */
+  private void checkMandatoryParams(final EmbedStreamingPlayerParams params) {
+    List<String> errorMessages = new ArrayList<>();
+    if (isNotDefined(params.getUrl())) {
+      errorMessages.add("url is not defined");
+    }
+    if (!errorMessages.isEmpty()) {
+      throw new WebApplicationException(errorMessages.stream().collect(Collectors.joining(", ")),
+          BAD_REQUEST);
+    }
+  }
+}

--- a/core-web/src/main/java/org/silverpeas/core/webapi/media/streaming/StreamingProviderDataEntity.java
+++ b/core-web/src/main/java/org/silverpeas/core/webapi/media/streaming/StreamingProviderDataEntity.java
@@ -1,0 +1,243 @@
+/*
+ * Copyright (C) 2000 - 2021 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.silverpeas.core.webapi.media.streaming;
+
+import org.silverpeas.core.io.media.Definition;
+import org.silverpeas.core.media.streaming.StreamingProvider;
+import org.silverpeas.core.media.streaming.StreamingProvidersRegistry;
+import org.silverpeas.core.util.JSONCodec;
+import org.silverpeas.core.util.URLUtil;
+import org.silverpeas.core.web.rs.WebEntity;
+import org.silverpeas.core.webapi.media.MediaDefinitionEntity;
+
+import javax.ws.rs.core.UriBuilder;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlTransient;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.silverpeas.core.util.StringUtil.isDefined;
+import static org.silverpeas.core.webapi.media.streaming.StreamingRequester.getJsonOembedAsString;
+
+/**
+ * This entity ensures that all streaming data are formatted in a single way whatever the
+ * streaming provider.
+ * @author silveryocha
+ */
+@XmlRootElement
+@XmlAccessorType(XmlAccessType.FIELD)
+public class StreamingProviderDataEntity implements WebEntity {
+  private static final long serialVersionUID = 4017230238128160967L;
+
+  public static final String NAME = "default";
+
+  @XmlElement(defaultValue = "")
+  private URI uri;
+
+  @XmlTransient
+  private String originalUrl;
+
+  @XmlElement
+  private String provider;
+
+  @XmlElement
+  private String title;
+
+  @XmlElement
+  private String author;
+
+  @XmlElement
+  private String formattedDurationHMS;
+
+  @XmlElement
+  private MediaDefinitionEntity definition =
+      MediaDefinitionEntity.createFrom(Definition.fromZero());
+
+  @XmlElement
+  private String embedHtml;
+
+  @XmlElement
+  private URI thumbnailUrl;
+
+  @XmlElement
+  private MediaDefinitionEntity thumbnailDefinition;
+
+  @XmlElement
+  private List<URI> thumbnailPreviewUrls = new ArrayList<>();
+
+  /**
+   * Creates a streaming provider data entity from specified homepage url.
+   * @param homepageUrl the streaming home page url.
+   * @return the streaming provider data entity representing the specified streaming.
+   */
+  public static Optional<StreamingProviderDataEntity> from(final String homepageUrl) {
+    return StreamingProvidersRegistry.get().getFromUrl(homepageUrl)
+        .map(p -> {
+          final OembedDataEntity oembedData =
+              JSONCodec.decode(getJsonOembedAsString(homepageUrl), OembedDataEntity.class);
+          final StreamingProviderDataEntity entity = StreamingProviderDataEntityFactory.get()
+              .createWith(p, oembedData);
+          entity.originalUrl = homepageUrl;
+          return entity;
+        })
+        .map(e -> {
+          if (URLUtil.getCurrentServerURL().startsWith("https")) {
+            e.forceSecureEmbedUrl();
+          }
+          return e;
+        });
+  }
+
+  public StreamingProviderDataEntity withURI(final URI uri) {
+    this.uri = uri;
+    return this;
+  }
+
+  /**
+   * Constructor from OembedDataEntity ({@literal http://oembed.com}).
+   * @param streamingProvider the Silverpeas provider identifier.
+   * @param oembedData the oembed data as JSON format.
+   */
+  protected StreamingProviderDataEntity(StreamingProvider streamingProvider,
+      final OembedDataEntity oembedData) {
+    this.provider = streamingProvider.getName();
+    this.title = oembedData.getTitle();
+    this.author = oembedData.getAuthor();
+    this.embedHtml = oembedData.getHtml();
+
+    String givenThumbnailUrl = oembedData.getThumbnailUrl();
+    if (isDefined(givenThumbnailUrl)) {
+      this.thumbnailUrl = URI.create(givenThumbnailUrl);
+      String thumbnailWidth = oembedData.getThumbnailWidth();
+      String thumbnailHeight = oembedData.getThumbnailHeight();
+      if (isDefined(thumbnailWidth) && isDefined(thumbnailHeight)) {
+        this.thumbnailDefinition = MediaDefinitionEntity.createFrom(Definition
+            .of(Integer.parseInt(thumbnailWidth.replaceAll("[^0-9].", "")),
+                Integer.parseInt(thumbnailHeight.replaceAll("[^0-9].", ""))));
+      }
+    }
+  }
+
+  @SuppressWarnings("UnusedDeclaration")
+  protected StreamingProviderDataEntity() {
+  }
+
+  @Override
+  public URI getURI() {
+    return uri;
+  }
+
+  public void setUri(final URI uri) {
+    this.uri = uri;
+  }
+
+  public StreamingProvider getProvider() {
+    return StreamingProvidersRegistry.get().getByName(provider).orElse(null);
+  }
+
+  public void setProvider(final StreamingProvider provider) {
+    this.provider = provider.getName();
+  }
+
+  public String getTitle() {
+    return title;
+  }
+
+  public void setTitle(final String title) {
+    this.title = title;
+  }
+
+  public String getAuthor() {
+    return author;
+  }
+
+  public void setAuthor(final String author) {
+    this.author = author;
+  }
+
+  public String getFormattedDurationHMS() {
+    return formattedDurationHMS;
+  }
+
+  public void setFormattedDurationHMS(final String formattedDurationHMS) {
+    this.formattedDurationHMS = formattedDurationHMS;
+  }
+
+  public MediaDefinitionEntity getDefinition() {
+    return definition;
+  }
+
+  public void setDefinition(final MediaDefinitionEntity definition) {
+    this.definition = definition;
+  }
+
+  public String getSilverpeasEmbedUrl() {
+    return UriBuilder.fromUri(URLUtil.getApplicationURL())
+        .path("services/media/streaming/player")
+        .queryParam("url", originalUrl)
+        .build()
+        .toString();
+  }
+
+  public String getEmbedHtml() {
+    return embedHtml;
+  }
+
+  public void setEmbedHtml(final String embedHtml) {
+    this.embedHtml = embedHtml;
+  }
+
+  public void forceSecureEmbedUrl() {
+    setEmbedHtml(getEmbedHtml().replace("http://", "https://"));
+  }
+
+  public URI getThumbnailUrl() {
+    return thumbnailUrl;
+  }
+
+  public void setThumbnailUrl(final URI thumbnailUrl) {
+    this.thumbnailUrl = thumbnailUrl;
+  }
+
+  public MediaDefinitionEntity getThumbnailDefinition() {
+    return thumbnailDefinition;
+  }
+
+  public void setThumbnailDefinition(final MediaDefinitionEntity thumbnailDefinition) {
+    this.thumbnailDefinition = thumbnailDefinition;
+  }
+
+  public List<URI> getThumbnailPreviewUrls() {
+    return thumbnailPreviewUrls;
+  }
+
+  public void setThumbnailPreviewUrls(final List<URI> thumbnailPreviewUrls) {
+    this.thumbnailPreviewUrls = thumbnailPreviewUrls;
+  }
+}

--- a/core-web/src/main/java/org/silverpeas/core/webapi/media/streaming/StreamingProviderDataEntityFactory.java
+++ b/core-web/src/main/java/org/silverpeas/core/webapi/media/streaming/StreamingProviderDataEntityFactory.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2000 - 2022 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.webapi.media.streaming;
+
+import org.silverpeas.core.annotation.Service;
+import org.silverpeas.core.media.streaming.StreamingProvider;
+import org.silverpeas.core.util.ServiceProvider;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Singleton;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.BiFunction;
+
+/**
+ * This factory permits to instantiate the right {@link StreamingProviderDataEntity} instance
+ * from a {@link OembedDataEntity} decoded from the response of a streaming provider about a full
+ * URL of a streaming.
+ * <p>
+ *   If the factory is not able to construct a {@link StreamingProviderDataEntity} from oembed
+ *   data, then a default one is instantiated.
+ * </p>
+ * <p>
+ *   When some specific behaviors MUST be taken into account for streamings of a provider, then a
+ *   specific constructor override of {@link StreamingProviderDataEntity} MUST be implemented and
+ *   indicated to factory by using {@link #registerConstructor(String, BiFunction)} method. As
+ *   {@link YoutubeDataEntity} for example.
+ * </p>
+ * @author silveryocha
+ */
+@Service
+@Singleton
+public class StreamingProviderDataEntityFactory {
+
+  private static final BiFunction<StreamingProvider, OembedDataEntity,
+      StreamingProviderDataEntity> DEFAULT = StreamingProviderDataEntity::new;
+
+  private final Map<String, BiFunction<StreamingProvider, OembedDataEntity, StreamingProviderDataEntity>>
+      constructorRegistry = Collections.synchronizedMap(new HashMap<>());
+
+  public static StreamingProviderDataEntityFactory get() {
+    return ServiceProvider.getService(StreamingProviderDataEntityFactory.class);
+  }
+
+  /**
+   * Registers default constructors of {@link StreamingProviderDataEntity} of Silverpeas's server.
+   */
+  @PostConstruct
+  protected void setupDefaults() {
+    registerConstructor(YoutubeDataEntity.NAME, YoutubeDataEntity::new);
+    registerConstructor(VimeoDataEntity.NAME, VimeoDataEntity::new);
+  }
+
+  /**
+   * Registers a new {@link StreamingProviderDataEntity} constructor.
+   * <p>
+   *   It permits to external projects to defined theirs own constructors if needed.
+   * </p>
+   * @param providerName name of streaming provider (lowercase).
+   * @param constructor the constructor of {@link StreamingProviderDataEntity}.
+   */
+  public void registerConstructor(final String providerName,
+      final BiFunction<StreamingProvider, OembedDataEntity, StreamingProviderDataEntity> constructor) {
+    constructorRegistry.put(providerName, constructor);
+  }
+
+  /**
+   * Initializes the {@link StreamingProviderDataEntity} from given elements.
+   * <p>
+   *   If no specific constructors is known for a streaming provider, then a default one is used.
+   * </p>
+   * @param streamingProvider a {@link StreamingProvider} instance.
+   * @param oembedData the oembed data.
+   * @return a {@link StreamingProviderDataEntity} instance.
+   */
+  StreamingProviderDataEntity createWith(final StreamingProvider streamingProvider,
+      final OembedDataEntity oembedData) {
+    return constructorRegistry
+        .getOrDefault(streamingProvider.getName(), DEFAULT)
+        .apply(streamingProvider, oembedData);
+  }
+}

--- a/core-web/src/main/java/org/silverpeas/core/webapi/media/streaming/StreamingRequester.java
+++ b/core-web/src/main/java/org/silverpeas/core/webapi/media/streaming/StreamingRequester.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2000 - 2021 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.webapi.media.streaming;
+
+import org.silverpeas.core.util.logging.SilverLogger;
+import org.silverpeas.core.media.streaming.StreamingProvider;
+import org.silverpeas.core.media.streaming.StreamingProvidersRegistry;
+
+import javax.ws.rs.WebApplicationException;
+import java.net.http.HttpResponse;
+
+import static java.net.http.HttpResponse.BodyHandlers.ofString;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static javax.ws.rs.core.Response.Status.OK;
+import static org.silverpeas.core.util.HttpUtil.httpClient;
+import static org.silverpeas.core.util.HttpUtil.toUrl;
+import static org.silverpeas.core.util.StringUtil.EMPTY;
+
+/**
+ * @author silveryocha
+ */
+public class StreamingRequester {
+
+  private StreamingRequester() {
+    // hidden constructor.
+  }
+
+  /**
+   * Gets OEMBED data as JSON string.<br>
+   * WARNING: performances can be altered when called from a list treatments as it performs an
+   * HTTP request.
+   * @return a JSON structure as string that represents oembed data.
+   */
+  protected static String getJsonOembedAsString(String homepageUrl) {
+    return StreamingProvidersRegistry.get().getOembedUrl(homepageUrl).map(u -> u.replace("http:", "https:")).map(oembedUrl -> {
+      try {
+        final HttpResponse<String> response = httpClient().send(toUrl(oembedUrl)
+            .header("Accept", APPLICATION_JSON)
+            .build(), ofString());
+        if (response.statusCode() != OK.getStatusCode()) {
+          throw new WebApplicationException(response.statusCode());
+        }
+        String jsonResponse = response.body();
+        for (StreamingProvider provider : StreamingProvidersRegistry.get().getAll()) {
+          jsonResponse = jsonResponse.replaceAll("(?i)" + provider.getName(), provider.getName());
+        }
+        return jsonResponse;
+      } catch (WebApplicationException wae) {
+        SilverLogger.getLogger(StreamingRequester.class)
+            .error("{0} -> HTTP ERROR {1}", oembedUrl, wae.getMessage());
+        throw wae;
+      } catch (Exception e) {
+        SilverLogger.getLogger(StreamingRequester.class).error("{0} -> {1}", oembedUrl, e.getMessage());
+        if (e instanceof InterruptedException) {
+          Thread.currentThread().interrupt();
+        }
+        throw new WebApplicationException(e);
+      }
+    }).orElse(EMPTY);
+  }
+}

--- a/core-web/src/main/java/org/silverpeas/core/webapi/media/streaming/VimeoDataEntity.java
+++ b/core-web/src/main/java/org/silverpeas/core/webapi/media/streaming/VimeoDataEntity.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2000 - 2021 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.silverpeas.core.webapi.media.streaming;
+
+import org.silverpeas.core.date.TimeUnit;
+import org.silverpeas.core.io.media.Definition;
+import org.silverpeas.core.util.StringUtil;
+import org.silverpeas.core.util.UnitUtil;
+import org.silverpeas.core.media.streaming.StreamingProvider;
+import org.silverpeas.core.webapi.media.MediaDefinitionEntity;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * @author silveryocha
+ */
+@XmlRootElement
+@XmlAccessorType(XmlAccessType.FIELD)
+public class VimeoDataEntity extends StreamingProviderDataEntity {
+  private static final long serialVersionUID = 724049725696379973L;
+
+  public static final String NAME = "vimeo";
+
+  /**
+   * Default hidden constructor.
+   */
+  VimeoDataEntity(final StreamingProvider streamingProvider,
+      final OembedDataEntity oembedVimeoData) {
+    super(streamingProvider, oembedVimeoData);
+
+    // As a specific way, vimeo is supplying additional information about the video streaming
+    // duration.
+    if (StringUtil.isInteger(oembedVimeoData.getDuration())) {
+      setFormattedDurationHMS(
+          UnitUtil.getDuration(Long.valueOf(oembedVimeoData.getDuration()), TimeUnit.SECOND)
+              .getFormattedDurationAsHMS());
+    }
+
+    // As the duration, the width and height supplied are those of the video and not
+    // those of the streaming player.
+    String width = oembedVimeoData.getWidth();
+    String height = oembedVimeoData.getHeight();
+    if (StringUtil.isInteger(width) && StringUtil.isInteger(height)) {
+      setDefinition(MediaDefinitionEntity
+          .createFrom(Definition.of(Integer.valueOf(width), Integer.valueOf(height))));
+    }
+  }
+
+  @SuppressWarnings("UnusedDeclaration")
+  protected VimeoDataEntity() {
+    super();
+  }
+}

--- a/core-web/src/main/java/org/silverpeas/core/webapi/media/streaming/YoutubeDataEntity.java
+++ b/core-web/src/main/java/org/silverpeas/core/webapi/media/streaming/YoutubeDataEntity.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2000 - 2021 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.silverpeas.core.webapi.media.streaming;
+
+import org.silverpeas.core.media.streaming.StreamingProvider;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+import java.net.URI;
+
+/**
+ * @author silveryocha
+ */
+@XmlRootElement
+@XmlAccessorType(XmlAccessType.FIELD)
+public class YoutubeDataEntity extends StreamingProviderDataEntity {
+  private static final long serialVersionUID = 6909168681705256783L;
+
+  public static final String NAME = "youtube";
+
+  private static final char PATH_SEPARATOR = '/';
+
+  /**
+   * Default hidden constructor.
+   */
+  YoutubeDataEntity(final StreamingProvider streamingProvider,
+      final OembedDataEntity oembedYoutubeData) {
+    super(streamingProvider, oembedYoutubeData);
+    if (getThumbnailUrl() != null) {
+      final String path = getThumbnailUrl().toString();
+      final String thumbnailUrlPrefix = path.substring(0, path.lastIndexOf(PATH_SEPARATOR) + 1);
+      for (int i = 1; i <= 3; i++) {
+        getThumbnailPreviewUrls().add(URI.create(thumbnailUrlPrefix + i + ".jpg"));
+      }
+    }
+  }
+
+  @SuppressWarnings("UnusedDeclaration")
+  protected YoutubeDataEntity() {
+    super();
+  }
+}


### PR DESCRIPTION
Implementing a registry of streaming provider.
Providers are specified into a property file.

Adding the transversal WEB service which can be used by any module of Silverpeas.

Moving to a centralized place Javascript stuffs permitting to handle Forms dealing with streaming.

Linked to PRs:
* https://github.com/Silverpeas/Silverpeas-Components/pull/767
* https://github.com/Silverpeas/silverpeasmobile/pull/28