### PR TITLE
Feature #13060: ignoring login case on user authentication when explicitly set into a property file.

### DIFF
--- a/core-configuration/src/main/config/properties/org/silverpeas/authentication/settings/authenticationSettings.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/authentication/settings/authenticationSettings.properties
@@ -70,3 +70,12 @@ termsOfServiceAcceptanceFrequency = NEVER
 # termsOfServiceAcceptanceFrequency.domainX = ALWAYS
 # Apply specific template content to the specified domain id terms of service.
 # termsOfServiceAcceptanceSpecificTemplateContent.domainX = true
+
+# If true value is set, then the login case will be ignored on user authentication.
+# Otherwise (default case), the login MUST be exactly exact to the one registered into Silverpeas's
+# repositories.
+# This is the default parameter applied on all domains.
+loginIgnoreCaseOnUserAuthentication.default = false
+#  It is possible to apply a different behavior to a specific domain by using this parameter,
+#  where 'XX' MUST be replaced by the identifier of the aimed domain.
+loginIgnoreCaseOnUserAuthentication.domainXX = true

--- a/core-configuration/src/main/config/properties/org/silverpeas/multilang/generalMultilang.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/multilang/generalMultilang.properties
@@ -267,6 +267,7 @@ GML.PDCPredefinePositions = D\u00e9finir le classement par d\u00e9faut
 GML.PDCPositionsPredefinition = D\u00e9finition du classement par d\u00e9faut
 
 #Contr\u00f4les d'acc\u00e8s
+GML.UnauthenticatedAccess = Un probl\u00e8me est survenu lors de votre authentification !
 GML.ForbiddenAccessContent = Vous n'avez pas les droits suffisants pour acc\u00e9der \u00e0 l'information d\u00e9sir\u00e9e !
 GML.DocumentNotFound = L'information que vous souhaitez consulter n'existe plus !
 

--- a/core-configuration/src/main/config/properties/org/silverpeas/multilang/generalMultilang_de.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/multilang/generalMultilang_de.properties
@@ -266,6 +266,7 @@ GML.PDCPredefinePositions = Definieren Sie die Standard-Klassierung
 GML.PDCPositionsPredefinition = Definition der Standard-Klassierung
 
 # Contr\u00f4les d'acc\u00e8s
+GML.UnauthenticatedAccess = Es gab ein Problem mit Ihrer Authentifizierung!
 GML.ForbiddenAccessContent = Sie verf\u00fcgen nicht \u00fcber gen\u00fcgende Rechte, um zur gew&#x00fc;nschten Information Zugang zu erhalten!
 GML.DocumentNotFound = Die Information, die Sie abfragen m\u00f6chten, existiert nicht mehr!
 

--- a/core-configuration/src/main/config/properties/org/silverpeas/multilang/generalMultilang_en.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/multilang/generalMultilang_en.properties
@@ -266,6 +266,7 @@ GML.PDCPredefinePositions = Define the default classification
 GML.PDCPositionsPredefinition = Settings of the default classification
 
 # Access Control
+GML.UnauthenticatedAccess = There was a problem with your authentication!
 GML.ForbiddenAccessContent = You are not allowed to access this information!
 GML.DocumentNotFound = The information you are trying to reach has been deleted!
 

--- a/core-configuration/src/main/config/properties/org/silverpeas/multilang/generalMultilang_fr.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/multilang/generalMultilang_fr.properties
@@ -267,6 +267,7 @@ GML.PDCPredefinePositions = D\u00e9finir le classement par d\u00e9faut
 GML.PDCPositionsPredefinition = D\u00e9finition du classement par d\u00e9faut
 
 # Contr\u00f4les d'acc\u00e8s
+GML.UnauthenticatedAccess = Un probl\u00e8me est survenu lors de votre authentification !
 GML.ForbiddenAccessContent = Vous n'avez pas les droits suffisants pour acc\u00e9der \u00e0 l'information d\u00e9sir\u00e9e !
 GML.DocumentNotFound = L'information que vous souhaitez consulter n'existe plus !
 

