### PR TITLE
Bug #13604 Don't open a Silverpeas session from a successful authentication by the API token

### DIFF
--- a/core-api/src/main/java/org/silverpeas/core/security/session/SilverpeasUserSession.java
+++ b/core-api/src/main/java/org/silverpeas/core/security/session/SilverpeasUserSession.java
@@ -70,4 +70,28 @@ public interface SilverpeasUserSession {
    * @param name the name of the attribute to unset.
    */
   void unsetAttribute(String name);
+
+  /**
+   * Is this session defined? A session is defined if it's a session opened for a user in
+   * Silverpeas.
+   * @return true if this session is defined, false otherwise.
+   */
+  boolean isDefined();
+
+  /**
+   * Is this session an anonymous one? A session is anonymous when no users are explicitly
+   * authenticated and hence identified. In such a situation, the users uses Silverpeas under the
+   * cover of a transparent anonymous user account.
+   * @return true if this session is a defined anonymous one, false otherwise.
+   */
+  boolean isAnonymous();
+
+  /**
+   * Is this session a one-shot one? A one-shot session is a short time living session that doesn't
+   * live over the scope of a single user call (id est over the scope of an HTTP request for web
+   * accesses). Usually a one-shot session is opened when accessing the Silverpeas Web resources
+   * API.
+   * @return true if this session is a one-shot one, false otherwise.
+   */
+  boolean isOneShot();
 }

--- a/core-library/src/main/java/org/silverpeas/core/security/session/SessionManagement.java
+++ b/core-library/src/main/java/org/silverpeas/core/security/session/SessionManagement.java
@@ -109,6 +109,17 @@ public interface SessionManagement {
   SessionInfo openSession(final User user, final HttpServletRequest request);
 
   /**
+   * Opens a new session for the specified user with the specified HTTP request at the origin of the
+   * session ask. The opened session is only for the given HTTP request and it will be closed once
+   * the request processing is done.
+   * @param user the user for which an HTTP session with Silverpeas has to be opened.
+   * @param request the HTTP request at the origin of the session opening ask.
+   * @return a SessionInfo instance representing the current opened session with information about
+   * that session.
+   */
+  SessionInfo openOneShotSession(final User user, final HttpServletRequest request);
+
+  /**
    * Opens explicitly a new anonymous session. The opened session is built upon an HTTP one managed
    * directly by the underlying HTTP server/container. In Silverpeas, any anonymous access to it is
    * done under the cover of a peculiar and specific user account, the anonymous user account. This

--- a/core-web-test/src/main/java/org/silverpeas/web/test/stub/SessionManagementStub.java
+++ b/core-web-test/src/main/java/org/silverpeas/web/test/stub/SessionManagementStub.java
@@ -113,6 +113,13 @@ public class SessionManagementStub implements SessionManagement {
   }
 
   @Override
+  public SessionInfo openOneShotSession(final User user, final HttpServletRequest request) {
+    SessionInfo session = openSession(user, request);
+    session.setAsOneShot();
+    return session;
+  }
+
+  @Override
   public SessionInfo openAnonymousSession(final HttpServletRequest httpServletRequest) {
     UserDetail anonymousUser = UserDetail.getAnonymousUser();
     if (anonymousUser != null) {

--- a/core-web/src/main/java/org/silverpeas/core/webapi/profile/UserProfileResource.java
+++ b/core-web/src/main/java/org/silverpeas/core/webapi/profile/UserProfileResource.java
@@ -67,10 +67,11 @@ import static org.silverpeas.core.webapi.profile.ProfileResourceBaseURIs.USERS_B
  * A REST-based Web service that acts on the user profiles in Silverpeas. Each provided method is a
  * way to access a representation of one or several user profile. This representation is vehiculed
  * as a Web entity in the HTTP requests and responses.
- *
+ * <p>
  * The users that are published depend on some parameters whose the domain isolation and the profile
  * of the user behind the requesting. The domain isolation defines the visibility of a user or a
  * group of users in a given domain to the others domains in Silverpeas.
+ * </p>
  */
 @WebService
 @Path(USERS_BASE_URI)
@@ -94,7 +95,12 @@ public class UserProfileResource extends RESTWebService {
   private RelationShipService relationShipService;
 
   /**
-   * @return The user entity corresponding to the token specified in the URI.
+   * Gets the profile of the user whose the API token is either passed in the {@code Authorization} HTTP header (Bearer
+   * authentication scheme, IETF RFC 6750) or with the query parameter {@code access_token} (see IETF RFC 6750).
+   * <p>
+   * This endpoint works also with a basic authentication instead of a bearer one.
+   * </p>
+   * @return The user entity corresponding to the token specified in the request.
    */
   @GET
   @Path("token")
@@ -112,14 +118,15 @@ public class UserProfileResource extends RESTWebService {
   /**
    * Gets the users defined in Silverpeas and that matches the specified optional query parameters.
    * If no query parameters are set, then all the users in Silverpeas are sent back.
-   *
+   * <p>
    * The users to sent back can be filtered by a pattern their name has to satisfy, by the group
    * they must belong to, and by some pagination parameters.
-   *
+   * </p>
+   * <p>
    * In the response is indicated as an HTTP header (named X-Silverpeas-UserSize) the real size of
    * the users that matches the query. This is usefull for clients that use the pagination to filter
    * the count of the answered users.
-   *
+   * </p>
    * @param userIds requested user identifiers
    * @param groupIds the identifier of the groups the users must belong to. The particular
    * identifier "all" means all user groups.
@@ -226,14 +233,15 @@ public class UserProfileResource extends RESTWebService {
    * Gets the profiles of the users that have access to the specified Silverpeas component instance
    * and that matches the specified optional query parameters. If no query parameters are set, then
    * all the users with the rights to access the component instance are sent back.
-   *
+   * <p>
    * The users to sent back can be filtered by a pattern their name has to satisfy, by the group
    * they must belong to, and by some pagination parameters.
-   *
+   * </p>
+   * <p>
    * In the response is indicated as an HTTP header (named X-Silverpeas-UserSize) the real size of
    * the users that matches the query. This is usefull for clients that use the pagination to filter
    * the count of the answered users.
-   *
+   * </p>
    * @param instanceId the unique identifier of the component instance the users should have access
    * to.
    * @param groupId the unique identifier of the group the users must belong to. The particular
@@ -273,11 +281,9 @@ public class UserProfileResource extends RESTWebService {
     List<String> domainIds = new ArrayList<>();
     if (isDefined(groupId) && !QUERY_ALL_GROUPS.equals(groupId)) {
       Group group = profileService.getGroupAccessibleToUser(groupId, UserDetail.from(getUser()));
+      // Limitation: when a group on MIXED domain if found, the filter on domain id is ignored
       if (StringUtil.isDefined(group.getDomainId())) {
         domainIds.add(group.getDomainId());
-      } else {
-        // Limitation: when a group on MIXED domain if found, the filter on domain id is ignored
-        domainIds.clear();
       }
     }
     if (getUser().isDomainRestricted()) {


### PR DESCRIPTION
A virtual Silverpeas session is created when a user authenticates himself by its API token. This won't then create a true session in Silverpeas.

Don't forget to merge also PR https://github.com/Silverpeas/Silverpeas-Components/pull/832