### PR TITLE
Bug #14158

### DIFF
--- a/core-api/src/main/java/org/silverpeas/core/contribution/model/Thumbnail.java
+++ b/core-api/src/main/java/org/silverpeas/core/contribution/model/Thumbnail.java
@@ -27,6 +27,8 @@ package org.silverpeas.core.contribution.model;
 import org.silverpeas.core.ResourceReference;
 
 import java.io.Serializable;
+import java.nio.file.Path;
+import java.util.Optional;
 
 /**
  * A thumbnail is an image summarizing a type of resource or the content of a contribution. Usually
@@ -100,4 +102,12 @@ public interface Thumbnail extends Serializable {
    * @return the URL of the non cropped thumbnail.
    */
   String getNonCroppedURL();
+
+  /**
+   * Gets the absolute path of this thumbnail in the file system. If no path is defined for this
+   * image (for example the image comes from an hyperlink), then nothing is returned.
+   * @return the path of the thumbnail in the file system or nothing if the image is provided by an
+   * hyperlink.
+   */
+  Optional<Path> getPath();
 }

--- a/core-library/src/main/java/org/silverpeas/core/contribution/publication/notification/PublicationEvent.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/publication/notification/PublicationEvent.java
@@ -24,8 +24,9 @@
 package org.silverpeas.core.contribution.publication.notification;
 
 import org.silverpeas.core.contribution.publication.model.PublicationDetail;
-import org.silverpeas.core.notification.system.ResourceEvent;
 import org.silverpeas.core.notification.system.AbstractResourceEvent;
