### PR TITLE
Feature #13608: allowing specifying the localized data of component descriptions into bundle property files.

### DIFF
--- a/core-configuration/src/main/config/resources/StringTemplates/core/workflow/xmlComponent.st
+++ b/core-configuration/src/main/config/resources/StringTemplates/core/workflow/xmlComponent.st
@@ -7,25 +7,27 @@
     <behavior>workflow</behavior>
   </behaviors>
   <label>
-    $WAComponent.label.keys:{k| <message lang="$k$">$WAComponent.label.(k)$</message>};separator="\n"$
+    $LocalizedCmpLabels:{<message lang="$it.language$">$it.label$</message>};separator="\n"$
   </label>
   <description>
-    $WAComponent.description.keys:{k| <message lang="$k$">$WAComponent.description.(k)$</message>};separator="\n"$
+    $LocalizedCmpDescriptions:{<message lang="$it.language$">$it.description$</message>};separator="\n"$
   </description>
   <suite>
     <message lang="fr">05 Workflow</message>
   </suite>
+  <inheritSpaceRightsByDefault>true</inheritSpaceRightsByDefault>
+  <publicByDefault>false</publicByDefault>
   <visible>true</visible>
   <visibleInPersonalSpace>false</visibleInPersonalSpace>
   <portlet>false</portlet>
   <router>RprocessManager</router>
   <profiles>
