### PR TITLE
Feature #13043: displaying HTML safely for event descriptions of synchronized calendars.

### DIFF
--- a/core-api/src/main/java/org/silverpeas/core/calendar/ICalendarEventImportProcessor.java
+++ b/core-api/src/main/java/org/silverpeas/core/calendar/ICalendarEventImportProcessor.java
@@ -32,6 +32,7 @@ import org.silverpeas.core.importexport.ImportException;
 import org.silverpeas.core.persistence.Transaction;
 import org.silverpeas.core.persistence.datasource.OperationContext;
 import org.silverpeas.core.persistence.datasource.model.jpa.JpaEntityReflection;
+import org.silverpeas.core.security.html.HtmlSanitizer;
 import org.silverpeas.core.util.Mutable;
 import org.silverpeas.core.util.StringUtil;
 
@@ -222,9 +223,13 @@ public class ICalendarEventImportProcessor {
     } else if (component.getTitle().length() > TITLE_MAX_LENGTH) {
       component.setTitle(StringUtil.truncate(component.getTitle().trim(), TITLE_MAX_LENGTH));
     }
-    if (component.getDescription().length() > DESCRIPTION_MAX_LENGTH) {
-      component.setDescription(
-          StringUtil.truncate(component.getDescription().trim(), DESCRIPTION_MAX_LENGTH));
+    if (StringUtil.isDefined(component.getDescription())) {
+      final String sanitizedDesc = HtmlSanitizer.get().sanitize(component.getDescription().trim());
+      if (sanitizedDesc.length() > DESCRIPTION_MAX_LENGTH) {
+        component.setDescription(StringUtil.truncate(sanitizedDesc, DESCRIPTION_MAX_LENGTH));
+      } else {
+        component.setDescription(sanitizedDesc);
+      }
     }
     if (component.getLocation().length() > TITLE_MAX_LENGTH) {
       component.setLocation(StringUtil.truncate(component.getLocation().trim(), TITLE_MAX_LENGTH));

--- a/core-api/src/main/java/org/silverpeas/core/security/html/HtmlSanitizer.java
+++ b/core-api/src/main/java/org/silverpeas/core/security/html/HtmlSanitizer.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2000 - 2022 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.security.html;
+
+import org.silverpeas.core.util.ServiceProvider;
+
+/**
+ * In data sanitization, HTML sanitization is the process of examining an HTML document and
+ * producing a new HTML document that preserves only whatever tags are designated "safe" and
+ * desired. HTML sanitization can be used to protect against attacks such as cross-site scripting
+ * (XSS) by sanitizing any HTML code submitted by a user.
+ * @author silveryocha
+ */
+public interface HtmlSanitizer {
+
+  static HtmlSanitizer get() {
+    return ServiceProvider.getSingleton(HtmlSanitizer.class);
+  }
+
+  /**
+   * Sanitizing the given content by keeping:
+   * <ul>
+   *   <li>safe formatting</li>
+   *   <li>safe blocks</li>
+   *   <li>safe images</li>
+   *   <li>safe links</li>
+   *   <li>safe tables</li>
+   *   <li>safe styles</li>
+   * </ul>
+   * <p>
+   *   All links are modified in order to be opened safely into a new blank page.
+   * </p>
+   * @param html a string representing an HTML content.
+   * @return a string representing the sanitized version of given parameter.
+   */
+  String sanitize(final String html);
+}

--- a/core-library/pom.xml
+++ b/core-library/pom.xml
@@ -229,6 +229,10 @@
       <groupId>org.owasp.encoder</groupId>
       <artifactId>encoder</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.googlecode.owasp-java-html-sanitizer</groupId>
+      <artifactId>owasp-java-html-sanitizer</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.hibernate</groupId>

--- a/core-library/src/integration-test/java/org/silverpeas/core/calendar/CalendarSynchronizationIT.java
+++ b/core-library/src/integration-test/java/org/silverpeas/core/calendar/CalendarSynchronizationIT.java
@@ -102,6 +102,7 @@ public class CalendarSynchronizationIT extends BaseCalendarTest {
   @Deployment
   public static Archive<?> createTestArchive() {
     return CalendarWarBuilder.onWarForTestClass(CalendarSynchronizationIT.class)
+        .addCalendarSynchronizationFeatures()
         .addAsResource(BaseCalendarTest.TABLE_CREATION_SCRIPT.substring(1))
         .addAsResource(INITIALIZATION_SCRIPT.substring(1))
         .addAsResource("org/silverpeas/util/logging")

--- a/core-library/src/integration-test/java/org/silverpeas/core/calendar/ICalendarEventImportProcessorIT.java
+++ b/core-library/src/integration-test/java/org/silverpeas/core/calendar/ICalendarEventImportProcessorIT.java
@@ -44,10 +44,8 @@ import java.time.DayOfWeek;
 import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
-import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
-import java.util.TimeZone;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -69,6 +67,7 @@ public class ICalendarEventImportProcessorIT extends BaseCalendarTest {
   @Deployment
   public static Archive<?> createTestArchive() {
     return CalendarWarBuilder.onWarForTestClass(ICalendarEventImportProcessorIT.class)
+        .addCalendarSynchronizationFeatures()
         .addAsResource(BaseCalendarTest.TABLE_CREATION_SCRIPT.substring(1))
         .addAsResource(INITIALIZATION_SCRIPT.substring(1))
         .addAsResource("org/silverpeas/util/logging")

--- a/core-library/src/integration-test/java/org/silverpeas/core/test/WarBuilder4LibCore.java
+++ b/core-library/src/integration-test/java/org/silverpeas/core/test/WarBuilder4LibCore.java
@@ -24,8 +24,8 @@
 package org.silverpeas.core.test;
 
 import org.silverpeas.core.ActionType;
-import org.silverpeas.core.SilverpeasResource;
 import org.silverpeas.core.ResourceReference;
+import org.silverpeas.core.SilverpeasResource;
 import org.silverpeas.core.WAPrimaryKey;
 import org.silverpeas.core.admin.BaseRightProfile;
 import org.silverpeas.core.admin.PaginationPage;
@@ -78,8 +78,8 @@ import org.silverpeas.core.contribution.attachment.repository.JcrContext;
 import org.silverpeas.core.contribution.content.form.FormException;
 import org.silverpeas.core.contribution.content.wysiwyg.service.WysiwygManager;
 import org.silverpeas.core.contribution.contentcontainer.content.ContentManagementEngine;
-import org.silverpeas.core.contribution.contentcontainer.content.ContentManagerException;
 import org.silverpeas.core.contribution.contentcontainer.content.ContentManagementEngineProvider;
+import org.silverpeas.core.contribution.contentcontainer.content.ContentManagerException;
 import org.silverpeas.core.contribution.contentcontainer.content.ContentPeas;
 import org.silverpeas.core.contribution.contentcontainer.content.SilverContentInterface;
 import org.silverpeas.core.contribution.contentcontainer.content.SilverContentPostUpdate;
@@ -114,6 +114,8 @@ import org.silverpeas.core.persistence.jcr.JcrRepositoryProvider;
 import org.silverpeas.core.persistence.jdbc.AbstractTable;
 import org.silverpeas.core.persistence.jdbc.DBUtil;
 import org.silverpeas.core.reminder.DefaultReminderRepository;
+import org.silverpeas.core.security.html.DefaultHtmlSanitizer;
+import org.silverpeas.core.security.html.HtmlSanitizer;
 import org.silverpeas.core.template.SilverpeasTemplate;
 import org.silverpeas.core.test.jcr.JcrIntegrationIT;
 import org.silverpeas.core.test.office.OfficeServiceInitializationListener;
@@ -147,7 +149,7 @@ public class WarBuilder4LibCore extends WarBuilder<WarBuilder4LibCore> {
     addServiceProviderFeatures();
     addBundleBaseFeatures();
     addClasses(EntityReference.class);
-    addCalendarFeatures();
+    addCalendarBaseFeatures();
     addPackages(true, "org.silverpeas.core.util.logging.sys");
     addClasses(LogAnnotationProcessor.class, LogsAccessor.class);
     addAsResource("META-INF/services/test-org.silverpeas.core.util.logging.SilverLoggerFactory",
@@ -754,7 +756,7 @@ public class WarBuilder4LibCore extends WarBuilder<WarBuilder4LibCore> {
    * Add calendar feature in web archive (war)
    * @return the instance of the war builder with calendar features
    */
-  public WarBuilder4LibCore addCalendarFeatures() {
+  public WarBuilder4LibCore addCalendarBaseFeatures() {
     addMavenDependenciesWithPersistence("org.silverpeas.core:silverpeas-core-api");
     addClasses(
         ICal4JCalendarEventOccurrenceGenerator.class,
@@ -765,6 +767,17 @@ public class WarBuilder4LibCore extends WarBuilder<WarBuilder4LibCore> {
         ICal4JExporter.class,
         ICal4JDateCodec.class,
         ICal4JRecurrenceCodec.class);
+    return this;
+  }
+
+  /**
+   * Add calendar feature in web archive (war)
+   * @return the instance of the war builder with calendar features
+   */
+  public WarBuilder4LibCore addCalendarSynchronizationFeatures() {
+    addMavenDependencies("com.googlecode.owasp-java-html-sanitizer:owasp-java-html-sanitizer");
+    addWysiwygFeatures();
+    addClasses(HtmlSanitizer.class, DefaultHtmlSanitizer.class);
     return this;
   }
 

--- a/core-library/src/main/java/org/silverpeas/core/contribution/content/wysiwyg/service/WysiwygContentTransformer.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/content/wysiwyg/service/WysiwygContentTransformer.java
@@ -26,6 +26,8 @@ package org.silverpeas.core.contribution.content.wysiwyg.service;
 import org.silverpeas.core.SilverpeasException;
 import org.silverpeas.core.contribution.content.wysiwyg.service.directive.ImageUrlAccordingToHtmlSizeDirective;
 import org.silverpeas.core.contribution.content.wysiwyg.service.directive.MailLinkCssApplierDirective;
+import org.silverpeas.core.contribution.content.wysiwyg.service.directive.OpenLinkOnBlankPageDirective;
+import org.silverpeas.core.contribution.content.wysiwyg.service.directive.SanitizeDirective;
 import org.silverpeas.core.contribution.content.wysiwyg.service.directive.SilverpeasLinkCssApplierDirective;
 import org.silverpeas.core.contribution.content.wysiwyg.service.directive.VariablesReplacementDirective;
 import org.silverpeas.core.contribution.content.wysiwyg.service.process.MailContentProcess;
@@ -100,6 +102,24 @@ public class WysiwygContentTransformer {
    */
   public WysiwygContentTransformer applySilverpeasLinkCssDirective() {
     directives.add(new SilverpeasLinkCssApplierDirective());
+    return this;
+  }
+
+  /**
+   * Applies the opening of links into a blank page.
+   * @return the instance of the current {@link WysiwygContentTransformer}.
+   */
+  public WysiwygContentTransformer applyOpenLinkOnBlankDirective() {
+    directives.add(new OpenLinkOnBlankPageDirective());
+    return this;
+  }
+
+  /**
+   * Applies HTML sanitize operations.
+   * @return the instance of the current {@link WysiwygContentTransformer}.
+   */
+  public WysiwygContentTransformer applySanitizeDirective() {
+    directives.add(new SanitizeDirective());
     return this;
   }
 

--- a/core-library/src/main/java/org/silverpeas/core/contribution/content/wysiwyg/service/directive/AbstractDirective.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/content/wysiwyg/service/directive/AbstractDirective.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2000 - 2022 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.silverpeas.core.contribution.content.wysiwyg.service.directive;
+
+import net.htmlparser.jericho.Source;
+import net.htmlparser.jericho.StartTag;
+import org.silverpeas.core.contribution.content.wysiwyg.service.WysiwygContentTransformerDirective;
+import org.silverpeas.core.util.Pair;
+import org.silverpeas.core.util.StringUtil;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.function.UnaryOperator;
+
+/**
+ * Centralization of code.
+ * @author silveryocha
+ */
+public abstract class AbstractDirective implements WysiwygContentTransformerDirective {
+
+  @Override
+  public String execute(final String wysiwygContent) {
+    if (wysiwygContent == null) {
+      return StringUtil.EMPTY;
+    }
+    final Source source = new Source(wysiwygContent);
+    final Map<String, String> replacements = new HashMap<>();
+    prepareReplacements(source, replacements);
+    String transformedWysiwygContent = wysiwygContent;
+    for (final Map.Entry<String, String> replacement : replacements.entrySet()) {
+      transformedWysiwygContent = transformedWysiwygContent.replace(replacement.getKey(),
+          replacement.getValue());
+    }
+    return transformedWysiwygContent;
+  }
+
+  /**
+   * Prepares all replacements to perform.
+   * @param source the initial source content.
+   * @param replacements the map into which replacements MUST be specified. The key represents
+   * the occurrence into source, the value the replacements.
+   */
+  protected abstract void prepareReplacements(final Source source,
+      final Map<String, String> replacements);
+
+  /**
+   * Centralizes the modification of the value of an attribute.
+   * @param linkStartTag the {@link StartTag} instance of current element.
+   * @param attrName the name of aimed attribute to modify.
+   * @param newValue the {@link Function} implementation taking as parameter the current value of
+   * attribute and returns the modified one. Null parameter means that attribute does not yet exist.
+   * @param replacements the map into which replacements MUST be specified. The key represents
+   * the occurrence into source, the value the replacements.
+   */
+  protected void modifyElementAttribute(final StartTag linkStartTag, final String attrName,
+      final UnaryOperator<String> newValue, final Map<String, String> replacements) {
+    modifyElementAttributes(linkStartTag, List.of(Pair.of(attrName, newValue)), replacements);
+  }
+
+  /**
+   * Centralizes the modification of the value of an attribute.
+   * @param linkStartTag the {@link StartTag} instance of current element.
+   * @param attrDirectives collection of attributes directives. Each directive is represented by
+   * a {@link Pair} instance which on left is the name of the attribute and on the right the
+   * {@link Function} implementation taking as parameter the current value of attribute and
+   * returns the modified one. Null parameter means that attribute does not yet exist.
+   * @param replacements the map into which replacements MUST be specified. The key represents
+   * the occurrence into source, the value the replacements.
+   */
+  protected void modifyElementAttributes(final StartTag linkStartTag,
+      final Collection<Pair<String, UnaryOperator<String>>> attrDirectives,
+      final Map<String, String> replacements) {
+    final String startTagAsString = linkStartTag.toString();
+    if (replacements.containsKey(startTagAsString)) {
+      return;
+    }
+    String currentStartTagAsString = startTagAsString;
+    for (final Pair<String, UnaryOperator<String>> attrDirective : attrDirectives) {
+      final String attrName = attrDirective.getFirst();
+      final UnaryOperator<String> newValue = attrDirective.getSecond();
+      final String currentAttrValue = linkStartTag.getAttributeValue(attrName);
+      if (currentAttrValue == null) {
+        currentStartTagAsString = currentStartTagAsString
+            .replaceFirst("([ \t\r\n]*)>$", " " + attrName + "=\"" + newValue.apply(null) + "\"$1>");
+      } else {
+        currentStartTagAsString = currentStartTagAsString.replaceAll(
+            "(" + attrName + "[ \t\r\n]*=[ \t\r\n]*([\"'])[ \t\r\n]*)" + currentAttrValue +
+                "([ \t\r\n]*([\"']))", "$1" + newValue.apply(currentAttrValue) + "$2");
+      }
+    }
+    replacements.put(startTagAsString, currentStartTagAsString);
+  }
+}

--- a/core-library/src/main/java/org/silverpeas/core/contribution/content/wysiwyg/service/directive/ImageUrlAccordingToHtmlSizeDirective.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/content/wysiwyg/service/directive/ImageUrlAccordingToHtmlSizeDirective.java
@@ -27,7 +27,6 @@ import net.htmlparser.jericho.Attribute;
 import net.htmlparser.jericho.Element;
 import net.htmlparser.jericho.HTMLElementName;
 import net.htmlparser.jericho.Source;
-import org.silverpeas.core.contribution.content.wysiwyg.service.WysiwygContentTransformerDirective;
 import org.silverpeas.core.util.Mutable;
 import org.silverpeas.core.util.ServiceProvider;
 import org.silverpeas.core.util.StringDataExtractor.RegexpPatternDirective;
@@ -38,7 +37,6 @@ import java.math.RoundingMode;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -55,7 +53,7 @@ import static org.silverpeas.core.util.StringUtil.EMPTY;
  * Transforms all URL of images to take into account theirs display size.
  * @author Yohann Chastagnier
  */
-public class ImageUrlAccordingToHtmlSizeDirective implements WysiwygContentTransformerDirective {
+public class ImageUrlAccordingToHtmlSizeDirective extends AbstractDirective {
 
   private static final String WIDTH_ATTR = "width";
   private static final String HEIGHT_ATTR = "height";
@@ -79,11 +77,8 @@ public class ImageUrlAccordingToHtmlSizeDirective implements WysiwygContentTrans
   }
 
   @Override
-  public String execute(final String wysiwygContent) {
-    final String wysiwygToTransform = wysiwygContent != null ? wysiwygContent : "";
-    final Source source = new Source(wysiwygToTransform);
+  public void prepareReplacements(final Source source, final Map<String, String> replacements) {
     final List<Element> imgElements = source.getAllElements(HTMLElementName.IMG);
-    final Map<String, String> replacements = new HashMap<>();
     if (!imgElements.isEmpty()) {
       final List<SrcTranslator> translators = SrcTranslator.getAll();
       for (Element currentImg : imgElements) {
@@ -105,14 +100,6 @@ public class ImageUrlAccordingToHtmlSizeDirective implements WysiwygContentTrans
         }
       }
     }
-    String transformedWysiwygContent = wysiwygToTransform;
-    for (Map.Entry<String, String> replacement : replacements.entrySet()) {
-      transformedWysiwygContent =
-          transformedWysiwygContent.replace(replacement.getKey(), replacement.getValue());
-    }
-
-    // Returning the transformed WYSIWYG.
-    return transformedWysiwygContent;
   }
 
   private void applyMinWidthIfNecessary(final Mutable<String> width, final Mutable<String> height) {

--- a/core-library/src/main/java/org/silverpeas/core/contribution/content/wysiwyg/service/directive/MailLinkCssApplierDirective.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/content/wysiwyg/service/directive/MailLinkCssApplierDirective.java
@@ -29,10 +29,8 @@ import net.htmlparser.jericho.HTMLElementName;
 import net.htmlparser.jericho.Segment;
 import net.htmlparser.jericho.Source;
 import net.htmlparser.jericho.StartTag;
-import org.silverpeas.core.contribution.content.wysiwyg.service.WysiwygContentTransformerDirective;
 import org.silverpeas.core.util.StringUtil;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -44,14 +42,11 @@ import static org.silverpeas.core.util.URLUtil.getCurrentServerURL;
  * Silverpeas's server.
  * @author silveryocha
  */
-public class MailLinkCssApplierDirective implements WysiwygContentTransformerDirective {
+public class MailLinkCssApplierDirective extends AbstractDirective {
 
   @Override
-  public String execute(final String wysiwygContent) {
-    final String wysiwygToTransform = wysiwygContent != null ? wysiwygContent : "";
-    final Source source = new Source(wysiwygToTransform);
+  public void prepareReplacements(final Source source, final Map<String, String> replacements) {
     final List<Element> linkElements = source.getAllElements(HTMLElementName.A);
-    final Map<String, String> replacements = new HashMap<>();
     for (final Element currentLink : linkElements) {
       final StartTag linkStartTag = currentLink.getStartTag();
       if (isCompliantHref(linkStartTag)) {
@@ -60,15 +55,6 @@ public class MailLinkCssApplierDirective implements WysiwygContentTransformerDir
         apply(linkStartTag, newHref, replacements);
       }
     }
-
-    String transformedWysiwygContent = wysiwygToTransform;
-    for (Map.Entry<String, String> replacement : replacements.entrySet()) {
-      transformedWysiwygContent = transformedWysiwygContent.replace(replacement.getKey(),
-          replacement.getValue());
-    }
-
-    // Returning the transformed WYSIWYG.
-    return transformedWysiwygContent;
   }
 
   private void apply(final StartTag linkStartTag, final String newHref,

--- a/core-library/src/main/java/org/silverpeas/core/contribution/content/wysiwyg/service/directive/OpenLinkOnBlankPageDirective.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/content/wysiwyg/service/directive/OpenLinkOnBlankPageDirective.java
@@ -26,41 +26,26 @@ package org.silverpeas.core.contribution.content.wysiwyg.service.directive;
 import net.htmlparser.jericho.Element;
 import net.htmlparser.jericho.HTMLElementName;
 import net.htmlparser.jericho.Source;
-import org.silverpeas.core.util.WebEncodeHelper;
-import org.silverpeas.core.variables.Variable;
+import net.htmlparser.jericho.StartTag;
+import org.silverpeas.core.util.Pair;
 
 import java.util.List;
 import java.util.Map;
 
 /**
- * Transforms all URL of images to take into account theirs display size.
- * @author Yohann Chastagnier
+ * Modify the content in order to make that links are opened on a blank page.
+ * @author silveryocha
  */
-public class VariablesReplacementDirective extends AbstractDirective {
+public class OpenLinkOnBlankPageDirective extends AbstractDirective {
 
   @Override
   public void prepareReplacements(final Source source, final Map<String, String> replacements) {
-    List<Element> spanElements = source.getAllElements(HTMLElementName.SPAN);
-    for (Element currentSpan : spanElements) {
-
-      // The part that is not modified
-      String spanTag = currentSpan.toString();
-
-      String spanClass = currentSpan.getAttributeValue("class");
-      if ("sp-variable".equals(spanClass)) {
-        String valueId = currentSpan.getAttributeValue("rel");
-        if (!replacements.containsKey(spanTag)) {
-          Variable variable = Variable.getById(valueId);
-          if (variable != null) {
-            variable.getVariableValues().getCurrent().ifPresent(v -> {
-              String newSpanTag = currentSpan.getStartTag().toString() +
-                  WebEncodeHelper.convertBlanksForHtml(v.getValue()) +
-                  currentSpan.getEndTag().toString();
-              replacements.put(spanTag, newSpanTag);
-            });
-          }
-        }
-      }
+    final List<Element> linkElements = source.getAllElements(HTMLElementName.A);
+    for (final Element currentLink : linkElements) {
+      final StartTag linkStartTag = currentLink.getStartTag();
+      modifyElementAttributes(linkStartTag, List.of(
+          Pair.of("target", c -> "_blank"),
+          Pair.of("rel", c -> "noopener noreferrer nofollow")), replacements);
     }
   }
 }

--- a/core-library/src/main/java/org/silverpeas/core/contribution/content/wysiwyg/service/directive/SanitizeDirective.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/content/wysiwyg/service/directive/SanitizeDirective.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2000 - 2022 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.silverpeas.core.contribution.content.wysiwyg.service.directive;
+
+import org.owasp.html.PolicyFactory;
+import org.silverpeas.core.contribution.content.wysiwyg.service.WysiwygContentTransformerDirective;
+import org.silverpeas.core.util.StringUtil;
+
+import static org.owasp.html.Sanitizers.*;
+
+/**
+ * Sanitize the WYSIWYG content in order to keep only:
+ * <ul>
+ *   <li>safe formatting</li>
+ *   <li>safe blocks</li>
+ *   <li>safe images</li>
+ *   <li>safe links</li>
+ *   <li>safe tables</li>
+ *   <li>safe styles</li>
+ * </ul>
+ * @author silveryocha
+ */
+public class SanitizeDirective implements WysiwygContentTransformerDirective {
+
+  private static final PolicyFactory POLICY_FACTORY =
+      FORMATTING.and(BLOCKS).and(LINKS).and(STYLES).and(TABLES).and(IMAGES);
+
+  @Override
+  public String execute(final String wysiwygContent) {
+    if (wysiwygContent == null) {
+      return StringUtil.EMPTY;
+    }
+    return POLICY_FACTORY.sanitize(wysiwygContent);
+  }
+}

--- a/core-library/src/main/java/org/silverpeas/core/security/html/DefaultHtmlSanitizer.java
+++ b/core-library/src/main/java/org/silverpeas/core/security/html/DefaultHtmlSanitizer.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2000 - 2022 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.security.html;
+
+import org.silverpeas.core.contribution.content.wysiwyg.service.WysiwygContentTransformer;
+
+import javax.enterprise.inject.Default;
+import javax.inject.Singleton;
+
+/**
+ * @author silveryocha
+ */
+@Default
+@Singleton
+public class DefaultHtmlSanitizer implements HtmlSanitizer {
+
+  @Override
+  public String sanitize(final String html) {
+    return WysiwygContentTransformer.on(html)
+        .applySanitizeDirective()
+        .applyOpenLinkOnBlankDirective()
+        .transform();
+  }
+}

--- a/core-library/src/test/java/org/silverpeas/core/contribution/content/wysiwyg/service/WysiwygContentTransformerTest.java
+++ b/core-library/src/test/java/org/silverpeas/core/contribution/content/wysiwyg/service/WysiwygContentTransformerTest.java
@@ -23,6 +23,7 @@
  */
 package org.silverpeas.core.contribution.content.wysiwyg.service;
 
+import net.htmlparser.jericho.HTMLElementName;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.junit.jupiter.api.AfterEach;
@@ -205,7 +206,7 @@ public class WysiwygContentTransformerTest {
   }
 
   @Test
-  void manageImageResizing() throws Exception {
+  void manageImageResizing() {
     WysiwygContentTransformer transformer =
         WysiwygContentTransformer.on(getContentOfDocumentNamed("wysiwygWithSeveralImages.txt"));
 
@@ -216,7 +217,7 @@ public class WysiwygContentTransformerTest {
   }
 
   @Test
-  void applyingSilverpeasLinkCss() throws Exception {
+  void applyingSilverpeasLinkCss() {
     WysiwygContentTransformer transformer =
         WysiwygContentTransformer.on(getContentOfDocumentNamed("wysiwygWithSeveralTypesOfLink.txt"));
 
@@ -227,7 +228,38 @@ public class WysiwygContentTransformerTest {
   }
 
   @Test
-  void applyingMailLinkCss() throws Exception {
+  void applyingSilverpeasBlankLinks() {
+    WysiwygContentTransformer transformer =
+        WysiwygContentTransformer.on(getContentOfDocumentNamed("wysiwygWithSeveralTypesOfLink.txt"));
+
+    String result = transformer.applyOpenLinkOnBlankDirective().transform();
+
+    assertThat(result, is(getContentOfDocumentNamed(
+        "wysiwygWithSeveralTypesOfLinkTransformedForOpeningOnBlankPage.txt")));
+  }
+
+  @Test
+  void sanitizeFromHtml() {
+    WysiwygContentTransformer transformer =
+        WysiwygContentTransformer.on(getContentOfDocumentNamed("wysiwygWithFullHtml.txt"));
+
+    String result = transformer.applySanitizeDirective().transform();
+
+    assertThat(result, is(getContentOfDocumentNamed(
+        "wysiwygWithFullHtmlTransformedBySanitization.txt")));
+  }
+
+  @Test
+  void sanitizeFromSimpleText() {
+    WysiwygContentTransformer transformer = WysiwygContentTransformer.on("Silverpeas's < simple\nText\t or > toto");
+
+    String result = transformer.applySanitizeDirective().transform();
+
+    assertThat(result, is("Silverpeas&#39;s &lt; simple\nText\t or &gt; toto"));
+  }
+
+  @Test
+  void applyingMailLinkCss() {
     WysiwygContentTransformer transformer =
         WysiwygContentTransformer.on(getContentOfDocumentNamed("wysiwygWithSeveralTypesOfLink.txt"));
 

--- a/core-library/src/test/java/org/silverpeas/core/contribution/content/wysiwyg/service/process/MailContentProcessTest.java
+++ b/core-library/src/test/java/org/silverpeas/core/contribution/content/wysiwyg/service/process/MailContentProcessTest.java
@@ -59,10 +59,7 @@ import java.util.stream.Collectors;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @EnableSilverTestEnv
 class MailContentProcessTest {

--- a/core-library/src/test/resources/org/silverpeas/core/contribution/content/wysiwyg/service/wysiwygWithFullHtml.txt
+++ b/core-library/src/test/resources/org/silverpeas/core/contribution/content/wysiwyg/service/wysiwygWithFullHtml.txt
@@ -1,0 +1,265 @@
+
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+  <meta http-equiv="Content-Type" content="application/xhtml+xml; charset=utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <meta name="author" content="Silverpeas"/>
+  <meta name="Date-Revision-yyyymmdd" content="20120831"/>
+  <meta http-equiv="Content-Language" content="en"/>
+  <title>Welcome at the Silverpeas Open-Source and Libre Project</title>
+  <link rel="stylesheet" href="css/apache-maven-fluido-1.10.0.min.css"/>
+  <link rel="stylesheet" href="css/site.css"/>
+  <link rel="stylesheet" href="css/print.css" media="print"/>
+  <script type="text/javascript" src="js/apache-maven-fluido-1.10.0.min.js"></script>
+  <!-- Google Analytics -->
+  <script>
+    (function(i, s, o, g, r, a, m) {
+      i['GoogleAnalyticsObject'] = r;
+      i[r] = i[r] || function() {
+        (i[r].q = i[r].q || []).push(arguments)
+      }, i[r].l = 1 * new Date();
+      a = s.createElement(o), m = s.getElementsByTagName(o)[0];
+      a.async = 1;
+      a.src = g;
+      m.parentNode.insertBefore(a, m)
+    })(window, document, 'script', '//www.google-analytics.com/analytics.js', 'ga');
+    ga('create', 'UA-2015926-3', 'auto');
+    ga('send', 'pageview');
+    ga('set', 'anonymizeIp', true);
+    ga('set', 'forceSSL', true);
+  </script>
+</head>
+<body class="topBarEnabled" id="home">
+<a href="http://github.com/Silverpeas">
+  <img style="position: absolute; top: 0; right: 0; border: 0; z-index: 10000;"
+       src="https://s3.amazonaws.com/github/ribbons/forkme_right_orange_ff7600.png"
+       alt="Fork me on GitHub"/>
+</a>
+<header id="topbar" class="navbar navbar-fixed-top navbar-inverse">
+  <div class="navbar-inner">
+    <div class="container">
+      <a data-target=".nav-collapse" data-toggle="collapse" class="btn btn-navbar">
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+      </a>
+      <nav class="nav-collapse">
+        <ul class="nav">
+          <li class="dropdown">
+            <a href="#" class="dropdown-toggle" data-toggle="dropdown">Silverpeas <b class="caret"></b></a>
+            <ul class="dropdown-menu">
+              <li><a href="intro.html" title="About">About</a></li>
+              <li><a href="product/features.html" title="Key Features">Key Features</a></li>
+              <li class="dropdown-submenu">
+                <a href="product/applications.html" title="Applications">Applications</a>
+                <ul class="dropdown-menu">
+                  <li><a href="product/social_network.html" title="Social Network">Social Network</a>
+                  </li>
+                  <li><a href="product/documentation_management.html"
+                         title="Electronic Documentation Management">Electronic Documentation Management</a></li>
+                  <li><a href="product/content_management.html" title="Content Management">Content Management</a></li>
+                  <li><a href="product/data_collection.html" title="Data Collection">Data Collection</a></li>
+                  <li><a href="product/gallery.html" title="Pictures Management">Pictures Management</a></li>
+                  <li><a href="product/knowledge_management.html" title="Knowledge Management">Knowledge Management</a></li>
+                  <li><a href="product/project_documentation.html" title="Project Documentation">Project Documentation</a></li>
+                </ul>
+              </li>
+              <li><a href="screenshots.html" title="Screenshots">Screenshots</a></li>
+              <li class="dropdown-submenu">
+                <a href="installation/index.html" title="Install Silverpeas">Install Silverpeas</a>
+                <ul class="dropdown-menu">
+                  <li><a href="installation/izpack.html" title="Try Silverpeas">Try Silverpeas</a>
+                  </li>
+                  <li><a href="installation/installationV6.html" title="Installation">Installation of Silverpeas 6</a></li>
+                  <li><a href="installation/cloud.html" title="Silverpeas in the Cloud">Silverpeas in the Cloud</a></li>
+                  <li><a href="installation/webdav.html" title="Online Edition of Documents">Online Edition of Documents</a></li>
+                </ul>
+              </li>
+              <li class="dropdown-submenu">
+                <a href="#" title="Our versions">Our versions</a>
+                <ul class="dropdown-menu">
+                  <li><a href="https://tracker.silverpeas.org/projects/silverpeas/roadmap" title="Roadmap">Roadmap</a></li>
+                  <li><a href="https://tracker.silverpeas.org/projects/silverpeas/roadmap?completed=1&with_subprojects=1" title="Changelog">Changelog</a></li>
+                  <li><a href="releasenotes.html" title="Release Notes">Release Notes</a></li>
+                </ul>
+              </li>
+              <li><a href="scm.html" title="Source Code">Source Code</a></li>
+              <li class="dropdown-submenu">
+                <a href="#" title="Some Configuration Tips">Some Configuration Tips</a>
+                <ul class="dropdown-menu">
+                  <li><a href="configuration/ldap.html" title="LDAP Synchronization">LDAP Synchronization</a></li>
+                  <li><a href="configuration/proxy.html" title="Configuring a reverse-proxy">Configuring a reverse-proxy</a></li>
+                </ul>
+              </li>
+              <li><a href="faq.html" title="FAQ">FAQ</a></li>
+            </ul>
+          </li>
+          <li class="dropdown">
+            <a href="#" class="dropdown-toggle" data-toggle="dropdown">Silverpeas Projects <b class="caret"></b></a>
+            <ul class="dropdown-menu">
+              <li class="dropdown-submenu">
+                <a href="#" title="Global information">Global information</a>
+                <ul class="dropdown-menu">
+                  <li><a href="intro.html" title="About Silverpeas">About Silverpeas</a></li>
+                  <li><a href="team.html" title="Team">Team</a></li>
+                  <li><a href="mailing-lists.html" title="Mailing List">Mailing List</a></li>
+                  <li><a href="issue-management.html" title="Issue Tracking">Issue Tracking</a></li>
+                  <li><a href="source-repository.html" title="Source Repository">Source Repository</a></li>
+                  <li><a href="ci-management.html" title="Continuous Integration">Continuous Integration</a></li>
+                </ul>
+              </li>
+              <li><a href="docs/core/index.html" title="Silverpeas Core">Silverpeas Core</a></li>
+              <li><a href="docs/components/index.html" title="Silverpeas Applications">Silverpeas Applications</a></li>
+            </ul>
+          </li>
+          <li class="dropdown">
+            <a href="#" class="dropdown-toggle" data-toggle="dropdown">How to contribute <b class="caret"></b></a>
+            <ul class="dropdown-menu">
+              <li><a href="dev/collaboration.html" title="Contribution">Contribution</a></li>
+              <li><a href="dev/quality.html" title="Code Quality">Code Quality</a></li>
+              <li><a href="dev/ldap_testing.html" title="Testing the LDAP code">Testing the LDAP code</a></li>
+            </ul>
+          </li>
+          <li class="dropdown">
+            <a href="#" class="dropdown-toggle" data-toggle="dropdown">Licensing <b class="caret"></b></a>
+            <ul class="dropdown-menu">
+              <li><a href="legal/licensing_gnu_affero.html" title="License">License</a></li>
+              <li><a href="legal/licensing_faq.html" title="Licensing FAQ">Licensing FAQ</a></li>
+              <li><a href="legal/floss_exception.html" title="FLOSS Exception">FLOSS Exception</a></li>
+              <li><a href="legal/trademark.html" title="Silverpeas Trade Mark">Silverpeas Trade Mark</a></li>
+            </ul>
+          </li>
+        </ul>
+      </nav>
+      <div class="nav-collapse"></div>
+    </div>
+  </div>
+</header>
+
+<div>
+  <header>
+  <div id="banner">
+    <div class="pull-left"><a href="https://www.silverpeas.org/" id="bannerLeft"> <img
+        src="images/logo.png" alt="Silverpeas"/> </a></div>
+    <div class="pull-right"></div>
+    <h1>Improving the <strong>collaboration</strong> and the <strong>sharing</strong></h1>
+    <p class="accroche">We believe in the work efficiency by the collaboration, by knowledge-sharing
+      and by a rapid feedback, and we want to extend and improve this way of thinking and of
+      working.
+      Therefore, we have built a collaborative and social-networking platform that is both intuitive
+      and ready to be used: Silverpeas.</p>
+    <p id="zone-bouton">
+      <a href="https://www.silverpeas.org/installation/izpack.html">
+        <img src="images/download_sidebar.png" alt="Download the IzpAck Installer" class="bouton"/>
+      </a>
+      <a href="installation/installationV6.html">
+        <img src="images/instruction_installation.png" alt="Find the instruction installation" class="bouton" id="btnInstruction"/>
+      </a>
+    </p>
+    <p id="discours-mr-coss">Silverpeas is available as <strong>Free Software</strong> under the Affero GPL</p>
+    <div class="clear">
+      <hr/>
+    </div>
+  </div>
+
+  <div id="principal-link">
+    <ul>
+      <li>
+        <a href="project-info.html">Documentation <span>Learn more about our project</span></a>
+      </li>
+      <li>
+        <a href="support.html">Support <span>Subscribe to our mailing List</span></a>
+      </li>
+      <li>
+        <a href="dev/collaboration.html">Contribution <span>How to contribute with GitHub</span></a>
+      </li>
+      <li>
+        <a href="https://www.silverpeas.org/files/silverpeas-6.2.2-wildfly20.zip">Download <span>the latest stable version of Silverpeas</span>
+        </a>
+      </li>
+      <li>
+        <a target="_blank" href="https://www.silverpeas.com/en/59/portail.html/">Screenshots <span>Some product screenshot on silverpeas.com</span>
+        </a>
+      </li>
+    </ul>
+  </div>
+  </header>
+</div>
+
+<div class="container">
+<main class="row-fluid">
+
+    <div id="leftColumn" class="span3">
+      <div class="well sidebar-nav">
+        <div id="poweredBy">
+          <!-- Tag google +1 -->
+          <g:plusone annotation="inline"></g:plusone>
+          <script type="text/javascript">
+            (function() {
+              var po = document.createElement('script');
+              po.type = 'text/javascript';
+              po.async = true;
+              po.src = 'https://apis.google.com/js/plusone.js';
+              var s = document.getElementsByTagName('script')[0];
+              s.parentNode.insertBefore(po, s);
+            })();
+          </script>
+          <div class="community center"><a target="_blank" href="https://twitter.com/Silverpeas"><img
+              title="Follow us on Twitter" alt="Twitter" src="images/btn-twitt-uk.png"/></a> <a
+              target="_blank" href="https://www.facebook.com/pages/Silverpeas/113429255383677"><img
+              title="Follow us on Facebook" alt="Facebook" src="images/btn-fb-uk.png"/></a></div>
+          <div class="clear"></div>
+        </div>
+      </div>
+    </div>
+
+    <div class="span9">
+      <div class="subSection">
+        <p>Accessible from a simple web browser or from a Smartphone, Silverpeas is used every days
+          by ourselves. It makes it possible for users to work together, share their knowledge and
+          good practices, and in general to improve their reciprocal empathy, therefore their
+          willingness to collaborate.
+          The introduction in the latest version of the conversational and relational (social
+          network) functions has once again improved its benchmark coverage.</p>
+        <h2>Collaborative workspaces </h2>
+        <p>Use Silverpeas to build an Intranet or Extranet and feed web 2.0 sites optimizing sharing
+          and performance.<br/>
+          Based on it's collaborative bus, Silverpeas is used to share documents (EDM for Electronic
+          Documentation Management), to optimize project managment, content management and knowledge
+          and skills management.<br/>
+          Silverpeas improves and encourages best practices and helps the creation of social
+          networks, thanks to improved workflow and information management.</p>
+        <h2>Ready-to-use applications </h2>
+        <p>With more than 30 ready-to-use applications, Silverpeas&trade; combines all the tools you
+          need to get your collaborative spaces up and running in a few clicks. Applications such as
+          blog, wiki, forum, directories, project management, ECM, picture gallery, diaries, and
+          many more let you develop your own personalized space. Other features: EDM (Electronic
+          Documentation Management), collaborative tools, agendas, booking system, chat, yellow
+          pages, social network, survey, quiz, forums, Project management tools (with Gantt
+          support), knowledge management, content management tools such as blogs, image gallery,
+          EDM, RSS flows, workflow engine, connections to databases, and groupware (Domino,
+          Groupwise, Zimbra, Outlook)...</p>
+        <p>A transverse social Network gives a user centric access to information and
+          activities. </p>
+      </div>
+    </div>
+  </main>
+
+</div>
+<hr/>
+<footer>
+  <div class="container-fluid">
+    <div class="row span12 license">Copyright &copy; 2021 <a href="https://www.silverpeas.org">Silverpeas</a>.
+      All Rights Reserved.
+    </div>
+  </div>
+  <div class="license">
+    <a rel="license" href="https://creativecommons.org/licenses/by-sa/4.0/"><img
+        alt="Licence Creative Commons" style="border-width:0"
+        src="https://i.creativecommons.org/l/by-sa/4.0/88x31.png"/></a>.
+  </div>
+</footer>
+</body>
+</html>

--- a/core-library/src/test/resources/org/silverpeas/core/contribution/content/wysiwyg/service/wysiwygWithFullHtmlTransformedBySanitization.txt
+++ b/core-library/src/test/resources/org/silverpeas/core/contribution/content/wysiwyg/service/wysiwygWithFullHtmlTransformedBySanitization.txt
@@ -1,0 +1,155 @@
+
+
+
+
+<a href="http://github.com/Silverpeas" rel="nofollow">
+  <img style="border:0" src="https://s3.amazonaws.com/github/ribbons/forkme_right_orange_ff7600.png" alt="Fork me on GitHub" />
+</a>
+
+  <div>
+    <div>
+      
+        
+        
+        
+      
+      
+        <ul><li>
+            <a href="#" rel="nofollow">Silverpeas <b></b></a>
+            <ul><li><a href="intro.html" rel="nofollow">About</a></li><li><a href="product/features.html" rel="nofollow">Key Features</a></li><li>
+                <a href="product/applications.html" rel="nofollow">Applications</a>
+                <ul><li><a href="product/social_network.html" rel="nofollow">Social Network</a>
+                  </li><li><a href="product/documentation_management.html" rel="nofollow">Electronic Documentation Management</a></li><li><a href="product/content_management.html" rel="nofollow">Content Management</a></li><li><a href="product/data_collection.html" rel="nofollow">Data Collection</a></li><li><a href="product/gallery.html" rel="nofollow">Pictures Management</a></li><li><a href="product/knowledge_management.html" rel="nofollow">Knowledge Management</a></li><li><a href="product/project_documentation.html" rel="nofollow">Project Documentation</a></li></ul>
+              </li><li><a href="screenshots.html" rel="nofollow">Screenshots</a></li><li>
+                <a href="installation/index.html" rel="nofollow">Install Silverpeas</a>
+                <ul><li><a href="installation/izpack.html" rel="nofollow">Try Silverpeas</a>
+                  </li><li><a href="installation/installationV6.html" rel="nofollow">Installation of Silverpeas 6</a></li><li><a href="installation/cloud.html" rel="nofollow">Silverpeas in the Cloud</a></li><li><a href="installation/webdav.html" rel="nofollow">Online Edition of Documents</a></li></ul>
+              </li><li>
+                <a href="#" rel="nofollow">Our versions</a>
+                <ul><li><a href="https://tracker.silverpeas.org/projects/silverpeas/roadmap" rel="nofollow">Roadmap</a></li><li><a href="https://tracker.silverpeas.org/projects/silverpeas/roadmap?completed&#61;1&amp;with_subprojects&#61;1" rel="nofollow">Changelog</a></li><li><a href="releasenotes.html" rel="nofollow">Release Notes</a></li></ul>
+              </li><li><a href="scm.html" rel="nofollow">Source Code</a></li><li>
+                <a href="#" rel="nofollow">Some Configuration Tips</a>
+                <ul><li><a href="configuration/ldap.html" rel="nofollow">LDAP Synchronization</a></li><li><a href="configuration/proxy.html" rel="nofollow">Configuring a reverse-proxy</a></li></ul>
+              </li><li><a href="faq.html" rel="nofollow">FAQ</a></li></ul>
+          </li><li>
+            <a href="#" rel="nofollow">Silverpeas Projects <b></b></a>
+            <ul><li>
+                <a href="#" rel="nofollow">Global information</a>
+                <ul><li><a href="intro.html" rel="nofollow">About Silverpeas</a></li><li><a href="team.html" rel="nofollow">Team</a></li><li><a href="mailing-lists.html" rel="nofollow">Mailing List</a></li><li><a href="issue-management.html" rel="nofollow">Issue Tracking</a></li><li><a href="source-repository.html" rel="nofollow">Source Repository</a></li><li><a href="ci-management.html" rel="nofollow">Continuous Integration</a></li></ul>
+              </li><li><a href="docs/core/index.html" rel="nofollow">Silverpeas Core</a></li><li><a href="docs/components/index.html" rel="nofollow">Silverpeas Applications</a></li></ul>
+          </li><li>
+            <a href="#" rel="nofollow">How to contribute <b></b></a>
+            <ul><li><a href="dev/collaboration.html" rel="nofollow">Contribution</a></li><li><a href="dev/quality.html" rel="nofollow">Code Quality</a></li><li><a href="dev/ldap_testing.html" rel="nofollow">Testing the LDAP code</a></li></ul>
+          </li><li>
+            <a href="#" rel="nofollow">Licensing <b></b></a>
+            <ul><li><a href="legal/licensing_gnu_affero.html" rel="nofollow">License</a></li><li><a href="legal/licensing_faq.html" rel="nofollow">Licensing FAQ</a></li><li><a href="legal/floss_exception.html" rel="nofollow">FLOSS Exception</a></li><li><a href="legal/trademark.html" rel="nofollow">Silverpeas Trade Mark</a></li></ul>
+          </li></ul>
+      
+      <div></div>
+    </div>
+  </div>
+
+
+<div>
+  
+  <div>
+    <div><a href="https://www.silverpeas.org/" rel="nofollow"> <img src="images/logo.png" alt="Silverpeas" /> </a></div>
+    <div></div>
+    <h1>Improving the <strong>collaboration</strong> and the <strong>sharing</strong></h1>
+    <p>We believe in the work efficiency by the collaboration, by knowledge-sharing
+      and by a rapid feedback, and we want to extend and improve this way of thinking and of
+      working.
+      Therefore, we have built a collaborative and social-networking platform that is both intuitive
+      and ready to be used: Silverpeas.</p>
+    <p>
+      <a href="https://www.silverpeas.org/installation/izpack.html" rel="nofollow">
+        <img src="images/download_sidebar.png" alt="Download the IzpAck Installer" />
+      </a>
+      <a href="installation/installationV6.html" rel="nofollow">
+        <img src="images/instruction_installation.png" alt="Find the instruction installation" />
+      </a>
+    </p>
+    <p>Silverpeas is available as <strong>Free Software</strong> under the Affero GPL</p>
+    <div>
+      
+    </div>
+  </div>
+
+  <div>
+    <ul><li>
+        <a href="project-info.html" rel="nofollow">Documentation Learn more about our project</a>
+      </li><li>
+        <a href="support.html" rel="nofollow">Support Subscribe to our mailing List</a>
+      </li><li>
+        <a href="dev/collaboration.html" rel="nofollow">Contribution How to contribute with GitHub</a>
+      </li><li>
+        <a href="https://www.silverpeas.org/files/silverpeas-6.2.2-wildfly20.zip" rel="nofollow">Download the latest stable version of Silverpeas
+        </a>
+      </li><li>
+        <a href="https://www.silverpeas.com/en/59/portail.html/" rel="nofollow">Screenshots Some product screenshot on silverpeas.com
+        </a>
+      </li></ul>
+  </div>
+  
+</div>
+
+<div>
+
+
+    <div>
+      <div>
+        <div>
+          
+          
+          
+          <div><a href="https://twitter.com/Silverpeas" rel="nofollow"><img alt="Twitter" src="images/btn-twitt-uk.png" /></a> <a href="https://www.facebook.com/pages/Silverpeas/113429255383677" rel="nofollow"><img alt="Facebook" src="images/btn-fb-uk.png" /></a></div>
+          <div></div>
+        </div>
+      </div>
+    </div>
+
+    <div>
+      <div>
+        <p>Accessible from a simple web browser or from a Smartphone, Silverpeas is used every days
+          by ourselves. It makes it possible for users to work together, share their knowledge and
+          good practices, and in general to improve their reciprocal empathy, therefore their
+          willingness to collaborate.
+          The introduction in the latest version of the conversational and relational (social
+          network) functions has once again improved its benchmark coverage.</p>
+        <h2>Collaborative workspaces </h2>
+        <p>Use Silverpeas to build an Intranet or Extranet and feed web 2.0 sites optimizing sharing
+          and performance.<br />
+          Based on it&#39;s collaborative bus, Silverpeas is used to share documents (EDM for Electronic
+          Documentation Management), to optimize project managment, content management and knowledge
+          and skills management.<br />
+          Silverpeas improves and encourages best practices and helps the creation of social
+          networks, thanks to improved workflow and information management.</p>
+        <h2>Ready-to-use applications </h2>
+        <p>With more than 30 ready-to-use applications, Silverpeas™ combines all the tools you
+          need to get your collaborative spaces up and running in a few clicks. Applications such as
+          blog, wiki, forum, directories, project management, ECM, picture gallery, diaries, and
+          many more let you develop your own personalized space. Other features: EDM (Electronic
+          Documentation Management), collaborative tools, agendas, booking system, chat, yellow
+          pages, social network, survey, quiz, forums, Project management tools (with Gantt
+          support), knowledge management, content management tools such as blogs, image gallery,
+          EDM, RSS flows, workflow engine, connections to databases, and groupware (Domino,
+          Groupwise, Zimbra, Outlook)...</p>
+        <p>A transverse social Network gives a user centric access to information and
+          activities. </p>
+      </div>
+    </div>
+  
+
+</div>
+
+
+  <div>
+    <div>Copyright © 2021 <a href="https://www.silverpeas.org" rel="nofollow">Silverpeas</a>.
+      All Rights Reserved.
+    </div>
+  </div>
+  <div>
+    <a href="https://creativecommons.org/licenses/by-sa/4.0/" rel="nofollow"><img alt="Licence Creative Commons" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/4.0/88x31.png" /></a>.
+  </div>
+
+

--- a/core-library/src/test/resources/org/silverpeas/core/contribution/content/wysiwyg/service/wysiwygWithSeveralTypesOfLinkTransformedForOpeningOnBlankPage.txt
+++ b/core-library/src/test/resources/org/silverpeas/core/contribution/content/wysiwyg/service/wysiwygWithSeveralTypesOfLinkTransformedForOpeningOnBlankPage.txt
@@ -1,0 +1,58 @@
+<p>Un contenu complexe pour une <span style="color:#FFFFE0;"><span style="background-color: rgb(255, 0, 0);">campagne</span></span> simple.</p>
+
+<p><u>Soulign&eacute;</u></p>
+
+<p><strong>Gras</strong></p>
+
+<p><strong><img alt="kiss" height="23" src="/silverpeas/wysiwyg/jsp/ckeditor/plugins/smiley/images/kiss.png" title="kiss" width="23" /></strong></p>
+
+<p>Photot&egrave;que :</p>
+
+<p><img alt="" border="0" src="/silverpeas/GalleryInWysiwyg/dummy?ImageId=187&amp;ComponentId=gallery4&amp;UseOriginal=false" /></p>
+
+<p>Upload image :</p>
+
+<p><img alt="" src="/silverpeas/attached_file/componentId/infoLetter175/attachmentId/d07411cc-19af-49f8-af57-16fc9fabf318/lang/fr/name/Aikido16.jpg" style="width: 100px; height: 100px;" /></p>
+
+<p><img alt="" src="/silverpeas/attached_file/componentId/infoLetter175/attachmentId/d07411cc-19af-49f8-af57-16fc9fabf318/lang/fr/size/100x/name/Aikido16.jpg" style="width: 100px; height: 100px;" /></p>
+
+<p><img alt="" src="http://www.toto.fr/silverpeas/File/d07411cc-19af-49f8-af57-16fc9fabf318-bis" style="width: 100px; height: 100px;" /></p>
+
+<p><img alt="" src="/silverpeas/File_bad_link/d07411cc-19af-49f8-af57-16fc9fabf318-bis" style="width: 100px; height: 100px;" /></p>
+
+<p><a href="/silverpeas/attached_file/componentId/infoLetter175/attachmentId/d07411cc-19af-49f8-af57-16fc9fabf318/lang/fr/size/100x100/name/Aikido16.jpg" target="_blank" rel="noopener noreferrer nofollow">/silverpeas/attached_file/componentId/infoLetter175/attachmentId/d07411cc-19af-49f8-af57-16fc9fabf318/lang/fr/size/100x100/name/Aikido16.jpg</a></p>
+
+<p><a href="/silverpeas/attached_file/componentId/infoLetter175/attachmentId/d07411cc-19af-49f8-af57-16fc9fabf318/lang/fr/size/100x/name/Aikido16.jpg" target="_blank" rel="noopener noreferrer nofollow">/silverpeas/attached_file/componentId/infoLetter175/attachmentId/d07411cc-19af-49f8-af57-16fc9fabf318/lang/fr/size/100x/name/Aikido16.jpg</a></p>
+
+<p><a href="https://www.toto.fr/silverpeas/attached_file/componentId/infoLetter175/attachmentId/72f56ba9-b089-40c4-b16c-255e93658259-bis/lang/fr/name/2-2_Formation_Developpeur-Partie-2.pdf" target="_blank" rel="noopener noreferrer nofollow">/silverpeas/attached_file/componentId/infoLetter175/attachmentId/72f56ba9-b089-40c4-b16c-255e93658259/lang/fr/name/2-2_Formation_Developpeur-Partie-2.pdf</a></p>
+
+<p><a href="/silverpeas/attached_file/componentId/infoLetter175/attachmentId/72f56ba9-b089-40c4-b16c-255e93658259/lang/fr/name/2-2_Formation_Developpeur-Partie-2.pdf" target="_blank" rel="noopener noreferrer nofollow">/silverpeas/attached_file/componentId/infoLetter175/attachmentId/72f56ba9-b089-40c4-b16c-255e93658259/lang/fr/name/2-2_Formation_Developpeur-Partie-2.pdf</a></p>
+
+<p><a href="/silverpeas/attached_file/componentId/infoLetter175/attachmentId_bad_link/72f56ba9-b089-40c4-b16c-255e93658259/lang/fr/name/2-2_Formation_Developpeur-Partie-2.pdf" target="_blank" rel="noopener noreferrer nofollow">/silverpeas/attached_file/componentId/infoLetter175/attachmentId/72f56ba9-b089-40c4-b16c-255e93658259/lang/fr/name/2-2_Formation_Developpeur-Partie-2.pdf</a></p>
+
+<p><a href="/silverpeas/Publication/345" target="_blank" rel="noopener noreferrer nofollow" >  A publication!!  </a></p>
+
+<p><a href="/silverpeas/Publication/346" target="_blank" rel="noopener noreferrer nofollow"
+ >  An other publication!!  </a></p>
+
+<p><a class="" href="/silverpeas/Publication/346" target="_blank" rel="noopener noreferrer nofollow">  Publication 346  </a></p>
+
+<p><a class="" href="/silverpeas/Publication/346" target="_blank" rel="noopener noreferrer nofollow">  Publication 346  </a></p>
+
+<p><a class=' ' href="/silverpeas/Publication/346" target="_blank" rel="noopener noreferrer nofollow">  Publication 346  </a></p>
+
+<p><a class="sp-link" href="/silverpeas/Publication/346" target="_blank" rel="noopener noreferrer nofollow">  Publication 346  </a></p>
+
+<p><a class=" sp-permalink " href="/silverpeas/Publication/346" target="_blank" rel="noopener noreferrer nofollow">  Publication 346  </a></p>
+
+<p><a class="toto" href="/silverpeas/Publication/346" target="_blank" rel="noopener noreferrer nofollow">  Publication 346  </a></p>
+
+<p><a class="sp-permalink toto" href="/silverpeas/Publication/346" target="_blank" rel="noopener noreferrer nofollow">  Publication 346  </a></p>
+
+<p><a class
+  =
+  "toto sp-link" href="/silverpeas/Publication/346?x=1&amp;y=2" target="_blank" rel="noopener noreferrer nofollow" >  Publication 346  </a></p>
+
+<p><a class="toto" href="/silverpeas/Publication/346" target="_blank" rel="noopener noreferrer nofollow">  Publication 346  </a></p>
+
+<p><a class="toto" href="/silverpeas/Publication/346" target="_blank" rel="noopener noreferrer nofollow">  Publication 346  </a></p>

--- a/core-war/src/main/webapp/util/javaScript/angularjs/directives/calendar/silverpeas-calendar-event-occurrence-list-item.jsp
+++ b/core-war/src/main/webapp/util/javaScript/angularjs/directives/calendar/silverpeas-calendar-event-occurrence-list-item.jsp
@@ -69,7 +69,8 @@
     </div>
   </div>
   <div class="occurrence-description">
-    <div ng-bind-html="$ctrl.occurrence.description | noHTML | newlines"></div>
+    <div ng-if="$ctrl.occurrence.calendarSync" ng-bind-html="$ctrl.occurrence.description | trustedHTML"></div>
+    <div ng-if="!$ctrl.occurrence.calendarSync" ng-bind-html="$ctrl.occurrence.description | noHTML | newlines"></div>
     <br class="clearAll">
   </div>
 </script>

--- a/core-war/src/main/webapp/util/javaScript/angularjs/directives/calendar/silverpeas-calendar-event-occurrence-tip.jsp
+++ b/core-war/src/main/webapp/util/javaScript/angularjs/directives/calendar/silverpeas-calendar-event-occurrence-tip.jsp
@@ -72,7 +72,8 @@
   </div>
 </div>
 <div>
-  <span class="occurrence-description" ng-bind-html="$ctrl.occurrence.description | noHTML | newlines"></span>
+  <span class="occurrence-description" ng-if="$ctrl.occurrence.calendarSync" ng-bind-html="$ctrl.occurrence.description | trustedHTML"></span>
+  <span class="occurrence-description" ng-if="!$ctrl.occurrence.calendarSync" ng-bind-html="$ctrl.occurrence.description | noHTML | newlines"></span>
 </div>
 <div>
   <silverpeas-attendees ng-if="$ctrl.occurrence.attendees.length"

--- a/core-war/src/main/webapp/util/javaScript/angularjs/directives/calendar/silverpeas-calendar-event-view-main.jsp
+++ b/core-war/src/main/webapp/util/javaScript/angularjs/directives/calendar/silverpeas-calendar-event-view-main.jsp
@@ -75,7 +75,8 @@
   </div>
 </div>
 <div class="occurrence-description" ng-if="$ctrl.ceo.description">
-  <p ng-bind-html="$ctrl.ceo.description | noHTML | newlines"></p>
+  <p ng-if="$ctrl.ceo.calendarSync" ng-bind-html="$ctrl.ceo.description | trustedHTML"></p>
+  <p ng-if="!$ctrl.ceo.calendarSync" ng-bind-html="$ctrl.ceo.description | noHTML | newlines"></p>
 </div>
 <div class="occurrence-content rich-content" ng-if="$ctrl.ceo.content">
   <p ng-bind-html="$ctrl.ceo.content | trustedHTML"></p>

--- a/core-war/src/main/webapp/util/javaScript/silverpeas-calendar.js
+++ b/core-war/src/main/webapp/util/javaScript/silverpeas-calendar.js
@@ -187,6 +187,7 @@
         occurrenceEditionUrl : occurrence.occurrenceEditionUrl,
         eventPermalinkUrl : occurrence.eventPermalinkUrl,
         calendarZoneId : occurrence.calendarZoneId,
+        calendarSync : occurrence.calendarSync,
         originalStartDate : occurrence.originalStartDate,
         firstEventOccurrence : occurrence.firstEventOccurrence,
         startDate : occurrence.startDate,


### PR DESCRIPTION
Adding a new HtmlSanitizer API in charge of the sanitizing of an HTML content.
Implementing this new API into library project into which WysiwygContentTransformer has been updated.

Using the new API when synchronizing the description of calendar events.

Adding 2 new directives to WysiwygContentTransformer:
* a directive to transform all links into safe ones by forcing the opening on a new page without any linking with the parent page
* a directive to sanitize an HTML content

Refactoring WysiwygContentTransformer API in order to centralize common code.

AngularJS templates of calendar feature have been modified in order to also perform a sanitize action on HTML on client side (about description data).

Linked to PR https://github.com/Silverpeas/silverpeas-dependencies-bom/pull/38