### PR TITLE
Bug #12825: avoiding to fill automatically password inputs on the other pages than the one of connexion.

### DIFF
--- a/core-war/src/main/webapp/defaultChangePassword.jsp
+++ b/core-war/src/main/webapp/defaultChangePassword.jsp
@@ -90,15 +90,15 @@
           <div class="clear"></div>
         </div>
         <p>
-          <label><span><fmt:message key="authentication.password.old" bundle="${authenticationBundle}"/></span><input type="password" name="oldPassword" id="oldPassword" autocomplete="off"/></label>
+          <label><span><fmt:message key="authentication.password.old" bundle="${authenticationBundle}"/></span><input type="password" name="oldPassword" id="oldPassword" autocomplete="new-password"/></label>
         </p>
 
         <p>
-          <label><span><fmt:message key="authentication.password.new" bundle="${authenticationBundle}"/></span><input type="password" name="newPassword" id="newPassword" autocomplete="off"/></label>
+          <label><span><fmt:message key="authentication.password.new" bundle="${authenticationBundle}"/></span><input type="password" name="newPassword" id="newPassword" autocomplete="new-password"/></label>
         </p>
 
         <p>
-          <label><span><fmt:message key="authentication.password.confirm" bundle="${authenticationBundle}"/></span><input type="password" name="confirmPassword" id="confirmPassword" autocomplete="off"/></label>
+          <label><span><fmt:message key="authentication.password.confirm" bundle="${authenticationBundle}"/></span><input type="password" name="confirmPassword" id="confirmPassword" autocomplete="new-password"/></label>
         </p>
         <c:if test="${isEmailAddress}">
           <p>

--- a/core-war/src/main/webapp/defaultForcePasswordChange.jsp
+++ b/core-war/src/main/webapp/defaultForcePasswordChange.jsp
@@ -78,15 +78,15 @@
           <div class="clear"></div>
         </div>
         <p><label><span><%=authenticationBundle.getString(
-            "authentication.password.old") %></span><input type="password" autocomplete="off" name="oldPassword" id="oldPassword"/></label>
+            "authentication.password.old") %></span><input type="password" autocomplete="new-password" name="oldPassword" id="oldPassword"/></label>
         </p>
 
         <p><label><span><%=authenticationBundle.getString(
-            "authentication.password.new") %> </span><input type="password" autocomplete="off" name="newPassword" id="newPassword"/></label>
+            "authentication.password.new") %> </span><input type="password" autocomplete="new-password" name="newPassword" id="newPassword"/></label>
         </p>
 
         <p><label><span><%=authenticationBundle.getString(
-            "authentication.password.confirm") %></span><input type="password" autocomplete="off" name="confirmPassword" id="confirmPassword"/></label>
+            "authentication.password.confirm") %></span><input type="password" autocomplete="new-password" name="confirmPassword" id="confirmPassword"/></label>
         </p>
 
         <div class="submit">

--- a/core-war/src/main/webapp/defaultLoginQuestion.jsp
+++ b/core-war/src/main/webapp/defaultLoginQuestion.jsp
@@ -96,7 +96,7 @@
           <div class="clear"></div>
         </div>
         <p><label><span><%=userDetail.getLoginQuestion()%></span>
-          <input type="password" autocomplete="off" name="answer" id="answer"/></label></p>
+          <input type="password" autocomplete="new-password" name="answer" id="answer"/></label></p>
 
         <div class="submit">
           <p>

--- a/core-war/src/main/webapp/defaultLoginQuestionSelection.jsp
+++ b/core-war/src/main/webapp/defaultLoginQuestionSelection.jsp
@@ -110,11 +110,11 @@
         <br/><br/>
 
         <p><label><span><%=authenticationBundle.getString(
-            "authentication.reminder.answer") %></span><input type="password" autocomplete="off" name="answer" id="answer"/></label>
+            "authentication.reminder.answer") %></span><input type="password" autocomplete="new-password" name="answer" id="answer"/></label>
         </p>
 
         <p><label><span><%=authenticationBundle.getString(
-            "authentication.reminder.confirm") %></span><input type="password" autocomplete="off" name="answerConfirmed" id="answerConfirmed"/></label>
+            "authentication.reminder.confirm") %></span><input type="password" autocomplete="new-password" name="answerConfirmed" id="answerConfirmed"/></label>
         </p>
 
         <div class="submit">

--- a/core-war/src/main/webapp/defaultPasswordAboutToExpire.jsp
+++ b/core-war/src/main/webapp/defaultPasswordAboutToExpire.jsp
@@ -86,15 +86,15 @@
           <div class="clear"></div>
         </div>
         <p><label><span><%=authenticationBundle.getString(
-            "authentication.password.old") %></span><input type="password" autocomplete="off" name="oldPassword" id="oldPassword"/></label>
+            "authentication.password.old") %></span><input type="password" autocomplete="new-password" name="oldPassword" id="oldPassword"/></label>
         </p>
 
         <p><label><span><%=authenticationBundle.getString(
-            "authentication.password.new") %></span><input type="password" autocomplete="off" name="newPassword" id="newPassword"/></label>
+            "authentication.password.new") %></span><input type="password" autocomplete="new-password" name="newPassword" id="newPassword"/></label>
         </p>
 
         <p><label><span><%=authenticationBundle.getString(
-            "authentication.password.confirm") %></span><input type="password" autocomplete="off" name="confirmPassword" id="confirmPassword"/></label>
+            "authentication.password.confirm") %></span><input type="password" autocomplete="new-password" name="confirmPassword" id="confirmPassword"/></label>
         </p>
 
         <div class="submit">

