### PR TITLE
Bug #13019

### DIFF
--- a/core-services/chat/src/main/java/org/silverpeas/core/chat/ChatSettings.java
+++ b/core-services/chat/src/main/java/org/silverpeas/core/chat/ChatSettings.java
@@ -24,6 +24,7 @@
 
 package org.silverpeas.core.chat;
 
+import org.silverpeas.core.SilverpeasRuntimeException;
 import org.silverpeas.core.annotation.Bean;
 import org.silverpeas.core.util.ResourceLocator;
 import org.silverpeas.core.util.ServiceProvider;
@@ -327,6 +328,20 @@ public class ChatSettings {
   }
 
   /**
+   * Gets the policy on how the JID should be formatted. This policy applies only on the local part
+   * of the JID.
+   * @return the policy on how the local part of the JID should be formatted.
+   */
+  public JidFormatPolicy getJidFormatPolicy() {
+    int policy = settings.getInteger("chat.xmpp.jid.policy", 1);
+    JidFormatPolicy[] policies = JidFormatPolicy.values();
+    if (policy >= policies.length) {
+      throw new SilverpeasRuntimeException("Unknown JID format policy value: " + policy);
+    }
+    return policies[policy];
+  }
+
+  /**
    * Gets the ACL on the chat client.
    * @return a {@link ChatACL} instance representing the ACL configured in the use of the chat
    * client.
@@ -384,5 +399,10 @@ public class ChatSettings {
     public GroupChat getAclOnGroupChat() {
       return new GroupChat();
     }
+  }
+
+  public enum JidFormatPolicy {
+    REMOVED,
+    SPECIFIC_CODE
   }
 }

--- a/core-services/chat/src/test/java/org/silverpeas/core/chat/ChatUserLoginTest.java
+++ b/core-services/chat/src/test/java/org/silverpeas/core/chat/ChatUserLoginTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2000 - 2022 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.chat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.silverpeas.core.admin.user.model.UserDetail;
+import org.silverpeas.core.test.extention.EnableSilverTestEnv;
+import org.silverpeas.core.test.extention.TestManagedMock;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.when;
+
+@EnableSilverTestEnv
+class ChatUserLoginTest {
+
+  @TestManagedMock
+  private ChatSettings chatSettings;
+
+  @Test
+  @DisplayName("When the login is an email address, the domain part should be removed from the " +
+      "chat login with the REMOVED JID format policy")
+  void domainPartShouldBeRemovedFromAnEmailAslogin() {
+    when(chatSettings.getJidFormatPolicy()).thenReturn(ChatSettings.JidFormatPolicy.REMOVED);
+
+    final ChatUser user = getChatUserWithLogin("miguel.moquillon@silverpeas.org");
+    assertThat(user.getChatLogin(), is("miguel.moquillon"));
+  }
+
+  @Test
+  @DisplayName("When the login is an email address, the @ character should be encoded in the chat" +
+      " login with the SPECIFIC_CODE JID format policy")
+  void specialCharactersShouldBeEncodedInAnEmailAslogin() {
+    when(chatSettings.getJidFormatPolicy()).thenReturn(ChatSettings.JidFormatPolicy.SPECIFIC_CODE);
+
+    final ChatUser user = getChatUserWithLogin("miguel.moquillon@silverpeas.org");
+    assertThat(user.getChatLogin(), is("miguel.moquillon0x40silverpeas.org"));
+  }
+
+  @Test
+  @DisplayName("The login of a Silverpeas user should be taken as such for the chat login")
+  void chatLoginShouldBeUserLoginByDefault() {
+    final ChatUser user = getChatUserWithLogin("miguel.moquillon");
+    assertThat(user.getChatLogin(), is("miguel.moquillon"));
+  }
+
+  @Test
+  @DisplayName("Any blanks in the login of a Silverpeas user should be removed")
+  void chatLoginShouldBeWithoutAnySpaces() {
+    final ChatUser user = getChatUserWithLogin("miguel  moquillon");
+    assertThat(user.getChatLogin(), is("miguelmoquillon"));
+  }
+
+  @Test
+  @DisplayName("The chat login of a user should be in lower case")
+  void chatLoginShouldBeAlwaysInLowerCaseByDefault() {
+    final ChatUser user = getChatUserWithLogin("Miguel.Moquillon");
+    assertThat(user.getChatLogin(), is("miguel.moquillon"));
+  }
+
+  @Test
+  @DisplayName("The chat login of a user should be in lower case even with an email-like address")
+  void chatLoginShouldBeAlwaysInLowerCaseInAnyCircumstances() {
+    when(chatSettings.getJidFormatPolicy()).thenReturn(ChatSettings.JidFormatPolicy.REMOVED);
+
+    final ChatUser user = getChatUserWithLogin("Miguel.Moquillon@silverpeas.com");
+    assertThat(user.getChatLogin(), is("miguel.moquillon"));
+  }
+
+  private ChatUser getChatUserWithLogin(final String login) {
+    UserDetail user = new UserDetail();
+    user.setId("42");
+    user.setLogin(login);
+    return ChatUser.fromUser(user);
+  }
+}

--- a/core-web/src/test/java/org/silverpeas/core/chat/ChatUserTest.java
+++ b/core-web/src/test/java/org/silverpeas/core/chat/ChatUserTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.Test;
 import org.silverpeas.core.admin.user.model.UserDetail;
 import org.silverpeas.core.admin.user.service.UserProvider;
 import org.silverpeas.core.test.extention.EnableSilverTestEnv;
+import org.silverpeas.core.test.extention.TestManagedBeans;
 import org.silverpeas.core.test.extention.TestManagedMock;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -41,7 +42,8 @@ import static org.mockito.Mockito.when;
  * @author silveryocha
  */
 @EnableSilverTestEnv
