### PR TITLE
Feature #14033

### DIFF
--- a/core-api/src/main/java/org/silverpeas/core/annotation/Bean.java
+++ b/core-api/src/main/java/org/silverpeas/core/annotation/Bean.java
@@ -24,16 +24,11 @@
 
 package org.silverpeas.core.annotation;
 
+import org.silverpeas.kernel.annotation.Managed;
+
 import javax.enterprise.context.Dependent;
 import javax.enterprise.inject.Stereotype;
-import java.lang.annotation.Documented;
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Inherited;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
-
-import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import java.lang.annotation.*;
 
 /**
  * This annotation is to tag an object as to be managed by the underlying IoC container with the
@@ -53,6 +48,7 @@ import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
 @Target({ElementType.TYPE, ElementType.ANNOTATION_TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
+@Managed
 @Dependent
 @Stereotype
 public @interface Bean {

--- a/core-api/src/main/java/org/silverpeas/core/annotation/Provider.java
+++ b/core-api/src/main/java/org/silverpeas/core/annotation/Provider.java
@@ -24,6 +24,8 @@
 
 package org.silverpeas.core.annotation;
 
+import org.silverpeas.kernel.annotation.Managed;
+
 import javax.enterprise.inject.Stereotype;
 import javax.inject.Singleton;
 import java.lang.annotation.Documented;
@@ -52,6 +54,7 @@ import java.lang.annotation.Target;
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
+@Managed
 @Singleton
 @Stereotype
 public @interface Provider {

--- a/core-api/src/main/java/org/silverpeas/core/annotation/Repository.java
+++ b/core-api/src/main/java/org/silverpeas/core/annotation/Repository.java
@@ -23,6 +23,8 @@
  */
 package org.silverpeas.core.annotation;
 
+import org.silverpeas.kernel.annotation.Managed;
+
 import javax.enterprise.inject.Stereotype;
 import javax.inject.Singleton;
 import java.lang.annotation.Documented;
@@ -35,19 +37,22 @@ import java.lang.annotation.Target;
  * This annotation is to tag an object as being a repository of business objects. A repository is an
  * object aimed to store and to retrieve objects in a given data source. It wraps the type of the
  * used data source and the mechanism to access them.
- *
+ * <p>
  * Beans annotated with this annotation are marked to be managed by the underlying IoC container and
  * to be singleton (there is only one single instance at a given time). If the bean declare another
  * life-cycle scope, then the new scope overrides the default one.
- *
+ * </p>
+ * <p>
  * The annotation is an abstraction above the IoC container used by Silverpeas so that it is can
  * possible to change the IoC container (Spring or CDI for example) by changing the wrapped
  * annotation to those specific at this IoC implementation without impacting the annotated IoC
  * managed beans.
