### PR TITLE
Bug #12840: [6.3.x] fixing restoring of a space which was not applying parent space profiles.

### DIFF
--- a/core-api/src/main/java/org/silverpeas/core/util/TriConsumer.java
+++ b/core-api/src/main/java/org/silverpeas/core/util/TriConsumer.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2000 - 2022 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.util;
+
+import java.util.function.Consumer;
+
+/**
+ * Represents an operation that accepts three input arguments and returns no
+ * result.  This is the three-arity specialization of {@link Consumer}.
+ * Unlike most other functional interfaces, {@code TriConsumer} is expected
+ * to operate via side-effects.
+ *
+ * <p>This is a <a href="package-summary.html">functional interface</a>
+ * whose functional method is {@link #accept(Object, Object, Object)}.
+ *
+ * @param <T> the type of the first argument to the operation
+ * @param <U> the type of the second argument to the operation
+ * @param <V> the type of the third argument to the operation
+ *
+ * @see Consumer
+ * @author silveryocha
+ */
+@FunctionalInterface
+public interface TriConsumer<T, U, V> {
+
+  /**
+   * Performs this operation on the given arguments.
+   *
+   * @param t the first input argument
+   * @param u the second input argument
+   * @param v the third input argument
+   */
+  void accept(T t, U u, V v);
+}

--- a/core-api/src/main/java/org/silverpeas/core/util/TriFunction.java
+++ b/core-api/src/main/java/org/silverpeas/core/util/TriFunction.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2000 - 2022 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.util;
+
+import java.util.function.Function;
+
+/**
+ * Represents a function that accepts three arguments and produces a result.
+ * This is the three-arity specialization of {@link Function}.
+ *
+ * <p>This is a <a href="package-summary.html">functional interface</a>
+ * whose functional method is {@link #apply(Object, Object, Object)}.
+ *
+ * @param <T> the type of the first argument to the function
+ * @param <U> the type of the second argument to the function
+ * @param <V> the type of the third argument to the function
+ * @param <R> the type of the result of the function
+ *
+ * @see Function
+ * @author silveryocha
+ */
+@FunctionalInterface
+public interface TriFunction<T, U, V, R> {
+
+  /**
+   * Applies this function to the given arguments.
+   *
+   * @param t the first function argument
+   * @param u the second function argument
+   * @param v the third function argument
+   * @return the function result
+   */
+  R apply(T t, U u, V v);
+}

