### PR TITLE
Feature #14023: synchronize synchronized group on user creation when 'new user registration' feature is enabled

### DIFF
--- a/core-configuration/src/main/config/properties/org/silverpeas/authentication/settings/authenticationSettings.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/authentication/settings/authenticationSettings.properties
@@ -29,6 +29,10 @@ loginAnswerEncrypted = false
 
 # Allow new user to self register in Silverpeas
 newRegistrationEnabled = false
+# If newRegistrationEnabled = true, then the following parameter is verified.
+# Allow to enable the synchronization of synchronized groups on user events (creation, modification, etc.)
+# enabled by default (true)
+registrationSynchroGroupEnabled=true
 # Such new user will be created in below domainId
 justRegisteredDomainId = 0
 

--- a/core-library/src/main/java/org/silverpeas/core/admin/domain/synchro/DefaultSynchroGroupManager.java
+++ b/core-library/src/main/java/org/silverpeas/core/admin/domain/synchro/DefaultSynchroGroupManager.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2000 - 2024 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.silverpeas.core.admin.domain.synchro;
+
+import org.silverpeas.core.admin.service.AdminException;
+import org.silverpeas.core.admin.service.Administration;
+import org.silverpeas.core.admin.user.model.Group;
+import org.silverpeas.core.annotation.Service;
+import org.silverpeas.kernel.logging.SilverLogger;
+
+import javax.transaction.Transactional;
+import java.util.HashSet;
+import java.util.Set;
+
+import static java.util.Collections.synchronizedSet;
+import static org.silverpeas.kernel.util.StringUtil.isNotDefined;
+
+@Service
+public class DefaultSynchroGroupManager implements SynchroGroupManager {
+
+  private final Set<String> synchronizedGroupIds = synchronizedSet(new HashSet<>());
+
+  @Override
+  public void resetContext() {
+    try {
+      synchronizedGroupIds.clear();
+      Administration.get().getSynchronizedGroups().forEach(this::updateContextWith);
+    } catch (AdminException e) {
+      SilverLogger.getLogger(this).error(e);
+    }
+  }
+
+  @Transactional
+  @Override
+  public void synchronize() {
+    synchronized (synchronizedGroupIds) {
+      SynchroGroupReport.startSynchro();
+      synchronizedGroupIds.forEach(i -> {
+        try {
+          Administration.get().synchronizeGroupByRule(i, true);
+        } catch (AdminException e) {
+          SilverLogger.getLogger(this).error(e.getMessage(), e);
+        }
+      });
+      SynchroGroupReport.stopSynchro();
+    }
+  }
+
+  @Override
+  public void updateContextWith(final Group group) {
+    final String groupId = group.getId();
+    if (isNotDefined(groupId)) {
+      throw new IllegalArgumentException("Missing group identifier");
+    }
+    if (group.isSynchronized()) {
+      synchronizedGroupIds.add(groupId);
+    } else {
+      synchronizedGroupIds.remove(groupId);
+    }
+  }
+
+  @Override
+  public void removeFromContext(final Group group) {
+    final String groupId = group.getId();
+    if (isNotDefined(groupId)) {
+      throw new IllegalArgumentException("Missing group identifier");
+    }
+    synchronizedGroupIds.remove(groupId);
+  }
+}

--- a/core-library/src/main/java/org/silverpeas/core/admin/domain/synchro/SynchroGroupManager.java
+++ b/core-library/src/main/java/org/silverpeas/core/admin/domain/synchro/SynchroGroupManager.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2000 - 2024 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.silverpeas.core.admin.domain.synchro;
+
+import org.silverpeas.core.admin.service.Administration;
+import org.silverpeas.core.admin.user.model.Group;
+import org.silverpeas.core.util.ServiceProvider;
+
+import javax.annotation.PostConstruct;
+
+/**
+ * This manager maintains a context of synchronized groups in the final aim to perform manual or
+ * scheduled synchronizations.
+ * <p>
+ *   A secondary goal of this manager is to avoid to request the database each time a
+ *   synchronization is requested. That is why it maintains a context of synchronized group that
+ *   MUST be updated mainly by administration services.
+ * </p>
+ * @apiNote the synchronization group manager MUST be application scoped in order to be handled
+ * properly.
+ * @implNote no @{@link PostConstruct} annotation is used to call {@link #resetContext()} to
+ * initialize the context. The reset method is called by {@link Administration} implementation.
+ */
+public interface SynchroGroupManager {
+
+  static SynchroGroupManager get() {
+    return ServiceProvider.getService(SynchroGroupManager.class);
+  }
+
+  /**
+   * Performs the synchronization of synchronized groups.
+   * @apiNote the synchronized groups are those from the contexts, no database requests are
+   * performed.
+   * @implSpec implementation takes into account that several call can be performed at a same time.
+   */
+  void synchronize();
+
+  /**
+   * Updates the context of the manager with the given group data.
+   * <p>
+   *   If the group is a synchronized one, then it will be added to the list of group to perform
+   *   update on. If it is not synchronized, then it is removed from this list.
+   * </p>
+   * @param group data representing a group.
+   * @throws IllegalArgumentException if group identifier does not exist into data.
+   */
+  void updateContextWith(final Group group);
+
+  /**
+   * Removes the given group from the context of the manager.
+   * @param group data representing a group.
+   * @throws IllegalArgumentException if group identifier does not exist into data.
+   */
+  void removeFromContext(final Group group);
+
+  /**
+   * Resets the context of the manager.
+   * @apiNote it performs mainly the load of synchronized groups from the repository (database).
+   */
+  void resetContext();
+}

