### PR TITLE
Bug #13546: fixing to anonymous user an unauthorized access when displaying images from presentation page of a community

### DIFF
--- a/core-library/src/main/java/org/silverpeas/core/security/authorization/ComponentInstanceSimpleDocumentAccessControlExtension.java
+++ b/core-library/src/main/java/org/silverpeas/core/security/authorization/ComponentInstanceSimpleDocumentAccessControlExtension.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2000 - 2022 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.silverpeas.core.security.authorization;
+
+import org.silverpeas.core.admin.component.model.SilverpeasComponentInstance;
+import org.silverpeas.core.annotation.Base;
+import org.silverpeas.core.cache.model.SimpleCache;
+import org.silverpeas.core.cache.service.CacheServiceProvider;
+import org.silverpeas.core.util.Mutable;
+import org.silverpeas.core.util.ServiceProvider;
+
+import javax.enterprise.util.AnnotationLiteral;
+
+/**
+ * This interface extends access controller extension for a SimpleDocument resource.
+ * <p>
+ * This interface defines an extension for {@link SimpleDocumentAccessControl} which is specific to
+ * a {@link SilverpeasComponentInstance}.
+ * </p>
+ * <p>
+ * If a component has specific rules about {@link SimpleDocumentAccessControl} mechanism, it should
+ * implement this interface in order to apply them.
+ * </p>
+ * <p>
+ * Any application that requires to implement this interface MUST qualify with the
+ * {@link javax.inject.Named} annotation by a name satisfying the following convention
+ * <code>[COMPONENT NAME]InstanceSimpleDocumentAccessControlExtension</code>. For example, for an
+ * application Kmelia, the implementation must be qualified with <code>@Named
+ * ("kmeliaInstanceSimpleDocumentAccessControlExtension")
+ * </code>
+ * <p>
+ * @author silveryocha
+ */
+public interface ComponentInstanceSimpleDocumentAccessControlExtension {
+
+  /**
+   * Constants are predefined value used by a contribution manager to work with and that carries a
+   * semantic that has to be shared by all the implementations of this interface.
+   */
+  class Constants {
+
+    private Constants() {}
+
+    /**
+     * The predefined suffix that must compound the name of each implementation of this interface.
+     * An implementation of this interface by a Silverpeas application named Kmelia must be named
+     * <code>kmelia[NAME_SUFFIX]</code> where NAME_SUFFIX is the predefined suffix as defined below.
+     */
+    public static final String NAME_SUFFIX = "InstanceSimpleDocumentAccessControlExtension";
+  }
+
+  /**
+   * Gets the {@link ComponentInstanceSimpleDocumentAccessControlExtension} according to the given
+   * identifier of component instance.
+   * <p>
+   * Instances of {@link ComponentInstanceSimpleDocumentAccessControlExtension} are request scoped
+   * (or thread scoped on backend treatments).
+   * </p>
+   * @param instanceId the identifier of a component instance from which the qualified name of the
+   * implementation will be extracted.
+   * @return a {@link ComponentInstanceSimpleDocumentAccessControlExtension} implementation.
+   */
+  @SuppressWarnings("serial")
+  static ComponentInstanceSimpleDocumentAccessControlExtension getByInstanceId(final String instanceId) {
+    final SimpleCache cache = CacheServiceProvider.getRequestCacheService().getCache();
+    final String cacheKey = ComponentInstanceSimpleDocumentAccessControlExtension.class.getName() + "###" + instanceId;
+
+    final Mutable<ComponentInstanceSimpleDocumentAccessControlExtension> accessControlExtension =
+        Mutable.ofNullable(cache.get(cacheKey, ComponentInstanceSimpleDocumentAccessControlExtension.class));
+    if (accessControlExtension.isPresent()) {
+      return accessControlExtension.get();
+    }
+
+    try {
+      accessControlExtension.set(ServiceProvider
+          .getServiceByComponentInstanceAndNameSuffix(instanceId, Constants.NAME_SUFFIX));
+    } catch (IllegalStateException e) {
+      // Default implementation if none existing for the component
+      accessControlExtension.set(ServiceProvider.getService(
+          ComponentInstanceSimpleDocumentAccessControlExtension.class, new AnnotationLiteral<Base>() {}));
+    }
+    cache.put(cacheKey, accessControlExtension.get());
+    return accessControlExtension.get();
+  }
+
+  void beforeComputingAuthorizations(final AccessControlContext context);
+}