--- a/core-library/src/main/java/org/silverpeas/core/security/authentication/Authentication.java
+++ b/core-library/src/main/java/org/silverpeas/core/security/authentication/Authentication.java
@@ -126,14 +126,16 @@ public abstract class Authentication {
    * isn't a password modification but a reset of it generally under the control of the system.
    * If the login of the user doesn't exist or if the reset cannot be done an exception is thrown.
    * @param login the user login
+   * @param loginIgnoreCase true to ignore case when comparing the login
    * @param newPassword the new password
    * @throws AuthenticationException if an error occurs while resetting the user password.
    */
-  public void resetPassword(final String login, final String newPassword) throws AuthenticationException {
+  public void resetPassword(final String login, final boolean loginIgnoreCase,
+      final String newPassword) throws AuthenticationException {
       doSecurityOperation(new SecurityOperation(SecurityOperation.PASSWORD_RESET) {
         @Override
         public <T> void perform(AuthenticationConnection<T> connection) throws AuthenticationException {
-          doResetPassword(connection, login, newPassword);
+          doResetPassword(connection, login, loginIgnoreCase, newPassword);
         }
       });
     }
@@ -207,12 +209,13 @@ public abstract class Authentication {
    * method.
    * @param connection the connection with a remote authentication server.
    * @param login the login of the user for which the password has to be reset.
+   * @param loginIgnoreCase true to ignore case when comparing the login.
    * @param newPassword the new password with which the user password will be reset.
    * @param <T> the type of the authentication server's connector.
    * @throws AuthenticationException if an error occurs while resetting the user password.
    */
   protected <T> void doResetPassword(AuthenticationConnection<T> connection, String login,
-      String newPassword) throws AuthenticationException {
+      final boolean loginIgnoreCase, String newPassword) throws AuthenticationException {
     throw new AuthenticationPwdChangeNotAvailException("The password reset isn't available");
   }
 

--- a/core-library/src/main/java/org/silverpeas/core/security/authentication/AuthenticationCredential.java
+++ b/core-library/src/main/java/org/silverpeas/core/security/authentication/AuthenticationCredential.java
@@ -22,9 +22,15 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package org.silverpeas.core.security.authentication;
+import org.silverpeas.core.util.ResourceLocator;
+import org.silverpeas.core.util.SettingBundle;
+import org.silverpeas.core.util.StringUtil;
+
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
+
+import static java.util.Optional.ofNullable;
 
 /**
  * A credential is a set of security-related capabilities for a given user, it contains information
@@ -46,14 +52,15 @@ import java.util.Map;
  */
 public class AuthenticationCredential {
 
+  private final SettingBundle authenticationSettings = ResourceLocator.getSettingBundle(
+      "org.silverpeas.authentication.settings.authenticationSettings");
+
+  private final Map<String, Serializable> capabilities = new HashMap<>();
   private String login;
   private String password;
   private String domainId;
 
-  private Map<String, Serializable> capabilities = new HashMap<>();
-
   private AuthenticationCredential() {
-
   }
 
   /**
@@ -120,6 +127,18 @@ public class AuthenticationCredential {
    */
   public Map<String, Serializable> getCapabilities() {
     return capabilities;
+  }
+
+  /**
+   * Indicates if login case can be ignored during authentication processing.
+   * @return true to ignore case, false to compare exactly.
+   */
+  public boolean loginIgnoreCase() {
+    return ofNullable(getDomainId()).filter(StringUtil::isDefined)
+        .map(d -> authenticationSettings.getString("loginIgnoreCaseOnUserAuthentication.domain" + d, null))
+        .filter(StringUtil::isDefined)
+        .map(StringUtil::getBooleanValue)
+        .orElseGet(() -> authenticationSettings.getBoolean("loginIgnoreCaseOnUserAuthentication.default", false));
   }
 
   private void setLogin(String login) {

--- a/core-library/src/main/java/org/silverpeas/core/security/authentication/AuthenticationLDAP.java
+++ b/core-library/src/main/java/org/silverpeas/core/security/authentication/AuthenticationLDAP.java
@@ -469,7 +469,7 @@ public class AuthenticationLDAP extends Authentication {
 
   @Override
   protected void doResetPassword(AuthenticationConnection connection, String login,
-      String newPassword)
+      final boolean loginIgnoreCase, String newPassword)
       throws AuthenticationException {
     String userFullDN;
     String searchString = userLoginFieldName + "=" + login;

--- a/core-library/src/main/java/org/silverpeas/core/security/authentication/AuthenticationServer.java
+++ b/core-library/src/main/java/org/silverpeas/core/security/authentication/AuthenticationServer.java
@@ -172,14 +172,14 @@ public class AuthenticationServer {
    * the password change. Please use the method
    * <code>isPasswordChangeAllowed()</code> to check this. This operation doesn't require the user
    * to be authenticated, so the reset must be under the control of the system for security reasons.
-   *
    * @param login the login of the user for which the password has to be reset.
+   * @param loginIgnoreCase true to ignore case when comparing the login.
    * @param newPassword the new password of the user.
    * @throws AuthenticationException if an error occurs while resetting the password with the new
    * one.
    */
-  public void resetPassword(final String login, final String newPassword) throws
-      AuthenticationException {
+  public void resetPassword(final String login, final boolean loginIgnoreCase,
+      final String newPassword) throws AuthenticationException {
     if (!passwordChangeAllowed) {
       throw new AuthenticationPwdChangeNotAvailException("The password reset isn't available");
     }
@@ -188,7 +188,7 @@ public class AuthenticationServer {
         AuthenticationCredential.newWithAsLogin(login)) {
       @Override
       public void performWith(Authentication authentication) throws AuthenticationException {
-        authentication.resetPassword(login, newPassword);
+        authentication.resetPassword(login, loginIgnoreCase, newPassword);
       }
     });
   }

--- a/core-library/src/main/java/org/silverpeas/core/security/authentication/verifier/AbstractAuthenticationVerifier.java
+++ b/core-library/src/main/java/org/silverpeas/core/security/authentication/verifier/AbstractAuthenticationVerifier.java
@@ -89,7 +89,9 @@ class AbstractAuthenticationVerifier {
             credential.getDomainId());
         return Optional.ofNullable(userId)
             .map(UserDetail::getById)
-            .filter(u -> u.getLogin().equals(credential.getLogin()))
+            .filter(u -> credential.loginIgnoreCase() ?
+                u.getLogin().equalsIgnoreCase(credential.getLogin()) :
+                u.getLogin().equals(credential.getLogin()))
             .orElse(null);
       } catch (AdminException ignore) {
         return null;

--- a/core-library/src/test/java/org/silverpeas/core/security/authentication/AuthenticationCredentialTest.java
+++ b/core-library/src/test/java/org/silverpeas/core/security/authentication/AuthenticationCredentialTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2000 - 2022 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.security.authentication;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.silverpeas.core.test.extention.EnableSilverTestEnv;
+import org.silverpeas.core.test.extention.SettingBundleStub;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * @author silveryocha
+ */
+@EnableSilverTestEnv
+class AuthenticationCredentialTest {
+
+  private static final String DOMAIN_ID = "26";
+  private static final String OTHER_DOMAIN_ID = "38";
+  private static final String FALSE = "false";
+  private static final String TRUE = "true";
+  private static final String DEFAULT_PARAM = "loginIgnoreCaseOnUserAuthentication.default";
+  private static final String DOMAIN_SPECIFIC_PARAM_PREFIX = "loginIgnoreCaseOnUserAuthentication.domain";
+
+  @RegisterExtension
+  static SettingBundleStub authenticationSettings =
+      new SettingBundleStub("org.silverpeas.authentication.settings.authenticationSettings");
+
+  @BeforeEach
+  void setupSettings() {
+    authenticationSettings.removeAll();
+  }
+
+  @Test
+  @DisplayName("When no setting exists, the login case is taken into account on user authentication")
+  void loginCaseBehaviorWhenNoSetting() {
+    assertThat(getCredentials().loginIgnoreCase(), is(false));
+  }
+
+  @Test
+  @DisplayName("When default setting exists, it is taken into account")
+  void loginCaseBehaviorWhenDefaultOneExists() {
+    authenticationSettings.put(DEFAULT_PARAM, FALSE);
+    assertThat(getCredentials().loginIgnoreCase(), is(false));
+    authenticationSettings.put(DEFAULT_PARAM, TRUE);
+    assertThat(getCredentials().loginIgnoreCase(), is(true));
+  }
+
+  @Test
+  @DisplayName("When specific domain setting exists, it is taken into account")
+  void loginCaseBehaviorWhenDomainSpecificOneExists() {
+    authenticationSettings.put(DOMAIN_SPECIFIC_PARAM_PREFIX + OTHER_DOMAIN_ID, FALSE);
+    assertThat(getCredentials().loginIgnoreCase(), is(false));
+    authenticationSettings.put(DOMAIN_SPECIFIC_PARAM_PREFIX + DOMAIN_ID, TRUE);
+    assertThat(getCredentials().loginIgnoreCase(), is(true));
+  }
+
+  @Test
+  @DisplayName("When specific domain and default settings exist, specific domain is taken into account")
+  void loginCaseBehaviorWhenDomainSpecificAndDefaultOnesExist() {
+    authenticationSettings.put(DEFAULT_PARAM, TRUE);
+    assertThat(getCredentials().loginIgnoreCase(), is(true));
+    authenticationSettings.put(DOMAIN_SPECIFIC_PARAM_PREFIX + DOMAIN_ID, FALSE);
+    assertThat(getCredentials().loginIgnoreCase(), is(false));
+  }
+
+  private AuthenticationCredential getCredentials() {
+    return AuthenticationCredential.newWithAsLogin("loginTest").withAsDomainId(DOMAIN_ID);
+  }
+}

--- a/core-test/src/main/java/org/silverpeas/core/test/extention/SettingBundleStub.java
+++ b/core-test/src/main/java/org/silverpeas/core/test/extention/SettingBundleStub.java
@@ -116,6 +116,15 @@ public class SettingBundleStub implements BeforeEachCallback, AfterEachCallback 
     return this;
   }
 
+  /**
+   * Removes all registered keys.
+   * @return itself.
+   */
+  public SettingBundleStub removeAll() {
+    settingMap.clear();
+    return this;
+  }
+
   @Override
   public void beforeEach(final ExtensionContext context) throws Exception {
     init();

--- a/core-war/src/main/webapp/admin/jsp/casAuthenticationError.jsp
+++ b/core-war/src/main/webapp/admin/jsp/casAuthenticationError.jsp
@@ -23,46 +23,37 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 --%>
-<%@page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
+<%@page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+<%@ taglib uri="http://www.silverpeas.com/tld/viewGenerator" prefix="view" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 
-<%@ page import="org.silverpeas.core.util.ResourceLocator"
-%>
-<%@ page import="org.silverpeas.core.util.SettingBundle" %>
-<%@ page import="org.silverpeas.core.util.LocalizationBundle" %>
-<%
-	SettingBundle general = ResourceLocator.getSettingBundle("org.silverpeas.lookAndFeel.generalLook");
-	LocalizationBundle generalMultilang = ResourceLocator.getGeneralLocalizationBundle(
-			request.getLocale().getLanguage());
-	String sURI = request.getRequestURI();
-	String sServletPath = request.getServletPath();
-	String sPathInfo = request.getPathInfo();
-	if (sPathInfo != null)
-	{
-	    sURI = sURI.substring(0, sURI.lastIndexOf(sPathInfo));
-	}
-	String m_context = "../../.." + sURI.substring(0, sURI.lastIndexOf(sServletPath));
-
-	String styleSheet = general.getString("defaultStyleSheet", m_context + "/util/styleSheets/silverpeas-main.css");
-%>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
-   "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-	<title><%=generalMultilang.getString("GML.popupTitle")%></title>
-	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
-	<link rel="stylesheet" href="<%=styleSheet%>"/>
-</head>
-
-<body>
-	<table cellpadding="0" cellspacing="2" border="0" width="98%" class="intfdcolor">
-		<tr>
-			<td class="intfdcolor4" align="center">
-				<br/>
-				<span class="txtnav"><%=generalMultilang.getString("GML.ForbiddenAccess")%></span>
-				<br/>
-				<br/>
-			</td>
-		</tr>
-	</table>
-</body>
-</html>
+<view:sp-page>
+  <fmt:setLocale value="${requestScope.userLanguage}"/>
+  <view:setBundle basename="org.silverpeas.multilang.generalMultilang"/>
+  <view:sp-head-part noLookAndFeel="true">
+    <view:link href="/style.css"/>
+    <style type="text/css">
+      .fnfinformation {
+        float: unset;
+        margin-top: 80px;
+      }
+    </style>
+  </view:sp-head-part>
+  <view:sp-body-part>
+    <div class="page">
+      <div id="background">
+        <div class="cadre">
+          <div id="header">
+            <c:url var="logoUrl" value="/images/logo.jpg"/>
+            <img src="${logoUrl}" class="logo" alt="logo"/>
+            <p class="information"></p>
+          </div>
+          <div class="fnfinformation">
+            <fmt:message key="GML.UnauthenticatedAccess"/><br/>
+          </div>
+        </div>
+      </div>
+    </div>
+  </view:sp-body-part>
+</view:sp-page>


### PR DESCRIPTION
Adding loginIgnoreCaseOnUserConnection.default and loginIgnoreCaseOnUserConnection.domainXX parameters into authenticationSettings.properties file.

Implementing the new parameter decoding into AuthenticationCredential class.

Using this new settings into login and user account verifier APIs.
Using this new settings into authentication services.

Fixing displayed page error on authentication problem with CAS SSO.