### PR TITLE
Bug #12805 for 6.3

### DIFF
--- a/core-api/pom.xml
+++ b/core-api/pom.xml
@@ -64,6 +64,10 @@
       <artifactId>commons-io</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-text</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.ehcache</groupId>
       <artifactId>ehcache</artifactId>
     </dependency>

--- a/core-api/src/main/java/org/silverpeas/core/notification/user/client/NotificationMetaData.java
+++ b/core-api/src/main/java/org/silverpeas/core/notification/user/client/NotificationMetaData.java
@@ -267,7 +267,7 @@ public class NotificationMetaData implements java.io.Serializable {
     result.append(AFTER_MESSAGE_FOOTER_TAG);
 
 
-    return WebEncodeHelper.convertWhiteSpacesForHTMLDisplay(result.toString());
+    return WebEncodeHelper.convertBlanksForHtml(result.toString());
   }
 
   private void appendMessageContent(final StringBuilder result, final String language) {

--- a/core-api/src/main/java/org/silverpeas/core/notification/user/client/NotificationTemplateKey.java
+++ b/core-api/src/main/java/org/silverpeas/core/notification/user/client/NotificationTemplateKey.java
@@ -23,14 +23,46 @@
  */
 package org.silverpeas.core.notification.user.client;
 
+/**
+ * Keys of the predefined fields injected by default in the text templates used in the notifications
+ * to users.
+ */
 public enum NotificationTemplateKey {
+  /**
+   * The name of the user at the origin of the notification.
+   */
   NOTIFICATION_SENDER_NAME("notification_sendername"),
+  /**
+   * The email address of the user at the origin of the notification.
+   */
   NOTIFICATION_SENDER_EMAIL("notification_senderemail"),
+  /**
+   * The identifiers of the users targeted by the notification.
+   */
   NOTIFICATION_RECEIVER_USERS("notification_receiver_users"),
+  /**
+   * The identifiers of the user groups targeted by the notification.
+   */
   NOTIFICATION_RECEIVER_GROUPS("notification_receiver_groups"),
+  /**
+   * The base URL of the server (the port number included if other than 80)
+   */
+  NOTIFICATION_BASE_SERVER_URL("notification_base_serverurl"),
+  /**
+   * The URL of the server including the application context if any (the URL of Silverpeas).
+   */
   NOTIFICATION_SERVER_URL("notification_serverurl"),
+  /**
+   * Link to the resource in Silverpeas for which the notification has been sent.
+   */
   NOTIFICATION_LINK("notification_link"),
+  /**
+   * Label associated with the notification link above.
+   */
   NOTIFICATION_LINK_LABEL("notification_linkLabel"),
+  /**
+   * Links to the attachments concerned by the notification.
+   */
   NOTIFICATION_ATTACHMENTS("notification_attachments");
 
   private final String name;

--- a/core-api/src/main/java/org/silverpeas/core/util/WebEncodeHelper.java
+++ b/core-api/src/main/java/org/silverpeas/core/util/WebEncodeHelper.java
@@ -23,68 +23,69 @@
  */
 package org.silverpeas.core.util;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+
+import org.apache.commons.text.StringEscapeUtils;
 
 import javax.xml.bind.DatatypeConverter;
 
 /**
  * Utility class to encode special string or characters to be compliant with the web (HTML and
- * Javascript). Useful to format text in HTML.
+ * Javascript). Useful to format text in HTML but not to encode unsafe text in HTML or Javascript.
+ * To encode unsafe text, please use instead {@link org.owasp.encoder.Encode}.
  *
  * @author lloiseau
  * @version 1.0
- * @deprecated please use instead {@link org.owasp.encoder.Encode}
  */
-@Deprecated
 public class WebEncodeHelper {
 
   /**
-   * Convert a java string to a javascript string Replace \,\n,\r and "
+   * Convert a java string to a javascript string. Replace \,\n,\r and "
    *
-   * @param javastring Java string to encode
+   * @param input Java string to encode
    * @return javascript string encoded
    */
-  public static String javaStringToJsString(String javastring) {
-    if (!isDefined(javastring)) {
+  public static String javaStringToJsString(String input) {
+    if (!isDefined(input)) {
       return "";
     }
-    return StringEscapeUtils.escapeEcmaScript(javastring);
+    return StringEscapeUtils.escapeEcmaScript(input);
   }
 
   /**
-   * Convert a java string to a html string for textArea Replace ", &gt;, &lt;, &amp; and \n
+   * Convert a java string to a html text for textArea value. Replace ", &gt;, &lt;, &amp; and \n
    *
-   * @param javastring Java string to encode
+   * @param input Java string to encode
    * @return html string encoded
    */
-  public static String javaStringToHtmlString(String javastring) {
-    if (!isDefined(javastring)) {
+  public static String javaStringToHtmlString(String input) {
+    if (!isDefined(input)) {
       return "";
     }
-    return StringEscapeUtils.escapeHtml4(javastring).replace("œ", "&oelig;");
+    return StringEscapeUtils.escapeHtml4(input).replace("œ", "&oelig;");
   }
 
-  public static String escapeXml(String javastring) {
-    if (isDefined(javastring)) {
-      return StringEscapeUtils.escapeXml11(javastring);
+  public static String escapeXml(String input) {
+    if (isDefined(input)) {
+      return StringEscapeUtils.escapeXml11(input);
     } else {
       return "";
     }
   }
 
   /**
-   * Convert a java string to a html string for textfield... Replace ", &gt;, &lt;, &amp; and \n
+   * Convert a text, possibly an HTML one, by replacing any blank tokens (tab and line-feeds) by
+   * their counterpart in HTML.
    *
-   * @param javastring Java string to encode
-   * @return html string encoded
+   * @param input a text in which blank tokens are converted in HTML.
+   * @return an HTML text
    */
-  public static String convertWhiteSpacesForHTMLDisplay(String javastring) {
-    if (!isDefined(javastring)) {
+  public static String convertBlanksForHtml(String input) {
+    if (!isDefined(input)) {
       return "";
     }
-    StringBuilder resSB = new StringBuilder(javastring.length() + 10);
-    for (int i = 0; i < javastring.length(); i++) {
-      switch (javastring.charAt(i)) {
+    StringBuilder resSB = new StringBuilder(input.length() + 10);
+    for (int i = 0; i < input.length(); i++) {
+      switch (input.charAt(i)) {
         case '\n':
           resSB.append("<br/>");
           break;
@@ -94,34 +95,34 @@ public class WebEncodeHelper {
           resSB.append("&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;");
           break;
         default:
-          resSB.append(javastring.charAt(i));
+          resSB.append(input.charAt(i));
       }
     }
     return resSB.toString();
   }
 
   /**
-   * Convert a java string to a html string for textfield... Replace ", &gt;, &lt;, &amp; and \n
+   * Convert a java string to a html string for HTML paragraph. Replace ", &gt;, &lt;, &amp; and \n
    *
-   * @param javastring Java string to encode
+   * @param input Java string to encode
    * @return html string encoded
    */
-  public static String javaStringToHtmlParagraphe(String javastring) {
-    String escapedString = javaStringToHtmlString(javastring);
-    return convertWhiteSpacesForHTMLDisplay(escapedString);
+  public static String javaStringToHtmlParagraphe(String input) {
+    String escapedString = javaStringToHtmlString(input);
+    return convertBlanksForHtml(escapedString);
   }
 
   /**
    * Convert a html string to a java string. Replace &quot;
    *
-   * @param htmlstring HTML string to encode
+   * @param input HTML text to encode
    * @return html string JAVA encoded
    */
-  public static String htmlStringToJavaString(String htmlstring) {
-    if (!isDefined(htmlstring)) {
+  public static String htmlStringToJavaString(String input) {
+    if (!isDefined(input)) {
       return "";
     }
-    return StringEscapeUtils.unescapeHtml4(htmlstring);
+    return StringEscapeUtils.unescapeHtml4(input);
   }
 
   public static String convertHTMLEntities(String text) {
@@ -129,7 +130,7 @@ public class WebEncodeHelper {
   }
 
   /**
-   * Encode an UTF-8 filename in Base64 for the content-disposition header according to
+   * Encode a UTF-8 filename in Base64 for the content-disposition header according to
    * <a href="http://www.ietf.org/rfc/rfc2047.txt">RFC2047</a>.
    *
    * @param filename the UTF-8 filename to be encoded.

--- a/core-api/src/test/java/org/silverpeas/core/util/WebEncodeHelperTest.java
+++ b/core-api/src/test/java/org/silverpeas/core/util/WebEncodeHelperTest.java
@@ -107,26 +107,26 @@ public class WebEncodeHelperTest {
   }
 
   @Test
-  public void convertWhiteSpacesForHTMLDisplayWhenNullOrEmpty() {
-    assertThat(WebEncodeHelper.convertWhiteSpacesForHTMLDisplay(null), isEmptyString());
-    assertThat(WebEncodeHelper.convertWhiteSpacesForHTMLDisplay(""), isEmptyString());
+  public void convertBlanksForHtmlWhenNullOrEmpty() {
+    assertThat(WebEncodeHelper.convertBlanksForHtml(null), isEmptyString());
+    assertThat(WebEncodeHelper.convertBlanksForHtml(""), isEmptyString());
   }
 
   @Test
-  public void convertWhiteSpacesForHTMLDisplayWithRealWhiteCharacters() {
-    assertThat(WebEncodeHelper.convertWhiteSpacesForHTMLDisplay("\r"), is(""));
-    assertThat(WebEncodeHelper.convertWhiteSpacesForHTMLDisplay("\r\r"), is(""));
-    assertThat(WebEncodeHelper.convertWhiteSpacesForHTMLDisplay("\n"), is("<br/>"));
-    assertThat(WebEncodeHelper.convertWhiteSpacesForHTMLDisplay("\n\n"), is("<br/><br/>"));
-    assertThat(WebEncodeHelper.convertWhiteSpacesForHTMLDisplay("\t"), is("&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"));
-    assertThat(WebEncodeHelper.convertWhiteSpacesForHTMLDisplay("\t\t"), is("&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"));
-    assertThat(WebEncodeHelper.convertWhiteSpacesForHTMLDisplay("a"), is("a"));
+  public void convertBlanksForHtmlWithRealWhiteCharacters() {
+    assertThat(WebEncodeHelper.convertBlanksForHtml("\r"), is(""));
+    assertThat(WebEncodeHelper.convertBlanksForHtml("\r\r"), is(""));
+    assertThat(WebEncodeHelper.convertBlanksForHtml("\n"), is("<br/>"));
+    assertThat(WebEncodeHelper.convertBlanksForHtml("\n\n"), is("<br/><br/>"));
+    assertThat(WebEncodeHelper.convertBlanksForHtml("\t"), is("&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"));
+    assertThat(WebEncodeHelper.convertBlanksForHtml("\t\t"), is("&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"));
+    assertThat(WebEncodeHelper.convertBlanksForHtml("a"), is("a"));
   }
 
   @Property(trials = 1000)
-  public void convertWhiteSpacesForHTMLDisplayQuickCheck(
+  public void convertBlanksForHtmlQuickCheck(
       @When(seed = 0) @SpSimpleString(includes = "5..2000") String string) {
-    final String actual = WebEncodeHelper.convertWhiteSpacesForHTMLDisplay(string);
+    final String actual = WebEncodeHelper.convertBlanksForHtml(string);
     final int rCount = (int) string.chars().filter(c -> c == '\r').count();
     final int nCount = (int) string.chars().filter(c -> c == '\n').count();
     final int tCount = (int) string.chars().filter(c -> c == '\t').count();

--- a/core-library/src/main/java/org/silverpeas/core/contribution/content/form/displayers/TextDisplayer.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/content/form/displayers/TextDisplayer.java
@@ -117,7 +117,7 @@ public class TextDisplayer extends AbstractFieldDisplayer<Field> {
           value = doc.getFilename();
         }
       } else {
-        value = WebEncodeHelper.convertWhiteSpacesForHTMLDisplay(field.getValue(language));
+        value = WebEncodeHelper.convertBlanksForHtml(field.getValue(language));
       }
     }
 

--- a/core-library/src/main/java/org/silverpeas/core/contribution/content/wysiwyg/service/directive/VariablesReplacementDirective.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/content/wysiwyg/service/directive/VariablesReplacementDirective.java
@@ -59,7 +59,7 @@ public class VariablesReplacementDirective implements WysiwygContentTransformerD
           if (variable != null) {
             variable.getVariableValues().getCurrent().ifPresent(v -> {
               String newSpanTag = currentSpan.getStartTag().toString() +
-                  WebEncodeHelper.convertWhiteSpacesForHTMLDisplay(v.getValue()) +
+                  WebEncodeHelper.convertBlanksForHtml(v.getValue()) +
                   currentSpan.getEndTag().toString();
               replacements.put(spanTag, newSpanTag);
             });

--- a/core-library/src/main/java/org/silverpeas/core/notification/user/client/NotificationParameterNames.java
+++ b/core-library/src/main/java/org/silverpeas/core/notification/user/client/NotificationParameterNames.java
@@ -20,26 +20,30 @@
  *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
  */
 package org.silverpeas.core.notification.user.client;
 
-public class NotificationParameterNames {
-  public static final String SOURCE = "SOURCE";
-  public static final String SERVERURL = "SERVERURL";
-  public static final String URL = "URL";
-  public static final String LINKLABEL = "LINKLABEL";
-  public static final String FROM = "FROM";
-  public static final String SUBJECT = "SUBJECT";
-  public static final String SESSIONID = "SESSIONID";
-  public static final String DATE = "DATE";
-  public static final String LANGUAGE = "LANGUAGE";
-  public static final String COMMUNICATION = "COMMUNICATION";
-  public static final String ATTACHMENTID = "ATTACHMENTID";
-  public static final String HIDESMTPHEADERFOOTER = "HIDESMTPHEADERFOOTER";
-  public static final String COMPONENTID = "COMPONENTID";
-  public static final String ATTACHMENT_TARGETID = "ATTACHMENT_TARGETID";
+public enum NotificationParameterNames {
 
-  private NotificationParameterNames() {
+  SOURCE,
+  SERVER_BASEURL,
+  SERVERURL,
+  URL,
+  LINKLABEL,
+  FROM,
+  SUBJECT,
+  SESSIONID,
+  DATE,
+  LANGUAGE,
+  COMMUNICATION,
+  ATTACHMENTID,
+  HIDESMTPHEADERFOOTER,
+  COMPONENTID,
+  ATTACHMENT_TARGETID;
 
+  @Override
+  public String toString() {
+    return name();
   }
 }

--- a/core-library/src/main/java/org/silverpeas/core/notification/user/client/NotificationURLProvider.java
+++ b/core-library/src/main/java/org/silverpeas/core/notification/user/client/NotificationURLProvider.java
@@ -28,26 +28,21 @@ import org.silverpeas.core.admin.user.model.UserDetail;
 import org.silverpeas.core.util.URLUtil;
 import org.silverpeas.core.util.logging.SilverLogger;
 
-/**
- * Class declaration
- * @author
- * @version %I%, %G%
- */
-public abstract class AbstractNotification {
+public interface NotificationURLProvider {
 
-  public String getApplicationURL() {
+  default String getApplicationURL() {
     return URLUtil.getApplicationURL();
   }
 
-  public String computeURL(final Integer userId, final String urlBase) {
+  default String computeURL(final Integer userId, final String urlBase) {
     return computeURL(Integer.toString(userId), urlBase);
   }
 
-  public String computeURL(final String userId, final String urlBase) {
+  default String computeURL(final String userId, final String urlBase) {
     return (urlBase.startsWith("http") ? urlBase : getUserAutoRedirectURL(userId, urlBase));
   }
 
-  public String getUserAutoRedirectURL(final String userId, final String target) {
+  default String getUserAutoRedirectURL(final String userId, final String target) {
     String encodedTarget = URLUtil.encodeURL(target);
     try {
       final UserDetail ud = UserDetail.getById(userId);
@@ -67,14 +62,18 @@ public abstract class AbstractNotification {
     }
   }
 
-  public String getUserAutoRedirectURL(final Domain dom) {
+  default String getUserAutoRedirectURL(final Domain dom) {
       return dom.getSilverpeasServerURL() + getApplicationURL()
           + "/autoRedirect.jsp?domainId=" + dom.getId() + "&goto=";
   }
 
-  public String getUserAutoRedirectSilverpeasServerURL(final String userId) {
+  default String getUserAutoRedirectSilverpeasServerURL(final String userId) {
+    return getUserAutoRedirectServerURL(userId) + getApplicationURL();
+  }
+
+  default String getUserAutoRedirectServerURL(final String userId) {
     final UserDetail ud = UserDetail.getById(userId);
     final Domain dom = ud.getDomain();
-    return dom.getSilverpeasServerURL() + getApplicationURL();
+    return dom.getSilverpeasServerURL();
   }
 }

--- a/core-library/src/main/java/org/silverpeas/core/notification/user/delayed/delegate/DelayedNotificationDelegate.java
+++ b/core-library/src/main/java/org/silverpeas/core/notification/user/delayed/delegate/DelayedNotificationDelegate.java
@@ -30,9 +30,9 @@ import org.silverpeas.core.admin.service.AdministrationServiceProvider;
 import org.silverpeas.core.admin.user.model.User;
 import org.silverpeas.core.admin.user.model.UserDetail;
 import org.silverpeas.core.notification.user.AttachmentLink;
-import org.silverpeas.core.notification.user.client.AbstractNotification;
 import org.silverpeas.core.notification.user.client.NotificationParameterNames;
 import org.silverpeas.core.notification.user.client.NotificationParameters;
+import org.silverpeas.core.notification.user.client.NotificationURLProvider;
 import org.silverpeas.core.notification.user.client.constant.NotifChannel;
 import org.silverpeas.core.notification.user.delayed.DelayedNotificationProvider;
 import org.silverpeas.core.notification.user.delayed.constant.DelayedNotificationFrequency;
@@ -57,6 +57,7 @@ import org.silverpeas.core.util.comparator.AbstractComplexComparator;
 import javax.annotation.Nonnull;
 import java.util.*;
 
+import static org.silverpeas.core.notification.user.client.NotificationTemplateKey.NOTIFICATION_BASE_SERVER_URL;
 import static org.silverpeas.core.notification.user.client.NotificationTemplateKey.NOTIFICATION_SERVER_URL;
 import static org.silverpeas.core.notification.user.delayed.DelayedNotificationProvider.getDelayedNotification;
 import static org.silverpeas.core.util.MapUtil.putAddList;
@@ -66,7 +67,7 @@ import static org.silverpeas.core.util.StringUtil.isDefined;
 /**
  * @author Yohann Chastagnier
  */
-public class DelayedNotificationDelegate extends AbstractNotification {
+public class DelayedNotificationDelegate implements NotificationURLProvider {
 
   private static final String LOCATION_SEPARATOR = " &gt; ";
 
@@ -101,8 +102,8 @@ public class DelayedNotificationDelegate extends AbstractNotification {
 
   /**
    * Deleting all delayed notification data of a user
-   * @param userId
-   * @throws Exception
+   * @param userId the identifier of a user in Silverpeas.
+   * @throws NotificationServerException if an error occurs
    */
   public static void executeUserDeleting(final int userId)
       throws NotificationServerException {
@@ -127,10 +128,10 @@ public class DelayedNotificationDelegate extends AbstractNotification {
   /**
    * When user settings change, if the new frequency is NONE then the delayed notifications saved
    * have to be sent
-   * @param userId
-   * @param channel
-   * @param frequency
-   * @throws Exception
+   * @param userId the unique identifier of a user
+   * @param channel the channel through which the notifications will be sent.
+   * @param frequency the frequency of the notification sending.
+   * @throws NotificationServerException if an error occurs
    */
   public static DelayedNotificationUserSetting executeUserSettingsUpdating(final int userId,
       final NotifChannel channel, final DelayedNotificationFrequency frequency)
@@ -163,8 +164,8 @@ public class DelayedNotificationDelegate extends AbstractNotification {
 
   /**
    * Easy call of new notification process
-   * @param delayedNotificationData
-   * @throws NotificationServerException
+   * @param delayedNotificationData the data about the notification to send.
+   * @throws NotificationServerException if an error occurs.
    */
   public static void executeNewNotification(final DelayedNotificationData delayedNotificationData)
       throws NotificationServerException {
@@ -173,8 +174,8 @@ public class DelayedNotificationDelegate extends AbstractNotification {
 
   /**
    * Handling a new notification
-   * @param delayedNotificationData
-   * @throws Exception
+   * @param delayedNotificationData the data about the notification to send.
+   * @throws NotificationServerException if an error occurs.
    */
   protected void performNewNotificationSending(
       final DelayedNotificationData delayedNotificationData) throws NotificationServerException {
@@ -188,8 +189,8 @@ public class DelayedNotificationDelegate extends AbstractNotification {
 
   /**
    * Checks if the notification has to be delayed or not
-   * @param delayedNotificationData
-   * @return
+   * @param delayedNotificationData the data about the notification to send.
+   * @return true if the notification can be delayed in the time.
    */
   private boolean isThatToBeDelayed(final DelayedNotificationData delayedNotificationData) {
 
@@ -228,8 +229,8 @@ public class DelayedNotificationDelegate extends AbstractNotification {
 
   /**
    * Easy call of delayed notifications process
-   * @param date
-   * @throws Exception
+   * @param date the date at which the sending of the notification will be delayed.
+   * @throws NotificationServerException if an error occurs
    */
   public static void executeDelayedNotificationsSending(final Date date)
       throws NotificationServerException {
@@ -240,7 +241,7 @@ public class DelayedNotificationDelegate extends AbstractNotification {
   /**
    * Easy call of delayed notifications process. Forces the sending of all the delayed notifications
    * saved for all users
-   * @throws Exception
+   * @throws NotificationServerException if an error occurs
    */
   public static void executeForceDelayedNotificationsSending()
       throws NotificationServerException {
@@ -251,9 +252,9 @@ public class DelayedNotificationDelegate extends AbstractNotification {
    * Easy call of delayed notifications process. Forces the sending of all the delayed notifications
    * saved for a given
    * user
-   * @param userId
-   * @param channels
-   * @throws Exception
+   * @param userId the unique identifier of a user targeted by the notification.
+   * @param channels the channels through which the notifications will be sent.
+   * @throws NotificationServerException if an error occurs
    */
   public static void executeForceDelayedNotificationsSending(final int userId,
       final Set<NotifChannel> channels) throws NotificationServerException {
@@ -264,9 +265,9 @@ public class DelayedNotificationDelegate extends AbstractNotification {
    * Easy call of delayed notifications process. Forces the sending of all the delayed notifications
    * saved for given
    * users and channels
-   * @param userIds
-   * @param channels
-   * @throws Exception
+   * @param userIds the identifiers of the users targeted by the notifications.
+   * @param channels the channels through which the notifications will be sent.
+   * @throws NotificationServerException if an error occurs
    */
   public static void executeForceDelayedNotificationsSending(final List<Integer> userIds,
       final Set<NotifChannel> channels) throws NotificationServerException {
@@ -275,7 +276,7 @@ public class DelayedNotificationDelegate extends AbstractNotification {
 
   /**
    * Forces the sending of all the delayed notifications saved for all users
-   * @throws Exception
+   * @throws NotificationServerException if an error occurs
    */
   protected void forceDelayedNotificationsSending()
       throws NotificationServerException {
@@ -292,9 +293,9 @@ public class DelayedNotificationDelegate extends AbstractNotification {
 
   /**
    * Forces the sending of all the delayed notifications saved for given users and channels
-   * @param userIds
-   * @param channels
-   * @throws Exception
+   * @param userIds the unique identifier of the users targeted by the notifications.
+   * @param channels the channels through which the notifications will be sent.
+   * @throws NotificationServerException if an error occurs
    */
   void forceDelayedNotificationsSending(final List<Integer> userIds,
       final Set<NotifChannel> channels) throws NotificationServerException {
@@ -351,16 +352,16 @@ public class DelayedNotificationDelegate extends AbstractNotification {
   private Collection<Long> performUserDelayedNotificationsOnChannel(final NotifChannel channel,
       final List<DelayedNotificationData> delayedNotifications)
       throws NotificationServerException {
-    final DelayedNotificationSyntheseData synthese = buildSynthese(delayedNotifications);
-    sendNotification(createNotificationData(channel, synthese));
-    return synthese.getDelayedNotificationIdProceeded();
+    final DelayedNotificationSyntheseData synthesis = buildSynthesis(delayedNotifications);
+    sendNotification(createNotificationData(channel, synthesis));
+    return synthesis.getDelayedNotificationIdProceeded();
   }
 
-  private DelayedNotificationSyntheseData buildSynthese(
+  private DelayedNotificationSyntheseData buildSynthesis(
       final List<DelayedNotificationData> delayedNotifications) {
 
     // Result
-    final DelayedNotificationSyntheseData synthese = initializeSynthese(delayedNotifications);
+    final DelayedNotificationSyntheseData synthesis = initializeSynthese(delayedNotifications);
 
     // Indexing
     final Map<NotificationResourceData, List<DelayedNotificationData>> resourcesAndNotifications =
@@ -375,47 +376,46 @@ public class DelayedNotificationDelegate extends AbstractNotification {
         new ArrayList<>(resourcesAndNotifications.keySet());
     orderedResources.sort(getResourceComparator());
 
-    // Browsing all the delayed notifications to build the synthese
+    // Browsing all the delayed notifications to build the synthesis
     for (final NotificationResourceData resource : orderedResources) {
 
       // Performing a resource and her associated notifications
-      prepareSyntheseResourceAndNotifications(synthese, resource,
+      prepareSynthesisResourceAndNotifications(synthesis, resource,
           resourcesAndNotifications.get(resource));
     }
 
     // Building the final message
-    synthese.setMessage(buildMessage(synthese));
+    synthesis.setMessage(buildMessage(synthesis));
 
-    // Returning the initialized synthese
-    return synthese;
+    // Returning the initialized synthesis
+    return synthesis;
   }
 
-  private void prepareSyntheseResourceAndNotifications(
-      final DelayedNotificationSyntheseData syntheses, final NotificationResourceData resource,
+  private void prepareSynthesisResourceAndNotifications(
+      final DelayedNotificationSyntheseData synthesis, final NotificationResourceData resource,
       final List<DelayedNotificationData> notifications) {
-    final String language = syntheses.getLanguage();
+    final String language = synthesis.getLanguage();
     resource.setCurrentLanguage(language);
 
     // Sorting delayed notifications
-    Collections.sort(notifications, getDelayedNotificationComparator());
+    notifications.sort(getDelayedNotificationComparator());
 
-    // Initializing the synthese resource
+    // Initializing the synthesis resource
     final SyntheseResource syntheseResource = new SyntheseResource();
-    syntheses.addResource(syntheseResource);
-    syntheses.addNbNotifications(notifications.size());
+    synthesis.addResource(syntheseResource);
+    synthesis.addNbNotifications(notifications.size());
 
-    // Filling the synthese resource data
+    // Filling the synthesis resource data
     syntheseResource.setName(resource.getResourceName());
     syntheseResource.setDescription(resource.getResourceDescription());
     if (syntheseResource.getDescription() != null) {
-      syntheseResource.setDescription(
-          WebEncodeHelper.convertWhiteSpacesForHTMLDisplay(syntheseResource.getDescription()));
+      syntheseResource.setDescription(forHtml(syntheseResource.getDescription()));
     }
     syntheseResource.setLocation(resource.getResourceLocation()
         .replace(NotificationResourceData.LOCATION_SEPARATOR, LOCATION_SEPARATOR));
     syntheseResource.setUrl(resource.getResourceUrl());
     if (syntheseResource.getUrl() != null) {
-      syntheseResource.setUrl(computeURL(syntheses.getUserId(), syntheseResource.getUrl()));
+      syntheseResource.setUrl(computeURL(synthesis.getUserId(), syntheseResource.getUrl()));
     }
     syntheseResource.setLinkLabel(getResourceLinkLabel(resource));
 
@@ -455,14 +455,13 @@ public class DelayedNotificationDelegate extends AbstractNotification {
       syntheseNotification.setPreviousHasMessage(isPreviousHasMessage);
       if (syntheseNotification.getMessage() != null) {
         isPreviousHasMessage = true;
-        syntheseNotification.setMessage(
-            WebEncodeHelper.convertWhiteSpacesForHTMLDisplay(syntheseNotification.getMessage()));
+        syntheseNotification.setMessage(forHtml(syntheseNotification.getMessage()));
       } else {
         isPreviousHasMessage = false;
       }
 
       // Indicates that the notification has been treated
-      syntheses.getDelayedNotificationIdProceeded()
+      synthesis.getDelayedNotificationIdProceeded()
           .add(Long.parseLong(delayedNotificationData.getId()));
     }
   }
@@ -485,10 +484,6 @@ public class DelayedNotificationDelegate extends AbstractNotification {
     return defaultStringIfNotDefined(resource.getLinkLabel(), defaultLinkLabel);
   }
 
-  /**
-   * Just a little tool
-   * @return
-   */
   private static String nullIfBlank(final String string) {
     return StringUtils.isBlank(string) ? null : string;
   }
@@ -496,6 +491,8 @@ public class DelayedNotificationDelegate extends AbstractNotification {
   private String buildMessage(final DelayedNotificationSyntheseData syntheses) {
     clearTemplate();
     final User user = getUserDetail(syntheses.getUserId());
+    getTemplate().setAttribute(NOTIFICATION_BASE_SERVER_URL.toString(),
+        getUserAutoRedirectServerURL(user.getId()));
     getTemplate().setAttribute(NOTIFICATION_SERVER_URL.toString(),
         getUserAutoRedirectSilverpeasServerURL(user.getId()));
     getTemplate().setAttribute("delay",
@@ -516,18 +513,10 @@ public class DelayedNotificationDelegate extends AbstractNotification {
     return getTemplate().applyFileTemplate("subject_" + synthese.getLanguage());
   }
 
-  /**
-   * Clears silverpeas template
-   * @return
-   */
   private void clearTemplate() {
     getTemplate().getAttributes().clear();
   }
 
-  /**
-   * Gets a Silverpeas template
-   * @return
-   */
   private SilverpeasTemplate getTemplate() {
     if (template == null) {
       template = SilverpeasTemplateFactory
@@ -538,9 +527,8 @@ public class DelayedNotificationDelegate extends AbstractNotification {
   }
 
   /**
-   * Initializing common data of the notification synthese from the first delayed notification
-   * @param delayedNotifications
-   * @return
+   * Initializing common data of the notification synthesis from the first delayed notification
+   * @param delayedNotifications a list of data about the notifications to send
    */
   private DelayedNotificationSyntheseData initializeSynthese(
       final List<DelayedNotificationData> delayedNotifications) {
@@ -558,9 +546,9 @@ public class DelayedNotificationDelegate extends AbstractNotification {
    * Creating the notification data from a given channel, a given delayed notification and with the
    * final message.
    * Currently, only the SMTP channel is managed
-   * @param channel notification channel
-   * @param syntheses syntheses data
-   * @return data about the notification to send.
+   * @param channel the channel through which the notification will be sent.
+   * @param syntheses a synthesis on the notifications to send.
+   * @return a data about the delayed notification to send.
    */
   private NotificationData createNotificationData(final NotifChannel channel,
       final DelayedNotificationSyntheseData syntheses) {
@@ -586,23 +574,25 @@ public class DelayedNotificationDelegate extends AbstractNotification {
     notificationData.setTargetParam(new HashMap<>());
 
     // Set sender in parameters
-    notificationData.getTargetParam().put(NotificationParameterNames.FROM,
-        NotifChannel.SMTP.equals(channel) ? sender.geteMail() : sender.getId());
+    notificationData.getTargetParam()
+        .put(NotificationParameterNames.FROM.toString(),
+            NotifChannel.SMTP.equals(channel) ? sender.geteMail() : sender.getId());
 
     // Set subject parameter
     notificationData.getTargetParam()
-        .put(NotificationParameterNames.SUBJECT, syntheses.getSubject());
+        .put(NotificationParameterNames.SUBJECT.toString(), syntheses.getSubject());
 
     // Set date parameter
-    notificationData.getTargetParam().put(NotificationParameterNames.DATE, new Date());
+    notificationData.getTargetParam()
+        .put(NotificationParameterNames.DATE.toString(), new Date());
 
     // Set the language
     notificationData.getTargetParam()
-        .put(NotificationParameterNames.LANGUAGE, syntheses.getLanguage());
+        .put(NotificationParameterNames.LANGUAGE.toString(), syntheses.getLanguage());
 
     // Hide Header and Footer in SMTP message
-    notificationData.getTargetParam().put(NotificationParameterNames.HIDESMTPHEADERFOOTER,
-        true);
+    notificationData.getTargetParam()
+        .put(NotificationParameterNames.HIDESMTPHEADERFOOTER.toString(), true);
 
 
     // Set the message
@@ -619,12 +609,6 @@ public class DelayedNotificationDelegate extends AbstractNotification {
    * Commons
    */
 
-  /**
-   * Gets the translation of an element
-   * @param key
-   * @param language
-   * @return
-   */
   private String getStringTranslation(final String key, final String language) {
     LocalizationBundle messages = ResourceLocator.getLocalizationBundle(
         "org.silverpeas.notificationManager.multilang.notificationManagerBundle",
@@ -632,13 +616,9 @@ public class DelayedNotificationDelegate extends AbstractNotification {
     return messages.getString(key);
   }
 
-  /**
-   * Gets the comprator of resource data
-   * @return
-   */
   private Comparator<NotificationResourceData> getResourceComparator() {
     if (resourceComparator == null) {
-      resourceComparator = new AbstractComplexComparator<NotificationResourceData>() {
+      resourceComparator = new AbstractComplexComparator<>() {
         @Override
         protected ValueBuffer getValuesToCompare(final NotificationResourceData object) {
           return new ValueBuffer().append(object.getResourceLocation())
@@ -650,13 +630,9 @@ public class DelayedNotificationDelegate extends AbstractNotification {
     return resourceComparator;
   }
 
-  /**
-   * Gets the comparator of delayed notification data
-   * @return
-   */
   private Comparator<DelayedNotificationData> getDelayedNotificationComparator() {
     if (delayedNotificationComparator == null) {
-      delayedNotificationComparator = new AbstractComplexComparator<DelayedNotificationData>() {
+      delayedNotificationComparator = new AbstractComplexComparator<>() {
         @Override
         protected ValueBuffer getValuesToCompare(final DelayedNotificationData object) {
           return new ValueBuffer().append(object.getCreationDate())
@@ -694,17 +670,28 @@ public class DelayedNotificationDelegate extends AbstractNotification {
 
   /**
    * Centralizes notification sending
-   * @param notificationData
-   * @throws NotificationServerException
+   * @param notificationData data about the notification to send.
+   * @throws NotificationServerException if an error occurs.
    */
   protected void sendNotification(final NotificationData notificationData)
       throws NotificationServerException {
 
     // Removing Java Strings of the computed message
-    notificationData.setMessage(notificationData.getMessage().replaceAll("[\r\n\t]", ""));
+    notificationData.setMessage(notificationData.getMessage()
+        .replaceAll("[\r\n\t]", ""));
 
     // Adding the notification
     NotificationServer notificationServer = NotificationServer.get();
     notificationServer.addNotification(notificationData);
+  }
+
+  /**
+   * Converts in the specified HTML content any line-feeds and tabulations by their counterpart in
+   * HTML.
+   * @param content a content in HTML.
+   * @return the converted content.
+   */
+  private String forHtml(final String content) {
+    return WebEncodeHelper.convertBlanksForHtml(content);
   }
 }

--- a/core-library/src/main/java/org/silverpeas/core/notification/user/delayed/scheduler/DelayedNotificationSchedulerInitializer.java
+++ b/core-library/src/main/java/org/silverpeas/core/notification/user/delayed/scheduler/DelayedNotificationSchedulerInitializer.java
@@ -26,7 +26,7 @@ package org.silverpeas.core.notification.user.delayed.scheduler;
 import org.silverpeas.core.annotation.Service;
 import org.silverpeas.core.scheduler.Scheduler;
 import org.silverpeas.core.scheduler.trigger.JobTrigger;
-import org.silverpeas.core.notification.user.client.AbstractNotification;
+import org.silverpeas.core.notification.user.client.NotificationURLProvider;
 import org.apache.commons.lang3.StringUtils;
 import org.silverpeas.core.initialization.Initialization;
 
@@ -39,8 +39,8 @@ import static org.silverpeas.core.notification.user.client.NotificationManagerSe
  * @author Yohann Chastagnier
  */
 @Service
-public class DelayedNotificationSchedulerInitializer extends AbstractNotification
-    implements Initialization {
+public class DelayedNotificationSchedulerInitializer implements NotificationURLProvider,
+    Initialization {
 
   public static final String JOB_NAME = "DelayedNotificationJob";
 

--- a/core-library/src/main/java/org/silverpeas/core/notification/user/server/channel/popup/POPUPListener.java
+++ b/core-library/src/main/java/org/silverpeas/core/notification/user/server/channel/popup/POPUPListener.java
@@ -23,11 +23,9 @@
  */
 package org.silverpeas.core.notification.user.server.channel.popup;
 
-import org.silverpeas.core.notification.user.client.NotificationParameterNames;
 import org.silverpeas.core.notification.user.server.NotificationData;
 import org.silverpeas.core.notification.user.server.NotificationServerException;
 import org.silverpeas.core.notification.user.server.channel.AbstractListener;
-import org.silverpeas.core.util.DateUtil;
 import org.silverpeas.core.util.logging.SilverLogger;
 
 import javax.ejb.ActivationConfigProperty;
@@ -36,7 +34,6 @@ import javax.ejb.TransactionAttribute;
 import javax.ejb.TransactionAttributeType;
 import javax.jms.Message;
 import javax.jms.MessageListener;
-import java.util.Date;
 
 @MessageDriven(activationConfig = {
     @ActivationConfigProperty(propertyName = "destinationType", propertyValue = "javax.jms.Queue"),
@@ -52,10 +49,6 @@ public class POPUPListener extends AbstractListener implements MessageListener {
     // Nothing to initialize
   }
 
-  /**
-   * listener of NotificationServer JMS message
-   * @param msg
-   */
   @Override
   public void onMessage(Message msg) {
     try {
@@ -65,28 +58,10 @@ public class POPUPListener extends AbstractListener implements MessageListener {
     }
   }
 
-  /**
-   * @param message
-   * @throws NotificationServerException
-   */
   @Override
   public void send(NotificationData message) throws NotificationServerException {
     try {
-      final StringBuilder content = new StringBuilder(500);
-      final String source =
-          (String) message.getTargetParam().get(NotificationParameterNames.SOURCE);
-      final Date date = (Date) message.getTargetParam().get(NotificationParameterNames.DATE);
-      if (source != null) {
-        content.append("Source : ").append(source).append("\n");
-      }
-      if (date != null) {
-        content.append("Date : ")
-            .append(DateUtil.dateToString(date, ""))
-            .append("\n");
-      }
-      content.append(message.getMessage());
       PopupMessageService.get().push(message.getTargetReceipt(), message);
-
     } catch (Exception e) {
       throw new NotificationServerException(e);
     }

--- a/core-library/src/main/java/org/silverpeas/core/notification/user/server/channel/server/SERVERListener.java
+++ b/core-library/src/main/java/org/silverpeas/core/notification/user/server/channel/server/SERVERListener.java
@@ -60,14 +60,10 @@ public class SERVERListener extends AbstractListener implements MessageListener 
     }
   }
 
-  /**
-   * @param notification
-   * @throws NotificationServerException
-   */
   @Override
   public void send(NotificationData notification) {
     Map<String, Object> params = notification.getTargetParam();
-    String sessionId = (String) params.get(NotificationParameterNames.SESSIONID);
+    String sessionId = (String) params.get(NotificationParameterNames.SESSIONID.toString());
     ServerMessageService.get()
         .push(notification.getTargetReceipt(), notification.getMessage(), sessionId);
   }

--- a/core-library/src/main/java/org/silverpeas/core/notification/user/server/channel/silvermail/SILVERMAILListener.java
+++ b/core-library/src/main/java/org/silverpeas/core/notification/user/server/channel/silvermail/SILVERMAILListener.java
@@ -49,10 +49,6 @@ import java.util.Map;
 @TransactionAttribute(TransactionAttributeType.NOT_SUPPORTED)
 public class SILVERMAILListener extends AbstractListener implements MessageListener {
 
-  /**
-   * listener of NotificationServer JMS message
-   * @param msg
-   */
   @Override
   public void onMessage(Message msg) {
     try {
@@ -67,13 +63,13 @@ public class SILVERMAILListener extends AbstractListener implements MessageListe
     try {
       Map<String, Object> keyValue = data.getTargetParam();
       // retrieves the SUBJECT key value.
-      String tmpSubjectString = (String) keyValue.get(NotificationParameterNames.SUBJECT);
+      String tmpSubjectString = (String) keyValue.get(NotificationParameterNames.SUBJECT.toString());
       // retrieves the SOURCE key value.
-      String tmpSourceString = (String) keyValue.get(NotificationParameterNames.SOURCE);
+      String tmpSourceString = (String) keyValue.get(NotificationParameterNames.SOURCE.toString());
       // retrieves the URL key value.
-      String tmpUrlString = (String) keyValue.get(NotificationParameterNames.URL);
+      String tmpUrlString = (String) keyValue.get(NotificationParameterNames.URL.toString());
       // retrieves the DATE key value.
-      Date tmpDate = (Date) keyValue.get(NotificationParameterNames.DATE);
+      Date tmpDate = (Date) keyValue.get(NotificationParameterNames.DATE.toString());
       SILVERMAILMessage sm = new SILVERMAILMessage();
       sm.setUserId(Integer.parseInt(data.getTargetReceipt()));
       sm.setSenderName(data.getSenderName());

--- a/core-war/src/main/webapp/look/jsp/spaceHomePage.jsp
+++ b/core-war/src/main/webapp/look/jsp/spaceHomePage.jsp
@@ -326,7 +326,7 @@
     </h1>
 
     <% if (StringUtil.isDefined(space.getDescription(helper.getLanguage()))) { %>
-    <p class="spaceDescription"><%=WebEncodeHelper.convertWhiteSpacesForHTMLDisplay(
+    <p class="spaceDescription"><%=WebEncodeHelper.convertBlanksForHtml(
         Encode.forHtml(space.getDescription(helper.getLanguage()))) %>
     </p>
     <% } else { %>

--- a/core-war/src/main/webapp/portlets/jsp/lastPublications/portlet.jsp
+++ b/core-war/src/main/webapp/portlets/jsp/lastPublications/portlet.jsp
@@ -68,7 +68,7 @@ for (PublicationDetail pub : publications) {
     <% } %>
     <% if ("checked".equalsIgnoreCase(pref.getValue("displayDescription", "")) && StringUtil
         .isDefined(pub.getDescription(language))) { %>
-      <br/><%=WebEncodeHelper.convertWhiteSpacesForHTMLDisplay(WebEncodeHelper.javaStringToHtmlString(pub.getDescription(language))) %>
+      <br/><%=WebEncodeHelper.convertBlanksForHtml(WebEncodeHelper.javaStringToHtmlString(pub.getDescription(language))) %>
     <% } %>
 <% } %>
 <br/>


### PR DESCRIPTION
Add a new predefined template field valued with the URL of the server on
which Silverpeas is running: notification_base_serverurl

WebEncodeHelper is no more deprecated as it doesn't in a whole conflict
with Encode of OWASP. Indeed, it provides additional features for HTML
rendering of texts.

Convert NotificationParameterNames to an enum and update the code in
consequency.

Linked to PRs:
https://github.com/Silverpeas/Silverpeas-Components/pull/773
https://github.com/Silverpeas/Silverpeas-Looks/pull/59