--- a/core-library/src/main/java/org/silverpeas/core/security/authorization/DefaultInstanceAccessControlExtension.java
+++ b/core-library/src/main/java/org/silverpeas/core/security/authorization/DefaultInstanceAccessControlExtension.java
@@ -47,7 +47,7 @@ public class DefaultInstanceAccessControlExtension
       final String componentId, final AccessControlContext context,
       final Set<SilverpeasRole> userRoles) {
     final Optional<SilverpeasComponentInstance> optionalInstance = dataManager.getComponentInstance(componentId);
-    if (optionalInstance.isEmpty() || (!canAnonymousAccessInstance() && user.isAnonymous())) {
+    if (optionalInstance.isEmpty() || (!canAnonymousAccessInstance(context) && user.isAnonymous())) {
       return true;
     }
 
@@ -79,7 +79,7 @@ public class DefaultInstanceAccessControlExtension
     return false;
   }
 
-  protected boolean canAnonymousAccessInstance() {
+  protected boolean canAnonymousAccessInstance(final AccessControlContext context) {
     return true;
   }
 }

--- a/core-library/src/main/java/org/silverpeas/core/security/authorization/DefaultInstanceSimpleDocumentAccessControlExtension.java
+++ b/core-library/src/main/java/org/silverpeas/core/security/authorization/DefaultInstanceSimpleDocumentAccessControlExtension.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2000 - 2022 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.security.authorization;
+
+import org.silverpeas.core.annotation.Base;
+
+import javax.inject.Singleton;
+
+/**
+ * @author silveryocha
+ */
+@Base
+@Singleton
+public class DefaultInstanceSimpleDocumentAccessControlExtension
+    implements ComponentInstanceSimpleDocumentAccessControlExtension {
+
+  @Override
+  public void beforeComputingAuthorizations(final AccessControlContext context) {
+    // nothing to do by default
+  }
+}

--- a/core-library/src/main/java/org/silverpeas/core/security/authorization/SimpleDocumentAccessController.java
+++ b/core-library/src/main/java/org/silverpeas/core/security/authorization/SimpleDocumentAccessController.java
@@ -78,6 +78,7 @@ public class SimpleDocumentAccessController extends AbstractAccessController<Sim
   @Override
   public boolean isUserAuthorized(String userId, SimpleDocument object,
       final AccessControlContext context) {
+    getComponentExtension(object.getInstanceId()).beforeComputingAuthorizations(context);
     Set<SilverpeasRole> componentUserRoles = null;
     boolean componentAccessAuthorized = false;
 
@@ -195,6 +196,10 @@ public class SimpleDocumentAccessController extends AbstractAccessController<Sim
       }
     }
     return authorized;
+  }
+
+  ComponentInstanceSimpleDocumentAccessControlExtension getComponentExtension(final String instanceId) {
+    return ComponentInstanceSimpleDocumentAccessControlExtension.getByInstanceId(instanceId);
   }
 
   private boolean isFileAttachedToWysiwygDescriptionOfNode(String foreignId) {

--- a/core-library/src/test/java/org/silverpeas/core/security/authorization/SimpleDocumentAccessControllerTest.java
+++ b/core-library/src/test/java/org/silverpeas/core/security/authorization/SimpleDocumentAccessControllerTest.java
@@ -1910,7 +1910,7 @@ class SimpleDocumentAccessControllerTest {
       final PublicationAccessControl publicationAccessController =
           new PublicationAccessController(componentAccessController, nodeAccessController);
       testInstance =
-          new SimpleDocumentAccessController(componentAccessController, nodeAccessController,
+          new SimpleDocumentAccessController4Test(componentAccessController, nodeAccessController,
               publicationAccessController);
       userIsAnonymous = false;
       userHasGuestAccess = false;
@@ -2135,5 +2135,24 @@ class SimpleDocumentAccessControllerTest {
           times(Math.max(nbCallOfPublicationBmGetMainLocation, nbCallOfPublicationBmGetAllAliases)))
           .getAllLocations(any(PublicationPK.class));
     }
+  }
+
+  private static class SimpleDocumentAccessController4Test extends SimpleDocumentAccessController {
+
+    SimpleDocumentAccessController4Test(final ComponentAccessControl componentAccessController,
+        final NodeAccessControl nodeAccessController,
+        final PublicationAccessControl publicationAccessController) {
+      super(componentAccessController, nodeAccessController, publicationAccessController);
+    }
+
+    @Override
+    ComponentInstanceSimpleDocumentAccessControlExtension getComponentExtension(
+        final String instanceId) {
+      return new DefaultInstanceSimpleDocumentAccessControlExtension4Test();
+    }
+  }
+
+  private static class DefaultInstanceSimpleDocumentAccessControlExtension4Test
+      extends DefaultInstanceSimpleDocumentAccessControlExtension {
   }
 }


### PR DESCRIPTION
Adding ComponentInstanceSimpleDocumentAccessControlExtension API which is an extension dedicated to SimpleDocumentAccessControl API. This extension allows to component implementations to implement some specific behaviors when verifying user authorizations about simple document accesses.

In the case of 'Community' component, anonymous users cannot access an instance of a community. But anonymous user can access the presentation page content and its attached images. To get it possible, the community component has its own implementation of ComponentInstanceSimpleDocumentAccessControlExtension.

Linked to PR https://github.com/Silverpeas/Silverpeas-Components/pull/818