--- a/core-war/src/main/webapp/defaultPasswordExpired.jsp
+++ b/core-war/src/main/webapp/defaultPasswordExpired.jsp
@@ -81,15 +81,15 @@
           <div class="clear"></div>
         </div>
         <p><label><span><%=authenticationBundle.getString(
-            "authentication.password.old") %></span><input type="password" autocomplete="off" name="oldPassword" id="oldPassword"/></label>
+            "authentication.password.old") %></span><input type="password" autocomplete="new-password" name="oldPassword" id="oldPassword"/></label>
         </p>
 
         <p><label><span><%=authenticationBundle.getString(
-            "authentication.password.new") %></span><input type="password" autocomplete="off" name="newPassword" id="newPassword"/></label>
+            "authentication.password.new") %></span><input type="password" autocomplete="new-password" name="newPassword" id="newPassword"/></label>
         </p>
 
         <p><label><span><%=authenticationBundle.getString(
-            "authentication.password.confirm") %></span><input type="password" autocomplete="off" name="confirmPassword" id="confirmPassword"/></label>
+            "authentication.password.confirm") %></span><input type="password" autocomplete="new-password" name="confirmPassword" id="confirmPassword"/></label>
         </p>
         <input type="hidden" name="login" value="${param.login}"/>
         <input type="hidden" name="domainId" value="${param.domainId}"/>

--- a/core-war/src/main/webapp/defaultResetPassword.jsp
+++ b/core-war/src/main/webapp/defaultResetPassword.jsp
@@ -79,11 +79,11 @@
           <div class="clear"></div>
         </div>
         <p><label><span><%=authenticationBundle.getString(
-            "authentication.password.new") %> </span><input type="password" autocomplete="off" name="password" id="password"/></label>
+            "authentication.password.new") %> </span><input type="password" autocomplete="new-password" name="password" id="password"/></label>
         </p>
 
         <p><label><span><%=authenticationBundle.getString(
-            "authentication.password.confirm") %></span><input type="password" autocomplete="off" name="confirmPassword" id="confirmPassword"/></label>
+            "authentication.password.confirm") %></span><input type="password" autocomplete="new-password" name="confirmPassword" id="confirmPassword"/></label>
         </p>
 
         <div class="submit">

--- a/core-war/src/main/webapp/jobDomainPeas/jsp/userCreate.jsp
+++ b/core-war/src/main/webapp/jobDomainPeas/jsp/userCreate.jsp
@@ -363,14 +363,14 @@ out.println(window.printBefore());
 	<div class="field" id="form-row-password">
 			<label class="txtlibform"><fmt:message key="GML.password"/></label>
 			<div class="champs">
-				<input type="password" autocomplete="off" name="userPassword" id="userPasswordId" size="50" maxlength="32" value=""/>
+				<input type="password" autocomplete="new-password" name="userPassword" id="userPasswordId" size="50" maxlength="32" value=""/>
 			</div>
 		</div>
 		<!--Password again-->
 	<div class="field" id="form-row-passwordAgain">
 			<label class="txtlibform"><fmt:message key="GML.passwordAgain"/></label>
 			<div class="champs">
-				<input type="password" autocomplete="off" name="userPasswordAgain" id="userPasswordAgainId" size="50" maxlength="32" value=""/>
+				<input type="password" autocomplete="new-password" name="userPasswordAgain" id="userPasswordAgainId" size="50" maxlength="32" value=""/>
 			</div>
 		</div>
 		<!--Send Email-->

--- a/core-war/src/main/webapp/socialNetwork/jsp/myProfil/myProfileTabIdentity.jsp
+++ b/core-war/src/main/webapp/socialNetwork/jsp/myProfil/myProfileTabIdentity.jsp
@@ -125,15 +125,15 @@
 	<%if (updateIsAllowed && isPasswordChangeAllowed) {%>
 		<tr id="oldPassword">
 	        <td class="txtlibform"><%=resource.getString("myProfile.OldPassword")%> :</td>
-	        <td><input <%=fieldAttribute%> type="password" autocomplete="off" name="OldPassword" size="50" maxlength="32"/></td>
+	        <td><input <%=fieldAttribute%> type="password" autocomplete="new-password" name="OldPassword" size="50" maxlength="32"/></td>
 	    </tr>
 		<tr>
 	        <td class="txtlibform"><%=resource.getString("myProfile.NewPassword")%> :</td>
-	        <td><input <%=fieldAttribute%> type="password" autocomplete="off" id="newPassword" name="NewPassword" size="50" maxlength="32"/>&nbsp;(<a tabindex="-1" href="#" onclick="$('#newPassword').focus()"><%=authRs.getString("authentication.password.showRules") %></a>)</td>
+	        <td><input <%=fieldAttribute%> type="password" autocomplete="new-password" id="newPassword" name="NewPassword" size="50" maxlength="32"/>&nbsp;(<a tabindex="-1" href="#" onclick="$('#newPassword').focus()"><%=authRs.getString("authentication.password.showRules") %></a>)</td>
 	    </tr>
 		<tr>
 	        <td class="txtlibform"><%=resource.getString("myProfile.NewPasswordConfirm")%> :</td>
-	        <td><input <%=fieldAttribute%>  autocomplete="off" id="newPasswordConfirmation" name="NewPasswordConfirm" type="password" size="50" maxlength="32"/></td>
+	        <td><input <%=fieldAttribute%>  autocomplete="new-password" id="newPasswordConfirmation" name="NewPasswordConfirm" type="password" size="50" maxlength="32"/></td>
 	    </tr>
     <%} else { %>
 	    <tr>


### PR DESCRIPTION
According to https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion explanations, setting 'new-password' value to autocomplete attribute of password inputs aiming password of user accounts.