-    $WAComponent.profiles:{<profile name="$it.name$">
+    $LocalizedCmpProfiles.keys:{k|<profile name="$k$">
   <label>
-    $it.label.keys:{k| <message lang="$k$">$it.label.(k)$</message>};separator="\n"$
+    $LocalizedCmpProfiles.(k):{<message lang="$it.language$">$it.label$</message>};separator="\n"$
   </label>
   <help>
-    $it.help.keys:{k| <message lang="$k$">$it.help.(k)$</message>};separator="\n"$
+    $LocalizedCmpProfiles.(k):{$if(it.help)$<message lang="$it.language$">$it.help$</message>$endif$};separator="\n"$
   </help>
 </profile>};separator="\n"$
   </profiles>

--- a/core-library/src/main/java/org/silverpeas/core/admin/component/model/AbstractSilverpeasComponent.java
+++ b/core-library/src/main/java/org/silverpeas/core/admin/component/model/AbstractSilverpeasComponent.java
@@ -49,6 +49,7 @@ package org.silverpeas.core.admin.component.model;
 
 import org.silverpeas.core.admin.component.GroupOfParametersSorter;
 import org.silverpeas.core.util.CollectionUtil;
+import org.silverpeas.core.util.MemoizedSupplier;
 
 import javax.xml.bind.annotation.XmlTransient;
 import java.util.HashMap;
@@ -62,6 +63,35 @@ public abstract class AbstractSilverpeasComponent implements SilverpeasComponent
 
   @XmlTransient
   protected Map<String, Parameter> indexedParametersByName = new HashMap<>();
+
+  @XmlTransient
+  private final MemoizedSupplier<Map<String, LocalizedComponent>> localized = new MemoizedSupplier<>(HashMap::new);
+
+  private LocalizedComponent getLocalized(final String lang) {
+    return localized.get().computeIfAbsent(lang, l -> new LocalizedComponent(this, l));
+  }
+
+  /**
+   * Gets the value of the label property.
+   * @return possible object is {@link Multilang }
+   */
+  protected abstract Map<String, String> getLabel();
+
+  @Override
+  public String getLabel(final String lang) {
+    return getLocalized(lang).getLabel();
+  }
+
+  /**
+   * Gets the value of the description property.
+   * @return possible object is {@link Multilang }
+   */
+  protected abstract Map<String, String> getDescription();
+
+  @Override
+  public String getDescription(final String lang) {
+    return getLocalized(lang).getDescription();
+  }
 
   /**
    * Gets defined parameters indexed by their names.

--- a/core-library/src/main/java/org/silverpeas/core/admin/component/model/ComponentLocalization.java
+++ b/core-library/src/main/java/org/silverpeas/core/admin/component/model/ComponentLocalization.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (C) 2000 - 2022 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.silverpeas.core.admin.component.model;
+
+import org.silverpeas.core.util.LocalizationBundle;
+import org.silverpeas.core.util.StringUtil;
+
+import java.util.Map;
+import java.util.MissingResourceException;
+import java.util.Objects;
+
+import static java.util.Optional.of;
+import static java.util.Optional.ofNullable;
+import static org.silverpeas.core.ui.DisplayI18NHelper.getDefaultLanguage;
+import static org.silverpeas.core.util.ResourceLocator.getLocalizationBundle;
+
+/**
+ * This is the main implementation of the mechanism in charge of the localized data providing.
+ * <p>
+ *   Each implementation MUST give the component context (by its technical name) and the locale
+ *   in which localized data have to be retrieved.
+ * </p>
+ * <p>
+ *   At instantiation, the bundle property file dedicated to a component is loaded if any. All
+ *   component bundles MUST be situated into $SILVERPEAS_HOME/properties root location. For a
+ *   component the bundle property path MUST be templated like following:<br/>
+ *   <code>xmlcomponents/[case sensitive component technical name]_[locale].properties</code><br/>
+ *   About kmelia component for example:<br/>
+ *   {@code xmlcomponents/kmelia_en.properties}
+ * </p>
+ * <p>
+ *   When a localized data is get, it is first looked up from bundle property file, and if
+ *   not found, it is then looked up from XML component descriptor file.
+ * </p>
+ * <p>
+ *   If no localized data is found, neither from bundle property file, neither from XML component
+ *   descriptor, then the localized data into default language is retrieved. If no localized data
+ *   is retrieved at the end a {@link MissingResourceException} exception is thrown.
+ * </p>
+ * <p>
+ *   The potential labels the bundle resource handles:
+ *   <ul>
+ *     <li>{@code label}: the label of the component</li>
+ *     <li>{@code description}: the description of the component</li>
+ *     <li>{@code suite}: the suite of the component</li>
+ *     <li>{@code profile.[case sensitive user role, 'admin' for example].label}: the label of profile handled by the component</li>
+ *     <li>{@code profile.[case sensitive user role, 'admin' for example].help}: the help about profile handled by the component</li>
+ *     <li>{@code parameter.[case sensitive parameter name].label}: the label of a component parameter not included into a parameter group</li>
+ *     <li>{@code parameter.[case sensitive parameter name].help}: the help about a component parameter not included into a parameter group</li>
+ *     <li>{@code parameter.[case sensitive parameter name].warning}: the warning about a component parameter not included into a parameter group</li>
+ *     <li>{@code parameter.[case sensitive parameter name].option.[case sensitive option name].name}: the name of an option about a component parameter not included into a parameter group</li>
+ *   </ul>
+ *   When a parameter is included into a group of parameters, the following key prefix MUST be used:<br/>
+ *   {@code parameterGroup.[case sensitive name of group parameter].}<br/>
+ *   For example:
+ *   {@code parameterGroup.folders.parameter.delegatedTopicManagement.label} where {@code folders}
+ *   is the name of the parameter group and {@code delegatedTopicManagement} is the parameter
+ *   name.
+ *   <p>Only one group of parameters into an XML component descriptor could have no name. In that
+ *   case, "noname" is used as group name.</p>
+ * </p>
+ * <p>
+ *   When all localized data are specified into a bundle property file, then if a {@link Warning}
+ *   MUST be handled on a {@link Parameter}, don't forget to write an empty warning TAG {@code
+ *   <warning />} into the XML description of the parameter. If not declared into XML descriptor
+ *   the localized data specified into bundle resource are not taken into account and no
+ *   {@link Warning} is then handled for the {@link Parameter}.
+ * </p>
+ * @author silveryocha
+ */
+abstract class ComponentLocalization {
+
+  private final SilverpeasComponent component;
+  private final String lang;
+  private final LocalizationBundle bundle;
+
+
+  public ComponentLocalization(final ComponentLocalization bundle) {
+    this.component = bundle.component;
+    this.lang = bundle.lang;
+    this.bundle = bundle.bundle;
+  }
+
+  public ComponentLocalization(final SilverpeasComponent component, String lang) {
+    this.component = component;
+    this.lang = lang;
+    this.bundle = getLocalizationBundle("xmlcomponents." + getComponentName(), getLanguage());
+  }
+
+  public String getComponentName() {
+    return component.getName();
+  }
+
+  public String getLanguage() {
+    return lang;
+  }
+
+  /**
+   * Gets the localized data first into bundle property files if any, then into map of translations.
+   * @param bundleKey the bundle key.
+   * @param messages the map of translations extracted from XML component descriptors.
+   * @return the localized data as string.
+   * @throws MissingResourceException if no translation can be found from the different resource
+   * locations.
+   */
+  protected String getLocalized(final String bundleKey, final Map<String, String> messages) {
+    return of(bundle)
+        .filter(LocalizationBundle::exists)
+        .map(b -> {
+          try {
+            return b.getString(bundleKey);
+          } catch (MissingResourceException ignore) {
+            return null;
+          }
+        })
+        .filter(StringUtil::isDefined)
+        .orElseGet(() -> {
+          if (messages.containsKey(lang)) {
+            return messages.get(lang);
+          }
+          return ofNullable(messages.get(getDefaultLanguage()))
+              .filter(Objects::nonNull)
+              .orElseThrow(() -> new MissingResourceException(String.format(
+                  "Can't find localization into %s with key %s, or into %s XML descriptor",
+                  bundle.getBaseBundleName() + "_" + getLanguage() + ".properties", bundleKey,
+                  getComponentName()), this.getClass().getName(), bundleKey));
+        });
+  }
+}

--- a/core-library/src/main/java/org/silverpeas/core/admin/component/model/GroupOfParameters.java
+++ b/core-library/src/main/java/org/silverpeas/core/admin/component/model/GroupOfParameters.java
@@ -23,10 +23,9 @@
  */
 package org.silverpeas.core.admin.component.model;
 
-import org.silverpeas.core.ui.DisplayI18NHelper;
-
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlType;
@@ -39,6 +38,9 @@ import java.util.Map;
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "GroupOfParametersType", propOrder = { "label", "description", "help", "order", "parameters" })
 public class GroupOfParameters {
+
+  @XmlAttribute
+  protected String name = "noname";
 
   @XmlElement(required = true)
   @XmlJavaTypeAdapter(MultilangHashMapAdapter.class)
@@ -65,6 +67,7 @@ public class GroupOfParameters {
   }
 
   public GroupOfParameters(final GroupOfParameters groupOfParameters) {
+    setName(groupOfParameters.getName());
     setLabel(new HashMap<>(groupOfParameters.getLabel()));
     setDescription(new HashMap<>(groupOfParameters.getDescription()));
     setHelp(new HashMap<>(groupOfParameters.getHelp()));
@@ -73,28 +76,37 @@ public class GroupOfParameters {
   }
 
   /**
+   * Gets the group name.
+   * @return a string.
+   */
+  public String getName() {
+    return name;
+  }
+
+  /**
+   * Sets the group name.
+   * @param name a group name.
+   */
+  public void setName(final String name) {
+    this.name = name;
+  }
+
+  /**
    * Gets the value of the label property.
    * @return possible object is {@link Multilang }
    */
-  public Map<String, String> getLabel() {
+  protected Map<String, String> getLabel() {
     if (label == null) {
       label = new HashMap<>();
     }
     return label;
   }
 
-  public String getLabel(String lang) {
-    if (getLabel().containsKey(lang)) {
-      return getLabel().get(lang);
-    }
-    return getLabel().get(DisplayI18NHelper.getDefaultLanguage());
-  }
-
   /**
    * Sets the value of the label property.
    * @param value allowed object is {@link Multilang }
    */
-  public void setLabel(Map<String, String> value) {
+  private void setLabel(Map<String, String> value) {
     this.label = value;
   }
 
@@ -102,25 +114,18 @@ public class GroupOfParameters {
    * Gets the value of the description property.
    * @return possible object is {@link Multilang }
    */
-  public Map<String, String> getDescription() {
+  protected Map<String, String> getDescription() {
     if (description == null) {
       description = new HashMap<>();
     }
     return description;
   }
 
-  public String getDescription(String lang) {
-    if (getDescription().containsKey(lang)) {
-      return getDescription().get(lang);
-    }
-    return getDescription().get(DisplayI18NHelper.getDefaultLanguage());
-  }
-
   /**
    * Sets the value of the description property.
    * @param value allowed object is {@link Multilang }
    */
-  public void setDescription(Map<String, String> value) {
+  private void setDescription(Map<String, String> value) {
     this.description = value;
   }
 
@@ -128,7 +133,7 @@ public class GroupOfParameters {
    * Gets the value of the help property.
    * @return possible object is {@link Multilang }
    */
-  public Map<String, String> getHelp() {
+  protected Map<String, String> getHelp() {
     if (help == null) {
       help = new HashMap<>();
     }
@@ -139,7 +144,7 @@ public class GroupOfParameters {
    * Sets the value of the help property.
    * @param value allowed object is {@link Multilang }
    */
-  public void setHelp(Map<String, String> value) {
+  private void setHelp(Map<String, String> value) {
     this.help = value;
   }
 
@@ -183,9 +188,4 @@ public class GroupOfParameters {
   public boolean isVisible() {
     return getParameterList().isVisible();
   }
-
-  public LocalizedGroupOfParameters localize(String lang) {
-    return new LocalizedGroupOfParameters(this, lang);
-  }
-
 }

--- a/core-library/src/main/java/org/silverpeas/core/admin/component/model/LocalizedComponent.java
+++ b/core-library/src/main/java/org/silverpeas/core/admin/component/model/LocalizedComponent.java
@@ -23,84 +23,31 @@
  */
 package org.silverpeas.core.admin.component.model;
 
-import org.silverpeas.core.ui.DisplayI18NHelper;
-import java.util.ArrayList;
-import java.util.List;
-
 /**
  * @author ehugonnet
  */
-public class LocalizedComponent {
+public class LocalizedComponent extends ComponentLocalization {
 
-  private final String lang;
-  private final WAComponent realComponent;
+  private final AbstractSilverpeasComponent realComponent;
 
-  public LocalizedComponent(WAComponent component, String lang) {
+  public LocalizedComponent(AbstractSilverpeasComponent component, String lang) {
+    super(component, lang);
     this.realComponent = component;
-    this.lang = lang;
   }
 
   public String getDescription() {
-    if (realComponent.getDescription().containsKey(lang)) {
-      return realComponent.getDescription().get(lang);
-    }
-    return realComponent.getDescription().get(DisplayI18NHelper.getDefaultLanguage());
+    return getLocalized("description", realComponent.getDescription());
   }
 
   public String getLabel() {
-    if (realComponent.getLabel().containsKey(lang)) {
-      return realComponent.getLabel().get(lang);
-    }
-    return realComponent.getLabel().get(DisplayI18NHelper.getDefaultLanguage());
+    return getLocalized("label", realComponent.getLabel());
   }
 
   public String getName() {
-    return realComponent.getName();
-  }
-
-  public List<LocalizedProfile> getProfiles() {
-    List<LocalizedProfile> localizedProfiles = new ArrayList<>();
-    for (Profile profile : realComponent.getProfiles()) {
-      localizedProfiles.add(new LocalizedProfile(profile, lang));
-    }
-    return localizedProfiles;
-  }
-
-  public LocalizedProfile getProfile(String name) {
-    List<LocalizedProfile> profiles = getProfiles();
-    for (LocalizedProfile profile : profiles) {
-      if (name.equals(profile.getName())) {
-        return profile;
-      }
-    }
-    return null;
-  }
-
-  public String getRouter() {
-    return realComponent.getRouter();
-  }
-
-  public String getSuite() {
-    if (realComponent.getSuite().containsKey(lang)) {
-      return realComponent.getSuite().get(lang);
-    }
-    return realComponent.getSuite().get(DisplayI18NHelper.getDefaultLanguage());
-  }
-
-  public boolean isPortlet() {
-    return realComponent.isPortlet();
+    return getComponentName();
   }
 
   public boolean isVisible() {
     return realComponent.isVisible();
-  }
-
-  @SuppressWarnings("unused")
-  public boolean isVisibleInPersonalSpace() {
-    return realComponent.isVisibleInPersonalSpace();
-  }
-
-  public String getLanguage() {
-    return lang;
   }
 }

--- a/core-library/src/main/java/org/silverpeas/core/admin/component/model/LocalizedGroupOfParameters.java
+++ b/core-library/src/main/java/org/silverpeas/core/admin/component/model/LocalizedGroupOfParameters.java
@@ -26,26 +26,33 @@ package org.silverpeas.core.admin.component.model;
 /**
  * @author Nicolas Eysseric
  */
-public class LocalizedGroupOfParameters {
+public class LocalizedGroupOfParameters extends ComponentLocalization {
 
-  private final String lang;
   private final GroupOfParameters group;
 
-  public LocalizedGroupOfParameters(GroupOfParameters group, String lang) {
+  public LocalizedGroupOfParameters(SilverpeasComponent component, GroupOfParameters group, String lang) {
+    super(component, lang);
     this.group = group;
-    this.lang = lang;
+  }
+
+  protected String getBundleKeyPrefix() {
+    return "parameterGroup." + group.getName();
   }
 
   public String getLabel() {
-    return group.getLabel(lang);
+    return getLocalized(getBundleKeyPrefix() + ".label", group.getLabel());
   }
 
   public String getDescription() {
-    return group.getDescription(lang);
+    return getLocalized(getBundleKeyPrefix() + ".description", group.getDescription());
+  }
+
+  public String getHelp() {
+    return getLocalized(getBundleKeyPrefix() + ".help", group.getHelp());
   }
 
   public LocalizedParameterList getParameters() {
-    return group.getParameterList().localize(lang);
+    return new LocalizedParameterList(this, group.getParameterList());
   }
 
 }

--- a/core-library/src/main/java/org/silverpeas/core/admin/component/model/LocalizedParameter.java
+++ b/core-library/src/main/java/org/silverpeas/core/admin/component/model/LocalizedParameter.java
@@ -27,7 +27,7 @@
  */
 package org.silverpeas.core.admin.component.model;
 
-import org.silverpeas.core.ui.DisplayI18NHelper;
+import org.silverpeas.core.util.StringUtil;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -38,39 +38,44 @@ import static java.util.Optional.ofNullable;
 /**
  * @author ehugonnet
  */
-public class LocalizedParameter {
+public class LocalizedParameter extends ComponentLocalization {
 
-  private final String lang;
   private final Parameter realParameter;
+  private final String localizedGroupPrefixKey;
   private List<LocalizedOption> localizedOptions;
   private LocalizedWarning localizedWarning;
 
-  public LocalizedParameter(Parameter parameter, String lang) {
+  public LocalizedParameter(LocalizedGroupOfParameters bundle, Parameter parameter) {
+    super(bundle);
     this.realParameter = parameter;
-    this.lang = lang;
+    this.localizedGroupPrefixKey = bundle.getBundleKeyPrefix() + ".";
+  }
+
+  public LocalizedParameter(SilverpeasComponent component, Parameter parameter, String lang) {
+    super(component, lang);
+    this.realParameter = parameter;
+    this.localizedGroupPrefixKey = StringUtil.EMPTY;
+  }
+
+  protected String getBundleKeyPrefix() {
+    return localizedGroupPrefixKey + "parameter." + getName();
   }
 
   public String getHelp() {
-    if (realParameter.getHelp().containsKey(lang)) {
-      return realParameter.getHelp().get(lang);
-    }
-    return realParameter.getHelp().get(DisplayI18NHelper.getDefaultLanguage());
+    return getLocalized(getBundleKeyPrefix() + ".help", realParameter.getHelp());
   }
 
   public Optional<LocalizedWarning> getWarning() {
     if (localizedWarning == null) {
       localizedWarning = realParameter.getWarning()
-          .map(w -> new LocalizedWarning(w, lang))
+          .map(w -> new LocalizedWarning(this, w))
           .orElse(null);
     }
     return ofNullable(localizedWarning);
   }
 
   public String getLabel() {
-    if (realParameter.getLabel().containsKey(lang)) {
-      return realParameter.getLabel().get(lang);
-    }
-    return realParameter.getLabel().get(DisplayI18NHelper.getDefaultLanguage());
+    return getLocalized(getBundleKeyPrefix() + ".label", realParameter.getLabel());
   }
 
   public String getName() {
@@ -81,7 +86,7 @@ public class LocalizedParameter {
     if (localizedOptions == null) {
       localizedOptions = new ArrayList<>();
       for (Option option : realParameter.getOptions()) {
-        localizedOptions.add(new LocalizedOption(option, lang));
+        localizedOptions.add(new LocalizedOption(this, option));
       }
     }
     return localizedOptions;

--- a/core-library/src/main/java/org/silverpeas/core/admin/component/model/LocalizedParameterList.java
+++ b/core-library/src/main/java/org/silverpeas/core/admin/component/model/LocalizedParameterList.java
@@ -25,20 +25,27 @@ package org.silverpeas.core.admin.component.model;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * @author Nicolas Eysseric
  */
 public class LocalizedParameterList extends ArrayList<LocalizedParameter> {
+  private static final long serialVersionUID = 8621941317822315512L;
 
-  private String lang;
+  private final String lang;
 
-  public LocalizedParameterList() {
-    super();
+  protected LocalizedParameterList(LocalizedGroupOfParameters bundle, ParameterList parameters) {
+    super(parameters.stream()
+        .map(p -> new LocalizedParameter(bundle, p))
+        .collect(Collectors.toList()));
+    this.lang = bundle.getLanguage();
   }
 
-  public LocalizedParameterList(ParameterList parameters, String lang) {
-    super(parameters.localize(lang));
+  public LocalizedParameterList(SilverpeasComponent component, ParameterList parameters, String lang) {
+    super(parameters.stream()
+        .map(p -> new LocalizedParameter(component, p, lang))
+        .collect(Collectors.toList()));
     this.lang = lang;
   }
 
@@ -68,5 +75,15 @@ public class LocalizedParameterList extends ArrayList<LocalizedParameter> {
 
   public String getLanguage() {
     return lang;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    return super.equals(o);
+  }
+
+  @Override
+  public int hashCode() {
+    return super.hashCode();
   }
 }

--- a/core-library/src/main/java/org/silverpeas/core/admin/component/model/LocalizedProfile.java
+++ b/core-library/src/main/java/org/silverpeas/core/admin/component/model/LocalizedProfile.java
@@ -23,19 +23,23 @@
  */
 package org.silverpeas.core.admin.component.model;
 
-import org.silverpeas.core.ui.DisplayI18NHelper;
+import static java.util.Optional.of;
+import static java.util.function.Predicate.not;
 
 /**
  * @author ehugonnet
  */
-public class LocalizedProfile {
+public class LocalizedProfile extends ComponentLocalization {
 
   private final Profile realProfile;
-  private final String lang;
 
-  LocalizedProfile(Profile realProfile, String lang) {
+  LocalizedProfile(ComponentLocalization bundle, Profile realProfile) {
+    super(bundle);
     this.realProfile = realProfile;
-    this.lang = lang;
+  }
+
+  private String getBundleKeyPrefix() {
+    return "profile." + getName();
   }
 
   public String getName() {
@@ -43,17 +47,12 @@ public class LocalizedProfile {
   }
 
   public String getHelp() {
-    if (realProfile.getHelp().containsKey(lang)) {
-      return realProfile.getHelp().get(lang);
-    }
-    return realProfile.getHelp().get(DisplayI18NHelper.getDefaultLanguage());
+    return of(getLocalized(getBundleKeyPrefix() + ".help", realProfile.getHelp()))
+        .filter(not(h -> h.equals(getLabel())))
+        .orElse(null);
   }
 
   public String getLabel() {
-    if (realProfile.getLabel().containsKey(lang)) {
-      return realProfile.getLabel().get(lang);
-    }
-    return realProfile.getLabel().get(DisplayI18NHelper.getDefaultLanguage());
+    return getLocalized(getBundleKeyPrefix()  + ".label", realProfile.getLabel());
   }
-
 }

--- a/core-library/src/main/java/org/silverpeas/core/admin/component/model/LocalizedWAComponent.java
+++ b/core-library/src/main/java/org/silverpeas/core/admin/component/model/LocalizedWAComponent.java
@@ -23,25 +23,53 @@
  */
 package org.silverpeas.core.admin.component.model;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * @author ehugonnet
  */
-public class LocalizedOption extends ComponentLocalization {
+public class LocalizedWAComponent extends LocalizedComponent {
 
-  private final String bundleKeyPrefix;
-  private final Option realOption;
+  private final WAComponent realComponent;
 
-  LocalizedOption(LocalizedParameter bundle, Option option) {
-    super(bundle);
-    this.bundleKeyPrefix = bundle.getBundleKeyPrefix();
-    this.realOption = option;
+  public LocalizedWAComponent(WAComponent component, String lang) {
+    super(component, lang);
+    this.realComponent = component;
   }
 
-  public String getName() {
-    return getLocalized(bundleKeyPrefix + ".option." + getValue() + ".name", realOption.getName());
+  public List<LocalizedProfile> getProfiles() {
+    List<LocalizedProfile> localizedProfiles = new ArrayList<>();
+    for (Profile profile : realComponent.getProfiles()) {
+      localizedProfiles.add(new LocalizedProfile(this, profile));
+    }
+    return localizedProfiles;
   }
 
-  public String getValue() {
-    return realOption.getValue();
+  public LocalizedProfile getProfile(String name) {
+    List<LocalizedProfile> profiles = getProfiles();
+    for (LocalizedProfile profile : profiles) {
+      if (name.equals(profile.getName())) {
+        return profile;
+      }
+    }
+    return null;
+  }
+
+  public String getRouter() {
+    return realComponent.getRouter();
+  }
+
+  public String getSuite() {
+    return getLocalized("suite", realComponent.getSuite());
+  }
+
+  public boolean isPortlet() {
+    return realComponent.isPortlet();
+  }
+
+  @SuppressWarnings("unused")
+  public boolean isVisibleInPersonalSpace() {
+    return realComponent.isVisibleInPersonalSpace();
   }
 }

--- a/core-library/src/main/java/org/silverpeas/core/admin/component/model/LocalizedWarning.java
+++ b/core-library/src/main/java/org/silverpeas/core/admin/component/model/LocalizedWarning.java
@@ -23,10 +23,6 @@
  */
 package org.silverpeas.core.admin.component.model;
 
-import org.silverpeas.core.ui.DisplayI18NHelper;
-
-import java.util.Map;
-
 /**
  * This localized warning allows to provide data of {@link Warning} instances on the Silverpeas's
  * user interfaces without having to manage the user language, which is carried by the localized
@@ -37,14 +33,15 @@ import java.util.Map;
  * </p>
  * @author silveryocha
  */
-public class LocalizedWarning {
+public class LocalizedWarning extends ComponentLocalization {
 
+  private final String bundleKeyPrefix;
   private final Warning warning;
-  private final String lang;
 
-  LocalizedWarning(Warning warning, String lang) {
+  LocalizedWarning(LocalizedParameter bundle, Warning warning) {
+    super(bundle);
+    this.bundleKeyPrefix = bundle.getBundleKeyPrefix();
     this.warning = warning;
-    this.lang = lang;
   }
 
   /**
@@ -61,10 +58,6 @@ public class LocalizedWarning {
    * @see Warning#getMessages()
    */
   public String getValue() {
-    final Map<String, String> messages = warning.getMessages();
-    if (messages.containsKey(lang)) {
-      return messages.get(lang);
-    }
-    return messages.get(DisplayI18NHelper.getDefaultLanguage());
+    return getLocalized(bundleKeyPrefix + ".warning", warning.getMessages());
   }
 }

--- a/core-library/src/main/java/org/silverpeas/core/admin/component/model/Option.java
+++ b/core-library/src/main/java/org/silverpeas/core/admin/component/model/Option.java
@@ -23,8 +23,6 @@
  */
 package org.silverpeas.core.admin.component.model;
 
-import org.silverpeas.core.ui.DisplayI18NHelper;
-
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
@@ -59,25 +57,18 @@ public class Option {
    * Gets the value of the name property.
    * @return possible object is {@link Multilang }
    */
-  public Map<String, String> getName() {
+  protected Map<String, String> getName() {
     if (name == null) {
       name = new HashMap<>();
     }
     return name;
   }
 
-  public String getName(String lang) {
-    if (getName().containsKey(lang)) {
-      return getName().get(lang);
-    }
-    return getName().get(DisplayI18NHelper.getDefaultLanguage());
-  }
-
   /**
    * Sets the value of the name property.
    * @param value allowed object is {@link Multilang }
    */
-  public void setName(Map<String, String> value) {
+  private void setName(Map<String, String> value) {
     this.name = value;
   }
 

--- a/core-library/src/main/java/org/silverpeas/core/admin/component/model/Parameter.java
+++ b/core-library/src/main/java/org/silverpeas/core/admin/component/model/Parameter.java
@@ -45,6 +45,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static java.util.Optional.ofNullable;
+import static org.silverpeas.core.i18n.I18NHelper.checkLanguage;
 
 /**
  * Instance parameter defined for an application component. An instance parameter is a
@@ -126,25 +127,27 @@ public class Parameter {
    * Gets the value of the label property.
    * @return possible object is {@link Multilang }
    */
-  public Map<String, String> getLabel() {
+  protected Map<String, String> getLabel() {
     if (label == null) {
       label = new HashMap<>();
     }
     return label;
   }
 
-  public String getLabel(String lang) {
-    if (getLabel().containsKey(lang)) {
-      return getLabel().get(lang);
-    }
-    return getLabel().get(DisplayI18NHelper.getDefaultLanguage());
+  /**
+   * Puts a localized label directly linked to the {@link Parameter} instance.
+   * @param language the language the label is localized into.
+   * @param label a localized label.
+   */
+  public void putLabel(final String language, final String label) {
+    getLabel().put(checkLanguage(language), label);
   }
 
   /**
    * Sets the value of the label property.
    * @param value allowed object is {@link Multilang }
    */
-  public void setLabel(Map<String, String> value) {
+  private void setLabel(Map<String, String> value) {
     this.label = value;
   }
 
@@ -266,18 +269,11 @@ public class Parameter {
     this.updatable = value;
   }
 
-  public String getHelp(String lang) {
-    if (getHelp().containsKey(lang)) {
-      return getHelp().get(lang);
-    }
-    return getHelp().get(DisplayI18NHelper.getDefaultLanguage());
-  }
-
   /**
    * Gets the value of the help property.
    * @return possible object is {@link Multilang }
    */
-  public Map<String, String> getHelp() {
+  protected Map<String, String> getHelp() {
     if (help == null) {
       help = new HashMap<>();
     }
@@ -285,10 +281,19 @@ public class Parameter {
   }
 
   /**
+   * Puts a localized help directly linked to the {@link Parameter} instance.
+   * @param language the language the help is localized into.
+   * @param help a localized help.
+   */
+  public void putHelp(final String language, final String help) {
+    getHelp().put(checkLanguage(language), help);
+  }
+
+  /**
    * Sets the value of the help property.
    * @param value allowed object is {@link Multilang }
    */
-  public void setHelp(Map<String, String> value) {
+  private void setHelp(Map<String, String> value) {
     this.help = value;
   }
 

--- a/core-library/src/main/java/org/silverpeas/core/admin/component/model/ParameterList.java
+++ b/core-library/src/main/java/org/silverpeas/core/admin/component/model/ParameterList.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 public class ParameterList extends ArrayList<Parameter> {
+  private static final long serialVersionUID = -2159180306618082474L;
 
   public static ParameterList copy(List<Parameter> parameters) {
     return new ParameterList(parameters.stream().map(Parameter::new).collect(Collectors.toList()));
@@ -93,14 +94,6 @@ public class ParameterList extends ArrayList<Parameter> {
       }
     }
     return false;
-  }
-
-  public LocalizedParameterList localize(String lang) {
-    LocalizedParameterList localized = new LocalizedParameterList();
-    for (Parameter param : this) {
-      localized.add(new LocalizedParameter(param, lang));
-    }
-    return localized;
   }
 
   public ParameterList copy() {

--- a/core-library/src/main/java/org/silverpeas/core/admin/component/model/PersonalComponent.java
+++ b/core-library/src/main/java/org/silverpeas/core/admin/component/model/PersonalComponent.java
@@ -105,7 +105,7 @@ public class PersonalComponent extends AbstractSilverpeasComponent {
   }
 
   @Override
-  public Map<String, String> getLabel() {
+  protected Map<String, String> getLabel() {
     if (label == null) {
       label = new HashMap<>();
     }
@@ -147,7 +147,7 @@ public class PersonalComponent extends AbstractSilverpeasComponent {
   }
 
   @Override
-  public Map<String, String> getDescription() {
+  protected Map<String, String> getDescription() {
     if (description == null) {
       description = new HashMap<>();
     }

--- a/core-library/src/main/java/org/silverpeas/core/admin/component/model/Profile.java
+++ b/core-library/src/main/java/org/silverpeas/core/admin/component/model/Profile.java
@@ -29,8 +29,6 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlType;
 
-import org.silverpeas.core.util.StringUtil;
-
 /**
  * A user profile defined in an application component. A user profile is a mix between a role and
  * some privileges. The name of the profile denotes the name of the role. If the application can
@@ -67,19 +65,6 @@ public class Profile extends ProfileDescription {
    */
   public void setName(String value) {
     this.name = value;
-  }
-
-  public String getHelp(String lang) {
-    String help = getHelp().get(lang);
-    String label = getLabel().get(lang);
-    if (!StringUtil.isDefined(help)) {
-      help = getHelp().get("en");
-      label = getLabel().get("en");
-    }
-    if (!help.equals(label)) {
-      return help;
-    }
-    return null;
   }
 
   /**

--- a/core-library/src/main/java/org/silverpeas/core/admin/component/model/ProfileDescription.java
+++ b/core-library/src/main/java/org/silverpeas/core/admin/component/model/ProfileDescription.java
@@ -32,6 +32,8 @@ import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.silverpeas.core.i18n.I18NHelper.checkLanguage;
+
 /**
  * Description of a user profile. It defines the common properties of such profile. A profile
  * defines the access rights of a user in an application instance according to the role he plays.
@@ -56,7 +58,7 @@ public class ProfileDescription {
    * Gets the value of the label property.
    * @return possible object is {@link Multilang }
    */
-  public Map<String, String> getLabel() {
+  protected Map<String, String> getLabel() {
     if (label == null) {
       label = new HashMap<>();
     }
@@ -64,18 +66,19 @@ public class ProfileDescription {
   }
 
   /**
-   * Sets the value of the label property.
-   * @param value allowed object is {@link Multilang }
+   * Puts a localized label directly linked to the {@link ProfileDescription} instance.
+   * @param language the language the label is localized into.
+   * @param label a localized label.
    */
-  public void setLabel(Map<String, String> value) {
-    this.label = value;
+  public void putLabel(final String language, final String label) {
+    getLabel().put(checkLanguage(language), label);
   }
 
   /**
    * Gets the value of the help property.
    * @return possible object is {@link Multilang }
    */
-  public Map<String, String> getHelp() {
+  protected Map<String, String> getHelp() {
     if (help == null) {
       help = new HashMap<>();
     }
@@ -83,11 +86,12 @@ public class ProfileDescription {
   }
 
   /**
-   * Sets the value of the help property.
-   * @param value allowed object is {@link Multilang }
+   * Puts a localized help directly linked to the {@link ProfileDescription} instance.
+   * @param language the language the help is localized into.
+   * @param help a localized help.
    */
-  public void setHelp(Map<String, String> value) {
-    this.help = value;
+  public void putHelp(final String language, final String help) {
+    getHelp().put(checkLanguage(language), help);
   }
 
   /**

--- a/core-library/src/main/java/org/silverpeas/core/admin/component/model/SilverpeasComponent.java
+++ b/core-library/src/main/java/org/silverpeas/core/admin/component/model/SilverpeasComponent.java
@@ -24,11 +24,9 @@
 
 package org.silverpeas.core.admin.component.model;
 
-import org.silverpeas.core.ui.DisplayI18NHelper;
 import org.silverpeas.core.util.StringUtil;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -79,40 +77,18 @@ public interface SilverpeasComponent {
   String getName();
 
   /**
-   * Gets the value of the label property.
-   * @return possible object is {@link Multilang }
-   */
-  Map<String, String> getLabel();
-
-  /**
    * Gets the value of the label property according to a given language.
    * @param lang the language into which the label must be translated.
    * @return possible object is {@link Multilang }
    */
-  default String getLabel(String lang) {
-    if (getLabel().containsKey(lang)) {
-      return getLabel().get(lang);
-    }
-    return getLabel().get(DisplayI18NHelper.getDefaultLanguage());
-  }
-
-  /**
-   * Gets the value of the description property.
-   * @return possible object is {@link Multilang }
-   */
-  Map<String, String> getDescription();
+  String getLabel(String lang);
 
   /**
    * Gets the value of the description property according to a given language.
    * @param lang the language into which the description must be translated.
    * @return possible object is {@link Multilang }
    */
-  default String getDescription(String lang) {
-    if (getDescription().containsKey(lang)) {
-      return getDescription().get(lang);
-    }
-    return getDescription().get(DisplayI18NHelper.getDefaultLanguage());
-  }
+  String getDescription(String lang);
 
   /**
    * Indicates if the component instance is a personal one.<br>

--- a/core-library/src/main/java/org/silverpeas/core/admin/component/model/Tool.java
+++ b/core-library/src/main/java/org/silverpeas/core/admin/component/model/Tool.java
@@ -75,7 +75,7 @@ public class Tool extends AbstractSilverpeasComponent {
   }
 
   @Override
-  public Map<String, String> getLabel() {
+  protected Map<String, String> getLabel() {
     return Collections.emptyMap();
   }
 
@@ -90,7 +90,7 @@ public class Tool extends AbstractSilverpeasComponent {
   }
 
   @Override
-  public Map<String, String> getDescription() {
+  protected Map<String, String> getDescription() {
     return Collections.emptyMap();
   }
 

--- a/core-library/src/main/java/org/silverpeas/core/admin/component/model/WAComponent.java
+++ b/core-library/src/main/java/org/silverpeas/core/admin/component/model/WAComponent.java
@@ -24,7 +24,6 @@
 package org.silverpeas.core.admin.component.model;
 
 import org.silverpeas.core.admin.component.WAComponentRegistry;
-import org.silverpeas.core.ui.DisplayI18NHelper;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -38,6 +37,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+
+import static org.silverpeas.core.i18n.I18NHelper.checkLanguage;
 
 /**
  * <p>
@@ -157,7 +158,7 @@ public class WAComponent extends AbstractSilverpeasComponent {
    * @return possible object is {@link Multilang }
    */
   @Override
-  public Map<String, String> getLabel() {
+  protected Map<String, String> getLabel() {
     if (label == null) {
       label = new HashMap<>();
     }
@@ -165,11 +166,12 @@ public class WAComponent extends AbstractSilverpeasComponent {
   }
 
   /**
-   * Sets the value of the label property.
-   * @param value allowed object is {@link Multilang }
+   * Puts a localized label directly linked to the {@link WAComponent} instance.
+   * @param language the language the label is localized into.
+   * @param label a localized label.
    */
-  public void setLabel(Map<String, String> value) {
-    this.label = value;
+  public void putLabel(final String language, final String label) {
+    getLabel().put(checkLanguage(language), label);
   }
 
   /**
@@ -177,7 +179,7 @@ public class WAComponent extends AbstractSilverpeasComponent {
    * @return possible object is {@link Multilang }
    */
   @Override
-  public Map<String, String> getDescription() {
+  protected Map<String, String> getDescription() {
     if (description == null) {
       description = new HashMap<>();
     }
@@ -185,38 +187,32 @@ public class WAComponent extends AbstractSilverpeasComponent {
   }
 
   /**
-   * Sets the value of the description property.
-   * @param value allowed object is {@link Multilang }
+   * Puts a localized description directly linked to the {@link WAComponent} instance.
+   * @param language the language the description is localized into.
+   * @param description a localized description.
    */
-  public void setDescription(Map<String, String> value) {
-    this.description = value;
+  public void putDescription(final String language, final String description) {
+    getDescription().put(checkLanguage(language), description);
   }
 
   /**
    * Gets the value of the suite property.
    * @return possible object is {@link Multilang }
    */
-  public Map<String, String> getSuite() {
+  protected Map<String, String> getSuite() {
     if (suite == null) {
       suite = new HashMap<>();
     }
     return suite;
   }
 
-  @SuppressWarnings("unused")
-  public String getSuite(String lang) {
-    if (getSuite().containsKey(lang)) {
-      return getSuite().get(lang);
-    }
-    return getSuite().get(DisplayI18NHelper.getDefaultLanguage());
-  }
-
   /**
-   * Sets the value of the suite property.
-   * @param value allowed object is {@link Multilang }
+   * Puts a localized suite directly linked to the {@link WAComponent} instance.
+   * @param language the language the suite is localized into.
+   * @param suite a localized suite.
    */
-  public void setSuite(Map<String, String> value) {
-    this.suite = value;
+  public void putSuite(final String language, final String suite) {
+    getSuite().put(checkLanguage(language), suite);
   }
 
   /**

--- a/core-library/src/main/java/org/silverpeas/core/admin/component/model/Warning.java
+++ b/core-library/src/main/java/org/silverpeas/core/admin/component/model/Warning.java
@@ -32,9 +32,9 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import static java.util.stream.Collectors.toMap;
+import static org.silverpeas.core.i18n.I18NHelper.checkLanguage;
 
 /**
  * A list of message with an attribute to specify whether the warning message MUST be displayed
@@ -83,11 +83,7 @@ public class Warning {
    * Gets a copy of registered messages.
    * @return messages indexed by languages.
    */
-  public Map<String, String> getMessages() {
-    return Map.copyOf(safeMessages());
-  }
-
-  private Map<String, String> safeMessages() {
+  protected Map<String, String> getMessages() {
     if (messages == null) {
       messages = message.stream().collect(toMap(Message::getLang, Message::getValue));
     }
@@ -95,16 +91,22 @@ public class Warning {
   }
 
   /**
-   * Sets messages.
-   * @param messages a map of messages indexed by languages.
+   * Puts a localized message directly linked to the {@link Warning} instance.
+   * @param language the language the message is localized into.
+   * @param message a localized message.
    */
-  public void setMessages(final Map<String, String> messages) {
+  public void putMessage(final String language, final String message) {
     this.messages = null;
-    this.message = messages.entrySet().stream().map(e -> {
-      final Message msg = new Message();
-      msg.setLang(e.getKey());
-      msg.setValue(e.getValue());
-      return msg;
-    }).collect(Collectors.toList());
+    final String safeLanguage = checkLanguage(language);
+    this.message.stream()
+        .filter(m -> m.getLang().equals(safeLanguage))
+        .findFirst()
+        .orElseGet(() -> {
+          final Message msg = new Message();
+          msg.setLang(safeLanguage);
+          this.message.add(msg);
+          return msg;
+        })
+        .setValue(message);
   }
 }

--- a/core-library/src/main/java/org/silverpeas/core/admin/persistence/InstanceDataTable.java
+++ b/core-library/src/main/java/org/silverpeas/core/admin/persistence/InstanceDataTable.java
@@ -23,6 +23,7 @@
  */
 package org.silverpeas.core.admin.persistence;
 
+import org.silverpeas.core.admin.component.model.LocalizedParameter;
 import org.silverpeas.core.admin.component.model.Parameter;
 import org.silverpeas.core.annotation.Repository;
 import org.silverpeas.core.i18n.I18NHelper;
@@ -69,13 +70,12 @@ public class InstanceDataTable extends Table<InstanceDataRow> {
   /**
    * Inserts in the database a new instanceData row.
    */
-  public void createInstanceData(int componentId, Parameter parameter) throws SQLException {
+  public void createInstanceData(int componentId, LocalizedParameter parameter) throws SQLException {
     InstanceDataRow idr = new InstanceDataRow();
-
     idr.id = getNextId();
     idr.componentId = componentId;
     idr.name = parameter.getName();
-    idr.label = parameter.getLabel().get(I18NHelper.DEFAULT_LANGUAGE);
+    idr.label = parameter.getLabel();
     idr.value = parameter.getValue();
 
     insertRow(INSERT_INSTANCEDATA, idr);
@@ -105,9 +105,7 @@ public class InstanceDataTable extends Table<InstanceDataRow> {
     Parameter param = new Parameter();
     param.setName(row.name);
     param.setValue(row.value);
-    HashMap<String, String> multilang = new HashMap<>();
-    multilang.put(I18NHelper.DEFAULT_LANGUAGE, row.label);
-    param.setLabel(multilang);
+    param.putLabel(I18NHelper.DEFAULT_LANGUAGE, row.label);
     return param;
   }
 
@@ -187,7 +185,7 @@ public class InstanceDataTable extends Table<InstanceDataRow> {
   /**
    * Updates a instance data row.
    */
-  public void updateInstanceData(int componentId, Parameter parameter) throws SQLException {
+  public void updateInstanceData(int componentId, LocalizedParameter parameter) throws SQLException {
     InstanceDataRow idr = new InstanceDataRow();
 
     idr.componentId = componentId;

--- a/core-library/src/main/java/org/silverpeas/core/admin/service/DefaultAdministration.java
+++ b/core-library/src/main/java/org/silverpeas/core/admin/service/DefaultAdministration.java
@@ -1654,16 +1654,12 @@ class DefaultAdministration implements Administration {
   }
 
   @Override
-  public String getProfileLabelFromName(String sComponentName, String sProfileName, String lang) {
-    return componentRegistry.getWAComponent(sComponentName).map(wac -> {
-      List<Profile> profiles = wac.getProfiles();
-      for (Profile profile : profiles) {
-        if (profile.getName().equals(sProfileName)) {
-          return profile.getLabel().get(lang);
-        }
-      }
-      return sProfileName;
-    }).orElse(sProfileName);
+  public String getProfileLabelFromName(String componentName, String profileName, String lang) {
+    return componentRegistry.getWAComponent(componentName)
+        .map(c -> new LocalizedWAComponent(c, lang))
+        .map(l -> l.getProfile(profileName))
+        .map(LocalizedProfile::getLabel)
+        .orElse(profileName);
   }
 
   @Override

--- a/core-library/src/test/java/org/silverpeas/core/admin/component/PersonalComponentRegistryTest.java
+++ b/core-library/src/test/java/org/silverpeas/core/admin/component/PersonalComponentRegistryTest.java
@@ -30,13 +30,15 @@ package org.silverpeas.core.admin.component;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.silverpeas.core.admin.component.model.LocalizedComponent;
 import org.silverpeas.core.admin.component.model.PersonalComponent;
 import org.silverpeas.core.test.extention.EnableSilverTestEnv;
 
 import java.util.Optional;
 
-import static org.hamcrest.Matchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
 
 /**
  * Unit test on the services provided by the PersonalComponentRegistry.
@@ -59,24 +61,22 @@ class PersonalComponentRegistryTest {
     assertThat(registry.getAllPersonalComponents().size(), is(2));
   }
 
-  @SuppressWarnings("OptionalGetWithoutIsPresent")
   @Test
   void getUserCalendarPersonalComponentShouldWork() {
     Optional<PersonalComponent> result = registry.getPersonalComponent("userCalendar");
     assertThat(result.isPresent(), is(true));
 
     PersonalComponent userCalendar = result.get();
+    LocalizedComponent frUserCalendar = new LocalizedComponent(userCalendar, "fr");
+    LocalizedComponent enUserCalendar = new LocalizedComponent(userCalendar, "en");
+    LocalizedComponent deUserCalendar = new LocalizedComponent(userCalendar, "de");
     assertThat(userCalendar.getName(), is("userCalendar"));
-    assertThat(userCalendar.getLabel(), hasKey("fr"));
-    assertThat(userCalendar.getLabel("fr"), is("Mes agendas"));
-    assertThat(userCalendar.getLabel(), hasKey("en"));
-    assertThat(userCalendar.getLabel("en"), is("My diaries"));
-    assertThat(userCalendar.getLabel(), hasKey("de"));
-    assertThat(userCalendar.getDescription(), hasKey("fr"));
-    assertThat(userCalendar.getDescription("fr"), is("Vos agendas personnels."));
-    assertThat(userCalendar.getDescription(), hasKey("en"));
-    assertThat(userCalendar.getDescription("en"), is("Your personal diaries."));
-    assertThat(userCalendar.getDescription(), hasKey("de"));
+    assertThat(frUserCalendar.getLabel(), is("Mes agendas"));
+    assertThat(enUserCalendar.getLabel(), is("My diaries"));
+    assertThat(deUserCalendar.getLabel(), is("My diaries"));
+    assertThat(frUserCalendar.getDescription(), is("Vos agendas personnels."));
+    assertThat(enUserCalendar.getDescription(), is("Your personal diaries."));
+    assertThat(deUserCalendar.getDescription(), is("Your personal diaries."));
     assertThat(userCalendar.isVisible(), is(true));
     assertThat(userCalendar.getParameters(), is(empty()));
   }

--- a/core-library/src/test/java/org/silverpeas/core/admin/component/model/ComponentLocalizationTest.java
+++ b/core-library/src/test/java/org/silverpeas/core/admin/component/model/ComponentLocalizationTest.java
@@ -1,0 +1,498 @@
+/*
+ * Copyright (C) 2000 - 2022 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception. You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "http://www.silverpeas.org/docs/core/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.admin.component.model;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+import org.silverpeas.core.admin.component.WAComponentRegistry;
+import org.silverpeas.core.contribution.template.publication.PublicationTemplateManager;
+import org.silverpeas.core.test.extention.EnableSilverTestEnv;
+import org.silverpeas.core.test.extention.TestManagedBean;
+import org.silverpeas.core.test.extention.TestManagedBeans;
+
+import java.util.MissingResourceException;
+
+import static java.lang.String.format;
+import static java.util.Comparator.comparing;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * This class of unit tests deals with the localized data of components described with XML
+ * descriptors.
+ * for each test, 3 locales are verified:
+ * <ul>
+ *   <li>FR locale is retrieved from XML component descriptor</li>
+ *   <li>ES locale is retrieved from XML bundle property file</li>
+ *   <li>IT locale does not exist, default language is used instead</li>
+ * </ul>
+ * @author silveryocha
+ */
+@EnableSilverTestEnv
+@TestManagedBeans(PublicationTemplateManager.class)
+class ComponentLocalizationTest {
+
+  private static final String COMPONENT_NAME = "kmeliaForLocalizedTests";
+  private static final String FR_LOCALE = "fr";
+  private static final String ES_LOCALE = "es";
+  private static final String IT_LOCALE = "it";
+  private static final String ERR_TEMPLATE = "Can't find localization into xmlcomponents.%s" +
+      "_%s.properties with key %s, or into %s XML descriptor";
+  private WAComponent kmeliaWA;
+
+  @TestManagedBean
+  private WAComponentRegistry registry;
+
+  @BeforeEach
+  public void setup() throws Exception {
+    registry.init();
+    kmeliaWA = registry.getWAComponent(COMPONENT_NAME).orElse(null);
+    assertThat(kmeliaWA, notNullValue());
+  }
+
+  @Test
+  @DisplayName("Localized data from XML component descriptor if bundle property file does not exist")
+  void noBundlePropertyFile() {
+    final SilverpeasComponent classifiedsWA = registry.getWAComponent("classifieds").orElse(null);
+    assertThat(classifiedsWA, notNullValue());
+    assertThat(classifiedsWA.getLabel(FR_LOCALE), is("Petites annonces"));
+    assertThat(classifiedsWA.getLabel(ES_LOCALE), is("Petites annonces"));
+    assertThat(classifiedsWA.getLabel(IT_LOCALE), is("Petites annonces"));
+  }
+
+  @Test
+  @DisplayName("Verifying that component label and description of SilverpeasComponent API " +
+      "implementation use LocalizedComponent. For FR locale, localized data are retrieved from " +
+      "the XML component descriptor whereas the ES one which are retrieved from bundle property " +
+      "file")
+  void labelAndDescriptionOfSilverpeasComponentApi() {
+    assertThat(kmeliaWA.getLabel(FR_LOCALE), is("Gestion documentaire I"));
+    assertThat(kmeliaWA.getLabel(ES_LOCALE), is("Gestión de documentos I"));
+    assertThat(kmeliaWA.getLabel(IT_LOCALE), is("Gestion documentaire I"));
+    assertThat(kmeliaWA.getDescription(FR_LOCALE),
+        startsWith("Les publications offrent la possibilité"));
+    assertThat(kmeliaWA.getDescription(ES_LOCALE),
+        startsWith("Las publicaciones ofrecen la posibilidad"));
+    assertThat(kmeliaWA.getDescription(IT_LOCALE),
+        startsWith("Les publications offrent la possibilité"));
+  }
+
+  @Test
+  @DisplayName("Verifying the LocalizedComponent implementation")
+  void localizedWAComponent() {
+    final LocalizedWAComponent frLocalized = getLocalizedWAComponent(FR_LOCALE);
+    final LocalizedWAComponent esLocalized = getLocalizedWAComponent(ES_LOCALE);
+    final LocalizedWAComponent itLocalized = getLocalizedWAComponent(IT_LOCALE);
+    assertThat(frLocalized.getLabel(), is("Gestion documentaire I"));
+    assertThat(esLocalized.getLabel(), is("Gestión de documentos I"));
+    assertThat(itLocalized.getLabel(), is("Gestion documentaire I"));
+    assertThat(frLocalized.getDescription(), startsWith("Les publications offrent la possibilité"));
+    assertThat(esLocalized.getDescription(), startsWith("Las publicaciones ofrecen la posibilidad"));
+    assertThat(itLocalized.getDescription(), startsWith("Les publications offrent la possibilité"));
+    assertThat(frLocalized.getSuite(), is("01 Gestion Documentaire"));
+    assertThat(esLocalized.getSuite(), is("01 Gestión de documentos"));
+    assertThat(itLocalized.getSuite(), is("01 Gestion Documentaire"));
+  }
+
+  @Test
+  @DisplayName("Verifying the LocalizedProfile implementation")
+  void localizedProfile() {
+    final LocalizedProfile frAdmin = getLocalizedWAComponent(FR_LOCALE).getProfile("admin");
+    final LocalizedProfile esAdmin = getLocalizedWAComponent(ES_LOCALE).getProfile("admin");
+    final LocalizedProfile itAdmin = getLocalizedWAComponent(FR_LOCALE).getProfile("admin");
+    assertThat(frAdmin, notNullValue());
+    assertThat(esAdmin, notNullValue());
+    assertThat(itAdmin, notNullValue());
+    assertThat(frAdmin.getLabel(), is("Gestionnaires"));
+    assertThat(esAdmin.getLabel(), is("Gestores"));
+    assertThat(itAdmin.getLabel(), is("Gestionnaires"));
+    assertThat(frAdmin.getHelp(), startsWith("Les gestionnaires créent des dossiers"));
+    assertThat(esAdmin.getHelp(), startsWith("Los gestores crean archivos"));
+    assertThat(itAdmin.getHelp(), startsWith("Les gestionnaires créent des dossiers"));
+  }
+
+  private LocalizedWAComponent getLocalizedWAComponent(final String locale) {
+    return new LocalizedWAComponent(kmeliaWA, locale);
+  }
+
+  @Test
+  @DisplayName("Verifying the LocalizedGroupOfParameters implementation")
+  void localizedGroupOfParameters() {
+    final GroupOfParameters group = getFirstGroupOfParametersWithName();
+    assertThat(group.getName(), is("folders"));
+    final LocalizedGroupOfParameters frGroup = getLocalizedGroupOfParameters(group, FR_LOCALE);
+    final LocalizedGroupOfParameters esGroup = getLocalizedGroupOfParameters(group, ES_LOCALE);
+    final LocalizedGroupOfParameters itGroup = getLocalizedGroupOfParameters(group, IT_LOCALE);
+    assertThat(frGroup.getLabel(), is("Dossiers"));
+    assertThat(esGroup.getLabel(), is("Archivos"));
+    assertThat(itGroup.getLabel(), is("Dossiers"));
+    assertThat(frGroup.getDescription(), is("Ils vous permettent d'organiser facilement votre GED"));
+    assertThat(esGroup.getDescription(), is("Le permiten organizar fácilmente su GED"));
+    assertThat(itGroup.getDescription(), is("Ils vous permettent d'organiser facilement votre GED"));
+  }
+
+  @Test
+  @DisplayName("Verifying the LocalizedParameter implementation from a LocalizedGroupOfParameters")
+  void localizedParameterOfLocalizedGroupOfParameters() {
+    final GroupOfParameters group = getFirstGroupOfParametersWithName();
+    assertThat(group.getName(), is("folders"));
+    final LocalizedParameter frParam = getFirstLocalizedParameterWithoutOptionAndWarning(
+        getLocalizedGroupOfParameters(group, FR_LOCALE));
+    final LocalizedParameter esParam = getFirstLocalizedParameterWithoutOptionAndWarning(
+        getLocalizedGroupOfParameters(group, ES_LOCALE));
+    final LocalizedParameter itParam = getFirstLocalizedParameterWithoutOptionAndWarning(
+        getLocalizedGroupOfParameters(group, IT_LOCALE));
+    assertThat(frParam.getLabel(), is("Gestion déléguée"));
+    assertThat(esParam.getLabel(), is("Gestión delegada"));
+    assertThat(itParam.getLabel(), is("Gestion déléguée"));
+    assertThat(frParam.getHelp(), startsWith("La gestion des dossiers est déléguée aux publieurs et rédacteurs."));
+    assertThat(esParam.getHelp(), startsWith("La gestión de los archivos se delega en los editores y redactores."));
+    assertThat(itParam.getHelp(), startsWith("La gestion des dossiers est déléguée aux publieurs et rédacteurs."));
+  }
+
+  @Test
+  @DisplayName("Verifying the LocalizedOption implementation of LocalizedParameter from a " +
+      "LocalizedGroupOfParameters")
+  void localizedOptionOfLocalizedParameterOfLocalizedGroupOfParameters() {
+    final GroupOfParameters group = getFirstGroupOfParametersWithName();
+    assertThat(group.getName(), is("folders"));
+    final LocalizedOption frOption = getOptionOfFirstLocalizedParameterWithoutWarning(
+        getLocalizedGroupOfParameters(group, FR_LOCALE));
+    final LocalizedOption esOption = getOptionOfFirstLocalizedParameterWithoutWarning(
+        getLocalizedGroupOfParameters(group, ES_LOCALE));
+    final LocalizedOption itOption = getOptionOfFirstLocalizedParameterWithoutWarning(
+        getLocalizedGroupOfParameters(group, IT_LOCALE));
+    assertThat(frOption.getName(), is("Oui avec explorateur de dossiers"));
+    assertThat(esOption.getName(), is("Sí con el explorador de carpetas"));
+    assertThat(itOption.getName(), is("Oui avec explorateur de dossiers"));
+  }
+
+  @Test
+  @DisplayName("Verifying the LocalizedWarning implementation of LocalizedParameter from a " +
+      "LocalizedGroupOfParameters")
+  void localizedWarningOfLocalizedParameterOfLocalizedGroupOfParameters() {
+    final GroupOfParameters group = kmeliaWA.getSortedGroupsOfParameters().get(3);
+    assertThat(group.getName(), is("sharing"));
+    final LocalizedWarning frWarning = getWarningOfFirstLocalizedParameterHasAny(
+        getLocalizedGroupOfParameters(group, FR_LOCALE));
+    final LocalizedWarning esWarning = getWarningOfFirstLocalizedParameterHasAny(
+        getLocalizedGroupOfParameters(group, ES_LOCALE));
+    final LocalizedWarning itWarning = getWarningOfFirstLocalizedParameterHasAny(
+        getLocalizedGroupOfParameters(group, IT_LOCALE));
+    assertThat(frWarning.getValue(), startsWith("Attention! En sélectionnant cette option"));
+    assertThat(esWarning.getValue(), startsWith("Atención Al seleccionar esta opción"));
+    assertThat(itWarning.getValue(), startsWith("Attention! En sélectionnant cette option"));
+  }
+
+  private GroupOfParameters getFirstGroupOfParametersWithName() {
+    return kmeliaWA.getSortedGroupsOfParameters()
+        .stream()
+        .filter(g -> !"noname".equals(g.getName()))
+        .findFirst()
+        .orElseGet(() -> fail(
+            "A group of parameters having the attribute name filled should have been found"));
+  }
+
+  private LocalizedGroupOfParameters getLocalizedGroupOfParameters(final GroupOfParameters group,
+      final String locale) {
+    return new LocalizedGroupOfParameters(kmeliaWA, group, locale);
+  }
+
+  private LocalizedParameter getFirstLocalizedParameterWithoutOptionAndWarning(final LocalizedGroupOfParameters group) {
+    final LocalizedParameterList parameters = group.getParameters();
+    parameters.sort(comparing(LocalizedParameter::getOrder));
+    return parameters.stream()
+        .filter(p -> p.getOptions().isEmpty())
+        .filter(p -> p.getWarning().isEmpty())
+        .findFirst()
+        .orElse(null);
+  }
+
+  private LocalizedOption getOptionOfFirstLocalizedParameterWithoutWarning(
+      final LocalizedGroupOfParameters group) {
+    final LocalizedParameterList parameters = group.getParameters();
+    parameters.sort(comparing(LocalizedParameter::getOrder));
+    return parameters.stream()
+        .filter(p -> !p.getOptions().isEmpty())
+        .filter(p -> p.getWarning().isEmpty())
+        .flatMap(p -> p.getOptions().stream())
+        .findFirst()
+        .orElse(null);
+  }
+
+  private LocalizedWarning getWarningOfFirstLocalizedParameterHasAny(
+      final LocalizedGroupOfParameters group) {
+    final LocalizedParameterList parameters = group.getParameters();
+    parameters.sort(comparing(LocalizedParameter::getOrder));
+    return parameters.stream()
+        .filter(p -> p.getWarning().isPresent())
+        .flatMap(p -> p.getWarning().stream())
+        .findFirst()
+        .orElse(null);
+  }
+
+  @Test
+  @DisplayName("Verifying the LocalizedGroupOfParameters implementation when no group name is set")
+  void localizedGroupOfParametersHavingNoGroupName() {
+    final GroupOfParameters group = getFirstGroupOfParametersWithoutName();
+    assertThat(group.getName(), is("noname"));
+    final LocalizedGroupOfParameters frGroup = getLocalizedGroupOfParameters(group, FR_LOCALE);
+    final LocalizedGroupOfParameters esGroup = getLocalizedGroupOfParameters(group, ES_LOCALE);
+    final LocalizedGroupOfParameters itGroup = getLocalizedGroupOfParameters(group, IT_LOCALE);
+    assertThat(frGroup.getLabel(), is("Divers"));
+    assertThat(esGroup.getLabel(), is("Miscelánea"));
+    assertThat(itGroup.getLabel(), is("Divers"));
+    assertThat(frGroup.getDescription(), is("Autres paramètres pouvant être tout aussi utiles..."));
+    assertThat(esGroup.getDescription(), is("Otros parámetros que pueden ser igual de útiles..."));
+    assertThat(itGroup.getDescription(), is("Autres paramètres pouvant être tout aussi utiles..."));
+  }
+
+  @Test
+  @DisplayName("Verifying the LocalizedParameter implementation from a LocalizedGroupOfParameters having no group name")
+  void localizedParameterOfLocalizedGroupOfParametersHavingNoGroupName() {
+    final GroupOfParameters group = getFirstGroupOfParametersWithoutName();
+    assertThat(group.getName(), is("noname"));
+    final LocalizedParameter frParam = getFirstLocalizedParameterWithoutOptionAndWarning(
+        getLocalizedGroupOfParameters(group, FR_LOCALE));
+    final LocalizedParameter esParam = getFirstLocalizedParameterWithoutOptionAndWarning(
+        getLocalizedGroupOfParameters(group, ES_LOCALE));
+    final LocalizedParameter itParam = getFirstLocalizedParameterWithoutOptionAndWarning(
+        getLocalizedGroupOfParameters(group, IT_LOCALE));
+    assertThat(frParam.getLabel(), is("Orienté CMS"));
+    assertThat(esParam.getLabel(), is("Orientación CMS"));
+    assertThat(itParam.getLabel(), is("Orienté CMS"));
+    assertThat(frParam.getHelp(), startsWith("Permet d'activer les fonctions liées à la gestion de contenu web"));
+    assertThat(esParam.getHelp(), startsWith("Permite activar funciones relacionadas con la gestión de contenidos web"));
+    assertThat(itParam.getHelp(), startsWith("Permet d'activer les fonctions liées à la gestion de contenu web"));
+  }
+
+  private GroupOfParameters getFirstGroupOfParametersWithoutName() {
+    return kmeliaWA.getSortedGroupsOfParameters()
+        .stream()
+        .filter(g -> "noname".equals(g.getName()))
+        .findFirst()
+        .orElseGet(() -> fail(
+            "A group of parameters having empty attribute name should have been found"));
+  }
+
+  @Test
+  @DisplayName("Verifying the LocalizedParameter implementation which is not part of a group")
+  void localizedParameterNotPartOfAGroup() {
+    final LocalizedParameter frParam = getFirstLocalizedParameterNotPartOfAGroup(FR_LOCALE);
+    final LocalizedParameter esParam = getFirstLocalizedParameterNotPartOfAGroup(ES_LOCALE);
+    final LocalizedParameter itParam = getFirstLocalizedParameterNotPartOfAGroup(IT_LOCALE);
+    assertThat(frParam.getLabel(), is("Nb dernières publi"));
+    assertThat(esParam.getLabel(), is("Nº de últimas publicaciones"));
+    assertThat(itParam.getLabel(), is("Nb dernières publi"));
+    assertThat(frParam.getHelp(), startsWith("Permet de définir le nombre de dernières publications"));
+    assertThat(esParam.getHelp(), startsWith("Permite definir el número de últimas publicaciones"));
+    assertThat(itParam.getHelp(), startsWith("Permet de définir le nombre de dernières publications"));
+  }
+
+  @Test
+  @DisplayName("Verifying the LocalizedOption implementation of LocalizedParameter which is not part of a group")
+  void localizedOptionOfLocalizedParameterNotPartOfAGroup() {
+    final LocalizedOption frOption = getOptionOfFirstLocalizedParameterNotPartOfAGroup(FR_LOCALE);
+    final LocalizedOption esOption = getOptionOfFirstLocalizedParameterNotPartOfAGroup(ES_LOCALE);
+    final LocalizedOption itOption = getOptionOfFirstLocalizedParameterNotPartOfAGroup(IT_LOCALE);
+    assertThat(frOption.getName(), is("Une première option"));
+    assertThat(esOption.getName(), is("Una primera opción"));
+    assertThat(itOption.getName(), is("Une première option"));
+  }
+
+  @Test
+  @DisplayName("Verifying the LocalizedWarning implementation of LocalizedParameter which is not part")
+  void localizedWarningOfLocalizedParameterNotPartOfAGroup() {
+    final LocalizedWarning frWarning = getWarningOfFirstLocalizedParameterNotPartOfAGroup(FR_LOCALE);
+    final LocalizedWarning esWarning = getWarningOfFirstLocalizedParameterNotPartOfAGroup(ES_LOCALE);
+    final LocalizedWarning itWarning = getWarningOfFirstLocalizedParameterNotPartOfAGroup(IT_LOCALE);
+    assertThat(frWarning.getValue(), startsWith("Un avertissement bien nécessaire"));
+    assertThat(esWarning.getValue(), startsWith("Una advertencia muy necesaria"));
+    assertThat(itWarning.getValue(), startsWith("Un avertissement bien nécessaire"));
+  }
+
+  private LocalizedParameter getFirstLocalizedParameterNotPartOfAGroup(final String locale) {
+    return kmeliaWA.getSortedParameters().stream()
+        .filter(p -> p.getOptions().isEmpty())
+        .filter(p -> p.getWarning().isEmpty())
+        .map(p -> new LocalizedParameter(kmeliaWA, p, locale))
+        .findFirst()
+        .orElse(null);
+  }
+
+  private LocalizedOption getOptionOfFirstLocalizedParameterNotPartOfAGroup(final String locale) {
+    return kmeliaWA.getSortedParameters().stream()
+        .filter(p -> !p.getOptions().isEmpty())
+        .map(p -> new LocalizedParameter(kmeliaWA, p, locale))
+        .flatMap(l -> l.getOptions().stream())
+        .findFirst()
+        .orElse(null);
+  }
+
+  private LocalizedWarning getWarningOfFirstLocalizedParameterNotPartOfAGroup(final String locale) {
+    return kmeliaWA.getSortedParameters().stream()
+        .filter(p -> p.getWarning().isPresent())
+        .map(p -> new LocalizedParameter(kmeliaWA, p, locale))
+        .flatMap(l -> l.getWarning().stream())
+        .findFirst()
+        .orElse(null);
+  }
+
+  @Test
+  @DisplayName("Verifying the LocalizedParameter implementation when it does not exists labels into XML descriptor")
+  void localizedParameterWithoutXmlDescriptorLocalization() {
+    final LocalizedParameter frParam = getLocalizedParameterWithoutXmlDescriptorLocalization(FR_LOCALE);
+    final LocalizedParameter esParam = getLocalizedParameterWithoutXmlDescriptorLocalization(ES_LOCALE);
+    final LocalizedParameter itParam = getLocalizedParameterWithoutXmlDescriptorLocalization(IT_LOCALE);
+    assertThat(frParam.getLabel(), is("Libellés uniquement dans le fichier bundle"));
+    assertThat(esParam.getLabel(), is("Etiquetas sólo en el archivo bundle"));
+    assertThat(itParam.getLabel(), is("Libellés uniquement dans le fichier bundle"));
+    assertThat(frParam.getHelp(), startsWith("Il est possible que les libellés soient"));
+    assertThat(esParam.getHelp(), startsWith("Las etiquetas pueden ser"));
+    assertThat(itParam.getHelp(), startsWith("Il est possible que les libellés soient"));
+  }
+
+  @Test
+  @DisplayName("Verifying the LocalizedOption implementation of a LocalizedParameter when it does" +
+      " not exists labels into XML descriptor")
+  void localizedOptionOfLocalizedParameterWithoutXmlDescriptorLocalization() {
+    final LocalizedOption frOption = getOptionOfLocalizedParameterWithoutXmlDescriptorLocalization(FR_LOCALE);
+    final LocalizedOption esOption = getOptionOfLocalizedParameterWithoutXmlDescriptorLocalization(ES_LOCALE);
+    final LocalizedOption itOption = getOptionOfLocalizedParameterWithoutXmlDescriptorLocalization(IT_LOCALE);
+    assertThat(frOption.getName(), is("Une première option"));
+    assertThat(esOption.getName(), is("Una primera opción"));
+    assertThat(itOption.getName(), is("Une première option"));
+  }
+
+  @Test
+  @DisplayName("Verifying the LocalizedWarning implementation of a LocalizedParameter when it does" +
+      " not exists labels into XML descriptor")
+  void localizedWarningOfLocalizedParameterWithoutXmlDescriptorLocalization() {
+    final LocalizedWarning frWarning = getWarningOfLocalizedParameterWithoutXmlDescriptorLocalization(FR_LOCALE);
+    final LocalizedWarning esWarning = getWarningOfLocalizedParameterWithoutXmlDescriptorLocalization(ES_LOCALE);
+    final LocalizedWarning itWarning = getWarningOfLocalizedParameterWithoutXmlDescriptorLocalization(IT_LOCALE);
+    assertThat(frWarning.getValue(), startsWith("Un avertissement bien nécessaire"));
+    assertThat(esWarning.getValue(), startsWith("Una advertencia muy necesaria"));
+    assertThat(itWarning.getValue(), startsWith("Un avertissement bien nécessaire"));
+  }
+
+  private LocalizedParameter getLocalizedParameterWithoutXmlDescriptorLocalization(final String locale) {
+    final LocalizedParameter localizedParameter =
+        new LocalizedParameterList(kmeliaWA, ParameterList.copy(kmeliaWA.getParameters()), locale)
+            .stream()
+            .filter(p -> "noXmlDescriptorLocalization".equals(p.getName()))
+            .findFirst()
+            .orElse(null);
+    assertThat(localizedParameter, notNullValue());
+    return localizedParameter;
+  }
+
+  private LocalizedOption getOptionOfLocalizedParameterWithoutXmlDescriptorLocalization(final String locale) {
+    return getLocalizedParameterWithoutXmlDescriptorLocalization(locale).getOptions().get(0);
+  }
+
+  private LocalizedWarning getWarningOfLocalizedParameterWithoutXmlDescriptorLocalization(final String locale) {
+    final LocalizedWarning warning = getLocalizedParameterWithoutXmlDescriptorLocalization(locale)
+        .getWarning()
+        .orElse(null);
+    assertThat(warning, notNullValue());
+    return warning;
+  }
+
+  @Test
+  @DisplayName("Verifying the LocalizedParameter implementation when it does not exists labels into XML descriptor")
+  void localizedParameterWithoutAnyLocalization() {
+    final LocalizedParameter frParam = getLocalizedParameterWithoutAnyLocalization(FR_LOCALE);
+    final LocalizedParameter esParam = getLocalizedParameterWithoutAnyLocalization(ES_LOCALE);
+    final LocalizedParameter itParam = getLocalizedParameterWithoutAnyLocalization(IT_LOCALE);
+    String bundleKey = "parameter.noLocalization.label";
+    assertMissingResourceException(frParam::getLabel, bundleKey, FR_LOCALE);
+    assertMissingResourceException(esParam::getLabel, bundleKey, ES_LOCALE);
+    assertMissingResourceException(itParam::getLabel, bundleKey, IT_LOCALE);
+    bundleKey = "parameter.noLocalization.help";
+    assertMissingResourceException(frParam::getHelp, bundleKey, FR_LOCALE);
+    assertMissingResourceException(esParam::getHelp, bundleKey, ES_LOCALE);
+    assertMissingResourceException(itParam::getHelp, bundleKey, IT_LOCALE);
+  }
+
+  @Test
+  @DisplayName("Verifying the LocalizedOption implementation of a LocalizedParameter when it does" +
+      " not exists labels into XML descriptor")
+  void localizedOptionOfLocalizedParameterWithoutAnyLocalization() {
+    final LocalizedOption frOption = getOptionOfLocalizedParameterWithoutAnyLocalization(FR_LOCALE);
+    final LocalizedOption esOption = getOptionOfLocalizedParameterWithoutAnyLocalization(ES_LOCALE);
+    final LocalizedOption itOption = getOptionOfLocalizedParameterWithoutAnyLocalization(IT_LOCALE);
+    final String bundleKey = "parameter.noLocalization.option.Op 1.name";
+    assertMissingResourceException(frOption::getName, bundleKey, FR_LOCALE);
+    assertMissingResourceException(esOption::getName, bundleKey, ES_LOCALE);
+    assertMissingResourceException(itOption::getName, bundleKey, IT_LOCALE);
+  }
+
+  @Test
+  @DisplayName("Verifying the LocalizedWarning implementation of a LocalizedParameter when it does" +
+      " not exists labels into XML descriptor")
+  void localizedWarningOfLocalizedParameterWithoutAnyLocalization() {
+    final LocalizedWarning frWarning = getWarningOfLocalizedParameterWithoutAnyLocalization(FR_LOCALE);
+    final LocalizedWarning esWarning = getWarningOfLocalizedParameterWithoutAnyLocalization(ES_LOCALE);
+    final LocalizedWarning itWarning = getWarningOfLocalizedParameterWithoutAnyLocalization(IT_LOCALE);
+    final String bundleKey = "parameter.noLocalization.warning";
+    assertMissingResourceException(frWarning::getValue, bundleKey, FR_LOCALE);
+    assertMissingResourceException(esWarning::getValue, bundleKey, ES_LOCALE);
+    assertMissingResourceException(itWarning::getValue, bundleKey, IT_LOCALE);
+  }
+
+  private void assertMissingResourceException(final Executable executable, final String bundleKey,
+      final String locale) {
+    assertThat(assertThrows(MissingResourceException.class, executable).getMessage(),
+        is(format(ERR_TEMPLATE, COMPONENT_NAME, locale, bundleKey, COMPONENT_NAME)));
+  }
+
+  private LocalizedParameter getLocalizedParameterWithoutAnyLocalization(final String locale) {
+    final LocalizedParameter localizedParameter =
+        new LocalizedParameterList(kmeliaWA, ParameterList.copy(kmeliaWA.getParameters()), locale)
+            .stream()
+            .filter(p -> "noLocalization".equals(p.getName()))
+            .findFirst()
+            .orElse(null);
+    assertThat(localizedParameter, notNullValue());
+    return localizedParameter;
+  }
+
+  private LocalizedOption getOptionOfLocalizedParameterWithoutAnyLocalization(final String locale) {
+    return getLocalizedParameterWithoutAnyLocalization(locale).getOptions().get(0);
+  }
+
+  private LocalizedWarning getWarningOfLocalizedParameterWithoutAnyLocalization(final String locale) {
+    final LocalizedWarning warning = getLocalizedParameterWithoutAnyLocalization(locale)
+        .getWarning()
+        .orElse(null);
+    assertThat(warning, notNullValue());
+    return warning;
+  }
+}

--- a/core-library/src/test/resources/properties/xmlcomponents/kmeliaForLocalizedTests_es.properties
+++ b/core-library/src/test/resources/properties/xmlcomponents/kmeliaForLocalizedTests_es.properties
@@ -1,0 +1,53 @@
+#
+# Copyright (C) 2000 - 2023 Silverpeas
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# As a special exception to the terms and conditions of version 3.0 of
+# the GPL, you may redistribute this Program in connection with Free/Libre
+# Open Source Software ("FLOSS") applications as described in Silverpeas's
+# FLOSS exception.  You should have received a copy of the text describing
+# the FLOSS exception, and it is also available here:
+# "https://www.silverpeas.org/legal/floss_exception.html"
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+label = Gesti\u00f3n de documentos I
+description=Las publicaciones ofrecen la posibilidad de agrupar metadatos, archivos adjuntos\
+      metadatos, archivos adjuntos (con seguimiento de las modificaciones) y contenido libre (Wysiwyg\
+      (Wysiwyg) o contenido estructurado (formulario).\
+      Se organizan en un \u00e1rbol de carpetas. Los usuarios pueden\
+      comentar las publicaciones, suscribirse a las carpetas, enviar notificaciones, etc.\
+      Los distintos roles y los numerosos par\u00e1metros permiten adaptarse a todas\
+      sus necesidades. Aplicaci\u00f3n insignia de Silverpeas, es digna de un jugador puro en el mercado de EDM.\
+      Reproductor DMS. Interact\u00faa con el motor de flujo de trabajo de la plataforma.
+suite=01 Gesti\u00f3n de documentos
+profile.admin.label=Gestores
+profile.admin.help=Los gestores crean archivos
+parameterGroup.folders.label=Archivos
+parameterGroup.folders.description=Le permiten organizar f\u00e1cilmente su GED
+parameterGroup.folders.parameter.delegatedTopicManagement.label=Gesti\u00f3n delegada
+parameterGroup.folders.parameter.delegatedTopicManagement.help=La gesti\u00f3n de los archivos se delega en los editores y redactores.
+parameterGroup.folders.parameter.isTree.option.0.name=S\u00ed con el explorador de carpetas
+parameterGroup.noname.label=Miscel\u00e1nea
+parameterGroup.noname.description=Otros par\u00e1metros que pueden ser igual de \u00fatiles...
+parameterGroup.noname.parameter.webContent.label=Orientaci\u00f3n CMS
+parameterGroup.noname.parameter.webContent.help=Permite activar funciones relacionadas con la gesti\u00f3n de contenidos web (wysiwyg asociado a la carpeta, visibilidad de la carpeta).
+parameterGroup.sharing.parameter.useFileSharing.warning=Atenci\u00f3n Al seleccionar esta opci\u00f3n, permitir\u00e1 que los archivos se compartan libremente con usuarios que no est\u00e9n registrados en la plataforma.
+parameter.nbPubliOnRoot.label=N\u00ba de \u00faltimas publicaciones
+parameter.nbPubliOnRoot.help=Permite definir el n\u00famero de \u00faltimas publicaciones mostradas en la p\u00e1gina de inicio de la aplicaci\u00f3n. No es posible crear una publicaci\u00f3n ra\u00edz. Si el valor introducido es 0, la publicaci\u00f3n ra\u00edz es posible pero las \u00faltimas publicaciones no se muestran en la p\u00e1gina de inicio.
+parameter.param4tests.warning=Una advertencia muy necesaria
+parameter.noXmlDescriptorLocalization.label=Etiquetas s\u00f3lo en el archivo bundle
+parameter.noXmlDescriptorLocalization.help=Las etiquetas pueden ser
+parameter.param4tests.option.Op\ 1.name=Una primera opci\u00f3n
+parameter.noXmlDescriptorLocalization.option.Op\ 1.name=Una primera opci\u00f3n
+parameter.noXmlDescriptorLocalization.warning=Una advertencia muy necesaria

--- a/core-library/src/test/resources/properties/xmlcomponents/kmeliaForLocalizedTests_fr.properties
+++ b/core-library/src/test/resources/properties/xmlcomponents/kmeliaForLocalizedTests_fr.properties
@@ -1,0 +1,27 @@
+#
+# Copyright (C) 2000 - 2023 Silverpeas
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# As a special exception to the terms and conditions of version 3.0 of
+# the GPL, you may redistribute this Program in connection with Free/Libre
+# Open Source Software ("FLOSS") applications as described in Silverpeas's
+# FLOSS exception.  You should have received a copy of the text describing
+# the FLOSS exception, and it is also available here:
+# "https://www.silverpeas.org/legal/floss_exception.html"
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+parameter.noXmlDescriptorLocalization.label=Libell\u00e9s uniquement dans le fichier bundle
+parameter.noXmlDescriptorLocalization.help=Il est possible que les libell\u00e9s soient
+parameter.noXmlDescriptorLocalization.option.Op\ 1.name=Une premi\u00e8re option
+parameter.noXmlDescriptorLocalization.warning=Un avertissement bien n\u00e9cessaire

--- a/core-library/src/test/resources/xmlcomponents/kmeliaForLocalizedTests.xml
+++ b/core-library/src/test/resources/xmlcomponents/kmeliaForLocalizedTests.xml
@@ -1,0 +1,1910 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2000 - 2022 Silverpeas
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    As a special exception to the terms and conditions of version 3.0 of
+    the GPL, you may redistribute this Program in connection with Free/Libre
+    Open Source Software ("FLOSS") applications as described in Silverpeas's
+    FLOSS exception.  You should have received a copy of the text describing
+    the FLOSS exception, and it is also available here:
+    "https://www.silverpeas.org/docs/core/legal/floss_exception.html"
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+-->
+
+<WAComponent xmlns="http://silverpeas.org/xml/ns/component"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://silverpeas.org/xml/ns/component https://www.silverpeas.org/xsd/component.xsd">
+  <name>kmeliaForLocalizedTests</name>
+  <behaviors>
+    <behavior>topicTracker</behavior>
+  </behaviors>
+  <label>
+    <message lang="fr">Gestion documentaire I</message>
+    <message lang="en">Document management</message>
+    <message lang="de">Dokumentenverwaltung</message>
+  </label>
+  <description>
+    <message lang="fr">Les publications offrent la possibilité de regrouper en
+      une seule et même page des méta-données, des fichiers joints (avec suivi des
+      modifications) ainsi qu’un contenu libre (Wysiwyg) ou structuré (formulaire).
+      Elles sont organisées dans une arborescence de dossiers. Les utilisateurs peuvent
+      commenter les publications, s’abonner aux dossiers, notifier...
+      Les différents rôles et de nombreux paramètres permettent de s’adapter à tous
+      vos besoins. Application phare de Silverpeas, elle est digne d’un « pure player »
+      de la GED. Elle est interfacée avec le moteur de workflow de la plate-forme.
+    </message>
+    <message lang="en">This application organizes documentation in hierarchical folders. You have
+      many options : XML
+      form for metadata, attachments versioned or not, workflows with many steps for validation /
+      acceptation,
+      classification on the classification scheme, readers list, comments, subscription to a folder
+      ,
+      a publication or a file.
+    </message>
+    <message lang="de">Diese Komponente organisiert Dokumentation in hierarchischen Themen.
+      Sie haben viele Möglichkeiten: XML-Formen für Metadaten, versionierte
+      oder nicht versionierte Anhänge, Workflows mit vielen Schritten
+      zur Validierung / Annahme, Klassifizierung auf dem Klassierungsplan,
+      Leser-Liste, Kommentare, Abonnement zu einem Thema, einer Publikation
+      oder einer Datei.
+    </message>
+  </description>
+  <suite>
+    <message lang="fr">01 Gestion Documentaire</message>
+    <message lang="en">01 Document Management</message>
+    <message lang="de">01 Dokumentenverwaltung</message>
+  </suite>
+  <visible>true</visible>
+  <visibleInPersonalSpace>true</visibleInPersonalSpace>
+  <portlet>true</portlet>
+  <profiles>
+    <profile name="admin">
+      <label>
+        <message lang="fr">Gestionnaires</message>
+        <message lang="en">Managers</message>
+        <message lang="de">Manager</message>
+      </label>
+      <help>
+        <message lang="fr">Les gestionnaires créent des dossiers, sélectionnent les formulaires de
+          métadonnées et paramètrent le Plan de Classement.
+        </message>
+        <message lang="en">Managers create folders, select metadata templates and set up the
+          Classification Scheme.
+        </message>
+        <message lang="de">Managers create folders, select metadata templates and set up the
+          Classification Scheme.
+        </message>
+      </help>
+      <spaceMapping>
+        <profile>admin</profile>
+      </spaceMapping>
+    </profile>
+    <profile name="publisher">
+      <label>
+        <message lang="fr">Publieurs</message>
+        <message lang="en">Publishers</message>
+        <message lang="de">Herausgeber</message>
+      </label>
+      <help>
+        <message lang="fr">Les publieurs créent des publications et valident les publications des
+          rédacteurs.
+        </message>
+        <message lang="en">Publisher create publication and validate writer's publications.
+        </message>
+        <message lang="de">Herausgeber</message>
+      </help>
+      <spaceMapping>
+        <profile>publisher</profile>
+      </spaceMapping>
+    </profile>
+    <profile name="writer">
+      <label>
+        <message lang="fr">Rédacteurs</message>
+        <message lang="en">Writers</message>
+        <message lang="de">Redaktor</message>
+      </label>
+      <help>
+        <message lang="fr">Les rédacteurs créent des publications.</message>
+        <message lang="en">Writers create publications.</message>
+        <message lang="de">Redaktor</message>
+      </help>
+      <spaceMapping>
+        <profile>writer</profile>
+      </spaceMapping>
+    </profile>
+    <profile name="user">
+      <label>
+        <message lang="fr">Lecteurs</message>
+        <message lang="en">Readers</message>
+        <message lang="de">Leser</message>
+      </label>
+      <help>
+        <message lang="fr">Les lecteurs accèdent aux publications, s'abonnent aux différents
+          dossiers et peuvent laisser des commentaires sur les publications.
+        </message>
+        <message lang="en">Readers have access to publications, subscribe to various folders and can
+          leave comments on publications.
+        </message>
+        <message lang="de">Leser</message>
+      </help>
+      <spaceMapping>
+        <profile>reader</profile>
+      </spaceMapping>
+    </profile>
+  </profiles>
+  <parameters>
+    <parameter>
+      <name>param4tests</name>
+      <label>
+        <message lang="fr">Paramètre pour les tests</message>
+        <message lang="en">Parameter for tests</message>
+        <message lang="de">Parameter für Tests</message>
+      </label>
+      <order>0</order>
+      <mandatory>true</mandatory>
+      <value>None</value>
+      <options>
+        <option>
+          <name>
+            <message lang="fr">Une première option</message>
+            <message lang="en">A first option</message>
+            <message lang="de">Eine erste Option</message>
+          </name>
+          <value>Op 1</value>
+        </option>
+        <option>
+          <name>
+            <message lang="fr">Une seconde option</message>
+            <message lang="en">A second option</message>
+            <message lang="de">Eine zweite Option</message>
+          </name>
+          <value>Op 2</value>
+        </option>
+      </options>
+      <type>select</type>
+      <updatable>always</updatable>
+      <warning>
+        <message lang="fr">Un avertissement bien nécessaire</message>
+        <message lang="en">A much-needed warning</message>
+        <message lang="de">Eine dringend benötigte Warnung</message>
+      </warning>
+      <personalSpaceValue>no</personalSpaceValue>
+    </parameter>
+    <parameter>
+      <name>noXmlDescriptorLocalization</name>
+      <label/>
+      <order>1</order>
+      <mandatory>true</mandatory>
+      <value>None</value>
+      <options>
+        <option>
+          <value>Op 1</value>
+        </option>
+        <option>
+          <value>Op 2</value>
+        </option>
+      </options>
+      <type>select</type>
+      <updatable>always</updatable>
+      <warning/>
+      <personalSpaceValue>no</personalSpaceValue>
+    </parameter>
+    <parameter>
+      <name>noLocalization</name>
+      <label/>
+      <order>1</order>
+      <mandatory>true</mandatory>
+      <value>None</value>
+      <options>
+        <option>
+          <value>Op 1</value>
+        </option>
+        <option>
+          <value>Op 2</value>
+        </option>
+      </options>
+      <type>select</type>
+      <updatable>always</updatable>
+      <warning/>
+      <personalSpaceValue>no</personalSpaceValue>
+    </parameter>
+    <parameter>
+      <name>nbPubliOnRoot</name>
+      <label>
+        <message lang="fr">Nb dernières publi</message>
+        <message lang="en">Number of last publications</message>
+        <message lang="de">Anzahl der letzten Veröffentlichungen</message>
+      </label>
+      <order>3</order>
+      <mandatory>true</mandatory>
+      <value>0</value>
+      <type>text</type>
+      <size>5</size>
+      <updatable>always</updatable>
+      <help>
+        <message lang="fr">Permet de définir le nombre de dernières publications affichées sur
+          la
+          page d'accueil de l'application. La création de publication à la racine est
+          impossible.
+          Si la valeur saisie est égale à 0, la publication à la racine est alors possible mais
+          les dernières publications ne sont pas affichées sur la page d'accueil.
+        </message>
+        <message lang="en">Defines the number of publications displayed on the home page of the
+          application. If not set to 0
+          you can't create publications in the root directory. When set to 0 you can create
+          publications on the root directory but the last publications are no longer displayed
+          on the home page.
+        </message>
+        <message lang="de">Definiert die Anzahl der Veröffentlichungen auf der Homepage des
+          component. Falls nicht auf 0 gesetzt,
+          können Sie keine Veröffentlichungen im Root-Verzeichnis machen. Wenn auf 0 gesetzt,
+          können Sie Veröffentlichungen
+          in das Root-Verzeichnis machen, aber die letzten Publikationen werden nicht mehr
+          angezeigt angezeigt.
+        </message>
+      </help>
+    </parameter>
+    <parameter>
+      <name>nbPubliPerPage</name>
+      <label>
+        <message lang="fr">Nombre par page</message>
+        <message lang="en">Number per page</message>
+        <message lang="de">Anzahl der Veröffentlichungen pro Seite</message>
+      </label>
+      <order>4</order>
+      <mandatory>false</mandatory>
+      <value></value>
+      <type>text</type>
+      <size>5</size>
+      <updatable>always</updatable>
+      <help>
+        <message lang="fr">Permet de définir le nombre de publications affichées par page
+        </message>
+        <message lang="en">Defines the number of publications displyed on a page</message>
+        <message lang="de">Definiert die Anzahl der Veröffentlichungen die auf einer Seite
+          angezeigt werden
+        </message>
+      </help>
+    </parameter>
+  </parameters>
+  <groupsOfParameters>
+    <groupOfParameters name="publications">
+      <label>
+        <message lang="fr">Publications</message>
+        <message lang="en">Publications</message>
+        <message lang="de">Publications</message>
+      </label>
+      <description>
+        <message lang="fr">Elles permettent de regrouper plusieurs fichiers et de les enrichir avec
+          des données textuelles plus ou moins structurées
+        </message>
+        <message lang="en">It allows you to group multiple files and enrich them with more or less
+          structured textual data
+        </message>
+        <message lang="de">Sie ermöglichen es, mehrere Dateien Gruppe und bereichern sie mit mehr
+          oder weniger strukturierte Textdaten
+        </message>
+      </description>
+      <order>2</order>
+      <parameters>
+        <parameter>
+          <name>publicationSort</name>
+          <label>
+            <message lang="fr">Ordre d'affichage</message>
+            <message lang="en">Publications sorting</message>
+            <message lang="de">Publications sorting</message>
+          </label>
+          <order>47</order>
+          <mandatory>true</mandatory>
+          <value>2</value>
+          <options>
+            <option>
+              <name>
+                <message lang="fr">Nom du créateur croissant</message>
+                <message lang="en">Ascending creator's name</message>
+                <message lang="de">Ascending creator's name</message>
+              </name>
+              <value>0</value>
+            </option>
+            <option>
+              <name>
+                <message lang="fr">Date de modification croissante</message>
+                <message lang="en">Ascending update date</message>
+                <message lang="de">Ascending update date</message>
+              </name>
+              <value>1</value>
+            </option>
+            <option>
+              <name>
+                <message lang="fr">Date de modification décroissante</message>
+                <message lang="en">Descending update date</message>
+                <message lang="de">Descending update date</message>
+              </name>
+              <value>2</value>
+            </option>
+            <option>
+              <name>
+                <message lang="fr">Importance croissante</message>
+                <message lang="en">Ascending importance</message>
+                <message lang="de">Ascending importance</message>
+              </name>
+              <value>3</value>
+            </option>
+            <option>
+              <name>
+                <message lang="fr">Titre croissant</message>
+                <message lang="en">Ascending title</message>
+                <message lang="de">Ascending title</message>
+              </name>
+              <value>4</value>
+            </option>
+            <option>
+              <name>
+                <message lang="fr">Date de création croissante</message>
+                <message lang="en">Ascending creation date</message>
+                <message lang="de">Ascending creation date</message>
+              </name>
+              <value>5</value>
+            </option>
+            <option>
+              <name>
+                <message lang="fr">Date de création décroissante</message>
+                <message lang="en">Descending creation date</message>
+                <message lang="de">Descending creation date</message>
+              </name>
+              <value>6</value>
+            </option>
+            <option>
+              <name>
+                <message lang="fr">Description croissante</message>
+                <message lang="en">Ascending description</message>
+                <message lang="de">Ascending description</message>
+              </name>
+              <value>7</value>
+            </option>
+          </options>
+          <type>select</type>
+          <updatable>always</updatable>
+          <help>
+            <message lang="fr">Permet de définir l'ordre d'affichage des publications par défaut.
+            </message>
+            <message lang="en">Sets the display order of publications.</message>
+            <message lang="de">Sets the display order of publications.</message>
+          </help>
+        </parameter>
+        <parameter>
+          <name>draft</name>
+          <label>
+            <message lang="fr">Mode brouillon</message>
+            <message lang="en">Draft mode</message>
+            <message lang="de">Entwurf</message>
+          </label>
+          <order>15</order>
+          <mandatory>true</mandatory>
+          <value>yes</value>
+          <type>checkbox</type>
+          <updatable>always</updatable>
+          <help>
+            <message lang="fr">Le mode brouillon permet de travailler sur une publication sans que
+              personne d'autre
+              puisse la voir.
+            </message>
+            <message lang="en">A publication in draft mode is visible only to the author, so he can
+              work on it.
+            </message>
+            <message lang="de">Eine Veröffentlichung im Entwurfs-Modus ist nur für den Autor
+              sichtbar, so kann er daran arbeiten.
+            </message>
+          </help>
+          <personalSpaceValue>no</personalSpaceValue>
+        </parameter>
+        <parameter>
+          <name>codification</name>
+          <label>
+            <message lang="fr">Codification unique</message>
+            <message lang="en">Unique code</message>
+            <message lang="de">Einzigartige Kodifizierung</message>
+          </label>
+          <order>30</order>
+          <mandatory>true</mandatory>
+          <value>no</value>
+          <type>checkbox</type>
+          <updatable>always</updatable>
+          <help>
+            <message lang="fr">Cette option permet d'afficher sur l'entête l'identifiant unique de
+              chaque publication.
+            </message>
+            <message lang="en">This feature displays the unique id of each publication in the header
+              tab.
+            </message>
+            <message lang="de">Diese Funktion zeigt die eindeutige ID jeder Veröffentlichung in der
+              Kopf Registerkarte.
+            </message>
+          </help>
+        </parameter>
+        <parameter>
+          <name>useAuthor</name>
+          <label>
+            <message lang="fr">Champ Auteur</message>
+            <message lang="en">Author field</message>
+            <message lang="de">Autor Feld</message>
+          </label>
+          <order>18</order>
+          <mandatory>true</mandatory>
+          <value>no</value>
+          <type>checkbox</type>
+          <updatable>always</updatable>
+          <help>
+            <message lang="fr">Les documents créés au sein de cette instance pourront comporter un
+              champ supplémentaire 'Auteur'.
+            </message>
+            <message lang="en">Publication have a field to enter the name of the author.</message>
+            <message lang="de">Veröffentlichung verfügen über ein Feld, um den Namen des Autors
+              anzugeben.
+            </message>
+          </help>
+        </parameter>
+        <parameter>
+          <name>useReminder</name>
+          <label>
+            <message lang="fr">Rappel</message>
+            <message lang="en">Reminder</message>
+            <message lang="de">Reminder</message>
+          </label>
+          <order>53</order>
+          <mandatory>true</mandatory>
+          <value>no</value>
+          <type>checkbox</type>
+          <updatable>always</updatable>
+          <help>
+            <message lang="fr">Ajout d'une date et d'une note pour rappeler (via notification
+              automatique) aux contributeurs de mettre à jour leur publication.
+            </message>
+            <message lang="en">Adding a date and a note to remind (automatic notification)
+              contributors to update their publication.
+            </message>
+            <message lang="de">Addieren Sie ein Datum und eine Notiz zu erinnern (automatische
+              Benachrichtigung) Mitwirkende deren Veröffentlichung zu aktualisieren.
+            </message>
+          </help>
+        </parameter>
+        <parameter>
+          <name>tabContent</name>
+          <label>
+            <message lang="fr">Contenu</message>
+            <message lang="en">Content</message>
+            <message lang="de">Inhalt</message>
+          </label>
+          <order>7</order>
+          <mandatory>true</mandatory>
+          <value>yes</value>
+          <type>checkbox</type>
+          <updatable>always</updatable>
+          <help>
+            <message lang="fr">Pour pouvoir ajouter un contenu aux publications</message>
+            <message lang="en">Add some content to a publication</message>
+            <message lang="de">Um einen Inhalt in Veröffentlichungen hinzufügen zu können</message>
+          </help>
+        </parameter>
+        <parameter>
+          <name>tabSeeAlso</name>
+          <label>
+            <message lang="fr">Voir Aussi</message>
+            <message lang="en">See also</message>
+            <message lang="de">Siehe auch</message>
+          </label>
+          <order>9</order>
+          <mandatory>true</mandatory>
+          <value>yes</value>
+          <type>checkbox</type>
+          <updatable>always</updatable>
+          <help>
+            <message lang="fr">Pour indiquer d'autres publicatins en rapport avec la publication
+              courante.
+            </message>
+            <message lang="en">Indicates publications you might want to see after looking at the
+              current publication.
+            </message>
+            <message lang="de">Um anderen Veröffentlichungen, im Zusammenhang mit der aktuellen
+              Veröffentlichung anzugeben.
+            </message>
+          </help>
+        </parameter>
+        <parameter>
+          <name>tabAccessPaths</name>
+          <label>
+            <message lang="fr">Emplacements multiples</message>
+            <message lang="en">Multiple locations</message>
+            <message lang="de">Mehrere Standorte</message>
+          </label>
+          <order>10</order>
+          <mandatory>true</mandatory>
+          <value>yes</value>
+          <type>checkbox</type>
+          <updatable>always</updatable>
+          <help>
+            <message lang="fr">Pour mettre une même publication à plusieurs endroits dans
+              l'arborescence de cette GED ou d'autres.
+            </message>
+            <message lang="en">Indicates that publications can be in many places in the
+              application's hierarchy or in other applications.
+            </message>
+            <message lang="de">Um eine Veröffentlichungen an mehreren Orten in der Komponente
+              Hierarchie anzeigen oder in einer anderen Komponente verwenden
+            </message>
+          </help>
+          <personalSpaceValue>no</personalSpaceValue>
+        </parameter>
+        <parameter>
+          <name>tabReadersList</name>
+          <label>
+            <message lang="fr">Contrôles de lecture</message>
+            <message lang="en">Readers list</message>
+            <message lang="de">Leser-Liste</message>
+          </label>
+          <order>11</order>
+          <mandatory>true</mandatory>
+          <value>yes</value>
+          <type>checkbox</type>
+          <updatable>always</updatable>
+          <help>
+            <message lang="fr">Affiche la liste des personnes ayant lu une publication</message>
+            <message lang="en">Display the list of people having read a publication</message>
+            <message lang="de">Zeigt eine Liste der Personen an, Die eine Veröffentlichung gelesen
+              haben
+            </message>
+          </help>
+          <personalSpaceValue>no</personalSpaceValue>
+        </parameter>
+        <parameter>
+          <name>tabComments</name>
+          <label>
+            <message lang="fr">Commentaires</message>
+            <message lang="en">Comments</message>
+            <message lang="de">Kommentare</message>
+          </label>
+          <order>12</order>
+          <mandatory>true</mandatory>
+          <value>yes</value>
+          <type>checkbox</type>
+          <updatable>always</updatable>
+          <help>
+            <message lang="fr">Pour commenter une publication</message>
+            <message lang="en">To comment a publication</message>
+            <message lang="de">Um eine Veröffentlichung zu kommentieren</message>
+          </help>
+        </parameter>
+        <parameter>
+          <name>tabLastVisitors</name>
+          <label>
+            <message lang="fr">Derniers visiteurs</message>
+            <message lang="en">Last visitors</message>
+            <message lang="de">Letzte Besucher</message>
+          </label>
+          <order>52</order>
+          <mandatory>true</mandatory>
+          <value>yes</value>
+          <type>checkbox</type>
+          <updatable>always</updatable>
+          <help>
+            <message lang="fr">Affiche les 4 derniers utilisateurs ayant consulté la publication
+            </message>
+            <message lang="en">Shows the last 4 users who viewed the publication</message>
+            <message lang="de">Zeigt die letzten 4 Benutzer, die die Publikation angesehen</message>
+          </help>
+          <personalSpaceValue>no</personalSpaceValue>
+        </parameter>
+        <parameter>
+          <name>notifications</name>
+          <label>
+            <message lang="fr">Notifications</message>
+            <message lang="en">Notifications</message>
+            <message lang="de">Benachrichtigungen</message>
+          </label>
+          <order>34</order>
+          <mandatory>true</mandatory>
+          <value>yes</value>
+          <type>checkbox</type>
+          <updatable>always</updatable>
+          <help>
+            <message lang="fr">Permet d'activer l'opération "Notifier" sur les publications.
+            </message>
+            <message lang="en">Enable "Notify" operation on publications.</message>
+            <message lang="de">Vermeidet "Benachrichtigungen" auf Veröffentlichungen</message>
+          </help>
+          <personalSpaceValue>no</personalSpaceValue>
+        </parameter>
+        <parameter>
+          <name>publicationRating</name>
+          <label>
+            <message lang="fr">Notes</message>
+            <message lang="en">Ratings</message>
+            <message lang="de">Bewertungen</message>
+          </label>
+          <order>51</order>
+          <mandatory>false</mandatory>
+          <value/>
+          <type>checkbox</type>
+          <updatable>always</updatable>
+          <help>
+            <message lang="fr">Permet aux lecteurs de donner une note (de 1 à 5) à chaque
+              publication
+            </message>
+            <message lang="en">Allows readers to give a rating to each publication</message>
+            <message lang="de">Ermöglicht den Leser auf eine Note auf jede Veröffentlichung geben
+            </message>
+          </help>
+        </parameter>
+        <parameter>
+          <name>targetValidation</name>
+          <label>
+            <message lang="fr">Mode de validation</message>
+            <message lang="en">Validation mode</message>
+            <message lang="de">Veröffentlichungsbestätigung</message>
+          </label>
+          <order>21</order>
+          <mandatory>true</mandatory>
+          <value>0</value>
+          <options>
+            <option>
+              <name>
+                <message lang="fr">Classique</message>
+                <message lang="en">Classical</message>
+                <message lang="de">Klassisch</message>
+              </name>
+              <value>0</value>
+            </option>
+            <option>
+              <name>
+                <message lang="fr">Ciblée (un seul valideur)</message>
+                <message lang="en">Targeted (only one validator)</message>
+                <message lang="de">Gezielte (nur ein Prüfer)</message>
+              </name>
+              <value>1</value>
+            </option>
+            <option>
+              <name>
+                <message lang="fr">Ciblée (plusieurs valideurs)</message>
+                <message lang="en">Targeted (various validators)</message>
+                <message lang="de">Gezielte (verschiedene Prüfer)</message>
+              </name>
+              <value>2</value>
+            </option>
+            <option>
+              <name>
+                <message lang="fr">Collégiale</message>
+                <message lang="en">Collegiate</message>
+                <message lang="de">Kollegial</message>
+              </name>
+              <value>3</value>
+            </option>
+          </options>
+          <type>select</type>
+          <updatable>always</updatable>
+          <help>
+            <message lang="fr">Classique : un valideur doit valider la publication, Ciblée (un seul
+              valideur) : Le rédacteur choisit le valideur devant valider la publication. Ceci
+              permet
+              d'éviter le phénomène de spam auprès des publieurs, Ciblée (plusieurs valideurs) : Le
+              rédacteur choisit les valideurs, Collégiale : Tous les valideurs doivent valider la
+              publication.
+            </message>
+            <message lang="en">Classical : once validator must validate publication, Targeted (only
+              one
+              validator) : Writer choose one validator. This avoid spam behaviour., Targeted
+              (various
+              validators) : Writer choose many validators, Collegiate : All validators must validate
+              publication
+            </message>
+            <message lang="de">Klassisch: Ein Validator muss die Veröffentlichung Prüfen.
+              Gezielte (nur eine Prüfung): Der Redaktor wählt einen Validator aus. Dieses Verhalten
+              Vermeidet Spam.
+              Gezielte (verschiedene Prüfungen): Der Redaktor wählt mehrere Validator aus.
+              Kollegial: Alle Validatoren müssen die Veröffentlichung validieren
+            </message>
+          </help>
+        </parameter>
+        <parameter>
+          <name>publicationAlwaysVisible</name>
+          <label>
+            <message lang="fr">Publication toujours visible</message>
+            <message lang="en">Publication always visible</message>
+            <message lang="de">Veröffentlichung immer sichtbar</message>
+          </label>
+          <order>25</order>
+          <mandatory>true</mandatory>
+          <value>no</value>
+          <type>checkbox</type>
+          <updatable>always</updatable>
+          <help>
+            <message lang="fr">La dernière version validée d'une publication est toujours visible
+              même lorsqu'elle est en attente de validation. Si activé, le paramètre "Suivi de
+              versions" est ignoré et est considéré comme désactivé.
+            </message>
+            <message lang="en">The latest valid version of a publication is always visible even if
+              it is waiting approval. If enabled, "Version tracking" parameter is ignored and is
+              considered deactivated.
+            </message>
+            <message lang="de">Die letztgültigen Fassung einer Veröffentlichung ist immer sichtbar,
+              auch wenn es auf einer Genehmigung wartet. Wenn aktiviert, die Parameter "Versionierte
+              Anhänge" wird ignoriert, und gilt als deaktiviert.
+            </message>
+          </help>
+        </parameter>
+        <parameter>
+          <name>coWriting</name>
+          <label>
+            <message lang="fr">Co-rédaction</message>
+            <message lang="en">Co-writing</message>
+            <message lang="de">Co-Schreibung</message>
+          </label>
+          <order>24</order>
+          <mandatory>true</mandatory>
+          <value>no</value>
+          <type>checkbox</type>
+          <updatable>always</updatable>
+          <help>
+            <message lang="fr">Cette fonction permet à un rédacteur de pouvoir modifier n'importe
+              quelle
+              publication.
+            </message>
+            <message lang="en">This function makes it possible to a writer to modify any
+              publications.
+            </message>
+            <message lang="de">Diese Funktion macht es einem Redaktor möglich, jede Veröffentlichung
+              zu ändern.
+            </message>
+          </help>
+        </parameter>
+        <parameter>
+          <name>suppressionOnlyForAdmin</name>
+          <label>
+            <message lang="fr">Suppression restreinte</message>
+            <message lang="en">Restricted suppression</message>
+            <message lang="de">Eingeschränkte Löschung</message>
+          </label>
+          <order>31</order>
+          <mandatory>true</mandatory>
+          <value>no</value>
+          <type>checkbox</type>
+          <updatable>always</updatable>
+          <help>
+            <message lang="fr">Seuls les gestionnaires de l'application peuvent supprimer une
+              publication et accéder à la corbeille de publications
+            </message>
+            <message lang="en">Only managers of this application are be able to remove publications
+              and to access to publications bin
+            </message>
+            <message lang="de">Nur Manager dieser Komponente können Veröffentlichungen entfernen und
+              am Papierkorb der Publikationen zugreifen
+            </message>
+          </help>
+        </parameter>
+        <parameter>
+          <name>XmlFormForPublis</name>
+          <label>
+            <message lang="fr">Formulaire complémentaire</message>
+            <message lang="en">Additional metadata</message>
+            <message lang="de">XML-Formular für Metadaten</message>
+          </label>
+          <order>32</order>
+          <mandatory>false</mandatory>
+          <value></value>
+          <type>xmltemplates</type>
+          <updatable>always</updatable>
+          <help>
+            <message lang="fr">Ce paramètre permet d'activer la saisie d'informations
+              complémentaires pour chaque publication. Ces informations sont saisies au travers d'un
+              formulaire personnalisé.
+            </message>
+            <message lang="en">This feature allows to enter additional informations on each
+              publication. Customized template is used to enter this data.
+            </message>
+            <message lang="de">Diese Funktion ermöglicht es, zusätzliche Informationen über jede
+              Datei einzugeben. Eine XML-Vorlage wird verwendet, um diese Daten einzugeben.
+            </message>
+          </help>
+        </parameter>
+      </parameters>
+    </groupOfParameters>
+    <groupOfParameters name="files">
+      <label>
+        <message lang="fr">Fichiers</message>
+        <message lang="en">Files</message>
+        <message lang="de">Files</message>
+      </label>
+      <description>
+        <message lang="fr">Paramétrez ici le comportement des fichiers joints aux publications
+        </message>
+        <message lang="en">Set up the behavior of files attached to publications</message>
+        <message lang="de">Stellt das Verhalten von Dateien an Publikationen befestigt</message>
+      </description>
+      <order>3</order>
+      <parameters>
+        <parameter>
+          <name>tabAttachments</name>
+          <label>
+            <message lang="fr">Fichiers joints</message>
+            <message lang="en">Attachments</message>
+            <message lang="de">Anhänge</message>
+          </label>
+          <order>8</order>
+          <mandatory>true</mandatory>
+          <value>yes</value>
+          <type>checkbox</type>
+          <updatable>always</updatable>
+          <help>
+            <message lang="fr">Permet de joindre des fichiers à une publication</message>
+            <message lang="en">Permit to add files to a publication</message>
+            <message lang="de">Um Dateien in einer Veröffentlichung beilegen zu können</message>
+          </help>
+        </parameter>
+        <parameter>
+          <name>attachmentsInPubList</name>
+          <label>
+            <message lang="fr">Listing</message>
+            <message lang="en">Listing</message>
+            <message lang="de">Listen</message>
+          </label>
+          <order>38</order>
+          <mandatory>true</mandatory>
+          <value>no</value>
+          <type>checkbox</type>
+          <updatable>always</updatable>
+          <help>
+            <message lang="fr">Ce paramètre permet d'afficher directement dans la liste des
+              publications les fichiers joints à chaque publication.
+            </message>
+            <message lang="en">This feature allows to display the attached files to each
+              publications directly in the publications list.
+            </message>
+            <message lang="de">Diese Funktion erlaubt es, die angehängten Dateien zu jeder
+              Veröffentlichung direkt in der Publikation anzuzeigen.
+            </message>
+          </help>
+          <personalSpaceValue>yes</personalSpaceValue>
+        </parameter>
+        <parameter>
+          <name>openSingleAttachment</name>
+          <label>
+            <message lang="fr">Ouverture directe</message>
+            <message lang="en">Direct opening</message>
+            <message lang="de">Anhänge direkt öffnen</message>
+          </label>
+          <order>19</order>
+          <mandatory>true</mandatory>
+          <value>no</value>
+          <type>checkbox</type>
+          <updatable>always</updatable>
+          <help>
+            <message lang="fr">Si une publication contient un seul fichier joint alors l'ouverture
+              de la publication déclenche automatiquement l'ouverture du fichier joint.
+            </message>
+            <message lang="en">Opening a publication with only once attachment will open this
+              attachment automatically.
+            </message>
+            <message lang="de">Öffnen einer Veröffentlichung mit nur einem Anhang wird diesen Anhang
+              automatisch öffnen.
+            </message>
+          </help>
+        </parameter>
+        <parameter>
+          <name>authorizedFileExtension</name>
+          <label>
+            <message lang="fr">Extension(s) autorisée(s)</message>
+            <message lang="en">Extension(s) authorized</message>
+            <message lang="de">Extension(s) authorized</message>
+          </label>
+          <order>49</order>
+          <mandatory>false</mandatory>
+          <value/>
+          <type>text</type>
+          <size>25</size>
+          <updatable>always</updatable>
+          <help>
+            <message lang="fr">Liste d'extensions de fichiers séparées par des virgules, le
+              paramètre
+              "Fichiers interdits" est ignoré si une valeur est saisie
+            </message>
+            <message lang="en">List of file extensions separated by comma, "Forbidden files"
+              parameter
+              is ignored if a value is filled
+            </message>
+            <message lang="de">List of file extensions separated by comma, "Forbidden files"
+              parameter
+              is ignored if a value is filled
+            </message>
+          </help>
+        </parameter>
+        <parameter>
+          <name>forbiddenFileExtension</name>
+          <label>
+            <message lang="fr">Extension(s) interdite(s)</message>
+            <message lang="en">Extension(s) forbidden</message>
+            <message lang="de">Extension(s) forbidden</message>
+          </label>
+          <order>50</order>
+          <mandatory>false</mandatory>
+          <value/>
+          <type>text</type>
+          <size>25</size>
+          <updatable>always</updatable>
+          <help>
+            <message lang="fr">Liste d'extensions de fichiers séparées par des virgules, ignoré si
+              une
+              valeur existe pour le paramètre "Fichiers autorisés"
+            </message>
+            <message lang="en">List of file extensions separated by comma, ignored if a value is
+              entered
+              into "Authorized files" parameter
+            </message>
+            <message lang="de">List of file extensions separated by comma, ignored if a value is
+              entered
+              into "Authorized files" parameter
+            </message>
+          </help>
+        </parameter>
+        <parameter>
+          <name>massiveDragAndDrop</name>
+          <label>
+            <message lang="fr">Glisser / Déposer</message>
+            <message lang="en">Drag And Drop</message>
+            <message lang="de">Drag And Drop</message>
+          </label>
+          <order>23</order>
+          <mandatory>true</mandatory>
+          <value>yes</value>
+          <type>checkbox</type>
+          <updatable>always</updatable>
+          <help>
+            <message lang="fr">Cette fonction permet de créer des dossiers et des publications par
+              glisser/déposer dans une zone de l'écran.
+            </message>
+            <message lang="en">This function allow to the manager to create folders and publications
+              using drag and drop.
+            </message>
+            <message lang="de">Diese Funktion ermöglicht es dem Manager Themen und Publikationen mit
+              Hilfe von Drag and Drop zu erstellen.
+            </message>
+          </help>
+        </parameter>
+        <parameter>
+          <name>importFiles</name>
+          <label>
+            <message lang="fr">Importation</message>
+            <message lang="en">Import</message>
+            <message lang="de">Importieren</message>
+          </label>
+          <order>20</order>
+          <mandatory>true</mandatory>
+          <value>0</value>
+          <options>
+            <option>
+              <name>
+                <message lang="fr">Non</message>
+                <message lang="en">No</message>
+                <message lang="de">Nein</message>
+              </name>
+              <value>0</value>
+            </option>
+            <option>
+              <name>
+                <message lang="fr">Import unitaire</message>
+                <message lang="en">Unit import</message>
+                <message lang="de">Einzelimport</message>
+              </name>
+              <value>1</value>
+            </option>
+            <option>
+              <name>
+                <message lang="fr">Import massif</message>
+                <message lang="en">Massive import</message>
+                <message lang="de">Massiven Import</message>
+              </name>
+              <value>2</value>
+            </option>
+            <option>
+              <name>
+                <message lang="fr">Tous</message>
+                <message lang="en">All</message>
+                <message lang="de">Alle</message>
+              </name>
+              <value>3</value>
+            </option>
+          </options>
+          <type>select</type>
+          <updatable>always</updatable>
+          <help>
+            <message lang="fr">Valeurs possibles: Non, Import unitaire, Import massif, Import
+              unitaire et massif.
+            </message>
+            <message lang="en">Available values : No, Unit import, Massive import, Unit and massive
+              import.
+            </message>
+            <message lang="de">Verfügbare Werte: Nein, Einzelimport, Massiven Import, Einzel und
+              massiven Import
+            </message>
+          </help>
+        </parameter>
+        <parameter>
+          <name>nbDayForReservation</name>
+          <label>
+            <message lang="fr">Gestion des retards</message>
+            <message lang="en">Backlog management</message>
+            <message lang="de">Verwaltung der Verspätungen</message>
+          </label>
+          <order>29</order>
+          <mandatory>false</mandatory>
+          <value></value>
+          <type>text</type>
+          <size>5</size>
+          <updatable>always</updatable>
+          <help>
+            <message lang="fr">Cette option permet de choisir un délai de réservation des fichiers
+              et d'en gérer les retards.
+              Ce délai est exprimé en jours et ne tient pas compte des samedis et dimanches.
+            </message>
+            <message lang="en">This option defines a maximum duration for booking a file and
+              managing the backlog.
+              This duration is expressed in days, and week-ends are not taken into account.
+            </message>
+            <message lang="de">Diese Option erlaubt, ein Buchungsfristen der verbundenen Dateien zu
+              wählen und die Verspätungen zu verwalten.
+              Die Frist ist in den Tagen ausgedrückt und berücksichtige keine Samstage und Sonntage.
+            </message>
+          </help>
+        </parameter>
+        <parameter>
+          <name>XmlFormForFiles</name>
+          <label>
+            <message lang="fr">Formulaire complémentaire</message>
+            <message lang="en">Additional metadata</message>
+            <message lang="de">XML-Formular für Metadaten auf Anhänge</message>
+          </label>
+          <order>33</order>
+          <mandatory>false</mandatory>
+          <value></value>
+          <type>xmltemplates</type>
+          <updatable>always</updatable>
+          <help>
+            <message lang="fr">Ce paramètre permet d'activer la saisie d'informations
+              complémentaires pour chaque fichier joint. Ces informations sont saisies au travers
+              d'un formulaire XML.
+            </message>
+            <message lang="en">This feature allows to enter additional informations on each file.
+              XML template is used to enter this data.
+            </message>
+            <message lang="de">Diese Funktion ermöglicht es, zusätzliche Informationen über jede
+              Datei einzugeben. Eine XML-Vorlage wird verwendet, um diese Daten einzugeben.
+            </message>
+          </help>
+        </parameter>
+        <parameter>
+          <name>versionControl</name>
+          <label>
+            <message lang="fr">Suivi de versions</message>
+            <message lang="en">Version tracking</message>
+            <message lang="de">Versionierte Anhänge</message>
+          </label>
+          <order>13</order>
+          <mandatory>true</mandatory>
+          <value>no</value>
+          <type>checkbox</type>
+          <updatable>always</updatable>
+          <help>
+            <message lang="fr">Permet de garder l'historique des différentes versions des documents.
+              Ce paramètre est ignoré et considéré comme désactivé si celui "Publication toujours
+              visible" est activé.
+            </message>
+            <message lang="en">Documents are versioned. This parameter is ignored and considered
+              disabled if "Publication always visible" is enabled.
+            </message>
+            <message lang="de">Anhänge werden versioniert. Dieser Parameter wird ignoriert und
+              deaktiviert, wenn "Veröffentlichung immer Sichtbar" aktiviert ist.
+            </message>
+          </help>
+          <warning always="true">
+            <message lang="fr">Le fait d'activer le suivi de versions entraîne la création d'une
+              version publique (v1.0) pour chaque fichier contenu dans l'application.&lt;/br&gt;A
+              l'inverse, si le suivi de versions est désactivé alors chaque fichier joint
+              versionné ne le sera plus. Dans ce cas, la dernière version publique sera préservée.
+              Toutes les autres versions (publiques ou de travail) seront définitivement
+              supprimées.&lt;p&gt;Que ce paramètre soit coché ou non, il est également possible
+              d'activer/désactiver le suivi de versions au niveau de chaque fichier dans
+              l'application.&lt;/p&gt;&lt;p&gt;Attention, le temps de traitement est en rapport
+              avec la volumétrie (fichiers) de l'application.&lt;/p&gt;
+            </message>
+            <message lang="en">Enabling version tracking will create a public version (v1.0) for
+              each file in the application.&lt;/br&gt;Conversely, if version tracking is disabled
+              then each versioned attachment will no longer be versioned. In this case, the latest
+              public version will be preserved. All other versions (public or working) will be
+              permanently deleted.&lt;p&gt;Whether this setting is checked or not, it is also
+              possible to enable/disable version tracking at the level of each file in the
+              application.&lt;/p&gt;&lt;p&gt;Please note that the processing time is related to
+              the volume (files) of the application.&lt;/p&gt;
+            </message>
+            <message lang="de">Wenn Sie die Versionsverfolgung aktivieren, wird für jede Datei in
+              der Anwendung eine öffentliche Version (v1.0) erstellt.&lt;/br&gt;Ist die
+              Versionsverfolgung hingegen deaktiviert, wird jeder versionierte Anhang nicht mehr
+              versioniert. In diesem Fall wird die letzte öffentliche Version beibehalten. Alle
+              anderen Versionen (öffentlich oder in Arbeit) werden dauerhaft gelöscht.&lt;p&gt;Unabhängig
+              davon, ob diese Einstellung aktiviert ist oder nicht, ist es auch möglich, die
+              Versionskontrolle auf der Ebene der einzelnen Dateien in der Anwendung zu
+              aktivieren/deaktivieren.&lt;/p&gt;&lt;p&gt;Bitte beachten Sie, dass die
+              Bearbeitungszeit vom Umfang (Dateien) des Antrags abhängt.&lt;/p&gt;
+            </message>
+          </warning>
+        </parameter>
+        <parameter>
+          <name>hideAllVersionsLink</name>
+          <label>
+            <message lang="fr">Dernière version publique</message>
+            <message lang="en">Last public version</message>
+            <message lang="de">Letzte öffentliche Version</message>
+          </label>
+          <order>45</order>
+          <mandatory>false</mandatory>
+          <value>no</value>
+          <type>checkbox</type>
+          <updatable>always</updatable>
+          <help>
+            <message lang="fr">Ce paramètre permet de limiter l'accès à la dernière version publique
+              d'un document.
+            </message>
+            <message lang="en">This feature allows readers to see only the last public version of a
+              document.
+            </message>
+            <message lang="de">Diese Funktion erlaubt es dem Leser nur die letzte öffentliche
+              Version eines Dokuments zu sehen.
+            </message>
+          </help>
+        </parameter>
+        <parameter>
+          <name>publicFiles</name>
+          <label>
+            <message lang="fr">Banque de fichiers</message>
+            <message lang="en">Re-usable files</message>
+            <message lang="de">Wiederverwendbare Dateien</message>
+          </label>
+          <order>39</order>
+          <mandatory>false</mandatory>
+          <value>no</value>
+          <type>checkbox</type>
+          <updatable>always</updatable>
+          <help>
+            <message lang="fr">
+              Ce paramètre permet de définir cette application comme une banque de fichiers.
+              Les pièces jointes d'une banque peuvent être insérées dans le corps d'une publication
+              grâce à l'éditeur Wysiwyg.
+            </message>
+            <message lang="en">
+              This feature allows indicating this application as a file storage. The
+              attachment of a file storage can be inserted into the body of a publication with the
+              help
+              of Wysiwyg editor.
+            </message>
+            <message lang="de">Diese Funktion ermöglicht es diese Komponente als eine Bank von
+              Dateien zu bestimmen. Das hizufügen einer Datei im Körper einer Veröffentlichung wird
+              mit der Hilfe vom Wysiwyg-Editor erfolgen.
+            </message>
+          </help>
+          <warning>
+            <message lang="fr">
+              En cochant cette case, les fichiers joints aux publications de cette application
+              seront librement utilisables (sans tenir compte des droits) par les autres
+              applications.
+            </message>
+            <message lang="en">
+              By checking this box, attached files to publications of this application will be
+              available for use (regardless of rights) by other applications.
+            </message>
+            <message lang="de">
+              By checking this box, attached files to publications of this application will be
+              available for use (regardless of rights) by other applications.
+            </message>
+          </warning>
+        </parameter>
+      </parameters>
+    </groupOfParameters>
+    <groupOfParameters name="folders">
+      <label>
+        <message lang="fr">Dossiers</message>
+        <message lang="en">Folders</message>
+        <message lang="de">Folders</message>
+      </label>
+      <description>
+        <message lang="fr">Ils vous permettent d'organiser facilement votre GED</message>
+        <message lang="en">It allows you to easily organize your ECM</message>
+        <message lang="de">Sie ermöglichen es, einfach organisieren Sie Ihre ECM</message>
+      </description>
+      <order>1</order>
+      <parameters>
+        <parameter>
+          <name>isTree</name>
+          <label>
+            <message lang="fr">Arborescence</message>
+            <message lang="en">Treeview</message>
+            <message lang="de">Baumansicht</message>
+          </label>
+          <order>5</order>
+          <mandatory>true</mandatory>
+          <value>0</value>
+          <options>
+            <option>
+              <name>
+                <message lang="fr">Oui avec explorateur de dossiers</message>
+                <message lang="en">Yes with explorer</message>
+                <message lang="de">Ja mit Explorer</message>
+              </name>
+              <value>0</value>
+            </option>
+            <option>
+              <name>
+                <message lang="fr">Oui sans explorateur de dossiers</message>
+                <message lang="en">Yes without explorer</message>
+                <message lang="de">Ja ohne Explorer</message>
+              </name>
+              <value>1</value>
+            </option>
+            <option>
+              <name>
+                <message lang="fr">Non</message>
+                <message lang="en">No</message>
+                <message lang="de">Nein</message>
+              </name>
+              <value>2</value>
+            </option>
+          </options>
+          <type>select</type>
+          <updatable>always</updatable>
+          <help>
+            <message lang="fr">Active l'organisation arborescente de dossiers.</message>
+            <message lang="en">Activates the tree organization of folders.</message>
+            <message lang="de">Aktiviert die Baum Organisation von Themen.</message>
+          </help>
+        </parameter>
+        <parameter>
+          <name>delegatedTopicManagement</name>
+          <label>
+            <message lang="fr">Gestion déléguée</message>
+            <message lang="en">Delegated management</message>
+            <message lang="de">Theme-Verwaltung Delegierung</message>
+          </label>
+          <order>17</order>
+          <mandatory>true</mandatory>
+          <value>no</value>
+          <type>checkbox</type>
+          <updatable>never</updatable>
+          <help>
+            <message lang="fr">La gestion des dossiers est déléguée aux publieurs et rédacteurs.
+            </message>
+            <message lang="en">Publishers and writers can manage the folders.</message>
+            <message lang="de">Veröffentlicher und Herausgeber können die Themen verwalten.
+            </message>
+          </help>
+        </parameter>
+        <parameter>
+          <name>rightsOnTopics</name>
+          <label>
+            <message lang="fr">Droits spécifiques</message>
+            <message lang="en">Specific rights</message>
+            <message lang="de">Rechte auf die Themen</message>
+          </label>
+          <order>28</order>
+          <mandatory>true</mandatory>
+          <value>no</value>
+          <type>checkbox</type>
+          <updatable>always</updatable>
+          <help>
+            <message lang="fr">Permet de définir des droits d'accès au niveau des dossiers.
+            </message>
+            <message lang="en">Allow to define rights on folders.</message>
+            <message lang="de">Erlaubt es, Zugangsrechte auf die Themen zu bestimmen.</message>
+          </help>
+        </parameter>
+        <parameter>
+          <name>wysiwygOnTopics</name>
+          <label>
+            <message lang="fr">Description riche</message>
+            <message lang="en">Rich description</message>
+            <message lang="de">Reiche Beschreibung</message>
+          </label>
+          <order>36</order>
+          <mandatory>true</mandatory>
+          <value>no</value>
+          <type>checkbox</type>
+          <updatable>always</updatable>
+          <help>
+            <message lang="fr">Ce paramètre permet de saisir une description Wysiwyg sur un dossier
+              qui sera affichée dans le dossier.
+            </message>
+            <message lang="en">This feature allows to make a rich description of a folder.</message>
+            <message lang="de">Diese Funktion ermöglicht es, einen reichen Beschreibung eines Themas
+              zu machen.
+            </message>
+          </help>
+        </parameter>
+        <parameter>
+          <name>displayNB</name>
+          <label>
+            <message lang="fr">Nombre de publications</message>
+            <message lang="en">Number of publications</message>
+            <message lang="de">Anzahl der Veröffentlichungen zeigen</message>
+          </label>
+          <order>27</order>
+          <mandatory>true</mandatory>
+          <value>yes</value>
+          <type>checkbox</type>
+          <updatable>always</updatable>
+          <help>
+            <message lang="fr">Affiche le nombre de publications par dossier</message>
+            <message lang="en">Display the number of publications per folder</message>
+            <message lang="de">Anzahl der Veröffentlichungen per Thema zeigen</message>
+          </help>
+        </parameter>
+      </parameters>
+    </groupOfParameters>
+    <groupOfParameters name="sharing">
+      <label>
+        <message lang="fr">Partages</message>
+        <message lang="en">Sharing</message>
+        <message lang="de">Sharing</message>
+      </label>
+      <description>
+        <message lang="fr">Partagez en toute sécurité des contenus avec des tiers non utilisateurs
+          de cette plate-forme
+        </message>
+        <message lang="en">Share content safely with third non-users of this platform</message>
+        <message lang="de">Sichere gemeinsame Inhalte mit Dritt Nicht-Nutzer dieser Plattform
+        </message>
+      </description>
+      <order>4</order>
+      <parameters>
+        <parameter>
+          <name>useFolderSharing</name>
+          <label>
+            <message lang="fr">Dossiers</message>
+            <message lang="en">Folders</message>
+            <message lang="de">Folders</message>
+          </label>
+          <order>48</order>
+          <mandatory>true</mandatory>
+          <value>0</value>
+          <options>
+            <option>
+              <name>
+                <message lang="fr">Désactivé</message>
+                <message lang="en">Deactivated</message>
+                <message lang="de">Untauglich</message>
+              </name>
+              <value>0</value>
+            </option>
+            <option>
+              <name>
+                <message lang="fr">Pour les gestionnaires</message>
+                <message lang="en">For managers</message>
+                <message lang="de">Für Manager</message>
+              </name>
+              <value>1</value>
+            </option>
+            <option>
+              <name>
+                <message lang="fr">Pour les contributeurs</message>
+                <message lang="en">For contributors</message>
+                <message lang="de">Für Beiträger</message>
+              </name>
+              <value>2</value>
+            </option>
+            <option>
+              <name>
+                <message lang="fr">Pour tous les utilisateurs</message>
+                <message lang="en">For all users</message>
+                <message lang="de">für alle Benutzer</message>
+              </name>
+              <value>3</value>
+            </option>
+          </options>
+          <type>select</type>
+          <updatable>always</updatable>
+          <help>
+            <message lang="fr">Ce paramètre permet de partager des dossiers avec des tiers non
+              utilisateurs de la plate-forme.
+            </message>
+            <message lang="en">This feature allows to share folders with some persons who have no
+              access to the platform.
+            </message>
+            <message lang="de">This feature allows to share folders with some persons who have no
+              access to the platform.
+            </message>
+          </help>
+          <warning>
+            <message lang="fr">Attention! En sélectionnant cette option, vous allez permettre de
+              partager librement les dossiers avec des utilisateurs non référencés dans la
+              plate-forme.
+            </message>
+            <message lang="en">Caution! By selecting this option, you will enable to freely share
+              folders with users not identified in the platform.
+            </message>
+            <message lang="de">Caution! By selecting this option, you will enable to freely share
+              folders with users not identified in the platform.
+            </message>
+          </warning>
+          <personalSpaceValue>no</personalSpaceValue>
+        </parameter>
+        <parameter>
+          <name>usePublicationSharing</name>
+          <label>
+            <message lang="fr">Publications</message>
+            <message lang="en">Publications</message>
+            <message lang="de">Publications</message>
+          </label>
+          <order>48</order>
+          <mandatory>true</mandatory>
+          <value>0</value>
+          <options>
+            <option>
+              <name>
+                <message lang="fr">Désactivé</message>
+                <message lang="en">Deactivated</message>
+                <message lang="de">Untauglich</message>
+              </name>
+              <value>0</value>
+            </option>
+            <option>
+              <name>
+                <message lang="fr">Pour les gestionnaires</message>
+                <message lang="en">For managers</message>
+                <message lang="de">Für Manager</message>
+              </name>
+              <value>1</value>
+            </option>
+            <option>
+              <name>
+                <message lang="fr">Pour les contributeurs</message>
+                <message lang="en">For contributors</message>
+                <message lang="de">Für Beiträger</message>
+              </name>
+              <value>2</value>
+            </option>
+            <option>
+              <name>
+                <message lang="fr">Pour tous les utilisateurs</message>
+                <message lang="en">For all users</message>
+                <message lang="de">für alle Benutzer</message>
+              </name>
+              <value>3</value>
+            </option>
+          </options>
+          <type>select</type>
+          <updatable>always</updatable>
+          <help>
+            <message lang="fr">Ce paramètre permet de partager des publications avec des tiers non
+              utilisateurs de la plate-forme.
+            </message>
+            <message lang="en">This feature allows to share publications with some persons who have
+              no access to the platform.
+            </message>
+            <message lang="de">This feature allows to share publications with some persons who have
+              no access to the platform.
+            </message>
+          </help>
+          <warning>
+            <message lang="fr">Attention! En sélectionnant cette option, vous allez permettre de
+              partager librement les publications avec des utilisateurs non référencés dans la
+              plate-forme.
+            </message>
+            <message lang="en">Caution! By selecting this option, you will enable to freely share
+              publications with users not identified in the platform.
+            </message>
+            <message lang="de">Caution! By selecting this option, you will enable to freely share
+              publications with users not identified in the platform.
+            </message>
+          </warning>
+          <personalSpaceValue>no</personalSpaceValue>
+        </parameter>
+        <parameter>
+          <name>useFileSharing</name>
+          <label>
+            <message lang="fr">Fichiers</message>
+            <message lang="en">Files</message>
+            <message lang="de">Anhänge freigeben</message>
+          </label>
+          <order>37</order>
+          <mandatory>true</mandatory>
+          <value>0</value>
+          <options>
+            <option>
+              <name>
+                <message lang="fr">Désactivé</message>
+                <message lang="en">Deactivated</message>
+                <message lang="de">Untauglich</message>
+              </name>
+              <value>0</value>
+            </option>
+            <option>
+              <name>
+                <message lang="fr">Pour les gestionnaires</message>
+                <message lang="en">For managers</message>
+                <message lang="de">Für Manager</message>
+              </name>
+              <value>1</value>
+            </option>
+            <option>
+              <name>
+                <message lang="fr">Pour les contributeurs</message>
+                <message lang="en">For contributors</message>
+                <message lang="de">Für Beiträger</message>
+              </name>
+              <value>2</value>
+            </option>
+            <option>
+              <name>
+                <message lang="fr">Pour tous les utilisateurs</message>
+                <message lang="en">For all users</message>
+                <message lang="de">für alle Benutzer</message>
+              </name>
+              <value>3</value>
+            </option>
+          </options>
+          <type>select</type>
+          <updatable>always</updatable>
+          <help>
+            <message lang="fr">Ce paramètre permet de partager des fichiers avec des tiers non
+              utilisateurs de la plate-forme.
+            </message>
+            <message lang="en">This feature allows to share files with some persons who have no
+              access to the platform.
+            </message>
+            <message lang="de">Mit dieser Funktion können Sie die Dateifreigabe mit Personen, die
+              keinen Zugang zu dem Portal haben, aktivieren.
+            </message>
+          </help>
+          <warning>
+            <message lang="fr">Attention! En sélectionnant cette option, vous allez permettre de
+              partager librement les fichiers avec des utilisateurs non référencés dans la
+              plate-forme.
+            </message>
+            <message lang="en">Caution! By selecting this option, you will enable to freely share
+              files with users not identified in the platform.
+            </message>
+            <message lang="de">Caution! By selecting this option, you will enable to freely share
+              files with users not identified in the platform.
+            </message>
+          </warning>
+          <personalSpaceValue>0</personalSpaceValue>
+        </parameter>
+      </parameters>
+    </groupOfParameters>
+    <groupOfParameters name="taxonomy">
+      <label>
+        <message lang="fr">Plan de classement</message>
+        <message lang="en">Taxonomy</message>
+        <message lang="de">Taxonomy</message>
+      </label>
+      <description>
+        <message lang="fr">Classez les publications sur le plan de classement transverse à la
+          plate-forme
+        </message>
+        <message lang="en">Classify publications on the transverse classification scheme to the
+          platform
+        </message>
+        <message lang="de">Ordnen Sie die Veröffentlichungen über die Querklassifikationsschema zur
+          Plattform
+        </message>
+      </description>
+      <order>5</order>
+      <parameters>
+        <parameter>
+          <name>usePdc</name>
+          <label>
+            <message lang="fr">Classification PDC</message>
+            <message lang="en">Classification Scheme</message>
+            <message lang="de">Klassierungsplan</message>
+          </label>
+          <order>6</order>
+          <mandatory>true</mandatory>
+          <value>no</value>
+          <type>checkbox</type>
+          <updatable>always</updatable>
+          <help>
+            <message lang="fr">Les publications créées au sein de cette instance pourront être
+              classées sur le Plan de Classement
+            </message>
+            <message lang="en">Publications would be classified on PDC</message>
+            <message lang="de">Veröffentlichungen würden auf dem KP klassifiziert werden</message>
+          </help>
+        </parameter>
+        <parameter>
+          <name>axisIdGlossary</name>
+          <label>
+            <message lang="fr">Lexique</message>
+            <message lang="en">Glossary</message>
+            <message lang="de">Glossar</message>
+          </label>
+          <order>40</order>
+          <mandatory>false</mandatory>
+          <value></value>
+          <type>text</type>
+          <size>5</size>
+          <updatable>always</updatable>
+          <help>
+            <message lang="fr">
+              Ce paramètre permet de définir l'identifiant de l'axe du PDC qui sera utilisé comme
+              lexique dans l'application courante.
+            </message>
+            <message lang="en">
+              This feature allows to indicate the identifier of classification scheme axis's used as
+              glossary for the current application.
+            </message>
+            <message lang="de">Diese Funktion ermöglicht es die Identifikazion der KP-Achsen
+              festzulegen, die als Glossar dür diese Kompnonte benützt werden.
+            </message>
+          </help>
+        </parameter>
+      </parameters>
+    </groupOfParameters>
+    <groupOfParameters name="thumbnail">
+      <label>
+        <message lang="fr">Vignette de publication</message>
+        <message lang="en">Thumbnail of publication</message>
+        <message lang="de">Thumbnail of publication</message>
+      </label>
+      <description>
+        <message lang="fr">Agrémentez la liste des publications avec une vignette</message>
+        <message lang="en">Enhance the publications list with thumbnail</message>
+        <message lang="de">Steigern Sie die Publikationsliste mit Miniatur</message>
+      </description>
+      <order>7</order>
+      <parameters>
+        <parameter>
+          <name>thumbnailMandatory</name>
+          <label>
+            <message lang="fr">Vignette obligatoire</message>
+            <message lang="en">Mandatory thumbnail</message>
+            <message lang="de">Obligatorisches Vorschaubild</message>
+          </label>
+          <order>42</order>
+          <mandatory>true</mandatory>
+          <value>no</value>
+          <type>checkbox</type>
+          <updatable>always</updatable>
+          <help>
+            <message lang="fr">Permet de rendre obligatoire l'ajout d'une vignette à chaque
+              publication.
+            </message>
+            <message lang="en">Lets make it mandatory to add a thumbnail to each publication.
+            </message>
+            <message lang="de">macht es zwingend erforderlich,eine Miniaturansicht für jede
+              Publikation hinzu zu fügen.
+            </message>
+          </help>
+        </parameter>
+        <parameter>
+          <name>thumbnailWidthSize</name>
+          <label>
+            <message lang="fr">Largeur de la vignette</message>
+            <message lang="en">Thumbnail's width</message>
+            <message lang="de">Breite des Vorschaubilds</message>
+          </label>
+          <order>43</order>
+          <mandatory>false</mandatory>
+          <value></value>
+          <type>text</type>
+          <size>5</size>
+          <updatable>always</updatable>
+          <help>
+            <message lang="fr">Ce paramètre permet de définir la largeur de la vignette à
+              afficher.
+            </message>
+            <message lang="en">This feature allows to define width of the displayed thumbnail.
+            </message>
+            <message lang="de">Diese Funktion erlaubt es, die Breite der angezeigten Miniaturansicht
+              zu definieren
+            </message>
+          </help>
+        </parameter>
+        <parameter>
+          <name>thumbnailHeightSize</name>
+          <label>
+            <message lang="fr">Hauteur de la vignette</message>
+            <message lang="en">Thumbnail's height</message>
+            <message lang="de">Höhe des Vorschaubilds</message>
+          </label>
+          <order>44</order>
+          <mandatory>false</mandatory>
+          <value></value>
+          <type>text</type>
+          <size>5</size>
+          <updatable>always</updatable>
+          <help>
+            <message lang="fr">Ce paramètre permet de définir la hauteur de la vignette à
+              afficher.
+            </message>
+            <message lang="en">This feature allows to define height of the displayed thumbnail.
+            </message>
+            <message lang="de">Diese Funktion erlaubt es, die Höhe der angezeigten Miniaturansicht
+              zu definieren
+            </message>
+          </help>
+        </parameter>
+      </parameters>
+    </groupOfParameters>
+    <groupOfParameters name="search">
+      <label>
+        <message lang="fr">Recherche</message>
+        <message lang="en">Search</message>
+        <message lang="de">Search</message>
+      </label>
+      <description>
+        <message lang="fr">Activez la recherche locale et/ou exclure cette GED de la recherche
+          générale
+        </message>
+        <message lang="en">Enable local search and/or exclude this ECM from general search</message>
+        <message lang="de">Aktivieren der lokalen Forschung und / oder löschen Sie die allgemeine
+          Suche
+        </message>
+      </description>
+      <order>6</order>
+      <parameters>
+        <parameter>
+          <name>searchOnTopics</name>
+          <label>
+            <message lang="fr">Recherche locale</message>
+            <message lang="en">Local search</message>
+            <message lang="de">Lokale Suche</message>
+          </label>
+          <order>41</order>
+          <mandatory>true</mandatory>
+          <value>no</value>
+          <type>checkbox</type>
+          <updatable>always</updatable>
+          <help>
+            <message lang="fr">Ce paramètre permet d'afficher une zone de recherche pour chaque
+              dossier.
+            </message>
+            <message lang="en">This feature allows to display a search box in each folder.</message>
+            <message lang="de">Diese Funktion erlaubt es, ein Suchfeld in jedem Thema anzuzeigen.
+            </message>
+          </help>
+        </parameter>
+        <parameter>
+          <name>privateSearch</name>
+          <label>
+            <message lang="fr">Exclu de la recherche générale</message>
+            <message lang="en">Excluded from the main search engine</message>
+            <message lang="de">Ausgeschlossen von der Haupt-Suchmaschine</message>
+          </label>
+          <order>35</order>
+          <mandatory>true</mandatory>
+          <value>no</value>
+          <type>checkbox</type>
+          <updatable>always</updatable>
+          <help>
+            <message lang="fr">
+              Si ce paramètre est activé, les informations indexées ne seront pas
+              retrouvables par le moteur de recherche général.
+            </message>
+            <message lang="en">
+              If this parameter is enabled, indexed informations won't be findable by the
+              global search engine.
+            </message>
+            <message lang="de">Falls dieser Parameter aktiviert ist, werden indexiert Informationen
+              nicht durch die globale Suchmaschine auffindbar sein.
+            </message>
+          </help>
+        </parameter>
+      </parameters>
+    </groupOfParameters>
+    <groupOfParameters>
+      <label>
+        <message lang="fr">Divers</message>
+        <message lang="en">Miscellaneous</message>
+        <message lang="de">Miscellaneous</message>
+      </label>
+      <description>
+        <message lang="fr">Autres paramètres pouvant être tout aussi utiles...</message>
+        <message lang="en">Other parameters that can be useful...</message>
+        <message lang="de">Andere Parameter, die ebenso nützlich sein kann ...</message>
+      </description>
+      <order>8</order>
+      <parameters>
+        <parameter>
+          <name>webContent</name>
+          <label>
+            <message lang="fr">Orienté CMS</message>
+            <message lang="en">Content for web</message>
+            <message lang="de">Inhalt für das Web</message>
+          </label>
+          <order>16</order>
+          <mandatory>true</mandatory>
+          <value>no</value>
+          <type>checkbox</type>
+          <updatable>always</updatable>
+          <help>
+            <message lang="fr">Permet d'activer les fonctions liées à la gestion de contenu web
+              (wysiwyg associé au dossier, visibilité des dossiers).
+            </message>
+            <message lang="en">Activate functionalities for managing web content (wysiwyg for folder
+              and folder visibility).
+            </message>
+            <message lang="de">Funktionalitäten für die Verwaltung von Web-Inhalten Aktivieren
+              (WYSIWYG für Themen und Themen Sichtbarkeit).
+            </message>
+          </help>
+        </parameter>
+        <parameter>
+          <name>exportComponent</name>
+          <label>
+            <message lang="fr">Exportation</message>
+            <message lang="en">Export</message>
+            <message lang="de">Export</message>
+          </label>
+          <order>22</order>
+          <mandatory>true</mandatory>
+          <value>no</value>
+          <options>
+            <option>
+              <name>
+                <message lang="fr">Non</message>
+                <message lang="en">No</message>
+                <message lang="de">Nein</message>
+              </name>
+              <value>no</value>
+            </option>
+            <option>
+              <name>
+                <message lang="fr">Au format ZIP</message>
+                <message lang="en">In a zip file</message>
+                <message lang="de">In einer ZIP-Datei</message>
+              </name>
+              <value>yes</value>
+            </option>
+            <option>
+              <name>
+                <message lang="fr">Des fichiers PDF</message>
+                <message lang="en">In pdf files</message>
+                <message lang="de">In einer PDF-Datei</message>
+              </name>
+              <value>pdf</value>
+            </option>
+            <option>
+              <name>
+                <message lang="fr">Tous</message>
+                <message lang="en">All</message>
+                <message lang="de">Alle</message>
+              </name>
+              <value>both</value>
+            </option>
+          </options>
+          <type>select</type>
+          <updatable>always</updatable>
+          <help>
+            <message lang="fr">Cette fonction permet d'exporter toutes les publications visibles de
+              l'application.
+            </message>
+            <message lang="en">This function allow the user to export all the visible publications
+              of the application.
+            </message>
+            <message lang="de">Diese Funktion ermöglicht es dem Benutzer, alle sichtbaren
+              Veröffentlichungen in der Komponente zu exportieren.
+            </message>
+          </help>
+        </parameter>
+      </parameters>
+    </groupOfParameters>
+  </groupsOfParameters>
+</WAComponent>

--- a/core-services/workflow/src/main/java/org/silverpeas/core/workflow/engine/model/SpecificLabelListHelper.java
+++ b/core-services/workflow/src/main/java/org/silverpeas/core/workflow/engine/model/SpecificLabelListHelper.java
@@ -23,17 +23,16 @@
  */
 package org.silverpeas.core.workflow.engine.model;
 
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-
 import org.silverpeas.core.workflow.api.WorkflowException;
 import org.silverpeas.core.workflow.api.model.ContextualDesignation;
 import org.silverpeas.core.workflow.api.model.ContextualDesignations;
 
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
 
 /**
  * Class managing a collection of ContextualDesigantion objects.
@@ -41,8 +40,10 @@ import javax.xml.bind.annotation.XmlRootElement;
 @XmlRootElement
 public class SpecificLabelListHelper implements ContextualDesignations, Serializable {
   private static final long serialVersionUID = -4580671511307866063L;
+  private static final String DEFAULT = "default";
+
   @XmlElement(type = SpecificLabel.class)
-  List<ContextualDesignation> labels = null;
+  private List<ContextualDesignation> labels;
 
   /**
    * Constructor
@@ -63,22 +64,23 @@ public class SpecificLabelListHelper implements ContextualDesignations, Serializ
    * @see ContextualDesignations#getLabel(java. lang.String,
    * java.lang.String)
    */
+  @Override
   public String getLabel(String role, String language) {
     ContextualDesignation label = getSpecificLabel(role, language);
 
     if (label != null) {
       return label.getContent();
     }
-    label = getSpecificLabel(role, "default"); //$NON-NLS-1$
+    label = getSpecificLabel(role, DEFAULT); //$NON-NLS-1$
     if (label != null) {
       return label.getContent();
     }
-    label = getSpecificLabel("default", language); //$NON-NLS-1$
+    label = getSpecificLabel(DEFAULT, language); //$NON-NLS-1$
     if (label != null) {
       return label.getContent();
     }
     //$NON-NLS-1$ //$NON-NLS-2$
-    label = getSpecificLabel("default", "default");
+    label = getSpecificLabel(DEFAULT, DEFAULT);
     if (label != null) {
       return label.getContent();
     }
@@ -90,6 +92,7 @@ public class SpecificLabelListHelper implements ContextualDesignations, Serializ
    * @see ContextualDesignations#getSpecificLabel
    * (java.lang.String, java.lang.String)
    */
+  @Override
   public ContextualDesignation getSpecificLabel(String role, String language) {
     SpecificLabel label = null;
     for (int l = 0; l < labels.size(); l++) {
@@ -107,6 +110,7 @@ public class SpecificLabelListHelper implements ContextualDesignations, Serializ
    * @seecom.silverpeas.workflow.api.model.ContextualDesignations# addContextualDesignation
    * (ContextualDesignation)
    */
+  @Override
   public void addContextualDesignation(
       ContextualDesignation contextualDesignation) {
     labels.add(contextualDesignation);
@@ -116,6 +120,7 @@ public class SpecificLabelListHelper implements ContextualDesignations, Serializ
    * (non-Javadoc)
    * @seecom.silverpeas.workflow.api.model.ContextualDesignations# createContextualDesignation()
    */
+  @Override
   public ContextualDesignation createContextualDesignation() {
     return new SpecificLabel();
   }
@@ -124,6 +129,7 @@ public class SpecificLabelListHelper implements ContextualDesignations, Serializ
    * (non-Javadoc)
    * @seecom.silverpeas.workflow.api.model.ContextualDesignations# iterateContextualDesignation()
    */
+  @Override
   public Iterator<ContextualDesignation> iterateContextualDesignation() {
     if (labels == null) {
       return null;
@@ -137,12 +143,15 @@ public class SpecificLabelListHelper implements ContextualDesignations, Serializ
    * @seecom.silverpeas.workflow.api.model.ContextualDesignations#
    * removeContextualDesignation(java.lang.String)
    */
+  @Override
   public void removeContextualDesignation(
       ContextualDesignation contextualDesignation) throws WorkflowException {
     if (labels == null) {
       return;
     }
-    if (!labels.remove(contextualDesignation)) {
+    if (!labels.removeIf(d ->
+        d.getRole().equals(contextualDesignation.getRole()) &&
+        d.getLanguage().equals(contextualDesignation.getLanguage()))) {
       throw new WorkflowException("SpecificLabelListHelper.removeContextualDesignation()",
           //$NON-NLS-1$
           "workflowEngine.EX_DESIGNATION_NOT_FOUND", // $NON-NLS-1$

--- a/core-war/src/main/java/org/silverpeas/web/jobdomain/ComponentProfiles.java
+++ b/core-war/src/main/java/org/silverpeas/web/jobdomain/ComponentProfiles.java
@@ -24,8 +24,8 @@
 package org.silverpeas.web.jobdomain;
 
 import org.silverpeas.core.admin.component.model.ComponentInstLight;
-import org.silverpeas.core.admin.component.model.LocalizedComponent;
 import org.silverpeas.core.admin.component.model.LocalizedProfile;
+import org.silverpeas.core.admin.component.model.LocalizedWAComponent;
 import org.silverpeas.core.admin.space.SpaceInstLight;
 import org.silverpeas.core.admin.user.model.ProfileInst;
 import org.silverpeas.core.util.StringUtil;
@@ -36,13 +36,13 @@ import java.util.List;
 public class ComponentProfiles {
 
   private ComponentInstLight component;
-  private LocalizedComponent localizedComponent;
+  private LocalizedWAComponent localizedWAComponent;
   private SpaceInstLight space;
   private List<String> profilesName = new ArrayList<>();
 
-  public ComponentProfiles(ComponentInstLight component, LocalizedComponent localizedComponent) {
+  public ComponentProfiles(ComponentInstLight component, LocalizedWAComponent localizedWAComponent) {
     this.component = component;
-    this.localizedComponent = localizedComponent;
+    this.localizedWAComponent = localizedWAComponent;
   }
 
   public ComponentInstLight getComponent() {
@@ -65,9 +65,9 @@ public class ComponentProfiles {
 
   public String getLocalizedProfilesName() {
     List<String> localizedProfilesName = new ArrayList<>();
-    if (localizedComponent != null) {
+    if (localizedWAComponent != null) {
       for (String profileName : profilesName) {
-        LocalizedProfile localizedProfile = localizedComponent.getProfile(profileName);
+        LocalizedProfile localizedProfile = localizedWAComponent.getProfile(profileName);
         if (localizedProfile != null) {
           localizedProfilesName.add(localizedProfile.getLabel());
         } else {
@@ -81,22 +81,22 @@ public class ComponentProfiles {
   }
 
   public String getLocalizedSpaceLabel() {
-    if (localizedComponent != null) {
-      return space.getName(localizedComponent.getLanguage());
+    if (localizedWAComponent != null) {
+      return space.getName(localizedWAComponent.getLanguage());
     }
     return space.getName();
   }
 
   public String getLocalizedInstanceLabel() {
-    if (localizedComponent != null) {
-      return component.getLabel(localizedComponent.getLanguage());
+    if (localizedWAComponent != null) {
+      return component.getLabel(localizedWAComponent.getLanguage());
     }
     return "";
   }
 
   public String getLocalizedComponentLabel() {
-    if (localizedComponent != null) {
-      return localizedComponent.getLabel();
+    if (localizedWAComponent != null) {
+      return localizedWAComponent.getLabel();
     }
     return "";
   }

--- a/core-war/src/main/java/org/silverpeas/web/jobdomain/control/JobDomainPeasSessionController.java
+++ b/core-war/src/main/java/org/silverpeas/web/jobdomain/control/JobDomainPeasSessionController.java
@@ -27,7 +27,7 @@ import org.apache.commons.fileupload.FileItem;
 import org.apache.ecs.xhtml.br;
 import org.silverpeas.core.SilverpeasRuntimeException;
 import org.silverpeas.core.admin.component.model.ComponentInstLight;
-import org.silverpeas.core.admin.component.model.LocalizedComponent;
+import org.silverpeas.core.admin.component.model.LocalizedWAComponent;
 import org.silverpeas.core.admin.component.model.WAComponent;
 import org.silverpeas.core.admin.domain.DomainDriver;
 import org.silverpeas.core.admin.domain.DomainDriver.UserFilterManager;
@@ -155,7 +155,7 @@ public class JobDomainPeasSessionController extends AbstractComponentSessionCont
       Arrays.asList("Admin", "AdminPdc", "AdminDomain", "User", "Guest");
   private static final String BR_ELEMENT = new br().toString();
 
-  private Map<String, LocalizedComponent> localizedComponents = new HashMap<>();
+  private Map<String, LocalizedWAComponent> localizedComponents = new HashMap<>();
 
   /**
    * Standard Session Controller Constructeur
@@ -2238,8 +2238,8 @@ public class JobDomainPeasSessionController extends AbstractComponentSessionCont
         ComponentInstLight currentComponent =
             adminCtrl.getComponentInstLight(String.valueOf(p.getComponentFatherId()));
         if (currentComponent.getStatus() == null && !currentComponent.isPersonal()) {
-          LocalizedComponent localizedComponent = getLocalizedComponent(currentComponent.getName());
-          componentProfiles = new ComponentProfiles(currentComponent, localizedComponent);
+          LocalizedWAComponent localizedWAComponent = getLocalizedComponent(currentComponent.getName());
+          componentProfiles = new ComponentProfiles(currentComponent, localizedWAComponent);
           SpaceInstLight space = adminCtrl.getSpaceInstLight(currentComponent.getSpaceId());
           componentProfiles.setSpace(space);
           allProfiles.add(componentProfiles);
@@ -2260,21 +2260,21 @@ public class JobDomainPeasSessionController extends AbstractComponentSessionCont
     return allProfiles;
   }
 
-  private LocalizedComponent getLocalizedComponent(String name) {
-    LocalizedComponent localizedComponent = localizedComponents.get(name);
-    if (localizedComponent == null) {
+  private LocalizedWAComponent getLocalizedComponent(String name) {
+    LocalizedWAComponent localizedWAComponent = localizedComponents.get(name);
+    if (localizedWAComponent == null) {
       try {
         Optional<WAComponent> optionalComponent = WAComponent.getByName(name);
         if (optionalComponent.isPresent()) {
           WAComponent component = optionalComponent.get();
-          localizedComponent = new LocalizedComponent(component, getLanguage());
-          localizedComponents.put(name, localizedComponent);
+          localizedWAComponent = new LocalizedWAComponent(component, getLanguage());
+          localizedComponents.put(name, localizedWAComponent);
         }
       } catch (Exception e) {
         SilverLogger.getLogger(this).warn(e);
       }
     }
-    return localizedComponent;
+    return localizedWAComponent;
   }
 
   public boolean isRightCopyReplaceEnabled() {

--- a/core-war/src/main/java/org/silverpeas/web/jobstartpage/AllComponentParameters.java
+++ b/core-war/src/main/java/org/silverpeas/web/jobstartpage/AllComponentParameters.java
@@ -26,6 +26,8 @@ package org.silverpeas.web.jobstartpage;
 import org.silverpeas.core.admin.component.model.LocalizedGroupOfParameters;
 import org.silverpeas.core.admin.component.model.LocalizedParameter;
 import org.silverpeas.core.admin.component.model.LocalizedParameterList;
+import org.silverpeas.core.admin.component.model.ParameterList;
+import org.silverpeas.core.admin.component.model.SilverpeasComponent;
 
 import java.util.List;
 
@@ -34,10 +36,13 @@ import java.util.List;
  */
 public class AllComponentParameters {
 
+  private final SilverpeasComponent component;
   private LocalizedParameterList parameters;
   private List<LocalizedGroupOfParameters> groupsOfParameters;
 
-  public AllComponentParameters(LocalizedParameterList parameters, List<LocalizedGroupOfParameters> groups) {
+  public AllComponentParameters(SilverpeasComponent component, LocalizedParameterList parameters,
+      List<LocalizedGroupOfParameters> groups) {
+    this.component = component;
     this.parameters = parameters;
     this.groupsOfParameters = groups;
   }
@@ -51,7 +56,8 @@ public class AllComponentParameters {
   }
 
   public LocalizedParameterList getParameters() {
-    LocalizedParameterList allParameters = new LocalizedParameterList();
+    final LocalizedParameterList allParameters = new LocalizedParameterList(component,
+        new ParameterList(), parameters.getLanguage());
     allParameters.addAll(parameters);
     for (LocalizedGroupOfParameters group : groupsOfParameters) {
       allParameters.addAll(group.getParameters());

--- a/core-war/src/main/java/org/silverpeas/web/look/PersonalSpaceJSONServlet.java
+++ b/core-war/src/main/java/org/silverpeas/web/look/PersonalSpaceJSONServlet.java
@@ -200,7 +200,7 @@ public class PersonalSpaceJSONServlet extends SilverpeasAuthenticatedHttpServlet
   private UnaryOperator<JSONObject> getWAComponentAsJSONObject(
       WAComponent component, LookHelper helper) {
     return (jsonObject -> jsonObject.put("name", component.getName())
-        .put(DESCRIPTION, component.getDescription().get(helper.getLanguage()))
+        .put(DESCRIPTION, component.getDescription(helper.getLanguage()))
         .put(LABEL, getComponentLabel(component.getName(), helper)));
   }
 

--- a/core-war/src/main/java/org/silverpeas/web/silverstatistics/control/SilverStatisticsPeasDAOVolumeServices.java
+++ b/core-war/src/main/java/org/silverpeas/web/silverstatistics/control/SilverStatisticsPeasDAOVolumeServices.java
@@ -25,10 +25,10 @@ package org.silverpeas.web.silverstatistics.control;
 
 import org.silverpeas.core.admin.component.model.WAComponent;
 import org.silverpeas.core.admin.service.AdministrationServiceProvider;
-import org.silverpeas.core.util.StringUtil;
+import org.silverpeas.core.exception.UtilException;
 import org.silverpeas.core.i18n.I18NHelper;
 import org.silverpeas.core.persistence.jdbc.DBUtil;
-import org.silverpeas.core.exception.UtilException;
+import org.silverpeas.core.util.StringUtil;
 
 import java.sql.Connection;
 import java.sql.ResultSet;
@@ -64,8 +64,8 @@ public class SilverStatisticsPeasDAOVolumeServices {
    */
   private static Collection[] getCollectionArrayFromResultset(ResultSet rs)
       throws SQLException {
-    List<String> apps = new ArrayList<String>();
-    List<String> counts = new ArrayList<String>();
+    List<String> apps = new ArrayList<>();
+    List<String> counts = new ArrayList<>();
     long count = 0;
     Map<String, WAComponent> components = AdministrationServiceProvider.getAdminService().getAllWAComponents();
     String label = null;
@@ -73,7 +73,7 @@ public class SilverStatisticsPeasDAOVolumeServices {
       String componentName = rs.getString(1);
       WAComponent compo = components.get(componentName);
       if (compo != null) {
-        String value = compo.getLabel().get(I18NHelper.DEFAULT_LANGUAGE);
+        String value = compo.getLabel(I18NHelper.DEFAULT_LANGUAGE);
         if (StringUtil.isDefined(value)) {
           label = (value.indexOf("-") == -1) ? value : value.substring(value.indexOf("-") + 1);
         } else {

--- a/core-war/src/main/java/org/silverpeas/web/templatedesigner/control/TemplateDesignerSessionController.java
+++ b/core-war/src/main/java/org/silverpeas/web/templatedesigner/control/TemplateDesignerSessionController.java
@@ -25,7 +25,7 @@ package org.silverpeas.web.templatedesigner.control;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
-import org.silverpeas.core.admin.component.model.LocalizedComponent;
+import org.silverpeas.core.admin.component.model.LocalizedWAComponent;
 import org.silverpeas.core.admin.component.model.WAComponent;
 import org.silverpeas.core.admin.service.AdminController;
 import org.silverpeas.core.contribution.content.form.FieldTemplate;
@@ -555,16 +555,16 @@ public class TemplateDesignerSessionController extends AbstractComponentSessionC
         .contains(fieldName);
   }
 
-  public List<LocalizedComponent> getComponentsUsingForms() {
+  public List<LocalizedWAComponent> getComponentsUsingForms() {
     Map<String, WAComponent> components = adminController.getAllComponents();
     String[] names =
         {"kmelia", "kmax", "classifieds", "gallery", "formsOnline", "resourcesManager", "webPages",
             "yellowpages"};
-    List<LocalizedComponent> result = new ArrayList<>();
+    List<LocalizedWAComponent> result = new ArrayList<>();
     for (String name : names) {
       WAComponent component = components.get(name);
       if (component != null) {
-        result.add(new LocalizedComponent(component, getLanguage()));
+        result.add(new LocalizedWAComponent(component, getLanguage()));
       }
     }
     if (!result.isEmpty()) {

--- a/core-war/src/main/webapp/templateDesigner/jsp/templateHeader.jsp
+++ b/core-war/src/main/webapp/templateDesigner/jsp/templateHeader.jsp
@@ -23,7 +23,7 @@
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 --%>
-<%@page import="org.silverpeas.core.admin.component.model.LocalizedComponent"%>
+<%@page import="org.silverpeas.core.admin.component.model.LocalizedWAComponent"%>
 <%@page import="org.apache.commons.io.FilenameUtils"%>
 <%@page import="org.silverpeas.core.security.encryption.cipher.CryptoException"%>
 <%@page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
@@ -48,7 +48,7 @@
 <%@ include file="check.jsp" %>
 <%
 PublicationTemplate template = (PublicationTemplate) request.getAttribute("Template");
-List<LocalizedComponent> components = (List<LocalizedComponent>) request.getAttribute("ComponentsUsingForms");
+List<LocalizedWAComponent> components = (List<LocalizedWAComponent>) request.getAttribute("ComponentsUsingForms");
 boolean encryptionAvailable = (Boolean) request.getAttribute("EncryptionAvailable");
 CryptoException cryptoException = (CryptoException) request.getAttribute("CryptoException");
 
@@ -347,7 +347,7 @@ $(function () {
 <tr id="applications-visibility" class="notApplicableToDirectory">
 	<td class="txtlibform"><fmt:message key="templateDesigner.header.visible.applications"/> </td>
 	<td><ul id="template-apps-visibility">
-		<% for (LocalizedComponent component : components) {
+		<% for (LocalizedWAComponent component : components) {
 			String checked = "";
 			if (visibilityApplications != null && visibilityApplications.contains(component.getName())) {
 			  checked = "checked=\"checked\"";

--- a/core-web/src/main/java/org/silverpeas/core/webapi/admin/PersonalComponentEntity.java
+++ b/core-web/src/main/java/org/silverpeas/core/webapi/admin/PersonalComponentEntity.java
@@ -45,8 +45,7 @@ public class PersonalComponentEntity extends AbstractPersonnalEntity {
 
   private PersonalComponentEntity(final SilverpeasComponent component, final String componentLabel,
       final String language) {
-    super(TYPE, "", 0, component.getName(), componentLabel, component.getDescription()
-        .get(language), "");
+    super(TYPE, "", 0, component.getName(), componentLabel, component.getDescription(language), "");
   }
 
   private PersonalComponentEntity(final SilverpeasComponentInstance component) {


### PR DESCRIPTION
In this first step, the current possibility to specify the localization data of a component directly into its corresponding XML descriptor is kept.

But, for each component, the priority is now given to its bundle property file if it exists. If a localized data is specified into bundle property file, this data is taken into account. If it does not exist, then the localization into XML descriptor file is looked up. If it does not exists localized data neither into bundle property file neither into XML descriptor one, then a technical error is thrown.

The localized data are manipulated from the classes having their name prefixed by 'Localized' which are situated into the same package of the models implemented for component XML descriptors. Some of the 'Localized' implementations, which was already existing, have been completed to observe the new priorities. Some have been added.

Linked to PR https://github.com/Silverpeas/Silverpeas-Components/pull/834