+ * </p>
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
+@Managed
 @Singleton
 @Stereotype
 public @interface Repository {

--- a/core-api/src/main/java/org/silverpeas/core/annotation/Service.java
+++ b/core-api/src/main/java/org/silverpeas/core/annotation/Service.java
@@ -23,6 +23,8 @@
  */
 package org.silverpeas.core.annotation;
 
+import org.silverpeas.kernel.annotation.Managed;
+
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Stereotype;
 import java.lang.annotation.Documented;
@@ -35,20 +37,25 @@ import java.lang.annotation.Target;
  * This annotation is to tag an object as being a business service. A business service is an object
  * whose goal is to provide transverse functionalities within which can be implied one or more types
  * of business objects.
- *
+ * <p>
  * Beans annotated with this annotation are marked to be managed by the underlying IoC container and
  * to be bound to the scope of the application execution. If the bean declare another
  * life-cycle scope, then the new scope overrides the default one.
- *
+ * </p>
+ * <p>
  * The annotation is an abstraction above the IoC container used by Silverpeas so that it is can
  * possible to change the IoC container (Spring or CDI for example) by changing the wrapped
  * annotation to those specific at this IoC implementation without impacting the annotated IoC
  * managed beans.
+ * </p>
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
+@Managed
 @ApplicationScoped
 @Stereotype
 public @interface Service {
 }
+
+

--- a/core-api/src/main/java/org/silverpeas/core/annotation/WebService.java
+++ b/core-api/src/main/java/org/silverpeas/core/annotation/WebService.java
@@ -23,6 +23,8 @@
  */
 package org.silverpeas.core.annotation;
 
+import org.silverpeas.kernel.annotation.Managed;
+
 import javax.enterprise.context.RequestScoped;
 import javax.enterprise.inject.Stereotype;
 import java.lang.annotation.Documented;
@@ -34,18 +36,22 @@ import java.lang.annotation.Target;
 /**
  * This annotation is to tag an object as being a web service whose lifecycle is bound to the scope
  * of the HTTP exchange (request/response) between him and the client behind de request.
- *
+ * <p>
  * Beans annotated with this annotation are marked to be managed by the underlying IoC container and
- * to be bound to the scope of the HTTP request processing. If the bean declare another
- * life-cycle scope, then the new scope overrides the default one.
- *
+ * to be bound to the scope of the HTTP request processing. If the bean declare another life-cycle
+ * scope, then the new scope overrides the default one.
+ * </p>
+ * <p>
  * The annotation is an abstraction above the IoC container used by Silverpeas so that it is can
- * possible to change the IoC container (Spring or CDI for example) by changing the wrapped annnotation
- * to those specific at this IoC implementation without impacting the annotated IoC managed beans.
+ * possible to change the IoC container (Spring or CDI for example) by changing the wrapped
+ * annotation to those specific at this IoC implementation without impacting the annotated IoC
+ * managed beans.
+ * </p>
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
+@Managed
 @RequestScoped
 @Stereotype
 public @interface WebService {

--- a/core-api/src/main/java/org/silverpeas/core/notification/system/AbstractResourceEvent.java
+++ b/core-api/src/main/java/org/silverpeas/core/notification/system/AbstractResourceEvent.java
@@ -73,7 +73,7 @@ public abstract class AbstractResourceEvent<T extends Serializable> implements R
       this.transition = StateTransition.transitionBetween(null, resource[0]);
     } else if (type == Type.UNLOCK || type == Type.UPDATE || type == Type.MOVE) {
       this.transition = StateTransition.transitionBetween(resource[0], resource[1]);
-    } else if (type == Type.REMOVING) {
+    } else if (type == Type.REMOVING || type == Type.RECOVERY) {
       this.transition = StateTransition.transitionBetween(resource[0], resource[0]);
     } else if (type == Type.DELETION) {
       this.transition = StateTransition.transitionBetween(resource[0], null);

--- a/core-api/src/main/java/org/silverpeas/core/notification/system/AbstractResourceEventListener.java
+++ b/core-api/src/main/java/org/silverpeas/core/notification/system/AbstractResourceEventListener.java
@@ -31,6 +31,6 @@ package org.silverpeas.core.notification.system;
  * JMS occurring with classes implementing more the the {@code javax.jms.MessageListener} interface.
  * @author mmoquillon
  */
-public abstract class AbstractResourceEventListener<T extends ResourceEvent>
+public abstract class AbstractResourceEventListener<T extends ResourceEvent<?>>
     implements ResourceEventListener<T> {
 }

--- a/core-api/src/main/java/org/silverpeas/core/notification/system/CDIAfterSuccessfulTransactionResourceEventListener.java
+++ b/core-api/src/main/java/org/silverpeas/core/notification/system/CDIAfterSuccessfulTransactionResourceEventListener.java
@@ -57,7 +57,7 @@ import static javax.enterprise.event.TransactionPhase.AFTER_SUCCESS;
  *
  * @author mmoquillon
  */
-public abstract class CDIAfterSuccessfulTransactionResourceEventListener<T extends ResourceEvent>
+public abstract class CDIAfterSuccessfulTransactionResourceEventListener<T extends ResourceEvent<?>>
     implements ResourceEventListener<T> {
 
   protected final SilverLogger logger = SilverLogger.getLogger(this);

--- a/core-api/src/main/java/org/silverpeas/core/notification/system/CDIResourceEventListener.java
+++ b/core-api/src/main/java/org/silverpeas/core/notification/system/CDIResourceEventListener.java
@@ -49,7 +49,7 @@ import javax.enterprise.event.Observes;
  *
  * @author mmoquillon
  */
-public abstract class CDIResourceEventListener<T extends ResourceEvent>
+public abstract class CDIResourceEventListener<T extends ResourceEvent<?>>
     implements ResourceEventListener<T> {
 
   protected final SilverLogger logger = SilverLogger.getLogger(this);

--- a/core-api/src/main/java/org/silverpeas/core/notification/system/CDIResourceEventNotifier.java
+++ b/core-api/src/main/java/org/silverpeas/core/notification/system/CDIResourceEventNotifier.java
@@ -36,7 +36,8 @@ import java.io.Serializable;
  * @param <T> the type of the resource event.
  * @author mmoquillon
  */
-public abstract class CDIResourceEventNotifier<R extends Serializable, T extends AbstractResourceEvent>
+public abstract class CDIResourceEventNotifier<R extends Serializable,
+    T extends AbstractResourceEvent<?>>
     implements ResourceEventNotifier<R, T> {
 
   @Inject

--- a/core-api/src/main/java/org/silverpeas/core/notification/system/JMSResourceEventListener.java
+++ b/core-api/src/main/java/org/silverpeas/core/notification/system/JMSResourceEventListener.java
@@ -59,7 +59,7 @@ import javax.jms.MessageListener;
  * </p>
  * @author mmoquillon
  */
-public abstract class JMSResourceEventListener<T extends AbstractResourceEvent>
+public abstract class JMSResourceEventListener<T extends AbstractResourceEvent<?>>
     extends AbstractResourceEventListener<T> implements MessageListener {
 
   /**

--- a/core-api/src/main/java/org/silverpeas/core/notification/system/JMSResourceEventNotifier.java
+++ b/core-api/src/main/java/org/silverpeas/core/notification/system/JMSResourceEventNotifier.java
@@ -39,7 +39,8 @@ import java.io.Serializable;
  * @param <T> the type of the resource event.
  * @author mmoquillon
  */
-public abstract class JMSResourceEventNotifier<R extends Serializable, T extends AbstractResourceEvent>
+public abstract class JMSResourceEventNotifier<R extends Serializable,
+    T extends AbstractResourceEvent<?>>
     implements ResourceEventNotifier<R, T> {
 
   /**

--- a/core-api/src/main/java/org/silverpeas/core/notification/system/ResourceEvent.java
+++ b/core-api/src/main/java/org/silverpeas/core/notification/system/ResourceEvent.java
@@ -72,7 +72,7 @@ public interface ResourceEvent<T extends Serializable> extends Serializable {
   StateTransition<T> getTransition();
 
   /**
-   * Is the event on the creation of a resource.
+   * Is the event on the creation of a resource?
    * @return true if the event is about a resource creation. False otherwise.
    */
   default boolean isOnCreation() {
@@ -80,7 +80,7 @@ public interface ResourceEvent<T extends Serializable> extends Serializable {
   }
 
   /**
-   * Is the event on the update of a resource.
+   * Is the event on the update of a resource?
    * @return true if the event is about a resource update. False otherwise.
    */
   default boolean isOnUpdate() {
@@ -88,18 +88,27 @@ public interface ResourceEvent<T extends Serializable> extends Serializable {
   }
 
   /**
-   * Is the event on the removing of a resource.
+   * Is the event on the removing of a resource?
    * @return true if the event is about a resource removing. False otherwise.
    */
   default boolean isOnRemoving() {
     return getType() == Type.REMOVING;
   }
 
-  /**Is the event on the deletion of a resource.
+  /**
+   * Is the event on the deletion of a resource?
    * @return true if the event is about a resource deletion. False otherwise.
    */
   default boolean isOnDeletion() {
     return getType() == Type.DELETION;
+  }
+
+  /**
+   * Is the event on the recovery of a removed resource?
+   * @return true if the event is about a resource recovery. False otherwise.
+   */
+  default boolean isOnRecovery() {
+    return getType() == Type.RECOVERY;
   }
 
   /**
@@ -137,6 +146,11 @@ public interface ResourceEvent<T extends Serializable> extends Serializable {
      * The notification is about the unlock of a resource in Silverpeas. When a resource is
      * unlocked, it is again available.
      */
-    UNLOCK;
+    UNLOCK,
+    /**
+     * The notification is about the recovery of a resource that has been removed. This event is
+     * about the state of the life-cycle of a such resource.
+     */
+    RECOVERY
   }
 }

--- a/core-api/src/main/java/org/silverpeas/core/notification/system/ResourceEventListener.java
+++ b/core-api/src/main/java/org/silverpeas/core/notification/system/ResourceEventListener.java
@@ -27,25 +27,31 @@ import org.silverpeas.kernel.logging.SilverLogger;
 
 /**
  * A resource event listener. This interface defines the common properties all listeners should
- * implement. The event dispatching method is already implemented here so that the implementers
- * have just to override one of the following method to perform their task:
+ * implement. The event dispatching method is already implemented here so that the implementers have
+ * just to override one of the following method to perform their task:
  * <ul>
- *   <li>{@code org.silverpeas.core.notification.system.ResourceEventListener#onCreation(ResourceEvent} to
+ *   <li>{@code org.silverpeas.core.notification.system.ResourceEventListener#onCreation
+ *   (ResourceEvent} to
  *   receive events about the creation of a resource,</li>
- *   <li>{@code org.silverpeas.core.notification.system.ResourceEventListener#onUpdate(ResourceEvent} to
+ *   <li>{@code org.silverpeas.core.notification.system.ResourceEventListener#onUpdate
+ *   (ResourceEvent} to
  *   receive events about the update of a resource,</li>
- *   <li>{@code org.silverpeas.core.notification.system.ResourceEventListener#onRemoving(ResourceEvent} to
+ *   <li>{@code org.silverpeas.core.notification.system.ResourceEventListener#onRemoving
+ *   (ResourceEvent} to
  *   receive events about the removing of a resource,</li>
- *   <li>{@code org.silverpeas.core.notification.system.ResourceEventListener#onDeletion(ResourceEvent} to
+ *   <li>{@code org.silverpeas.core.notification.system.ResourceEventListener#onDeletion
+ *   (ResourceEvent} to
  *   receive events about the deletion of a resource,</li>
  * </ul>
+ *
  * @author mmoquillon
  */
-public interface ResourceEventListener<T extends ResourceEvent> {
+public interface ResourceEventListener<T extends ResourceEvent<?>> {
 
   /**
    * An event on the deletion of a resource has be listened. A deleted resource is nonexistent and
    * nonrecoverable. By default, this method does nothing.
+   *
    * @param event the event on the deletion of a resource.
    * @throws java.lang.Exception if an error occurs while treating the event.
    */
@@ -55,6 +61,7 @@ public interface ResourceEventListener<T extends ResourceEvent> {
   /**
    * An event on the removing of a resource has be listened. A removed resource is again existent
    * and it is recoverable; it is usually put in a trash. By default, this method does nothing.
+   *
    * @param event the event on the removing of a resource.
    * @throws java.lang.Exception if an error occurs while treating the event.
    */
@@ -62,7 +69,18 @@ public interface ResourceEventListener<T extends ResourceEvent> {
   }
 
   /**
+   * An event on the recovery of a removed resource has be listened. By default, this method does
+   * nothing.
+   *
+   * @param event the event on the removing of a resource.
+   * @throws java.lang.Exception if an error occurs while treating the event.
+   */
+  default void onRecovery(final T event) throws Exception {
+  }
+
+  /**
    * An event on the update of a resource has be listened. By default, this method does nothing.
+   *
    * @param event the event on the update of a resource.
    * @throws java.lang.Exception if an error occurs while treating the event.
    */
@@ -71,6 +89,7 @@ public interface ResourceEventListener<T extends ResourceEvent> {
 
   /**
    * An event on the move of a resource has be listened. By default, this method does nothing.
+   *
    * @param event the event on the move of a resource.
    * @throws java.lang.Exception if an error occurs while treating the event.
    */
@@ -79,6 +98,7 @@ public interface ResourceEventListener<T extends ResourceEvent> {
 
   /**
    * An event on the creation of a resource has be listened. By default, this method does nothing.
+   *
    * @param event the event on the creation of a resource.
    * @throws java.lang.Exception if an error occurs while treating the event.
    */
@@ -87,6 +107,7 @@ public interface ResourceEventListener<T extends ResourceEvent> {
 
   /**
    * An event on the unlock of a resource has be listened. By default, this method does nothing.
+   *
    * @param event the event on the unlock of a resource.
    * @throws java.lang.Exception if an error occurs while treating the event.
    */
@@ -96,18 +117,23 @@ public interface ResourceEventListener<T extends ResourceEvent> {
   /**
    * Dispatches the treatment of the specified event to the correct method according to its type:
    * <ul>
-   *   <li>{@code org.silverpeas.core.notification.system.ResourceEventListener#onCreation(ResourceEvent} for
+   *   <li>{@code org.silverpeas.core.notification.system.ResourceEventListener#onCreation
+   *   (ResourceEvent} for
    *   events about the creation of a resource,</li>
-   *   <li>{@code org.silverpeas.core.notification.system.ResourceEventListener#onUpdate(ResourceEvent} for
+   *   <li>{@code org.silverpeas.core.notification.system.ResourceEventListener#onUpdate
+   *   (ResourceEvent} for
    *   events about the update of a resource,</li>
-   *   <li>{@code org.silverpeas.core.notification.system.ResourceEventListener#onRemoving(ResourceEvent} for
+   *   <li>{@code org.silverpeas.core.notification.system.ResourceEventListener#onRemoving
+   *   (ResourceEvent} for
    *   events about the removing of a resource,</li>
-   *   <li>{@code org.silverpeas.core.notification.system.ResourceEventListener#onDeletion(ResourceEvent} for
+   *   <li>{@code org.silverpeas.core.notification.system.ResourceEventListener#onDeletion
+   *   (ResourceEvent} for
    *   events about the deletion of a resource,</li>
    * </ul>
    * <p>
    *   This method shouldn't be overridden as the dispatch mechanism is already implemented here.
    * </p>
+   *
    * @param event the event to dispatch.
    * @throws java.lang.Exception if an error occurs while treating the event.
    */
@@ -132,6 +158,9 @@ public interface ResourceEventListener<T extends ResourceEvent> {
         case DELETION:
           onDeletion(event);
           break;
+        case RECOVERY:
+          onRecovery(event);
+          break;
         default:
           SilverLogger.getLogger(this).
               warn("Event type {0} not yet supported", event.getType().toString());
@@ -143,7 +172,7 @@ public interface ResourceEventListener<T extends ResourceEvent> {
   /**
    * Is this listener enabled? When a listener is enabled, it processes then all the incoming events
    * it listens for. Otherwise, nothing the event isn't consumed.
-   *
+   * <p>
    * By default, the listener is enabled. If the listener has to be enabled according to some
    * conditions, then overrides this method.
    *

--- a/core-api/src/main/java/org/silverpeas/core/notification/system/ResourceEventNotifier.java
+++ b/core-api/src/main/java/org/silverpeas/core/notification/system/ResourceEventNotifier.java
@@ -40,7 +40,7 @@ import java.io.Serializable;
  * </ul>
  * @author mmoquillon
  */
-public interface ResourceEventNotifier<R extends Serializable, T extends ResourceEvent> {
+public interface ResourceEventNotifier<R extends Serializable, T extends ResourceEvent<?>> {
 
   /**
    * Notify about the specified event.

--- a/core-library/src/main/java/org/silverpeas/core/admin/user/GroupManager.java
+++ b/core-library/src/main/java/org/silverpeas/core/admin/user/GroupManager.java
@@ -108,6 +108,7 @@ public class GroupManager {
 
   /**
    * Gets the {@link GroupState#VALID} groups that match the specified criteria.
+   *
    * @param criteria the criteria in searching of user groups.
    * @return a slice of the list of user groups matching the criteria or an empty list of no ones
    * are found.
@@ -154,6 +155,7 @@ public class GroupManager {
   /**
    * Gets the total number of users in the specified group, that is to say the number of distinct
    * users in the specified group and in its subgroups.
+   *
    * @param domainId the unique identifier to which the group belong.
    * @param groupId the unique identifier of the group.
    * @return the total users count in the specified group.
@@ -179,12 +181,12 @@ public class GroupManager {
   /**
    * Add a user to a group
    *
-   * @param sUserId
-   * @param sGroupId
-   * @throws AdminException
+   * @param sUserId the unique identifier of the user.
+   * @param sGroupId the unique identifier of the group.
+   * @throws AdminException if the user cannot be added into the group.
    */
   public void addUserInGroup(String sUserId, String sGroupId) throws
-          AdminException {
+      AdminException {
     try (Connection connection = DBUtil.openConnection()) {
       groupDao.addUserInGroup(connection, sUserId, sGroupId);
       notifyUserInGroup(ResourceEvent.Type.CREATION, sUserId, sGroupId);
@@ -206,12 +208,12 @@ public class GroupManager {
   /**
    * Remove a user from a group
    *
-   * @param sUserId
-   * @param sGroupId
-   * @throws AdminException
+   * @param sUserId the unique identifier of the user.
+   * @param sGroupId the unique identifier of the group.
+   * @throws AdminException if the removing of the user from the group fails.
    */
   public void removeUserFromGroup(String sUserId, String sGroupId)
-          throws AdminException {
+      throws AdminException {
     try (Connection connection = DBUtil.openConnection()) {
       SynchroDomainReport.debug("GroupManager.removeUserFromGroup()",
           "Retrait de l'utilisateur d'ID " + sUserId + " du groupe d'ID " + sGroupId);
@@ -231,14 +233,14 @@ public class GroupManager {
       }
     } catch (SQLException e) {
       throw new AdminException(
-          failureOnDeleting("users " + userIds.stream().collect(Collectors.joining("n")),
+          failureOnDeleting("users " + String.join("n", userIds),
               IN_GROUP + groupId), e);
     }
   }
 
   public List<String> getDirectGroupIdsInSpaceRole(final String spaceRoleId,
       final boolean includeRemoved) throws AdminException {
-    try(Connection connection = DBUtil.openConnection()) {
+    try (Connection connection = DBUtil.openConnection()) {
       return groupDao.getDirectGroupIdsBySpaceUserRole(connection, spaceRoleId, includeRemoved);
     } catch (Exception e) {
       throw new AdminException(failureOnGetting("groups in space role", spaceRoleId), e);
@@ -248,6 +250,7 @@ public class GroupManager {
   /**
    * Get the direct {@link GroupState#VALID} group ids containing a user. Groups that the user is
    * linked to by transitivity are not returned.
+   *
    * @param userId an identifier of a user.
    * @return a list of {@link GroupDetail} instance.
    * @throws AdminException in any technical error.
@@ -262,8 +265,9 @@ public class GroupManager {
   }
 
   /**
-   * Get the direct group ids, whatever their {@link GroupState}, containing a user. Groups that
-   * the user is linked to by transitivity are not returned.
+   * Get the direct group ids, whatever their {@link GroupState}, containing a user. Groups that the
+   * user is linked to by transitivity are not returned.
+   *
    * @param sUserId an identifier of a user.
    * @return a list of {@link GroupDetail} instance.
    * @throws AdminException in any technical error.
@@ -280,6 +284,7 @@ public class GroupManager {
   /**
    * Get all {@link GroupState#VALID} group ids containing a user. So, groups that the user is
    * linked to by transitivity are returned too (recursive treatment).
+   *
    * @param userId identifier of a user.
    * @return list of group identifiers.
    * @throws AdminException on any technical error.
@@ -304,15 +309,15 @@ public class GroupManager {
   }
 
   /**
-   * Get the Silverpeas group id of group qualified by given specific Id and domain id
+   * Get the Silverpeas identifier of the group by its identifier specific to the specified domain.
    *
-   * @param sSpecificId
-   * @param sDomainId
-   * @return
-   * @throws AdminException
+   * @param sSpecificId the specific identifier of the group in the user domain it belongs to.
+   * @param sDomainId the unique identifier of the domain in which the group is defined.
+   * @return the unique identifier of the group in Silverpeas.
+   * @throws AdminException if an error occurs while getting the unique identifier of the group.
    */
   public String getGroupIdBySpecificIdAndDomainId(String sSpecificId,
-          String sDomainId) throws AdminException {
+      String sDomainId) throws AdminException {
     try (Connection connection = DBUtil.openConnection()) {
       GroupDetail gr = groupDao.getGroupBySpecificId(connection, sDomainId, sSpecificId);
       return gr.getId();
@@ -376,14 +381,15 @@ public class GroupManager {
   }
 
   /**
-   * Get the path from root to a given group
+   * Get the path from root to the given group.
    *
-   * @param groupId
-   * @return
-   * @throws AdminException
+   * @param groupId the unique identifier of a group.
+   * @return a list of hierachical parent groups, from the root one to the direct parent of the
+   * specified group.
+   * @throws AdminException if an error occurs while getting the path of the specified group.
    */
   public List<String> getPathToGroup(String groupId) throws
-          AdminException {
+      AdminException {
     try (Connection connection = DBUtil.openConnection()) {
       List<String> path = new ArrayList<>();
       GroupDetail superGroup = groupDao.getSuperGroup(connection, groupId);
@@ -399,12 +405,11 @@ public class GroupManager {
   }
 
   /**
-   * /**
-   * Check if the given group exists
+   * /** Check if there is at least one group in Silverpeas having the specified name.
    *
-   * @param sName
-   * @return true if a group with the given name
-   * @throws AdminException
+   * @param sName the name of a group.
+   * @return true if at least one group with the given name exists in Silverpeas. False otherwise.
+   * @throws AdminException if an error occurs while checking the name.
    */
   public boolean isGroupExist(String sName) throws AdminException {
     try (Connection connection = DBUtil.openConnection()) {
@@ -416,12 +421,13 @@ public class GroupManager {
 
   /**
    * Gets the group detail instance from group DAO without decoration data.
+   *
    * @param groupId the aimed group id.
    * @return the group detail instance without decoration data.
-   * @throws AdminException
+   * @throws AdminException if an error occurs while getting the group.
    */
   private GroupDetail getGroupDetail(String groupId) throws AdminException {
-    try(Connection connection = DBUtil.openConnection()) {
+    try (Connection connection = DBUtil.openConnection()) {
       return groupDao.getGroup(connection, groupId);
     } catch (Exception e) {
       throw new AdminException(failureOnGetting(GROUP, groupId), e);
@@ -431,9 +437,10 @@ public class GroupManager {
   /**
    * Get group information with the given id from Silverpeas
    *
-   * @param groupId
-   * @return
-   * @throws AdminException
+   * @param groupId the unique identifier of a group.
+   * @return the group with the given identifier.
+   * @throws AdminException if an error occurs while getting the group and setting its direct
+   * users.
    */
   public GroupDetail getGroup(String groupId) throws AdminException {
     GroupDetail group = getGroupDetail(groupId);
@@ -450,6 +457,7 @@ public class GroupManager {
 
   /**
    * Get the all the {@link GroupState#VALID} subgroup ids of a given group.
+   *
    * @param superGroupId the identifier of the parent group.
    * @return a list of group identifier.
    * @throws AdminException in case of any technical error.
@@ -474,15 +482,15 @@ public class GroupManager {
   }
 
   /**
-   * Get group information with the given group name
+   * Get group information with the given name and in the specified domain.
    *
-   * @param sGroupName
-   * @param sDomainFatherId
-   * @return
-   * @throws AdminException
+   * @param sGroupName the name of a group.
+   * @param sDomainFatherId the unique identifier of a domain.
+   * @return the group or null if no such group exists.
+   * @throws AdminException if an error occurs while getting the group details.
    */
   public GroupDetail getGroupByNameInDomain(String sGroupName,
-          String sDomainFatherId) throws AdminException {
+      String sDomainFatherId) throws AdminException {
     try (Connection connection = DBUtil.openConnection()) {
       GroupDetail group = domainDriverManager.getGroupByNameInDomain(sGroupName, sDomainFatherId);
 
@@ -504,17 +512,18 @@ public class GroupManager {
   }
 
   /**
+   * Gets all the root groups of the specified domain.
    *
-   * @param sDomainId
-   * @return
-   * @throws AdminException
+   * @param sDomainId the unique identifier of a domain.
+   * @return an array with all the root groups details.
+   * @throws AdminException if an error occurs while getting the root groups of the given domain.
    */
   public GroupDetail[] getRootGroupsOfDomain(String sDomainId) throws
-          AdminException {
+      AdminException {
     try (Connection connection = DBUtil.openConnection()) {
       List<GroupDetail> groups = groupDao.getAllRootGroupsByDomainId(connection, sDomainId);
       setDirectUsersOfGroups(groups);
-      return groups.toArray(new GroupDetail[groups.size()]);
+      return groups.toArray(new GroupDetail[0]);
     } catch (Exception e) {
       throw new AdminException(failureOnGetting("root groups in domain", sDomainId), e);
     }
@@ -534,6 +543,7 @@ public class GroupManager {
 
   /**
    * Get the groups of domain, including these with {@link GroupState#REMOVED} state.
+   *
    * @param domainId the identifier of the domain.
    * @return a list of {@link GroupDetail} instance.
    * @throws AdminException if any technical occurs.
@@ -542,7 +552,7 @@ public class GroupManager {
     try (Connection connection = DBUtil.openConnection()) {
       // Get organization
       SynchroDomainReport.debug(GROUP_MANAGER_GET_GROUPS_OF_DOMAIN,
-              "Recherche des groupes du domaine dans la base...");
+          "Recherche des groupes du domaine dans la base...");
       // Get groups of domain from Silverpeas database
       final List<GroupDetail> groups = groupDao.getAllGroupsByDomainId(connection, domainId, true);
       setDirectUsersOfGroups(groups);
@@ -573,18 +583,20 @@ public class GroupManager {
   /**
    * Add the given group in Silverpeas
    *
-   * @param group
-   * @param onlyInSilverpeas
-   * @param indexation
-   * @return
-   * @throws AdminException
+   * @param group the group to add.
+   * @param onlyInSilverpeas a flag indicating if the group has to be added in Silverpeas only and
+   * not also in the domain. The mixed domain is a specific domain of Silverpeas and the flag should
+   * be true for a group to add into this domain.
+   * @param indexation a flag indicating if the group has to be indexed once added.
+   * @return the unique identifier of the added group.
+   * @throws AdminException if an error occurs while adding the group in Silverpeas.
    */
   public String addGroup(GroupDetail group, boolean onlyInSilverpeas, final boolean indexation)
       throws AdminException {
     if (group == null || !StringUtil.isDefined(group.getName())) {
       if (group != null) {
         SynchroDomainReport.error(GROUP_MANAGER_ADD_GROUP, "Problème lors de l'ajout du groupe "
-                + group.getSpecificId() + " dans la base, ce groupe n'a pas de nom", null);
+            + group.getSpecificId() + " dans la base, ce groupe n'a pas de nom", null);
       }
       return "";
     }
@@ -602,11 +614,11 @@ public class GroupManager {
       // Create the group node in Silverpeas
       if (StringUtil.isDefined(group.getSuperGroupId())) {
         SynchroDomainReport.debug(GROUP_MANAGER_ADD_GROUP, "Ajout du groupe " + group.getName()
-                + " (père=" + getGroupDetail(group.getSuperGroupId()).getSpecificId()
-                + ") dans la table ST_Group");
+            + " (père=" + getGroupDetail(group.getSuperGroupId()).getSpecificId()
+            + ") dans la table ST_Group");
       } else {
         SynchroDomainReport.debug(GROUP_MANAGER_ADD_GROUP, "Ajout du groupe " + group.getName()
-                + " (groupe racine) dans la table ST_Group...");
+            + " (groupe racine) dans la table ST_Group...");
       }
       String groupId = groupDao.addGroup(connection, group);
       group.setId(groupId);
@@ -619,7 +631,7 @@ public class GroupManager {
 
       // Create the links group_user in Silverpeas
       SynchroDomainReport.debug(GROUP_MANAGER_ADD_GROUP,
-              "Inclusion des utilisateurs directement associés au groupe " + group.getName()
+          "Inclusion des utilisateurs directement associés au groupe " + group.getName()
               + " (table ST_Group_User_Rel)");
       String[] asUserIds = group.getUserIds();
       int nUserAdded = 0;
@@ -635,7 +647,7 @@ public class GroupManager {
       return groupId;
     } catch (SQLException e) {
       SynchroDomainReport.error(GROUP_MANAGER_ADD_GROUP, "problème lors de l'ajout du groupe "
-              + group.getName() + " - " + e.getMessage(), null);
+          + group.getName() + " - " + e.getMessage(), null);
       throw new AdminException(failureOnAdding(GROUP, group.getName()), e);
     }
   }
@@ -654,6 +666,7 @@ public class GroupManager {
 
   /**
    * Restores the given group in Silverpeas.
+   *
    * @param group the group to restore.
    * @param indexation true to perform indexation.
    * @return all parent group ids (including given group at first position).
@@ -702,6 +715,7 @@ public class GroupManager {
 
   /**
    * Removes the given group in Silverpeas.
+   *
    * @param group the group to remove.
    * @param indexation true to perform indexation.
    * @return all removed subgroup ids (including given group at first position).
@@ -730,6 +744,7 @@ public class GroupManager {
 
   /**
    * Removes given group and its subgroups.
+   *
    * @param connection a {@link Connection} instance.
    * @param group the group to remove from.
    * @return all removed subgroup ids (including given group at first position).
@@ -741,7 +756,8 @@ public class GroupManager {
     SynchroDomainReport.debug(GROUP_MANAGER_REMOVE_GROUP,
         AWAITING_DELETION_MESSAGE + group.getName() + " dans la base...");
     // remove all the subgroups
-    final List<GroupDetail> subgroups = groupDao.getDirectSubGroups(connection, group.getId(), true);
+    final List<GroupDetail> subgroups = groupDao.getDirectSubGroups(connection, group.getId(),
+        true);
     if (!subgroups.isEmpty()) {
       SynchroDomainReport.debug(GROUP_MANAGER_REMOVE_GROUP,
           "En attente de suppression des groupes fils de " + group.getName() + IN_SILVERPEAS_MESSAGE);
@@ -756,15 +772,17 @@ public class GroupManager {
   }
 
   /**
-   * Delete the group with the given Id The delete is apply recursively to the sub-groups
+   * Delete the group with the given id. The delete is apply recursively to the sub-groups.
    *
-   * @param group
-   * @param onlyInSilverpeas
-   * @return
-   * @throws AdminException
+   * @param group the group to delete.
+   * @param onlyInSilverpeas a flag indicating if the group has to be delete in Silverpeas only and
+   * not also in the domain. The mixed domain is a specific domain of Silverpeas and the flag should
+   * be true for a group of this domain.
+   * @return a list of all the deleted groups (the group itself and its children groups).
+   * @throws AdminException if an error occurs while deleting the group and its children groups.
    */
   public List<GroupDetail> deleteGroup(GroupDetail group,
-          boolean onlyInSilverpeas) throws AdminException {
+      boolean onlyInSilverpeas) throws AdminException {
     try (Connection connection = DBUtil.openConnection()) {
       if (group.getDomainId() != null && !onlyInSilverpeas) {
         domainDriverManager.deleteGroup(group.getId());
@@ -779,7 +797,7 @@ public class GroupManager {
       return deletedGroups;
     } catch (SQLException e) {
       SynchroDomainReport.error(GROUP_MANAGER_DELETE_GROUP,
-              "problème lors de la suppression du groupe " + group.getName()
+          "problème lors de la suppression du groupe " + group.getName()
               + " - " + e.getMessage(), null);
       throw new AdminException(failureOnDeleting(GROUP, group.getId()), e);
     }
@@ -787,6 +805,7 @@ public class GroupManager {
 
   /**
    * Deletes given group and its subgroups.
+   *
    * @param connection a {@link Connection} instance.
    * @param group the group to delete from.
    * @return all deleted subgroup ids (including given group at first position).
@@ -866,18 +885,20 @@ public class GroupManager {
   /**
    * Update the given group
    *
-   * @param group
-   * @param onlyInSilverpeas
-   * @return
-   * @throws AdminException
+   * @param group the new details of the group.
+   * @param onlyInSilverpeas a flag indicating if the group has to be updated in Silverpeas only and
+   * not also in the domain. The mixed domain is a specific domain of Silverpeas and the flag should
+   * be true for a group of this domain.
+   * @return the unique identifier of the updated group.
+   * @throws AdminException if an error occurs while updating the group with the given details.
    */
   public String updateGroup(GroupDetail group, boolean onlyInSilverpeas)
-          throws AdminException {
+      throws AdminException {
     if (group == null || !StringUtil.isDefined(group.getName()) || !StringUtil.isDefined(
-            group.getId())) {
+        group.getId())) {
       if (group != null) {
         SynchroDomainReport.error(GROUP_MANAGER_UPDATE_GROUP, "Problème lors de maj du groupe "
-                + group.getSpecificId() + " dans la base, ce groupe n'a pas de nom", null);
+            + group.getSpecificId() + " dans la base, ce groupe n'a pas de nom", null);
       }
       return "";
     }
@@ -890,10 +911,10 @@ public class GroupManager {
       String strInfoSycnhro;
       if (group.getSuperGroupId() != null) {
         strInfoSycnhro = "Maj du groupe " + group.getName() + " (père=" + getGroupDetail(group.
-                getSuperGroupId()).getSpecificId() + ") dans la base (table ST_Group)...";
+            getSuperGroupId()).getSpecificId() + ") dans la base (table ST_Group)...";
       } else {
         strInfoSycnhro = "Maj du groupe " + group.getName()
-                + " (groupe racine) dans la base (table ST_Group)...";
+            + " (groupe racine) dans la base (table ST_Group)...";
       }
       SynchroDomainReport.debug(GROUP_MANAGER_UPDATE_GROUP, strInfoSycnhro);
       // Update the group
@@ -903,9 +924,10 @@ public class GroupManager {
       domainDriverManager.indexGroup(group);
 
       // Update the users if necessary
-      SynchroDomainReport.debug(GROUP_MANAGER_UPDATE_GROUP, "Maj éventuelle des relations du groupe "
-              + group.getName()
-              + " avec les utilisateurs qui y sont directement inclus (tables ST_Group_User_Rel)");
+      SynchroDomainReport.debug(GROUP_MANAGER_UPDATE_GROUP, "Maj éventuelle des relations du " +
+          "groupe "
+          + group.getName()
+          + " avec les utilisateurs qui y sont directement inclus (tables ST_Group_User_Rel)");
 
       List<String> asOldUsersId = userDao.getDirectUserIdsInGroup(connection, sGroupId, false);
 
@@ -922,7 +944,7 @@ public class GroupManager {
       return sGroupId;
     } catch (Exception e) {
       SynchroDomainReport.error(GROUP_MANAGER_UPDATE_GROUP,
-              "problème lors de la maj du groupe " + group.getName() + " - "
+          "problème lors de la maj du groupe " + group.getName() + " - "
               + e.getMessage(), null);
       throw new AdminException(failureOnUpdate(GROUP, group.getId()), e);
     }
@@ -965,7 +987,7 @@ public class GroupManager {
   }
 
   public List<String> getManageableGroupIds(String userId, List<String> groupIds)
-          throws AdminException {
+      throws AdminException {
     Connection con = null;
     try {
       con = DBUtil.openConnection();
@@ -978,40 +1000,15 @@ public class GroupManager {
     }
   }
 
-  public int getNBUsersDirectlyInGroup(String groupId) throws AdminException {
-    Connection con = null;
-    try {
-      con = DBUtil.openConnection();
-
-      return groupDao.getNBUsersDirectlyInGroup(con, groupId);
-    } catch (Exception e) {
-      throw new AdminException(failureOnGetting("user count in group", groupId), e);
-    } finally {
-      DBUtil.close(con);
-    }
-  }
-
-  public List<String> getUsersDirectlyInGroup(String groupId) throws AdminException {
-    Connection con = null;
-    try {
-      con = DBUtil.openConnection();
-
-      return groupDao.getUsersDirectlyInGroup(con, groupId);
-    } catch (Exception e) {
-      throw new AdminException(failureOnGetting("users in group", groupId), e);
-    } finally {
-      DBUtil.close(con);
-    }
-  }
-
   /**
    * Gets all the removed groups in the specified domains. If no domains are given, then all the
    * removed groups in Silverpeas are returned.
+   *
    * @param domainIds zero, one or more unique identifiers of group domains in Silverpeas.
    * @return a list of the removed groups in Silverpeas. If no groups are removed in the specified
    * domains, then an empty list is returned.
-   * @throws AdminException if the removed groups cannot be fetched or if an unexpected exception
-   * is thrown.
+   * @throws AdminException if the removed groups cannot be fetched or if an unexpected exception is
+   * thrown.
    */
   public List<GroupDetail> getRemovedGroupsOfDomains(final String... domainIds)
       throws AdminException {
@@ -1095,7 +1092,7 @@ public class GroupManager {
       if (rolesByGroup != null) {
         final Iterator<GroupDetail> it = groups.iterator();
         final int nbRoles = criteria.getCriterionOnRoleNames().length;
-        while(it.hasNext()) {
+        while (it.hasNext()) {
           final GroupDetail group = it.next();
           if (rolesByGroup.getOrDefault(group.getId(), emptySet()).size() != nbRoles) {
             it.remove();
@@ -1109,7 +1106,7 @@ public class GroupManager {
       if (childrenRequired) {
         final List<GroupDetail> allSubGroups = new LinkedList<>();
         final Iterator<GroupDetail> it = groups.iterator();
-        while(it.hasNext()) {
+        while (it.hasNext()) {
           final GroupDetail group = it.next();
           if (logicalNameFiltering && !likeIgnoreCase(group.getName(), nameFilter)) {
             it.remove();
@@ -1121,7 +1118,8 @@ public class GroupManager {
           }
           if (rolesByGroup != null) {
             subGroups.forEach(g -> {
-              final Set<String> roles = rolesByGroup.computeIfAbsent(g.getId(), k -> new HashSet<>());
+              final Set<String> roles = rolesByGroup.computeIfAbsent(g.getId(),
+                  k -> new HashSet<>());
               roles.addAll(rolesByGroup.get(groupId));
             });
           }

--- a/core-library/src/main/java/org/silverpeas/core/admin/user/dao/GroupDAO.java
+++ b/core-library/src/main/java/org/silverpeas/core/admin/user/dao/GroupDAO.java
@@ -330,7 +330,7 @@ public class GroupDAO {
    * Returns all the Root Groups having a given domain id.
    * @param domainId domain id
    * @return all the Root Groups having a given domain id.
-   * @throws SQLException
+   * @throws SQLException if an error occurs
    */
   public List<GroupDetail> getAllRootGroupsByDomainId(final Connection connection,
       final String domainId) throws SQLException {
@@ -349,7 +349,7 @@ public class GroupDAO {
    * @param domainId domain id
    * @param includeRemoved true to include REMOVED from the result, false otherwise
    * @return all the Groups having a given domain id.
-   * @throws SQLException
+   * @throws SQLException if an error occurs
    */
   public List<GroupDetail> getAllGroupsByDomainId(final Connection connection,
       final String domainId, final boolean includeRemoved) throws SQLException {
@@ -369,7 +369,7 @@ public class GroupDAO {
    * @param connection connection to the data source.
    * @param groupId a group id
    * @return the parent of the specified group or null.
-   * @throws SQLException
+   * @throws SQLException if an error occurs
    */
   public GroupDetail getSuperGroup(Connection connection, String groupId) throws SQLException {
     return JdbcSqlQuery.select(format(GROUP_COLUMNS_PATTERN, "sg."))
@@ -442,20 +442,6 @@ public class GroupDAO {
       query.and(STATE).notIn(GroupState.REMOVED);
     }
     return query.executeWith(con, GroupDAO::fetchGroup);
-  }
-
-  public int getNBUsersDirectlyInGroup(Connection con, String groupId) throws SQLException {
-    return JdbcSqlQuery.select("COUNT(userId)")
-        .from(GROUP_USERS_TABLE)
-        .where(GROUP_ID_CRITERION, Integer.parseInt(groupId))
-        .executeUniqueWith(con, rs -> rs.getInt(1));
-  }
-
-  public List<String> getUsersDirectlyInGroup(Connection con, String groupId) throws SQLException {
-    return JdbcSqlQuery.select(USER_ID)
-        .from(GROUP_USERS_TABLE)
-        .where(GROUP_ID_CRITERION, Integer.parseInt(groupId))
-        .executeWith(con, rs -> String.valueOf(rs.getInt(1)));
   }
 
   public List<String> getManageableGroupIds(Connection con, String userId,

--- a/core-library/src/main/java/org/silverpeas/core/calendar/notification/AbstractNotifier.java
+++ b/core-library/src/main/java/org/silverpeas/core/calendar/notification/AbstractNotifier.java
@@ -38,7 +38,7 @@ import static org.silverpeas.core.calendar.CalendarEventUtil.asAttendee;
  * A notifier of attendees about some lifecycle events triggered by the Calendar engine.
  * @author mmoquillon
  */
-public abstract class AbstractNotifier<T extends ResourceEvent>
+public abstract class AbstractNotifier<T extends ResourceEvent<?>>
     extends CDIAfterSuccessfulTransactionResourceEventListener<T> {
 
   protected List<Attendee> ownerOf(final CalendarComponent calendarComponent) {

--- a/core-services/chat/src/main/java/org/silverpeas/core/chat/ChatSettings.java
+++ b/core-services/chat/src/main/java/org/silverpeas/core/chat/ChatSettings.java
@@ -386,7 +386,7 @@ public class ChatSettings {
    * Gets all the user groups in Silverpeas that are allowed to use the chat service, id est the
    * groups for which the chat is enabled. If no groups of users is defined, then an empty string
    * is returned and the chat is enabled for all the groups in Silverpeas (default behaviour).
-   * @return an array of group identifiers or an empty array if all the groups are allowed.
+   * @return a list of group identifiers or an empty array if all the groups are allowed.
    */
   public List<String> getAllowedUserGroups() {
     return getListProperty("chat.xmpp.domain.groups");

--- a/core-services/chat/src/main/java/org/silverpeas/core/chat/ChatUsersRegistration.java
+++ b/core-services/chat/src/main/java/org/silverpeas/core/chat/ChatUsersRegistration.java
@@ -34,8 +34,8 @@ import javax.inject.Inject;
 import java.util.List;
 
 /**
- * Registers into the remote Chat server an existing Silverpeas user with all of its relationships.
- * If the user is already registered then nothing is performed.
+ * Registration of a user in the remote Chat server.
+ *
  * @author mmoquillon
  */
 @Service
@@ -46,12 +46,13 @@ public class ChatUsersRegistration {
   private ChatServer chatServer;
   @Inject
   private RelationShipService relationShipService;
-  private SilverLogger logger = SilverLogger.getLogger(this);
+  private final SilverLogger logger = SilverLogger.getLogger(this);
 
   /**
    * Is the chat service enabled in Silverpeas?
-   * @return true if the chat service is enabled and then the users can be registered into the
-   * chat service. False otherwise.
+   *
+   * @return true if the chat service is enabled and then the users can be registered into the chat
+   * service. False otherwise.
    */
   public boolean isChatServiceEnabled() {
     return ChatServer.isEnabled();
@@ -59,10 +60,11 @@ public class ChatUsersRegistration {
 
   /**
    * Is the specified user already registered into the remote chat server?
+   *
    * @param user the user to check the existence.
    * @return true if the user has an account in the remote chat server, false otherwise.
-   * @throws ChatServerException a runtime exception if an error occurs while communicating with the remote chat
-   * server.
+   * @throws ChatServerException a runtime exception if an error occurs while communicating with the
+   * remote chat server.
    */
   public boolean isAlreadyRegistered(final User user) {
     return chatServer.isUserExisting(user);
@@ -72,21 +74,24 @@ public class ChatUsersRegistration {
    * Registers the specified user into the remote chat server. If the user is already registered
    * into the remote chat server, then nothing is performed. If the chat service isn't enabled then
    * nothing is performed. If the Silverpeas domain of the user isn't mapped to a chat domain, then
-   * nothing is performed. If the specified user hasn't the right to access the chat service (id
-   * est if he doesn't belong to a group allowed to access the chat service in the case this
-   * feature is enabled), then nothing is performed.
+   * nothing is performed. If the specified user hasn't the right to access the chat service (id est
+   * if he doesn't belong to a group allowed to access the chat service in the case this feature is
+   * enabled), then nothing is performed.
    * <p>
    * With the user registration, his relationships are also browsed in order to create each of them
-   * into the remote chat server. If a user targeted by a relationship hasn't yet an account in
-   * the chat server, then he's registered before creating the relationship in the server.
+   * into the remote chat server. If a user targeted by a relationship hasn't yet an account in the
+   * chat server, then he's registered before creating the relationship in the server.
+   *
    * @param user the user to register if not yet done.
    * @throws ChatServerException a runtime exception if the registration fails.
    */
   public void registerUser(final User user) {
     if (!isChatServiceAllowed(user)) {
-      logger.debug("The user {0} isn't allowed to access the chat service", user.getDisplayedName());
+      logger.debug("The user {0} isn't allowed to access the chat service",
+          user.getDisplayedName());
     } else if (isAlreadyRegistered(user)) {
-      logger.debug("The user {0} is already registered to access the chat service", user.getDisplayedName());
+      logger.debug("The user {0} is already registered to access the chat service",
+          user.getDisplayedName());
     } else {
       logger.debug("Register user {0}", user.getDisplayedName());
       chatServer.createUser(user);
@@ -100,6 +105,22 @@ public class ChatUsersRegistration {
                 c.getDisplayedName());
             chatServer.createRelationShip(user, c);
           });
+    }
+  }
+
+  /**
+   * Unregisters the specified user from the remote chat server. If the chat service isn't enabled
+   * then nothing is done. If the user isn't registered into the chat service then nothing is done.
+   *
+   * @param user the user to unregister.
+   * @throws ChatServerException a runtime exception if the user cannot be unregistered.
+   * @apiNote This is a shortcut of the {@link ChatServer#deleteUser(User)} method but by checking
+   * the chat service is enabled and the user has an account on the remote chat service.
+   */
+  public void unregisterUser(final User user) {
+    if (isChatServiceEnabled() && isAlreadyRegistered(user)) {
+      logger.debug("Unregister user {0}", user.getDisplayedName());
+      chatServer.deleteUser(user);
     }
   }
 

--- a/core-services/chat/src/main/java/org/silverpeas/core/chat/listeners/ChatUserEventListener.java
+++ b/core-services/chat/src/main/java/org/silverpeas/core/chat/listeners/ChatUserEventListener.java
@@ -29,6 +29,7 @@ import org.silverpeas.core.annotation.Service;
 import org.silverpeas.core.chat.servers.ChatServer;
 import org.silverpeas.core.chat.servers.DefaultChatServer;
 import org.silverpeas.core.notification.system.CDIResourceEventListener;
+import org.silverpeas.kernel.annotation.Technical;
 
 import javax.inject.Inject;
 
@@ -36,6 +37,7 @@ import javax.inject.Inject;
  * Listen user modifications to clone them in Chat server
  * @author remipassmoilesel
  */
+@Technical
 @Service
 public class ChatUserEventListener extends CDIResourceEventListener<UserEvent> {
 

--- a/core-services/chat/src/main/java/org/silverpeas/core/chat/listeners/RelationShipListener.java
+++ b/core-services/chat/src/main/java/org/silverpeas/core/chat/listeners/RelationShipListener.java
@@ -30,6 +30,7 @@ import org.silverpeas.core.chat.servers.DefaultChatServer;
 import org.silverpeas.core.notification.system.CDIResourceEventListener;
 import org.silverpeas.core.socialnetwork.relationship.RelationShip;
 import org.silverpeas.core.socialnetwork.relationship.RelationShipEvent;
+import org.silverpeas.kernel.annotation.Technical;
 
 import javax.inject.Inject;
 import java.util.stream.Stream;
@@ -38,6 +39,7 @@ import java.util.stream.Stream;
  * Listen relationship modifications to clone them in the Chat server
  * @author remipassmoilesel
  */
+@Technical
 @Service
 public class RelationShipListener extends CDIResourceEventListener<RelationShipEvent> {
 
@@ -46,7 +48,7 @@ public class RelationShipListener extends CDIResourceEventListener<RelationShipE
   private ChatServer server;
 
   @Override
-  public void onCreation(final RelationShipEvent event) throws Exception {
+  public void onCreation(final RelationShipEvent event) {
     final RelationShip rs = event.getTransition().getAfter();
     final User uf1 = User.getById(String.valueOf(rs.getUser1Id()));
     final User uf2 = User.getById(String.valueOf(rs.getUser2Id()));
@@ -59,7 +61,7 @@ public class RelationShipListener extends CDIResourceEventListener<RelationShipE
   }
 
   @Override
-  public void onDeletion(final RelationShipEvent event) throws Exception {
+  public void onDeletion(final RelationShipEvent event) {
     final RelationShip rs = event.getTransition().getBefore();
     final User uf1 = User.getById(String.valueOf(rs.getUser1Id()));
     final User uf2 = User.getById(String.valueOf(rs.getUser2Id()));


### PR DESCRIPTION
This PR is related to the PR https://github.com/Silverpeas/Silverpeas-Components/pull/851

The method Administration#getGroupByNameInDomain doesn't take into account the specified domain is the mixed one. This peculiar domain hasn't driver so specific code need to be written to take into account of it. In the case the asked group is one of the mixed domain, the method now search directly in Silverpeas without passing through a domain driver to get the specific identifier of asked group in the domain.