--- a/core-library/src/main/java/org/silverpeas/core/admin/user/GroupManager.java
+++ b/core-library/src/main/java/org/silverpeas/core/admin/user/GroupManager.java
@@ -524,7 +524,9 @@ public class GroupManager {
     try (Connection connection = DBUtil.openConnection()) {
       // Get groups of domain from Silverpeas database
       final List<GroupDetail> groups = groupDao.getSynchronizedGroups(connection);
-      return setDirectUsersOfGroups(groups);
+      return setDirectUsersOfGroups(groups).stream()
+          .filter(GroupDetail::isSynchronized)
+          .collect(Collectors.toList());
     } catch (SQLException e) {
       throw new AdminException(failureOnGetting("synchronized groups", ""), e);
     }

--- a/core-web/src/main/java/org/silverpeas/core/web/authentication/credentials/RegistrationSettings.java
+++ b/core-web/src/main/java/org/silverpeas/core/web/authentication/credentials/RegistrationSettings.java
@@ -33,11 +33,8 @@ import org.silverpeas.kernel.bundle.SettingBundle;
  */
 public class RegistrationSettings {
 
-  private static SettingBundle settings = ResourceLocator.getSettingBundle(
+  private static final SettingBundle settings = ResourceLocator.getSettingBundle(
       "org.silverpeas.authentication.settings.authenticationSettings");
-  private static String SELF_AUTHENTICATION_ACTIVATION = "newRegistrationEnabled";
-  private static String SELF_AUTHENTICATION_DOMAINID = "justRegisteredDomainId";
-  private static long PURGE_PERIOD = 10;
   private static final RegistrationSettings instance = new RegistrationSettings();
 
   public static RegistrationSettings getSettings() {
@@ -52,7 +49,7 @@ public class RegistrationSettings {
    * @return true if a user can create an account in Silverpeas. False otherwise.
    */
   public boolean isUserSelfRegistrationEnabled() {
-    return settings.getBoolean(SELF_AUTHENTICATION_ACTIVATION, false);
+    return settings.getBoolean("newRegistrationEnabled", false);
   }
 
   /**
@@ -61,6 +58,15 @@ public class RegistrationSettings {
    * @return specified domain id. "0" otherwise.
    */
   public String userSelfRegistrationDomainId() {
-    return settings.getString(SELF_AUTHENTICATION_DOMAINID, "0");
+    return settings.getString("justRegisteredDomainId", "0");
+  }
+
+  /**
+   * Is the group synchronization enabled when new user registration is enabled.
+   * @return true if enabled, false otherwise.
+   */
+  public boolean isGroupSynchronizationEnabled() {
+    return isUserSelfRegistrationEnabled() &&
+        settings.getBoolean("registrationSynchroGroupEnabled", true);
   }
 }

--- a/core-web/src/main/java/org/silverpeas/core/web/authentication/credentials/RegistrationUserEventListener.java
+++ b/core-web/src/main/java/org/silverpeas/core/web/authentication/credentials/RegistrationUserEventListener.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2000 - 2024 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.silverpeas.core.web.authentication.credentials;
+
+import org.silverpeas.core.admin.domain.synchro.SynchroGroupManager;
+import org.silverpeas.core.admin.user.notification.UserEvent;
+import org.silverpeas.core.annotation.Bean;
+import org.silverpeas.core.notification.system.CDIResourceEventListener;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+/**
+ * A listener of events about a given user account in Silverpeas.
+ * <p>
+ *   It is in charge of performing some operations linked to user registration on user
+ *   administration events.
+ * </p>
+ * @author silveryocha
+ */
+@Bean
+@Singleton
+public class RegistrationUserEventListener extends CDIResourceEventListener<UserEvent> {
+
+  @Inject
+  private SynchroGroupManager synchroGroupManager;
+
+  @Override
+  public void onCreation(final UserEvent event) {
+    synchronize();
+  }
+
+  private void synchronize() {
+    if (RegistrationSettings.getSettings().isGroupSynchronizationEnabled()) {
+      synchroGroupManager.synchronize();
+    }
+  }
+}


### PR DESCRIPTION
Adding a new parameter `registrationSynchroGroupEnabled` into `authenticationSettings.properties` file in order to disabled if needed the synchronization in a such context.

The processing of synchronizing all synchronized group has been extracted from scheduler in charge to trigger the synchronization. Now, it exists a manager of synchronized group which is invoked by the scheduler and also by the new user registration services.