+
+import java.io.Serializable;
 
 /**
  * Event about a publication. This event can be about a creation, an update or a deletion of a
@@ -35,12 +36,8 @@ import org.silverpeas.core.notification.system.AbstractResourceEvent;
 public class PublicationEvent extends AbstractResourceEvent<PublicationDetail> {
   private static final long serialVersionUID = 7579870966508990655L;
 
-  protected PublicationEvent() {
-    super();
-  }
-
   /**
-   * @see AbstractResourceEvent#AbstractResourceEvent(ResourceEvent.Type, Object[])
+   * @see AbstractResourceEvent#AbstractResourceEvent(Type, Serializable[])
    */
   public PublicationEvent(Type type, PublicationDetail... publication) {
     super(type, publication);

--- a/core-library/src/main/java/org/silverpeas/core/io/file/SilverpeasFile.java
+++ b/core-library/src/main/java/org/silverpeas/core/io/file/SilverpeasFile.java
@@ -53,7 +53,7 @@ public class SilverpeasFile extends File {
   public static final SilverpeasFile NO_FILE = new SilverpeasFile("", "", "");
 
   private final String instanceId;
-  private String mimeType;
+  private final String mimeType;
 
   /**
    * Creates a new Silverpeas file belonging to the specified component instance and located at the
@@ -171,6 +171,7 @@ public class SilverpeasFile extends File {
    * @throws java.io.IOException if an error occurs while moving this file into the specified
    * directory
    */
+  @SuppressWarnings("UnusedReturnValue")
   public SilverpeasFile moveInto(String directoryPath) throws IOException {
     SilverpeasFile movedFile = NO_FILE;
     if (exists()) {
@@ -193,6 +194,7 @@ public class SilverpeasFile extends File {
    * @throws java.io.IOException if an error occurs while copying this file into the specified
    * directory
    */
+  @SuppressWarnings("unused")
   public SilverpeasFile copyInto(String directoryPath) throws IOException {
     SilverpeasFile copiedFile = NO_FILE;
     if (exists()) {
@@ -241,6 +243,7 @@ public class SilverpeasFile extends File {
    * Indicates if the current file is of type OpenOffice compatible.
    * @return true if it is a OpenOffice compatible file, false otherwise.
    */
+  @SuppressWarnings("unused")
   public boolean isOpenOfficeCompatible() {
     return FileUtil.isOpenOfficeCompatible(getPath());
   }

--- a/core-library/src/main/java/org/silverpeas/core/io/media/image/thumbnail/control/ThumbnailController.java
+++ b/core-library/src/main/java/org/silverpeas/core/io/media/image/thumbnail/control/ThumbnailController.java
@@ -223,6 +223,7 @@ public class ThumbnailController implements ComponentInstanceDeletion {
     }
   }
 
+  @SuppressWarnings("UnusedReturnValue")
   public static ThumbnailDetail createThumbnail(ThumbnailDetail thumbDetail, int thumbnailWidth,
       int thumbnailHeight) {
     try {
@@ -265,7 +266,7 @@ public class ThumbnailController implements ComponentInstanceDeletion {
           String from = getImageDirectory(fromPK.getInstanceId()) + vignette.getOriginalFileName();
 
           String type = FilenameUtils.getExtension(vignette.getOriginalFileName());
-          String newOriginalImage = String.valueOf(System.currentTimeMillis()) + "." + type;
+          String newOriginalImage = System.currentTimeMillis() + "." + type;
 
           String to = getImageDirectory(toPK.getInstanceId()) + newOriginalImage;
           FileRepositoryManager.copyFile(from, to);
@@ -275,7 +276,7 @@ public class ThumbnailController implements ComponentInstanceDeletion {
           if (vignette.getCropFileName() != null) {
             from = getImageDirectory(fromPK.getInstanceId()) + vignette.getCropFileName();
             type = FilenameUtils.getExtension(vignette.getCropFileName());
-            String newThumbnailImage = String.valueOf(System.currentTimeMillis()) + "." + type;
+            String newThumbnailImage = System.currentTimeMillis() + "." + type;
             to = getImageDirectory(toPK.getInstanceId()) + newThumbnailImage;
             FileRepositoryManager.copyFile(from, to);
             thumbDetail.setCropFileName(newThumbnailImage);
@@ -408,7 +409,7 @@ public class ThumbnailController implements ComponentInstanceDeletion {
     String path = getImageDirectory(componentId) + fileName;
     try {
       SilverpeasFile image = SilverpeasFileProvider.getFile(path);
-      image.delete();
+      Files.deleteIfExists(image.toPath());
     } catch (Exception e) {
       SilverLogger.getLogger(ThumbnailController.class).warn(e);
     }
@@ -434,6 +435,7 @@ public class ThumbnailController implements ComponentInstanceDeletion {
     }
   }
 
+  @SuppressWarnings("UnusedReturnValue")
   private static ThumbnailDetail cropThumbnail(ThumbnailDetail thumbnail, int thumbnailWidth,
       int thumbnailHeight) {
     try {

--- a/core-library/src/main/java/org/silverpeas/core/io/media/image/thumbnail/model/ThumbnailDetail.java
+++ b/core-library/src/main/java/org/silverpeas/core/io/media/image/thumbnail/model/ThumbnailDetail.java
@@ -24,10 +24,14 @@
 package org.silverpeas.core.io.media.image.thumbnail.model;
 
 import org.silverpeas.core.contribution.model.Thumbnail;
+import org.silverpeas.core.util.file.FileRepositoryManager;
+import org.silverpeas.core.util.file.FileServerUtils;
 import org.silverpeas.kernel.bundle.ResourceLocator;
 import org.silverpeas.kernel.bundle.SettingBundle;
 import org.silverpeas.kernel.util.StringUtil;
-import org.silverpeas.core.util.file.FileServerUtils;
+
+import java.nio.file.Path;
+import java.util.Optional;
 
 /**
  * Representation of a thumbnail of an object.
@@ -183,5 +187,21 @@ public class ThumbnailDetail implements Thumbnail {
     }
     return FileServerUtils.getUrl(getInstanceId(), "thumbnail", image, getMimeType(),
         publicationSettings.getString("imagesSubDirectory"));
+  }
+
+  @Override
+  public Optional<Path> getPath() {
+    String image;
+    if (getCropFileName() != null) {
+      image = getCropFileName();
+    } else {
+      image = getOriginalFileName();
+    }
+    if (image.startsWith("/")) {
+      return Optional.empty();
+    }
+    String directory = FileRepositoryManager.getAbsolutePath(getInstanceId()) +
+        publicationSettings.getString("imagesSubDirectory");
+    return Optional.of(Path.of(directory, image));
   }
 }

--- a/core-services/importExport/src/main/java/org/silverpeas/core/importexport/control/RepositoriesTypeManager.java
+++ b/core-services/importExport/src/main/java/org/silverpeas/core/importexport/control/RepositoriesTypeManager.java
@@ -27,6 +27,7 @@ import org.apache.commons.text.translate.CharSequenceTranslator;
 import org.apache.commons.text.translate.EntityArrays;
 import org.apache.commons.text.translate.LookupTranslator;
 import org.silverpeas.core.ResourceReference;
+import org.silverpeas.core.admin.user.model.User;
 import org.silverpeas.kernel.SilverpeasException;
 import org.silverpeas.core.admin.component.model.ComponentInst;
 import org.silverpeas.core.admin.service.OrganizationControllerProvider;
@@ -659,7 +660,7 @@ public class RepositoriesTypeManager {
   }
 
   public static class AttachmentDescriptor {
-    private UserDetail currentUser = null;
+    private User currentUser = null;
     private String componentId = null;
     private String resourceId = null;
     private String oldSilverpeasId = null;
@@ -675,11 +676,11 @@ public class RepositoriesTypeManager {
     private boolean publicVersionRequired;
     private String versionComment;
 
-    public UserDetail getCurrentUser() {
+    public User getCurrentUser() {
       return currentUser;
     }
 
-    public AttachmentDescriptor setCurrentUser(final UserDetail currentUser) {
+    public AttachmentDescriptor setCurrentUser(final User currentUser) {
       this.currentUser = currentUser;
       return this;
     }

--- a/core-war/src/main/java/org/silverpeas/web/attachment/DragAndDrop.java
+++ b/core-war/src/main/java/org/silverpeas/web/attachment/DragAndDrop.java
@@ -41,7 +41,6 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.File;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -58,14 +57,6 @@ import static org.silverpeas.kernel.util.StringUtil.getBooleanValue;
 public class DragAndDrop extends SilverpeasAuthenticatedHttpServlet {
   private static final long serialVersionUID = 4084217276750892258L;
 
-  /**
-   * Method declaration
-   * @param req
-   * @param res
-   * @throws IOException
-   * @throws ServletException
-   *
-   */
   @Override
   public void doGet(HttpServletRequest req, HttpServletResponse res) {
     try {
@@ -75,14 +66,6 @@ public class DragAndDrop extends SilverpeasAuthenticatedHttpServlet {
     }
   }
 
-  /**
-   * Method declaration
-   * @param req
-   * @param res
-   * @throws IOException
-   * @throws ServletException
-   *
-   */
   @Override
   public void doPost(HttpServletRequest req, HttpServletResponse res) {
     try {

--- a/core-war/src/main/webapp/ddwe/jsp/javaScript/silverpeas-ddwe-components.js
+++ b/core-war/src/main/webapp/ddwe/jsp/javaScript/silverpeas-ddwe-components.js
@@ -22,6 +22,8 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+//# sourceURL=/util/javaScript/ddwe/silverpeas-ddwe-component.js
+
 (function() {
 
   /**
@@ -47,9 +49,12 @@
 
   const UTILS = new function() {
     this.setupRunCommandOnEvent = function(componentType, command, editor, model) {
-      const models = Array.isArray(model)
-          ? model
-          : (model ? [model] : [])
+      let models;
+      if (Array.isArray(model)) {
+        models = model;
+      } else {
+        models = model ? [model] : [];
+      }
       models.forEach(function(m) {
         if (m.get('type') === componentType) {
           editor.select(m);
@@ -73,6 +78,94 @@
   };
 
   /**
+   * Stores into the targeted application the thumbnail of the contribution referred by the
+   * specified item in the selection basket. By storing the thumbnail as a regular uploaded image
+   * in the application, we ensure the image can be managed as it is got from the image selector.
+   * This will also ensure the image to not be broken in the case the contribution is deleted or
+   * its thumbnail updated or removed.
+   * @param requesterOptions options to request the operation to the remote service in Silverpeas
+   * @param basketElement the item in the basket referring an existing contribution in Silverpeas.
+   * @returns {string} the URL of the new duplicated thumbnail.
+   * @private
+   */
+  function __storeThumbnail(requesterOptions, basketElement) {
+    return sp.ajaxRequest(webContext + '/Rddwe/jsp/thumbnail')
+        .withHeaders({
+          access_token : requesterOptions.userToken,
+          file_id : requesterOptions.fileId,
+          initialization : true
+        })
+        .byPostMethod()
+        .sendAndPromiseJsonResponse({
+          id: basketElement.getId(),
+          thumbnailUrl: basketElement.getImageSrc()
+        });
+  }
+
+  const __isTheComponent = function(model, componentType) {
+    return model.get('type') === componentType;
+  }
+
+  function __updateModelWithUpdaters(model, basketElement, updaters) {
+    updaters.forEach(function(updater) {
+      model.find(updater.cssSelector).forEach(function(cmp) {
+        updater.updateWith(cmp, basketElement);
+      });
+    });
+  }
+
+  function __isComponentType(el) {
+    if (el?.tagName && el.tagName.toLowerCase() === 'div' && el.classList.contains(componentType)) {
+      return {
+        tagName: 'div',
+        type : componentType
+      };
+    }
+  }
+
+  /**
+   * Sets up the behaviour of a GraphJS component deriving from an element of the specified
+   * type in the selection basket.
+   * @param editor {object} the GrapeJS editor
+   * @param component {string} the name of the component in the editor
+   * @param componentType {string} the type of the component
+   * @param basketElementType {string} the type of the element in the selection basket with
+   * which the
+   * component can be provided.
+   * @private
+   */
+  function __setUpEditorComponentBehaviour(editor, component, componentType,
+                                           basketElementType) {
+    // setting up now the behaviour of our component in GrapeJS
+    editor.on('component:hovered', function(model) {
+      const $highlighterEl = editor.Canvas.getHighlighter(model.view);
+      const $badgeEl = editor.Canvas.getBadgeEl(model.view);
+      if (__isTheComponent(model, componentType)) {
+        $highlighterEl.classList.add(component);
+        $badgeEl.classList.add(component);
+      } else {
+        $highlighterEl.classList.remove(component);
+        $badgeEl.classList.remove(component);
+      }
+    });
+    editor.on('component:selected', function(model) {
+      if (__isTheComponent(model, componentType)) {
+        const $toolbar = editor.Canvas.getToolbarEl();
+        $toolbar.classList.add(component);
+      }
+    });
+    editor.on('component:deselected', function(model) {
+      if (__isTheComponent(model, componentType)) {
+        const $toolbar = editor.Canvas.getToolbarEl();
+        $toolbar.classList.remove(component);
+      }
+    });
+    editor.on('block:drag:stop', function(model) {
+      UTILS.setupRunCommandOnEvent(componentType, 'tlb-sp-basket-selector-' + basketElementType, editor, model);
+    });
+  }
+  
+  /**
    * Setups the Contribution component.
    * @param editor grapes instance.
    * @param initOptions the options given at initialization of DragAndDropWebEditorManager instance.
@@ -82,121 +175,126 @@
   function __setupContributionComponent(editor, initOptions, gI18n) {
     const componentType = 'contribution-header';
     gI18n.domComponents.names[componentType] = sp.i18n.get('contributionBlockTitle');
+
+    // model of a Silverpeas contribution in GrapeJS
+    const contributionModel = {
+      defaults : {
+        tagName: 'div',
+        className: componentType,
+        attributes: {
+          'class': componentType
+        },
+        components : [{
+          tagName : 'div',
+          attributes : {
+            'class': 'blocImageContribution'
+          },
+          components : [{
+            type : 'image',
+            tagName : 'img',
+            attributes : {
+              'src' : initOptions.defaultEditorImageSrc,
+              'class': 'imageContribution'
+            }
+          }]
+        }, {
+          tagName : 'div',
+          attributes: {
+            'class': 'editorialContribution'
+          },
+          components : [{
+            type : 'text',
+            tagName : 'h3',
+            attributes: {
+              'class': 'titreContribution'
+            },
+            components : sp.i18n.get('contributionBlockContentTitle')
+          }, {
+            type : 'text',
+            tagName : 'div',
+            attributes: {
+              'class': 'textContribution'
+            },
+            components : sp.i18n.get('contributionBlockContent')
+          }, {
+            type : 'link',
+            tagName : 'a',
+            attributes: {
+              'class': 'lienContribution',
+              'target': '_blank',
+              'rel': 'noopener noreferrer'
+            },
+            components : sp.i18n.get('contributionBlockContentReadMore')
+          }]
+        }]
+      },
+      init : function() {
+        __addPickupBasketElementMenu.call(this, 'tlb-sp-basket-selector-contribution');
+      }
+    };
+
+    // the updaters of a component model from an element (id est an existing Silverpeas
+    // contribution) taken from the selection basket. Each updater takes in charge to set the value
+    // of a given model's attribute.
+    const contributionModelUpdaters = [{
+      cssSelector : 'img',
+      updateWith : function(model, basketElement) {
+        if (basketElement.getImageSrc()) {
+          __storeThumbnail(initOptions, basketElement).then(function(item) {
+            model.set({
+              src: item.thumbnailUrl
+            });
+          });
+        }
+      }
+    }, {
+      cssSelector : '.titreContribution',
+      updateWith : function(model, basketElement) {
+        model.components(basketElement.getTitle().noHTML().convertNewLineAsHtml());
+      }
+    }, {
+      cssSelector : '.textContribution',
+      updateWith : function(model, basketElement) {
+        model.components(basketElement.getDescription().noHTML().convertNewLineAsHtml());
+      }
+    }, {
+      cssSelector : '.lienContribution',
+      updateWith : function(model, basketElement) {
+        model.addAttributes({
+          'href' : basketElement.getLink()
+        });
+      }
+    }];
+
+    // adding our contribution component into the GrapeJS editor by specifying, among others things,
+    // its model and how to set up its attributes.
     editor.DomComponents.addType(componentType, {
       /**
        * This method permits to identify a component when code is added manually.
        * @param el an HTML element.
        * @returns {{type: string}}
        */
-      isComponent : function(el) {
-        if (el && el.tagName && el.tagName.toLowerCase() === 'div' && el.classList.contains(componentType)) {
-          return {
-            tagName: 'div',
-            type : componentType
-          };
-        }
-      },
-      model : {
-        defaults : {
-          tagName: 'div',
-          className: componentType,
-          attributes: {
-            'class': componentType
-          },
-          components : [{
-            tagName : 'div',
-            attributes : {
-              'class': 'blocImageContribution'
-            },
-            components : [{
-              type : 'image',
-              tagName : 'img',
-              attributes : {
-                'src' : initOptions.defaultEditorImageSrc,
-                'class': 'imageContribution'
-              }
-            }]
-          }, {
-            tagName : 'div',
-            attributes: {
-              'class': 'editorialContribution'
-            },
-            components : [{
-              type : 'text',
-              tagName : 'h3',
-              attributes: {
-                'class': 'titreContribution'
-              },
-              components : sp.i18n.get('contributionBlockContentTitle')
-            }, {
-              type : 'text',
-              tagName : 'div',
-              attributes: {
-                'class': 'textContribution'
-              },
-              components : sp.i18n.get('contributionBlockContent')
-            }, {
-              type : 'link',
-              tagName : 'a',
-              attributes: {
-                'class': 'lienContribution',
-                'target': '_blank',
-                'rel': 'noopener noreferrer'
-              },
-              components : sp.i18n.get('contributionBlockContentReadMore')
-            }]
-          }]
-        },
-        init : function() {
-          __addPickupBasketElementMenu.call(this, 'tlb-sp-basket-selector-contribution');
-        }
-      },
+      isComponent : __isComponentType,
+      model : contributionModel,
       view : {
-        events: {
-          dblclick: function() {
-            // editor.runCommand('tlb-sp-basket-selector-contribution');
-          }
-        },
         onRender : function() {
           const nonCopyable = {
             copyable : false
           };
-          this.model.find('.blocImageContribution, .imageContribution, .editorialContribution, .titreContribution, .textContribution, .lienContribution').forEach(function(model) {
+          this.model
+              .find('.blocImageContribution, .imageContribution, .editorialContribution, .titreContribution, .textContribution, .lienContribution')
+              .forEach(function(model) {
             model.set(nonCopyable);
             initOptions.tools.updateToolbar(model);
-          }.bind(this.model));
+          });
         }
       }
     });
-    const __isTheComponent = function(model) {
-      return model.get('type') === componentType;
-    }
-    editor.on('component:hovered', function(model) {
-      const $highlighterEl = editor.Canvas.getHighlighter(model.view);
-      const $badgeEl = editor.Canvas.getBadgeEl(model.view);
-      if (__isTheComponent(model)) {
-        $highlighterEl.classList.add('contribution-header');
-        $badgeEl.classList.add('contribution-header');
-      } else {
-        $highlighterEl.classList.remove('contribution-header');
-        $badgeEl.classList.remove('contribution-header');
-      }
-    });
-    editor.on('component:selected', function(model) {
-      if (__isTheComponent(model)) {
-        const $toolbar = editor.Canvas.getToolbarEl();
-        $toolbar.classList.add('contribution-header');
-      }
-    });
-    editor.on('component:deselected', function(model) {
-      if (__isTheComponent(model)) {
-        const $toolbar = editor.Canvas.getToolbarEl();
-        $toolbar.classList.remove('contribution-header');
-      }
-    });
-    editor.on('block:drag:stop', function(model) {
-      UTILS.setupRunCommandOnEvent(componentType, 'tlb-sp-basket-selector-contribution', editor, model);
-    });
+
+    __setUpEditorComponentBehaviour(editor, 'contribution-header', componentType, 'contribution');
+
+    // when the contribution component is dragged into the content area, open the selection basket
+    // UI to allow the user to choose the contribution to set within the component body
     editor.Commands.add('tlb-sp-basket-selector-contribution', {
       run : function(ed, sender, opts) {
         if (opts) {
@@ -206,42 +304,14 @@
             },
             select : function(basketElement) {
               const selectedModel = ed.getSelected();
-              [{
-                cssSelector : 'img',
-                updateWith : function(model) {
-                  if (basketElement.getImageSrc()) {
-                    model.set({
-                      src : basketElement.getImageSrc()
-                    });
-                  }
-                }
-              }, {
-                cssSelector : '.titreContribution',
-                updateWith : function(model) {
-                  model.components(basketElement.getTitle().noHTML().convertNewLineAsHtml());
-                }
-              }, {
-                cssSelector : '.textContribution',
-                updateWith : function(model) {
-                  model.components(basketElement.getDescription().noHTML().convertNewLineAsHtml());
-                }
-              }, {
-                cssSelector : '.lienContribution',
-                updateWith : function(model) {
-                  model.addAttributes({
-                    'href' : basketElement.getLink()
-                  });
-                }
-              }].forEach(function(target) {
-                selectedModel.find(target.cssSelector).forEach(function(model) {
-                  target.updateWith(model);
-                });
-              });
+              __updateModelWithUpdaters(selectedModel, basketElement, contributionModelUpdaters);
             }
           });
         }
       }
     });
+    // define how and where the contribution component is rendered within the component blocks
+    // selector in GrapeJS
     editor.BlockManager.add(componentType, {
       label : sp.i18n.get('contributionBlockTitle'),
       media : '<svg viewBox="0 0 24 24"><path fill="currentColor" d="M20 5L20 19L4 19L4 5H20M20 3H4C2.89 3 2 3.89 2 5V19C2 20.11 2.89 21 4 21H20C21.11 21 22 20.11 22 19V5C22 3.89 21.11 3 20 3M18 15H6V17H18V15M10 7H6V13H10V7M12 9H18V7H12V9M18 11H12V13H18V11Z" /></path></svg>',
@@ -262,82 +332,108 @@
   function __setupEventComponent(editor, initOptions, gI18n) {
     const componentType = 'calendar-event';
     gI18n.domComponents.names[componentType] = sp.i18n.get('eventBlockTitle');
+
+    // model of a Silverpeas calendar event in GrapeJS
+    const calendarEventModel = {
+      defaults : {
+        tagName: 'div',
+        className: componentType,
+        attributes: {
+          'class': componentType
+        },
+        components : [{
+          type : 'text',
+          tagName : 'h3',
+          attributes: {
+            'class': 'event-title'
+          },
+          components : sp.i18n.get('eventBlockContentTitle')
+        }, {
+          tagName : 'div',
+          attributes: {
+            'class': 'event-date'
+          },
+          components : [{
+            type : 'text',
+            tagName : 'span',
+            attributes: {
+              'class': 'event-start-date'
+            },
+            components : sp.i18n.get('eventBlockContentFrom') + ' ...'
+          }, {
+            type : 'text',
+            tagName : 'span',
+            attributes: {
+              'class': 'event-end-date'
+            },
+            components : '&#160;' + sp.i18n.get('eventBlockContentTo') + ' ...'
+          }]
+        }, {
+          type : 'text',
+          tagName : 'div',
+          attributes: {
+            'class': 'event-description'
+          },
+          components : sp.i18n.get('eventBlockDescription')
+        }, {
+          type : 'link',
+          tagName : 'a',
+          attributes: {
+            'class': 'event-link',
+            'target': '_blank',
+            'rel': 'noopener noreferrer'
+          },
+          components : sp.i18n.get('eventBlockOpen')
+        }]
+      },
+      init : function() {
+        __addPickupBasketElementMenu.call(this, 'tlb-sp-basket-selector-event');
+      }
+    };
+
+    // the updaters of a component model from an element (id est an existing Silverpeas
+    // calendar event) taken from the selection basket. Each updater takes in charge to set the
+    // value of a given model's attribute.
+    const calendarEventModelUpdaters = [{
+      cssSelector : '.event-title',
+      updateWith : function(model, basketElement) {
+        model.components(basketElement.getTitle().noHTML().convertNewLineAsHtml());
+      }
+    }, {
+      cssSelector : '.event-start-date',
+      updateWith : function(model, basketElement) {
+        model.components(basketElement.getPeriod().formatStartDate().noHTML().convertNewLineAsHtml());
+      }
+    }, {
+      cssSelector : '.event-end-date',
+      updateWith : function(model, basketElement) {
+        model.components('&#160;' + basketElement.getPeriod().formatEndDate().noHTML().convertNewLineAsHtml());
+      }
+    }, {
+      cssSelector : '.event-description',
+      updateWith : function(model, basketElement) {
+        model.components(basketElement.getDescription().noHTML().convertNewLineAsHtml());
+      }
+    }, {
+      cssSelector : '.event-link',
+      updateWith : function(model, basketElement) {
+        model.addAttributes({
+          'href' : basketElement.getLink()
+        });
+      }
+    }];
+
+    // adding our calendar event component into the GrapeJS editor by specifying, among others
+    // things, its model
     editor.DomComponents.addType(componentType, {
       /**
        * This method permits to identify a component when code is added manually.
        * @param el an HTML element.
        * @returns {{type: string}}
        */
-      isComponent : function(el) {
-        if (el && el.tagName && el.tagName.toLowerCase() === 'div' && el.classList.contains(componentType)) {
-          return {
-            tagName: 'div',
-            type : componentType
-          };
-        }
-      },
-      model : {
-        defaults : {
-          tagName: 'div',
-          className: componentType,
-          attributes: {
-            'class': componentType
-          },
-          components : [{
-            type : 'text',
-            tagName : 'h3',
-            attributes: {
-              'class': 'event-title'
-            },
-            components : sp.i18n.get('eventBlockContentTitle')
-          }, {
-            tagName : 'div',
-            attributes: {
-              'class': 'event-date'
-            },
-            components : [{
-              type : 'text',
-              tagName : 'span',
-              attributes: {
-                'class': 'event-start-date'
-              },
-              components : sp.i18n.get('eventBlockContentFrom') + ' ...'
-            }, {
-              type : 'text',
-              tagName : 'span',
-              attributes: {
-                'class': 'event-end-date'
-              },
-              components : '&#160;' + sp.i18n.get('eventBlockContentTo') + ' ...'
-            }]
-          }, {
-            type : 'text',
-            tagName : 'div',
-            attributes: {
-              'class': 'event-description'
-            },
-            components : sp.i18n.get('eventBlockDescription')
-          }, {
-            type : 'link',
-            tagName : 'a',
-            attributes: {
-              'class': 'event-link',
-              'target': '_blank',
-              'rel': 'noopener noreferrer'
-            },
-            components : sp.i18n.get('eventBlockOpen')
-          }]
-        },
-        init : function() {
-          __addPickupBasketElementMenu.call(this, 'tlb-sp-basket-selector-event');
-        }
-      },
+      isComponent : __isComponentType,
+      model : calendarEventModel,
       view : {
-        events: {
-          dblclick: function() {
-            // editor.runCommand('tlb-sp-basket-selector-event');
-          }
-        },
         onRender : function() {
           const nonCopyable = {
             copyable : false
@@ -345,39 +441,15 @@
           this.model.find('.event-title, .event-date, .event-start-date, .event-end-date, .event-description, .event-link').forEach(function(model) {
             model.set(nonCopyable);
             initOptions.tools.updateToolbar(model);
-          }.bind(this.model));
+          });
         }
       }
     });
-    const __isTheComponent = function(model) {
-      return model.get('type') === componentType;
-    }
-    editor.on('component:hovered', function(model) {
-      const $highlighterEl = editor.Canvas.getHighlighter(model.view);
-      const $badgeEl = editor.Canvas.getBadgeEl(model.view);
-      if (__isTheComponent(model)) {
-        $highlighterEl.classList.add('calendar-event');
-        $badgeEl.classList.add('calendar-event');
-      } else {
-        $highlighterEl.classList.remove('calendar-event');
-        $badgeEl.classList.remove('calendar-event');
-      }
-    });
-    editor.on('component:selected', function(model) {
-      if (__isTheComponent(model)) {
-        const $toolbar = editor.Canvas.getToolbarEl();
-        $toolbar.classList.add('calendar-event');
-      }
-    });
-    editor.on('component:deselected', function(model) {
-      if (__isTheComponent(model)) {
-        const $toolbar = editor.Canvas.getToolbarEl();
-        $toolbar.classList.remove('calendar-event');
-      }
-    });
-    editor.on('block:drag:stop', function(model) {
-      UTILS.setupRunCommandOnEvent(componentType, 'tlb-sp-basket-selector-event', editor, model);
-    });
+
+    __setUpEditorComponentBehaviour(editor, 'calendar-event', componentType, 'event');
+
+    // when the calendar event component is dragged into the content area, open the selection
+    // basket UI to allow the user to choose the calendar event to set within the component body
     editor.Commands.add('tlb-sp-basket-selector-event', {
       run : function(ed, sender, opts) {
         if (opts) {
@@ -387,43 +459,14 @@
             },
             select : function(basketElement) {
               const selectedModel = ed.getSelected();
-              [{
-                cssSelector : '.event-title',
-                updateWith : function(model) {
-                  model.components(basketElement.getTitle().noHTML().convertNewLineAsHtml());
-                }
-              }, {
-                cssSelector : '.event-start-date',
-                updateWith : function(model) {
-                  model.components(basketElement.getPeriod().formatStartDate().noHTML().convertNewLineAsHtml());
-                }
-              }, {
-                cssSelector : '.event-end-date',
-                updateWith : function(model) {
-                  model.components('&#160;' + basketElement.getPeriod().formatEndDate().noHTML().convertNewLineAsHtml());
-                }
-              }, {
-                cssSelector : '.event-description',
-                updateWith : function(model) {
-                  model.components(basketElement.getDescription().noHTML().convertNewLineAsHtml());
-                }
-              }, {
-                cssSelector : '.event-link',
-                updateWith : function(model) {
-                  model.addAttributes({
-                    'href' : basketElement.getLink()
-                  });
-                }
-              }].forEach(function(target) {
-                selectedModel.find(target.cssSelector).forEach(function(model) {
-                  target.updateWith(model);
-                });
-              });
+              __updateModelWithUpdaters(selectedModel, basketElement, calendarEventModelUpdaters);
             }
           });
         }
       }
     });
+    // define how and where the calendar event component is rendered within the component blocks
+    // selector in GrapeJS
     editor.BlockManager.add(componentType, {
       label : sp.i18n.get('eventBlockTitle'),
       media : '<svg viewBox="0 0 24 24"><path fill="currentColor" d="M7 11H9V13H7V11M21 5V19C21 20.11 20.11 21 19 21H5C3.89 21 3 20.1 3 19V5C3 3.9 3.9 3 5 3H6V1H8V3H16V1H18V3H19C20.11 3 21 3.9 21 5M5 7H19V5H5V7M19 19V9H5V19H19M15 13V11H17V13H15M11 13V11H13V13H11M7 15H9V17H7V15M15 17V15H17V17H15M11 17V15H13V17H11Z" /></path></svg>',
@@ -444,72 +487,71 @@
   function __setupImageLinkComponent(editor, initOptions, gI18n) {
     const componentType = 'bloc-image-link';
     gI18n.domComponents.names[componentType] = sp.i18n.get('imageWithLinkBlockTitle');
+
+    // model of a Silverpeas image link in GrapeJS
+    const imageLinkModel = {
+      defaults : {
+        tagName: 'div',
+        className: componentType,
+        attributes: {
+          'class': componentType
+        },
+        href: '',
+        target : '_blank',
+        traits:['id', 'title', {
+          name:'href',
+          changeProp:true
+        }, {
+          name:'target',
+          type:'select',
+          options: editor.TraitManager.getConfig().optionsTarget,
+          changeProp:true
+        }],
+        components : {
+          type : 'link',
+          attributes: {
+            'href': 'javascript:void(0)',
+            'title': '',
+            'class': 'link-image',
+            'target': '_blank',
+            'rel': 'noopener noreferrer'
+          },
+          components : {
+            type : 'image',
+            attributes : {
+              'src' : initOptions.defaultEditorImageSrc,
+              'class': 'image-with-link',
+              'alt': ''
+            }
+          }
+        }
+      },
+      init : function() {
+        this.on('change:href', this.handleCustomPropertyChange);
+        this.on('change:target', this.handleCustomPropertyChange);
+      },
+      handleCustomPropertyChange : function() {
+        this.find('.link-image').forEach(function(model) {
+          const newAttr = {};
+          const props = this.props();
+          ['href', 'target'].forEach(function(name) {
+            newAttr[name] = props[name];
+          });
+          model.addAttributes(newAttr);
+        }.bind(this));
+      }
+    };
+
+    // adding our image link component into the GrapeJS editor by specifying, among others things,
+    // its model.
     editor.DomComponents.addType(componentType, {
       /**
        * This method permits to identify a component when code is added manually.
        * @param el an HTML element.
        * @returns {{type: string}}
        */
-      isComponent : function(el) {
-        if (el && el.tagName && el.tagName.toLowerCase() === 'div' && el.classList.contains(componentType)) {
-          return {
-            tagName: 'div',
-            type : componentType
-          };
-        }
-      },
-      model : {
-        defaults : {
-          tagName: 'div',
-          className: componentType,
-          attributes: {
-            'class': componentType
-          },
-          href: '',
-          target : '_blank',
-          traits:['id', 'title', {
-            name:'href',
-            changeProp:true
-          }, {
-            name:'target',
-            type:'select',
-            options: editor.TraitManager.getConfig().optionsTarget,
-            changeProp:true
-          }],
-          components : {
-            type : 'link',
-            attributes: {
-              'href': 'javascript:void(0)',
-              'title': '',
-              'class': 'link-image',
-              'target': '_blank',
-              'rel': 'noopener noreferrer'
-            },
-            components : {
-              type : 'image',
-              attributes : {
-                'src' : initOptions.defaultEditorImageSrc,
-                'class': 'image-with-link',
-                'alt': ''
-              }
-            }
-          }
-        },
-        init : function() {
-          this.on('change:href', this.handleCustomPropertyChange);
-          this.on('change:target', this.handleCustomPropertyChange);
-        },
-        handleCustomPropertyChange : function() {
-          this.find('.link-image').forEach(function(model) {
-            const newAttr = {};
-            const props = this.props();
-            ['href', 'target'].forEach(function(name) {
-              newAttr[name] = props[name];
-            }.bind(this));
-            model.addAttributes(newAttr);
-          }.bind(this));
-        }
-      },
+      isComponent : __isComponentType,
+      model : imageLinkModel,
       view : {
         onRender : function() {
           const props = this.model.props();
@@ -525,8 +567,8 @@
             initOptions.tools.updateToolbar(model);
             ['href', 'target'].forEach(function(name) {
               props[name] = model.getAttributes()[name];
-            }.bind(this));
-          }.bind(this.model));
+            });
+          });
           this.model.find('img').forEach(function(model) {
             model.set({
               copyable : false,
@@ -534,10 +576,13 @@
               removable : false
             });
             initOptions.tools.updateToolbar(model);
-          }.bind(this.model));
+          });
         }
       }
     });
+
+    // define how and where the image link component is rendered within the component blocks
+    // selector in GrapeJS
     editor.BlockManager.add(componentType, {
       label : sp.i18n.get('imageWithLinkBlockTitle'),
       media : '<svg viewBox="0 0 24 24"><path fill="currentColor" d="M21,3H3C2,3 1,4 1,5V19A2,2 0 0,0 3,21H21C22,21 23,20 23,19V5C23,4 22,3 21,3M5,17L8.5,12.5L11,15.5L14.5,11L19,17H5Z"></path></svg>',
@@ -558,6 +603,8 @@
   function __setupSimpleBlockComponent(editor, initOptions, gI18n) {
     const componentType = 'simple-block';
     gI18n.domComponents.names[componentType] = sp.i18n.get('simpleBlockTitle');
+
+    // adding a custom simple textual block by specifying, among others things, its model
     editor.DomComponents.addType(componentType, {
       /**
        * This method permits to identify a component when code is added manually.
@@ -565,7 +612,7 @@
        * @returns {{type: string}}
        */
       isComponent : function(el) {
-        if (el && el.tagName && el.tagName.toLowerCase() === 'div' &&
+        if (el?.tagName && el.tagName.toLowerCase() === 'div' &&
             StringUtil.defaultStringIfNotDefined(el.getAttribute('sp-behavior')).indexOf(componentType) >= 0) {
           return {
             tagName: 'div',
@@ -590,6 +637,9 @@
         }
       }
     });
+
+    // define how and where the simple block component is rendered within the component blocks
+    // selector in GrapeJS
     editor.BlockManager.add(componentType, {
       label : sp.i18n.get('simpleBlockTitle'),
       media: '<svg viewBox="0 0 24 24"> <path fill="currentColor" d="M2 20h20V4H2v16Zm-1 0V4a1 1 0 0 1 1-1h20a1 1 0 0 1 1 1v16a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1Z"/> </svg>',


### PR DESCRIPTION
In the Drag&Drop Web Edition API, the images as components (a GrapeJS components as GrapJS is used here as the front framework for the API) are treated like attachments to the contribution for which the API is used as editor. But, in the case of a thumbnail uploaded by the user, the image is just a simply link that can be broken when the original thumbnail is deleted or replaced by another image. In order to avoid such issues, and to conform to the way images are treated in the API, now the uploaded thumbnails are now transformed as a simple image component, id est as an attachment to the currently edited contribution through the Drag&Drop Web Edition API.