-public class ChatUserTest {
+@TestManagedBeans({ChatSettings.class})
+class ChatUserTest {
 
   @BeforeEach
   public void setup(@TestManagedMock UserProvider userProvider) {
@@ -53,19 +55,19 @@ public class ChatUserTest {
   }
 
   @Test
-  public void emailLoginShouldWork() throws Exception {
+  void emailLoginShouldWork() throws Exception {
     final ChatUser user = createChatUserWithLogin("yohann.chastagnier@silverpeas.org");
     assertThat(user.getChatLogin(), is("yohann.chastagnier"));
   }
 
   @Test
-  public void chatLoginShouldAlwaysBeLowercase() throws Exception {
+  void chatLoginShouldAlwaysBeLowercase() throws Exception {
     final ChatUser user = createChatUserWithLogin("yohann26.cHastaGNier@silverpeas.org");
     assertThat(user.getChatLogin(), is("yohann26.chastagnier"));
   }
 
   @Test
-  public void complexEmailLoginShouldWork() throws Exception {
+  void complexEmailLoginShouldWork() throws Exception {
     final ChatUser user = createChatUserWithLogin("yo.CHA.boule-de_boule@silverpeas.co.uk");
     assertThat(user.getChatLogin(), is("yo.cha.boule-de_boule"));
   }

--- a/core-web/src/test/resources/org/silverpeas/chat/settings/chat.properties
+++ b/core-web/src/test/resources/org/silverpeas/chat/settings/chat.properties
@@ -84,9 +84,8 @@ chat.xmpp.domain.groups =
 # <localpart>@<xmpp domain> (see RFC 7622), an address email as login cannot be used as such, and it
 # requires then to be converted. Currently, there is two ways to convert such logins: either by
 # removing the domain part of the address email (value O) or by encoding the special character @
-# with a specific code (value 1). The removing of the domain part of an address email as login is
-# the default.
-chat.xmpp.jid.policy = 1
+# with a specific code (value 1). The latter is the default.
+chat.xmpp.jid.policy = 0
 
 # ACL on the chat behaviours. By default, all the users for which the chat is enabled have access
 # the whole functionalities of the chat client. To restrict the access to some functionalities, then


### PR DESCRIPTION
Format of JID (XMPP identifiers) follows the RFC 7622.
According to this RFC, a JID is formatted as <localpart>@<domainpart>
for a user.
In Silverpeas, the localpart of the JID for a user is computed from his
login. So, when this login is an address email or contains a @
character, the localpart requires to be converted to be compliant with
the RFC. Previously, any part of a login that starts with such a special
character were removed from the login before being used as localpart of
a JID.
Now a new policy is implemented: any @ characters are replaced by a
specific code (for instance its UTF-8 hex equivalent but as word and not
as codepoint, id est 0x40). The policy of the JID formatting is defined
in the properties/org/silverpeas/chat/settings/chat.properties settings
file, under the property chat.xmpp.jid.policy. By default, the previous
policy is used (value 0).