--- a/core-library/src/main/java/org/silverpeas/core/admin/persistence/ComponentInstanceTable.java
+++ b/core-library/src/main/java/org/silverpeas/core/admin/persistence/ComponentInstanceTable.java
@@ -153,7 +153,7 @@ public class ComponentInstanceTable extends Table<ComponentInstanceRow> {
    */
   public String[] getAllComponentInstanceIdsInSpace(int spaceId) throws SQLException {
     List<String> ids = getIds(SELECT_ALL_SPACE_INSTANCE_IDS, spaceId);
-    return ids.toArray(new String[ids.size()]);
+    return ids.toArray(new String[0]);
   }
 
   private static final String SELECT_ALL_SPACE_INSTANCE_IDS =

--- a/core-library/src/main/java/org/silverpeas/core/admin/persistence/SpaceUserRoleTable.java
+++ b/core-library/src/main/java/org/silverpeas/core/admin/persistence/SpaceUserRoleTable.java
@@ -128,7 +128,7 @@ public class SpaceUserRoleTable extends Table<SpaceUserRoleRow> {
    */
   public String[] getAllSpaceUserRoleIdsOfSpace(int spaceId) throws SQLException {
     List<String> ids = getIds(SELECT_ALL_SPACE_USERROLE_IDS, spaceId);
-    return ids.toArray(new String[ids.size()]);
+    return ids.toArray(new String[0]);
   }
 
   private static final String SELECT_ALL_SPACE_USERROLE_IDS =

--- a/core-library/src/main/java/org/silverpeas/core/admin/service/Administration.java
+++ b/core-library/src/main/java/org/silverpeas/core/admin/service/Administration.java
@@ -328,8 +328,8 @@ public interface Administration {
   void setSpaceProfilesToSubSpace(final SpaceInst subSpace, final SpaceInst space)
       throws AdminException;
 
-  void setSpaceProfilesToSubSpace(final SpaceInst subSpace, final SpaceInst space, boolean persist,
-      boolean startNewTransaction) throws AdminException;
+  void setSpaceProfilesToSubSpace(final SpaceInst subSpace, final SpaceInst space, boolean persist)
+      throws AdminException;
 
   void setSpaceProfilesToComponent(ComponentInst component, SpaceInst space) throws AdminException;
 

--- a/core-library/src/main/java/org/silverpeas/core/admin/service/RightRecover.java
+++ b/core-library/src/main/java/org/silverpeas/core/admin/service/RightRecover.java
@@ -73,7 +73,7 @@ public class RightRecover {
         }
       } else {
         // recover space rights (those inherited from parent)
-        admin.setSpaceProfilesToSubSpace(space, null, true, true);
+        admin.setSpaceProfilesToSubSpace(space, null, true);
       }
     }
 

--- a/core-library/src/main/java/org/silverpeas/core/admin/space/SpaceInstLazyDataLoader.java
+++ b/core-library/src/main/java/org/silverpeas/core/admin/space/SpaceInstLazyDataLoader.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright (C) 2000 - 2022 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.admin.space;
+
+import org.silverpeas.core.admin.component.model.ComponentInst;
+import org.silverpeas.core.admin.service.SpaceInstManager;
+import org.silverpeas.core.persistence.Transaction;
+import org.silverpeas.core.util.ServiceProvider;
+import org.silverpeas.core.util.TriConsumer;
+import org.silverpeas.core.util.TriFunction;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This class handles the lazy loading of following data of a SpaceInst:
+ * <ul>
+ *   <li>profiles</li>
+ *   <li>sub spaces</li>
+ *   <li>components</li>
+ * </ul>
+ * <p>
+ *  The aim of this lazy loading is about avoiding to walk through the entire space tree when
+ *  loading a space from repository.<br/>
+ *  It permits to get rapidly a space from repository if not yet into cache, and to load later the
+ *  linked data which are not necessary used just after repository get.
+ * </p>
+ * <p>
+ *   Technically, if load has not yet been performed, then all data are loaded before performing
+ *   process given to {@link #safeRead(TriFunction)} or {@link #safeWrite(TriConsumer)} method.
+ * </p>
+ * @author silveryocha
+ */
+public class SpaceInstLazyDataLoader implements Serializable {
+  private static final long serialVersionUID = -1770031353832624141L;
+
+  private final transient Object mutex = new Object();
+
+  private final SpaceInst space;
+
+  /* Collection of components Instances */
+  private final List<ComponentInst> components = new ArrayList<>();
+
+  /* Collection of subspaces Instances */
+  private final List<SpaceInst> subSpaces = new ArrayList<>();
+
+  /* Collection of space profiles Instances */
+  private final List<SpaceProfileInst> spaceProfiles = new ArrayList<>();
+
+  private boolean loaded = false;
+
+  SpaceInstLazyDataLoader(final SpaceInst space) {
+    this.space = space;
+  }
+
+  /**
+   * Reset all data loaded lazily.
+   * <p>
+   *   Data will be loaded again at next {@link #safeRead(TriFunction)} or
+   *   {@link #safeWrite(TriConsumer)} method call.
+   * </p>
+   */
+  void reset() {
+    synchronized (mutex) {
+      loaded = false;
+      spaceProfiles.clear();
+      subSpaces.clear();
+      components.clear();
+    }
+  }
+
+
+  /**
+   * Allows performing data reading.
+   * <p>
+   *   If not yet done, data are loaded before the read process is performed.
+   * </p>
+   * @param process the read process.
+   */
+  <T> T safeRead(
+      final TriFunction<List<SpaceProfileInst>, List<SpaceInst>, List<ComponentInst>, T> process) {
+    synchronized (mutex) {
+      if (!loaded) {
+        loaded = true;
+        load();
+      }
+      return process.apply(spaceProfiles, subSpaces, components);
+    }
+  }
+
+  /**
+   * Allows performing data modification without taking care if data have been loaded or not.
+   * <p>
+   *   This method does not perform a clear of data, so if data MUST be cleared before calling
+   *   the method, please call {@link #reset()} before.
+   * </p>
+   * <p>
+   *   Please notice that data will be marked as loaded.
+   * </p>
+   * @param process the modification process.
+   */
+  void manualWrite(
+      final TriConsumer<List<SpaceProfileInst>, List<SpaceInst>, List<ComponentInst>> process) {
+    synchronized (mutex) {
+      loaded = true;
+      process.accept(spaceProfiles, subSpaces, components);
+    }
+  }
+
+  /**
+   * Allows performing data modifications.
+   * <p>
+   *   If not yet done, data are loaded before the modification process is performed.
+   * </p>
+   * @param process the modification process.
+   */
+  void safeWrite(
+      final TriConsumer<List<SpaceProfileInst>, List<SpaceInst>, List<ComponentInst>> process) {
+    synchronized (mutex) {
+      if (!loaded) {
+        loaded = true;
+        load();
+      }
+      process.accept(spaceProfiles, subSpaces, components);
+    }
+  }
+
+  /**
+   * This method handles the load of the missing data.
+   */
+  protected void load() {
+    Transaction.getTransaction().perform(() -> {
+      final SpaceInstManager spaceInstManager = ServiceProvider.getSingleton(SpaceInstManager.class);
+      spaceInstManager.loadSpaceInstData(space);
+      return null;
+    });
+  }
+}

--- a/core-library/src/test/java/org/silverpeas/core/admin/space/SpaceInstLazyDataLoaderTest.java
+++ b/core-library/src/test/java/org/silverpeas/core/admin/space/SpaceInstLazyDataLoaderTest.java
@@ -1,0 +1,321 @@
+/*
+ * Copyright (C) 2000 - 2022 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.admin.space;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.silverpeas.core.SilverpeasRuntimeException;
+import org.silverpeas.core.admin.component.model.ComponentInst;
+import org.silverpeas.core.test.extention.EnableSilverTestEnv;
+import org.silverpeas.core.util.Mutable;
+import org.silverpeas.core.util.StringUtil;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.apache.commons.lang3.reflect.FieldUtils.readField;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * @author silveryocha
+ */
+@EnableSilverTestEnv
+class SpaceInstLazyDataLoaderTest {
+
+  private long lastLogTime = -1;
+  private SpaceInstLazyDataLoader4Test test;
+
+  @BeforeEach
+  void setup() {
+    test = new SpaceInstLazyDataLoader4Test();
+    assertDataNotLoaded(test);
+  }
+
+  @Test
+  void testSafeRead() {
+    final String result = test.safeRead((p, s, c) -> "readDone");
+    assertThat(result, is("readDone"));
+    assertDataLoadedOneTime(test);
+    IntStream.rangeClosed(1, 10).forEach(i -> {
+      final String r = test.safeRead((p, s, c) -> "readDone" + i);
+      assertThat(r, is("readDone" + i));
+    });
+    assertDataLoadedOneTime(test);
+  }
+
+  @Test
+  void testSafeWrite() {
+    final Mutable<Boolean> performed = Mutable.of(false);
+    test.safeWrite((p, s, c) -> performed.set(true));
+    assertDataLoadedOneTime(test);
+    assertThat(performed.orElse(false), is(true));
+    IntStream.rangeClosed(1, 10).forEach(i -> {
+      performed.set(false);
+      assertThat(performed.orElse(false), is(false));
+      test.safeWrite((p, s, c) -> performed.set(true));
+      assertThat(performed.orElse(false), is(true));
+    });
+    assertDataLoadedOneTime(test);
+  }
+
+  @Test
+  void testManualWrite() {
+    final Mutable<Boolean> performed = Mutable.of(false);
+    test.manualWrite((p, s, c) -> {
+      performed.set(true);
+      test.setData();
+    });
+    assertDataWrittenManually(test, 1);
+    assertThat(performed.orElse(false), is(true));
+    IntStream.rangeClosed(1, 10).forEach(i -> {
+      performed.set(false);
+      assertThat(performed.orElse(false), is(false));
+      test.safeWrite((p, s, c) -> {
+        performed.set(true);
+        test.setData();
+      });
+      assertThat(performed.orElse(false), is(true));
+    });
+    assertDataWrittenManually(test, 11);
+  }
+
+  @Test
+  void testReset() {
+    testSafeWrite();
+    assertDataLoadedOneTime(test);
+    test.reset();
+    assertDataHasBeenResetAfterOneLoading(test);
+    final Mutable<Boolean> performed = Mutable.of(false);
+    test.safeWrite((p, s, c) -> performed.set(true));
+    assertThat(performed.orElse(false), is(true));
+    test.reset();
+    assertDataHasBeenResetAfterTwoLoadings(test);
+  }
+
+  @Test
+  void testConcurrency() throws Exception {
+    final int nbThreadsPerType = 1000;
+    final CountDownLatch latch = new CountDownLatch(1);
+    final List<Thread> threads = new ArrayList<>(4 * nbThreadsPerType);
+    final AtomicInteger safeReads = new AtomicInteger(0);
+    final AtomicInteger safeWrites = new AtomicInteger(0);
+    final AtomicInteger manualWritesIncludingReset = new AtomicInteger(0);
+    final AtomicInteger resets = new AtomicInteger(0);
+    IntStream.range(0, nbThreadsPerType).forEach(i -> {
+      // Profile 1: safeRead
+      threads.add(new Thread(() -> {
+        try {
+          latch.await();
+          test.safeRead((p, s, c) -> {
+            final int count = safeReads.incrementAndGet();
+            log(String.format("safeRead n°%s", count));
+            return count;
+          });
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          throw new SilverpeasRuntimeException(e);
+        }
+      }));
+      // Profile 2: safeWrite
+      threads.add(new Thread(() -> {
+        try {
+          latch.await();
+          test.safeWrite((p, s, c) ->
+              log(String.format("safeWrite n°%s", safeWrites.incrementAndGet())));
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          throw new SilverpeasRuntimeException(e);
+        }
+      }));
+      // Profile 3: manualWrite (including a reset)
+      threads.add(new Thread(() -> {
+        try {
+          latch.await();
+          test.manualWrite((p, s, c) -> {
+            test.reset();
+            log(String.format("manualWrite n°%s", manualWritesIncludingReset.incrementAndGet()));
+          });
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          throw new SilverpeasRuntimeException(e);
+        }
+      }));
+      // Profile 4: reset
+      threads.add(new Thread(() -> {
+        try {
+          latch.await();
+          test.reset();
+          log(String.format("reset n°%s", resets.incrementAndGet()));
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          throw new SilverpeasRuntimeException(e);
+        }
+      }));
+    });
+
+    log("STARTING THREADS...");
+    Collections.shuffle(threads);
+    for (Thread thread : threads) {
+      thread.start();
+    }
+    log(threads.size() + " THREADS STARTED");
+    log("WAITING 1s...");
+    await().pollDelay(1, SECONDS).until(() -> true);
+    latch.countDown();
+
+    log("WAITING ENDING OF THREADS...");
+    for (Thread thread : threads) {
+      thread.join(60000);
+    }
+    log(threads.size() + " THREADS STOPPED");
+    assertThat(test.getNbLoad(), greaterThan(1));
+    assertThat(safeReads.get(), is(nbThreadsPerType));
+    assertThat(safeWrites.get(), is(nbThreadsPerType));
+    assertThat(manualWritesIncludingReset.get(), is(nbThreadsPerType));
+    assertThat(resets.get(), is(nbThreadsPerType));
+  }
+
+  private static void assertDataNotLoaded(SpaceInstLazyDataLoader4Test data) {
+    assertThat(data.isLoaded(), is(false));
+    assertThat(data.getNbLoad(), is(0));
+    assertThat(data.getProfiles(), hasSize(0));
+    assertThat(data.getSubSpaces(), hasSize(0));
+    assertThat(data.getComponents(), hasSize(0));
+  }
+
+  private static void assertDataLoadedOneTime(SpaceInstLazyDataLoader4Test data) {
+    assertThat(data.isLoaded(), is(true));
+    assertThat(data.getNbLoad(), is(1));
+    assertThat(data.getProfiles(), hasSize(1));
+    assertThat(data.getSubSpaces(), hasSize(1));
+    assertThat(data.getComponents(), hasSize(2));
+  }
+
+  private static void assertDataHasBeenResetAfterOneLoading(SpaceInstLazyDataLoader4Test data) {
+    assertThat(data.isLoaded(), is(false));
+    assertThat(data.getNbLoad(), is(1));
+    assertThat(data.getProfiles(), hasSize(0));
+    assertThat(data.getSubSpaces(), hasSize(0));
+    assertThat(data.getComponents(), hasSize(0));
+  }
+
+  private static void assertDataHasBeenResetAfterTwoLoadings(SpaceInstLazyDataLoader4Test data) {
+    assertThat(data.isLoaded(), is(false));
+    assertThat(data.getNbLoad(), is(2));
+    assertThat(data.getProfiles(), hasSize(0));
+    assertThat(data.getSubSpaces(), hasSize(0));
+    assertThat(data.getComponents(), hasSize(0));
+  }
+
+  private static void assertDataWrittenManually(SpaceInstLazyDataLoader4Test data,
+      final int nbWrites) {
+    assertThat(data.isLoaded(), is(true));
+    assertThat(data.getNbLoad(), is(0));
+    assertThat(data.getProfiles(), hasSize(nbWrites));
+    assertThat(data.getSubSpaces(), hasSize(nbWrites));
+    assertThat(data.getComponents(), hasSize(2 * nbWrites));
+  }
+
+  static class SpaceInstLazyDataLoader4Test extends SpaceInstLazyDataLoader {
+
+    private int nbLoad;
+
+    SpaceInstLazyDataLoader4Test() {
+      super(null);
+    }
+
+    public boolean isLoaded() {
+      return extract("loaded");
+    }
+
+    public int getNbLoad() {
+      return nbLoad;
+    }
+
+    public List<SpaceProfileInst> getProfiles() {
+      return extract("spaceProfiles");
+    }
+
+    public List<SpaceInst> getSubSpaces() {
+      return extract("subSpaces");
+    }
+
+    public List<ComponentInst> getComponents() {
+      return extract("components");
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> T extract(final String fieldName) {
+      try {
+        return (T) readField(this, fieldName, true);
+      } catch (IllegalAccessException e) {
+        throw new SilverpeasRuntimeException(e);
+      }
+    }
+
+    @Override
+    protected void load() {
+      nbLoad++;
+      setData();
+    }
+
+    private void setData() {
+      final SpaceProfileInst profile = new SpaceProfileInst();
+      profile.setId("2601");
+      profile.setSpaceFatherId("26");
+      getProfiles().add(profile);
+      final SpaceInst subSpace = new SpaceInst();
+      subSpace.setLocalId(38);
+      getSubSpaces().add(subSpace);
+      final ComponentInst component1 = new ComponentInst();
+      component1.setLocalId(1);
+      getComponents().add(component1);
+      final ComponentInst component2 = new ComponentInst();
+      component2.setLocalId(2);
+      getComponents().add(component2);
+    }
+  }
+
+  /*
+  Tool methods
+   */
+
+  private void log(String message) {
+    long currentTime = System.currentTimeMillis();
+    if (lastLogTime < 0) {
+      lastLogTime = currentTime;
+    }
+    System.out.println(
+        StringUtil.leftPad(String.valueOf(currentTime - lastLogTime), 6, " ") + " ms -> " +
+            message);
+  }
+}


### PR DESCRIPTION
Fixing the spreading of space rights which was not merging correctly several space roles on a single instance role.

Fixing the non spreading of specific rights of a space to components and sub spaces when blocking its inheritance.

Adding a mechanism in charge of the lazy loading of some SpaceInst data:
* profiles
* sub spaces
* components
Wiring this mechanism into SpaceInst Object and into services in charge of the feeding of these data.

Fixing little sonarQube feedback.