### PR TITLE
Bug JCR item not found: fixing a technical problem.

### DIFF
--- a/core-library/src/main/java/org/silverpeas/core/contribution/attachment/repository/DocumentConverter.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/attachment/repository/DocumentConverter.java
@@ -38,6 +38,7 @@ import org.silverpeas.core.persistence.jcr.AbstractJcrConverter;
 import org.silverpeas.core.util.CollectionUtil;
 import org.silverpeas.core.util.StringUtil;
 
+import javax.jcr.ItemNotFoundException;
 import javax.jcr.Node;
 import javax.jcr.NodeIterator;
 import javax.jcr.PathNotFoundException;
@@ -122,7 +123,8 @@ class DocumentConverter extends AbstractJcrConverter {
       historisedDocument.setHistory(documentHistory);
       historisedDocument.setVersionIndex(versionIndex);
     } catch (RepositoryException ex) {
-      if (ex.getCause() instanceof NoSuchItemStateException) {
+      if (ex.getCause() instanceof NoSuchItemStateException ||
+          ex instanceof ItemNotFoundException) {
         historisedDocument.setHistory(new ArrayList<SimpleDocumentVersion>(0));
       } else {
         throw ex;


### PR DESCRIPTION
When two several threads are switching a same versioned document to a normal one in a same time, the version history of the document can be broken. In a such case, it is no more possible to display the foreign resources linked to a such document in error.

This correction takes into account this case by catching the JCR 2.0 ItemNotFoundException exception as it is already the case with the jackrabbit NoSuchItemStateException one.