### PR TITLE
Bug #14277 Cache the checked password to ensure this one is effectively the password to save

### DIFF
--- a/core-library/src/integration-test/java/org/silverpeas/core/security/authentication/password/service/PasswordRulesServiceIT.java
+++ b/core-library/src/integration-test/java/org/silverpeas/core/security/authentication/password/service/PasswordRulesServiceIT.java
@@ -73,7 +73,7 @@ public class PasswordRulesServiceIT {
         .addSilverpeasExceptionBases()
         .addCommonBasicUtilities()
         .addStringTemplateFeatures()
-        .testFocusedOn((warBuilder) -> {
+        .testFocusedOn(warBuilder -> {
           warBuilder.addPackages(true, "org.silverpeas.core.security.authentication.password.constant");
           warBuilder.addPackages(true, "org.silverpeas.core.security.authentication.password.service");
           warBuilder.addClasses(AbstractPasswordRule.class, AtLeastXDigitPasswordRule.class,
@@ -123,7 +123,10 @@ public class PasswordRulesServiceIT {
 
   @Test
   public void check() {
-    assertThat(passwordRulesService.check("aA0$1234").isCorrect(), is(true));
+    String password = "aA0$1234";
+    PasswordCheck check = passwordRulesService.check(password);
+    assertThat(check.isCorrect(), is(true));
+    assertThat(passwordRulesService.isChecked(check.getId(), password), is(true));
 
     // Min length is not validated
     assertCheckRequired("aA0$123", PasswordRuleType.MIN_LENGTH);
@@ -146,7 +149,10 @@ public class PasswordRulesServiceIT {
     // - Min length is not validated
     // - At least one uppercase is not validated
     // - At least one special char is not validated
-    assertThat(passwordRulesService.check("ab0c123").getRequiredRulesInError().size(), is(3));
+    String badPassword = "ab0c123";
+    PasswordCheck badCheck = passwordRulesService.check(badPassword);
+    assertThat(badCheck.getRequiredRulesInError().size(), is(3));
+    assertThat(passwordRulesService.isChecked(badCheck.getId(), badPassword), is(false));
   }
 
   private void assertCheckRequired(String password, PasswordRuleType typeExpected) {
@@ -158,7 +164,11 @@ public class PasswordRulesServiceIT {
   @Test
   public void checkWithCombination() {
     setCombinationSettings();
-    assertThat(passwordRulesService.check("aABC;0$1234").isCorrect(), is(true));
+
+    String password = "aABC;0$1234";
+    PasswordCheck check = passwordRulesService.check(password);
+    assertThat(check.isCorrect(), is(true));
+    assertThat(passwordRulesService.isChecked(check.getId(), password), is(true));
 
     // Min length is not validated and combination fail
     assertCheckRequiredAndCombined("aA0$123", PasswordRuleType.MIN_LENGTH, false,
@@ -170,9 +180,11 @@ public class PasswordRulesServiceIT {
     // - Min length is not validated
     // - Blank forbidden
     // - Sequential forbidden
-    PasswordCheck passwordCheck = passwordRulesService.check("ab0 c1123");
+    String badPassword = "ab0 c1123";
+    PasswordCheck passwordCheck = passwordRulesService.check(badPassword);
     assertThat(passwordCheck.getRequiredRulesInError().size(), is(3));
     assertThat(passwordCheck.getCombinedRulesInError().size(), is(2));
+    assertThat(passwordRulesService.isChecked(passwordCheck.getId(), badPassword), is(false));
   }
 
   private void assertCheckRequiredAndCombined(String password,

--- a/core-library/src/main/java/org/silverpeas/core/security/authentication/password/service/PasswordCheck.java
+++ b/core-library/src/main/java/org/silverpeas/core/security/authentication/password/service/PasswordCheck.java
@@ -40,11 +40,12 @@ public class PasswordCheck {
   protected static SettingBundle settings =
       ResourceLocator.getSettingBundle("org.silverpeas.password.settings.password");
 
-  private Collection<PasswordRule> requiredRulesInError = new ArrayList<PasswordRule>();
-  private Collection<PasswordRule> combinedRules = new ArrayList<PasswordRule>();
-  private Collection<PasswordRule> combinedRulesInError = new ArrayList<PasswordRule>();
-  private int nbMatchingCombinedRules;
-  private int nbCombinedErrorsAuthorized;
+  private final Collection<PasswordRule> requiredRulesInError = new ArrayList<>();
+  private final Collection<PasswordRule> combinedRules;
+  private final Collection<PasswordRule> combinedRulesInError = new ArrayList<>();
+  private final int nbMatchingCombinedRules;
+  private final int nbCombinedErrorsAuthorized;
+  private String id;
 
   /**
    * Default hidden constructor
@@ -63,9 +64,17 @@ public class PasswordCheck {
     combinedRulesInError.add(rule);
   }
 
+  void setId(String id) {
+    this.id = id;
+  }
+
+  public String getId() {
+    return id;
+  }
+
   /**
    * Gets required rules in error.
-   * @return
+   * @return a collection of failed required rules
    */
   public Collection<PasswordRule> getRequiredRulesInError() {
     return requiredRulesInError;
@@ -73,7 +82,7 @@ public class PasswordCheck {
 
   /**
    * Gets combined rules in error.
-   * @return
+   * @return a collection of failed combined rules
    */
   public Collection<PasswordRule> getCombinedRulesInError() {
     return combinedRulesInError;
@@ -81,7 +90,7 @@ public class PasswordCheck {
 
   /**
    * Indicated if the checked password is correct.
-   * @return
+   * @return true if the password satisfied all the password rules. False otherwise.
    */
   public boolean isCorrect() {
     return requiredRulesInError.isEmpty() && isRuleCombinationRespected();
@@ -89,7 +98,7 @@ public class PasswordCheck {
 
   /**
    * Indicated if the combination of rules is respected.
-   * @return
+   * @return true if the combined rules has been satisfied by the password. False otherwise.
    */
   public boolean isRuleCombinationRespected() {
     return combinedRulesInError.isEmpty() ||
@@ -98,8 +107,8 @@ public class PasswordCheck {
 
   /**
    * Gets a formatted error message according to the given language
-   * @param language
-   * @return
+   * @param language the ISO 639-1 code of a language in which the message has to be written.
+   * @return a l10n message about the error.
    */
   public String getFormattedErrorMessage(String language) {
     StringBuilder errorMessage = new StringBuilder();
@@ -129,13 +138,6 @@ public class PasswordCheck {
     return formattedMessage.toString();
   }
 
-  /**
-   * Gets a string message according to the given language.
-   * @param key
-   * @param language
-   * @param params
-   * @return
-   */
   protected String getString(final String key, final String language, final String... params) {
     LocalizationBundle messages =
         ResourceLocator.getLocalizationBundle("org.silverpeas.password.multilang.passwordBundle",

--- a/core-library/src/main/java/org/silverpeas/core/security/authentication/password/service/PasswordRulesService.java
+++ b/core-library/src/main/java/org/silverpeas/core/security/authentication/password/service/PasswordRulesService.java
@@ -29,53 +29,62 @@ import org.silverpeas.core.security.authentication.password.rule.PasswordRule;
 import java.util.Collection;
 
 /**
- * User: Yohann Chastagnier
- * Date: 07/01/13
+ * A service to access password rules and to check a password satisfies the rules.
+ * @author Yohann Chastagnier
  */
 public interface PasswordRulesService {
 
   /**
-   * Gets a server password rule from its type.
-   * @return
+   * Gets a server password rule by its type.
+   * @return a password rule or null if no such rule of this type exists
    */
   PasswordRule getRule(PasswordRuleType passwordRuleType);
 
   /**
-   * Gets server password rules.
-   * @return
+   * Gets all defined the password rules.
+   * @return a collection of all the possible password rules
    */
   Collection<PasswordRule> getRules();
 
   /**
-   * Gets server required password rules.
-   * @return
+   * Gets all the required password rules.
+   * @return a collection of all rules a password has to satisfy.
    */
   Collection<PasswordRule> getRequiredRules();
 
   /**
-   * Gets server combined password rules.
-   * @return
+   * Gets the combined password rules.
+   * @return a collection of combined password rules.
    */
   Collection<PasswordRule> getCombinedRules();
 
   /**
-   * Checks server required and combined password rule on the given password.
-   * @param password
+   * Checks the specified password satisfy both the required and the combined rules.
+   * @param password the password to check
    * @return Password rules in error if any.
    */
   PasswordCheck check(String password);
 
   /**
-   * Generates a random password from existing rules.
-   * @return
+   * Is the specified password has been successfully checked by the service?
+   * @param checkId the unique identifier of a possible previous check.
+   * @param password a password.
+   * @return true if the given password has been checked by the given check process and the
+   * checking result was successful. False otherwise.
+   */
+  boolean isChecked(String checkId, String password);
+
+  /**
+   * Generates a random password satisfying the existing rules.
+   * @return a new random password.
    */
   String generate();
 
   /**
    * Gets additional rule message.
-   * All rules explicited in this message are not verifiable within Silverpeas services.
-   * @param language
-   * @return
+   * All rules explicated in this message are not verifiable within Silverpeas services.
+   * @param language the ISO 639-1 code of the language in which is written the message.
+   * @return the message about the extra rule.
    */
   String getExtraRuleMessage(String language);
 }

--- a/core-war/src/main/webapp/password.js
+++ b/core-war/src/main/webapp/password.js
@@ -22,13 +22,15 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+//# sourceURL=/silverpeas/util/javaScript/password.js
+
 /**
  * Setting password UI & behaviour and form submit.
  * @param params
  * @return {boolean}
  */
 function handlePasswordForm(params) {
-  var settings = $.extend({
+  const settings = $.extend({
     passwordFormId: '',
     passwordInputId: '',
     passwordFormAction: '',
@@ -41,28 +43,29 @@ function handlePasswordForm(params) {
     bundle : 'org.silverpeas.authentication.multilang.authentication',
     async : true
   });
-  var $pwdInput = $('#' + settings.passwordInputId);
+  let $pwdInput = $('#' + settings.passwordInputId);
   $pwdInput.password();
   $('#' + settings.passwordFormId).on("submit", function() {
-    var errorStack = [];
-    var _self = this;
-    var nextValidations = function() {
+    let errorStack = [];
+    let _self = this;
+    let nextValidations = function (checkId) {
       if ($pwdInput.val() === $('#oldPassword').val()) {
         errorStack.push(sp.i18n.get('authentication.password.newMustBeDifferentToOld'));
       }
       if ($pwdInput.val() !== $('#confirmPassword').val()) {
         errorStack.push(sp.i18n.get('authentication.password.different'));
       }
-      var $submit = function() {
+      let $submit = function () {
         if (errorStack.length) {
           jQuery.popup.error(errorStack.join("\n"));
         } else {
           _self.action = settings.passwordFormAction;
+          $('#' + settings.passwordFormId).append('<input type="hidden" name="checkId" value="' + checkId + '">')
           _self.submit();
         }
       };
       if (typeof settings.extraValidations === 'function') {
-        settings.extraValidations(errorStack).then(function() {
+        settings.extraValidations(errorStack).then(function () {
           $submit();
         });
       } else {
@@ -70,12 +73,12 @@ function handlePasswordForm(params) {
       }
     };
     $pwdInput.password('verify', {
-      onSuccess: function() {
-        nextValidations();
+      onSuccess: function(checkId) {
+        nextValidations(checkId);
       },
       onError: function() {
         errorStack.push(sp.i18n.get('authentication.password.error'));
-        nextValidations();
+        nextValidations('');
       }
     });
     return false;

--- a/core-war/src/main/webapp/util/javaScript/silverpeas-password.js
+++ b/core-war/src/main/webapp/util/javaScript/silverpeas-password.js
@@ -35,7 +35,7 @@
     extraRuleMessage: null
   };
 
-  var __uiPromises = [];
+  const __uiPromises = [];
   if (webContext) {
     __uiPromises.push(sp.i18n.load({
       bundle : 'org.silverpeas.password.multilang.passwordBundle',
@@ -48,16 +48,16 @@
       $.password.extraRuleMessage = $.trim(policy.extraRuleMessage);
     }));
   }
-  var __uiReady = Promise.all(__uiPromises);
+  const __uiReady = Promise.all(__uiPromises);
 
   /**
    * The different password methods handled by the plugin.
    */
-  var methods = {
+  const methods = {
     /**
      * Prepare UI and behavior
      */
-    init: function() {
+    init: function () {
       return __init($(this));
     },
     /**
@@ -65,14 +65,14 @@
      * - displaying rules
      * - showing to user the validated and unvalidated rules
      */
-    verify: function(options) {
+    verify: function (options) {
       return __verify($(this), options)
     }
   };
 
   /**
    * The password Silverpeas plugin based on JQuery.
-   * This JQuery plugin abstrats the way an HTML element (usually a form or a div) is rendered
+   * This JQuery plugin abstracts the way an HTML element (usually a form or a div) is rendered
    * within a JQuery UI dialog.
    *
    * Here the password namespace in JQuery.
@@ -101,13 +101,13 @@
     }
 
     return $targets.each(function() {
-      var $this = $(this);
+      const $this = $(this);
 
       // Root id
-      var infoBoxId = __getInfoBoxId($this);
+      const infoBoxId = __getInfoBoxId($this);
 
       // Clean if necessary
-      var $box = $('#' + infoBoxId);
+      let $box = $('#' + infoBoxId);
       if ($box.length === 0) {
         $box = __prepareUI($this);
       }
@@ -125,7 +125,7 @@
    * @private
    */
   function __checking($target, $box, options) {
-    var deferred = new $.Deferred();
+    const deferred = new $.Deferred();
 
     // Checking
     __postJSonData($.password.webServiceContext + '/password/policy/checking',
@@ -136,7 +136,7 @@
 
             // All rules are verified by default
             $box.find('li').each(function() {
-              var $rule = $(this);
+              const $rule = $(this);
               if ($rule.attr('id')) {
                 if (!$rule.hasClass('combined')) {
                   __switchStatusStyleClass($rule, 'success');
@@ -153,13 +153,13 @@
             try {
               if (passwordCheck.isCorrect) {
                 if (options.onSuccess) {
-                  options.onSuccess.call(this);
+                  options.onSuccess.call(this, passwordCheck.checkId);
                 }
               } else {
                 // Indicate the rules in error
                 $.each(passwordCheck.requiredRuleIdsInError, function(index, value) {
                   $box.find('li[id="' + value + '"]').each(function() {
-                    var $rule = $(this);
+                    const $rule = $(this);
                     if (!$rule.hasClass('combined')) {
                       __switchStatusStyleClass($rule, 'error');
                     }
@@ -221,10 +221,10 @@
     //  </div>
 
     // Root id
-    var infoBoxId = __getInfoBoxId($target);
+    const infoBoxId = __getInfoBoxId($target);
 
     // Clean if necessary
-    var $box = $('#' + infoBoxId);
+    let $box = $('#' + infoBoxId);
     if ($box.length > 0) {
       $box.remove();
     }
@@ -232,8 +232,8 @@
     // Common body
     $box = $('<div>').css('display', 'none').css('z-index', '100000').attr('id',
             infoBoxId).addClass('password-box-info');
-    $box.append($('<span>').append(__getFromBundleKey('password.rule.requirements')));
-    var $rules = $('<ul>');
+    $box.append($('<span>').append(__getFromBundleKey('password.rule.requirements', null)));
+    const $rules = $('<ul>');
     $box.append($rules);
 
     // Rules
@@ -246,8 +246,8 @@
       $rules.append($('<li>').attr('id',
               __getCombinedRuleId()).addClass('info').append(__getFromBundleKey('password.rule.combination',
               $.password.nbMatchingCombinedRules)));
-      var $combinedRule = $('<li>');
-      var $combinedRuleDetails = $('<ul>');
+      const $combinedRule = $('<li>');
+      const $combinedRuleDetails = $('<ul>');
       $combinedRule.append($combinedRuleDetails);
       $.each($.password.combinedRules, function(name, rule) {
         $combinedRuleDetails.append($('<li>').attr('id',
@@ -263,7 +263,7 @@
 
     // Events
     $target.on("keyup", function(event) {
-      var deferred = new $.Deferred();
+      const deferred = new $.Deferred();
       // Toggle info box display on 'Escape'
       if (event.keyCode === 27) {
         $box.toggle();
@@ -280,7 +280,7 @@
       }
 
       deferred.then(function() {
-        var deferred2 = new $.Deferred();
+        const deferred2 = new $.Deferred();
         // Position
         if ($box.css('display') !== 'none') {
           // Checking when displaying the box from 'Escape' key event
@@ -305,7 +305,7 @@
       }
     });
     $target.on("focus", function() {
-      var deferred = new $.Deferred();
+      const deferred = new $.Deferred();
       if ($target.val()) {
         __checking($target, $box, {}).then(function() {
           deferred.resolve();
@@ -350,8 +350,8 @@
    * @private
    */
   function __setBoxInfoPosition($target, $box) {
-    var top = $target.offset().top + $target.outerHeight(true) + 8;
-    var left = $target.offset().left - ($box.outerWidth(true) / 2) + ($target.outerWidth(true) / 2);
+    const top = $target.offset().top + $target.outerHeight(true) + 8;
+    const left = $target.offset().left - ($box.outerWidth(true) / 2) + ($target.outerWidth(true) / 2);
     $box.offset({top: top, left: left});
   }
 
@@ -408,16 +408,16 @@
    * Private function that performs an ajax request.
    */
   function __performAjaxRequest(settings) {
-    var deferred = new $.Deferred();
+    const deferred = new $.Deferred();
 
     // Default options.
     // url, type, dataType are missing.
-    var options = {
-      cache : false,
-      success : function(data) {
+    let options = {
+      cache: false,
+      success: function (data) {
         deferred.resolve(data);
       },
-      error : function(jqXHR, textStatus, errorThrown) {
+      error: function (jqXHR, textStatus, errorThrown) {
         window.console &&
         window.console.log('Silverpeas Check Password Request - ERROR - ' + errorThrown);
         deferred.reject();
@@ -434,9 +434,9 @@
 
   /**
    * Private method that handles i18n.
-   * @param key
-   * @param params
-   * @return message
+   * @param key the identifier of the l10n message
+   * @param params optionally parameters to pass to the value to build the final message
+   * @return message the message bound to the specified key.
    * @private
    */
   function __getFromBundleKey(key, params) {

--- a/core-web/src/main/java/org/silverpeas/core/web/authentication/credentials/ChangeCredentialFunctionHandler.java
+++ b/core-web/src/main/java/org/silverpeas/core/web/authentication/credentials/ChangeCredentialFunctionHandler.java
@@ -36,11 +36,11 @@ public abstract class ChangeCredentialFunctionHandler extends FunctionHandler {
 
   /**
    * Handle bad credential error.
-   * @param request
-   * @param originalUrl
-   * @param userCanTryAgainToLoginVerifier
-   * @param messageBundleKey
-   * @return destination url
+   * @param request the incoming request asking for credential change.
+   * @param originalUrl the targeted original URL by the request.
+   * @param userCanTryAgainToLoginVerifier verifier of user login attempts.
+   * @param messageBundleKey the key of a l10n message to pass in the case of an error.
+   * @return destination url the URL to which the request has to be redirected in case of error.
    */
   protected String performUrlOnBadCredentialError(HttpServletRequest request, String originalUrl,
       UserCanTryAgainToLoginVerifier userCanTryAgainToLoginVerifier, String messageBundleKey) {

--- a/core-web/src/main/java/org/silverpeas/core/web/authentication/credentials/ChangeExpiredPasswordHandler.java
+++ b/core-web/src/main/java/org/silverpeas/core/web/authentication/credentials/ChangeExpiredPasswordHandler.java
@@ -44,9 +44,11 @@ public class ChangeExpiredPasswordHandler extends ChangePasswordFunctionHandler 
     String domainId = request.getParameter("domainId");
     String oldPassword = request.getParameter("oldPassword");
     String newPassword = request.getParameter("newPassword");
+    String checkId = request.getParameter("checkId");
     AuthenticationCredential credential = null;
     try {
       // Change password.
+      assertPasswordHasBeenCorrectlyChecked(checkId, newPassword);
       credential = AuthenticationCredential.newWithAsLogin(login)
           .withAsPassword(oldPassword)
           .withAsDomainId(domainId);

--- a/core-web/src/main/java/org/silverpeas/core/web/authentication/credentials/ChangePasswordFunctionHandler.java
+++ b/core-web/src/main/java/org/silverpeas/core/web/authentication/credentials/ChangePasswordFunctionHandler.java
@@ -25,6 +25,8 @@ package org.silverpeas.core.web.authentication.credentials;
 
 import org.silverpeas.core.admin.user.model.UserDetail;
 import org.silverpeas.core.security.authentication.AuthenticationCredential;
+import org.silverpeas.core.security.authentication.exception.AuthenticationException;
+import org.silverpeas.core.security.authentication.password.service.PasswordRulesServiceProvider;
 import org.silverpeas.core.security.authentication.verifier.AuthenticationUserVerifierFactory;
 
 import javax.servlet.http.HttpServletRequest;
@@ -61,5 +63,21 @@ public abstract class ChangePasswordFunctionHandler extends ChangeCredentialFunc
     return performUrlOnBadCredentialError(request, originalUrl,
         AuthenticationUserVerifierFactory.getUserCanTryAgainToLoginVerifier(user),
         "badCredentials");
+  }
+
+  /**
+   * Asserts the specified password has been checked against the password rules and the checking
+   * has been successful.
+   * @param checkId the unique identifier of a password check process.
+   * @param password the password to assert.
+   * @throws AuthenticationException if the password hasn't been successfully checked by the
+   * specidfed ckeck process.
+   */
+  protected void assertPasswordHasBeenCorrectlyChecked(String checkId,String password)
+      throws AuthenticationException {
+    var passwordRuleService = PasswordRulesServiceProvider.getPasswordRulesService();
+    if (!passwordRuleService.isChecked(checkId, password)) {
+      throw new AuthenticationException("Password wasn't checked against the password rules!");
+    }
   }
 }

--- a/core-web/src/main/java/org/silverpeas/core/web/authentication/credentials/ChangePasswordHandler.java
+++ b/core-web/src/main/java/org/silverpeas/core/web/authentication/credentials/ChangePasswordHandler.java
@@ -34,15 +34,17 @@ import javax.servlet.http.HttpServletRequest;
  * Navigation case : user has changed his password.
  * @author ehugonnet
  */
-public class ChangePasswordHandler extends FunctionHandler {
+public class ChangePasswordHandler extends ChangePasswordFunctionHandler {
 
   @Override
   public String doAction(HttpServletRequest request) {
     String login = request.getParameter("Login");
     String domainId = request.getParameter("DomainId");
     String password = request.getParameter("password");
+    String checkId = request.getParameter("checkId");
     try {
       // Reset password.
+      assertPasswordHasBeenCorrectlyChecked(checkId, password);
       AuthenticationCredential credential = AuthenticationCredential
           .newWithAsLogin(login)
           .withAsDomainId(domainId);

--- a/core-web/src/main/java/org/silverpeas/core/web/authentication/credentials/EffectiveChangePasswordBeforeExpirationHandler.java
+++ b/core-web/src/main/java/org/silverpeas/core/web/authentication/credentials/EffectiveChangePasswordBeforeExpirationHandler.java
@@ -57,6 +57,8 @@ public class EffectiveChangePasswordBeforeExpirationHandler extends ChangePasswo
       String domainId = ud.getDomainId();
       String oldPassword = request.getParameter("oldPassword");
       String newPassword = request.getParameter("newPassword");
+      String checkId = request.getParameter("checkId");
+      assertPasswordHasBeenCorrectlyChecked(checkId, newPassword);
       AuthenticationCredential credential = AuthenticationCredential.newWithAsLogin(login)
           .withAsPassword(oldPassword).withAsDomainId(domainId);
       AuthenticationService authenticator = AuthenticationServiceProvider.getService();

--- a/core-web/src/main/java/org/silverpeas/core/web/authentication/credentials/EffectiveChangePasswordFromLoginHandler.java
+++ b/core-web/src/main/java/org/silverpeas/core/web/authentication/credentials/EffectiveChangePasswordFromLoginHandler.java
@@ -46,9 +46,11 @@ public class EffectiveChangePasswordFromLoginHandler extends ChangePasswordFunct
     String oldPassword = request.getParameter("oldPassword");
     String newPassword = request.getParameter("newPassword");
     String email = request.getParameter("emailAddress");
+    String checkId = request.getParameter("checkId");
     AuthenticationCredential credential = null;
     try {
       // Change password.
+      assertPasswordHasBeenCorrectlyChecked(checkId, newPassword);
       credential = AuthenticationCredential.newWithAsLogin(login)
           .withAsPassword(oldPassword)
           .withAsDomainId(domainId);

--- a/core-web/src/main/java/org/silverpeas/core/web/authentication/credentials/EffectiveChangePasswordHandler.java
+++ b/core-web/src/main/java/org/silverpeas/core/web/authentication/credentials/EffectiveChangePasswordHandler.java
@@ -67,6 +67,8 @@ public class EffectiveChangePasswordHandler extends ChangePasswordFunctionHandle
       String domainId = ud.getDomainId();
       String oldPassword = request.getParameter("oldPassword");
       String newPassword = request.getParameter("newPassword");
+      String checkId = request.getParameter("checkId");
+      assertPasswordHasBeenCorrectlyChecked(checkId, newPassword);
       AuthenticationCredential credential = AuthenticationCredential.newWithAsLogin(login)
           .withAsPassword(oldPassword).withAsDomainId(domainId);
       authenticator.changePassword(credential, newPassword);

--- a/core-web/src/main/java/org/silverpeas/core/webapi/password/PasswordCheckEntity.java
+++ b/core-web/src/main/java/org/silverpeas/core/webapi/password/PasswordCheckEntity.java
@@ -23,9 +23,6 @@
  */
 package org.silverpeas.core.webapi.password;
 
-import com.fasterxml.jackson.annotation.JsonAutoDetect;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import org.owasp.encoder.Encode;
 import org.silverpeas.core.security.authentication.password.rule.PasswordRule;
 import org.silverpeas.core.security.authentication.password.service.PasswordCheck;
 
@@ -52,13 +49,17 @@ public class PasswordCheckEntity implements Serializable {
   @XmlElement
   private boolean isRuleCombinationRespected;
 
+  /* indicates the identifier of the check process */
+  @XmlElement
+  private String checkId;
+
   /* List of password required rule ids that are not verified */
   @XmlElement
-  private Collection<String> requiredRuleIdsInError = new ArrayList<>();
+  private final Collection<String> requiredRuleIdsInError = new ArrayList<>();
 
   /* List of password combined rule ids that are not verified */
   @XmlElement
-  private Collection<String> combinedRuleIdsInError = new ArrayList<>();
+  private final Collection<String> combinedRuleIdsInError = new ArrayList<>();
 
   /**
    * Creates a new password check entity
@@ -75,6 +76,7 @@ public class PasswordCheckEntity implements Serializable {
   private PasswordCheckEntity(final PasswordCheck passwordCheck) {
     isCorrect = passwordCheck.isCorrect();
     isRuleCombinationRespected = passwordCheck.isRuleCombinationRespected();
+    checkId = passwordCheck.getId();
     for (PasswordRule rule : passwordCheck.getRequiredRulesInError()) {
       requiredRuleIdsInError.add(rule.getType().name());
     }
@@ -84,6 +86,10 @@ public class PasswordCheckEntity implements Serializable {
   }
 
   protected PasswordCheckEntity() {
+  }
+
+  public String getCheckId() {
+    return this.checkId;
   }
 
   public boolean isCorrect() {


### PR DESCRIPTION
 In order to ensure the password to save is the one that was checked, the password that was effectively checked is cached under an auto generated key that is sent back to the client that asked for check. The client, in the case the password satisfied all the password rules, sends to the server the check key with the password to save. If the key doesn't match any cache entry or if the password in the cache (hence the checked password) doesn't match the password to save, then an Authentication exception is thrown.