### PR TITLE
Bug #14387

### DIFF
--- a/core-api/src/main/java/org/silverpeas/core/admin/user/model/SilverpeasRole.java
+++ b/core-api/src/main/java/org/silverpeas/core/admin/user/model/SilverpeasRole.java
@@ -26,8 +26,8 @@ package org.silverpeas.core.admin.user.model;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import org.silverpeas.core.util.CollectionUtil;
-import org.silverpeas.kernel.util.StringUtil;
 import org.silverpeas.kernel.logging.SilverLogger;
+import org.silverpeas.kernel.util.StringUtil;
 
 import javax.annotation.Nonnull;
 import java.util.*;
@@ -77,7 +77,7 @@ public enum SilverpeasRole {
   private final String name;
 
   // Unfortunately, several codes of role can define the same role nature in Silverpeas ...
-  public static final Set<SilverpeasRole> READER_ROLES = EnumSet.of(USER, READER);
+  public static final Set<SilverpeasRole> READER_ROLES = Set.of(USER, READER);
 
   SilverpeasRole(final String name) {
     this.name = name;

--- a/core-war/src/main/webapp/admin/jsp/silverpeas-body-part.jsp
+++ b/core-war/src/main/webapp/admin/jsp/silverpeas-body-part.jsp
@@ -28,6 +28,7 @@
 <%@ page import="org.silverpeas.core.web.look.LookHelper"%>
 <%@ page import="org.silverpeas.kernel.util.StringUtil" %>
 <%@ page import="org.silverpeas.core.util.URLUtil" %>
+<%@ page import="org.silverpeas.core.web.util.WebRedirection" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 <%@ taglib uri="http://www.silverpeas.com/tld/viewGenerator" prefix="view"%>
@@ -42,7 +43,7 @@
   <jsp:useBean id="helper" type="org.silverpeas.core.web.look.LookHelper"/>
 
 <%
-String strGoToNew 	= (String) session.getAttribute("gotoNew");
+String strGoToNew 	= (String) session.getAttribute(WebRedirection.REDIRECT_URL);
 String spaceId 		= request.getParameter("SpaceId");
 String subSpaceId 	= request.getParameter("SubSpaceId");
 String componentId	= request.getParameter("ComponentId");
@@ -93,9 +94,9 @@ if (displayLoginHomepage) {
 }
 
 session.removeAttribute("goto");
-session.removeAttribute("gotoNew");
-session.removeAttribute("RedirectToComponentId");
-session.removeAttribute("RedirectToSpaceId");
+session.removeAttribute(WebRedirection.REDIRECT_URL);
+session.removeAttribute(WebRedirection.REDIRECT_TO_COMPONENT);
+session.removeAttribute(WebRedirection.REDIRECT_TO_SPACE);
 %>
 <style type="text/css">
 

--- a/core-war/src/main/webapp/admin/jsp/silverpeas-main.jsp
+++ b/core-war/src/main/webapp/admin/jsp/silverpeas-main.jsp
@@ -37,14 +37,18 @@
 <%@ include file="importFrameSet.jsp" %>
 <%@ page import="org.silverpeas.kernel.util.StringUtil" %>
 <%@ page import="org.silverpeas.core.web.look.LookHelper" %>
+<%@ page import="org.silverpeas.core.web.util.WebRedirection" %>
+<%@ page import="static org.silverpeas.core.web.util.WebRedirection.REDIRECT_TO_COMPONENT" %>
+<%@ page import="static org.silverpeas.core.web.util.WebRedirection.REDIRECT_TO_SPACE" %>
+<%@ page import="static org.silverpeas.core.web.util.WebRedirection.*" %>
 
 <%
-  String componentIdFromRedirect = (String) session.getAttribute("RedirectToComponentId");
-  String spaceIdFromRedirect = (String) session.getAttribute("RedirectToSpaceId");
+  String componentIdFromRedirect = (String) session.getAttribute(REDIRECT_TO_COMPONENT);
+  String spaceIdFromRedirect = (String) session.getAttribute(REDIRECT_TO_SPACE);
   if (!StringUtil.isDefined(spaceIdFromRedirect)) {
-    spaceIdFromRedirect = request.getParameter("RedirectToSpaceId");
+    spaceIdFromRedirect = request.getParameter(REDIRECT_TO_SPACE);
   }
-  String attachmentId = (String) session.getAttribute("RedirectToAttachmentId");
+  String attachmentId = (String) session.getAttribute(REDIRECT_TO_ATTACHMENT);
   LocalizationBundle generalMessage = ResourceLocator.getGeneralLocalizationBundle(language);
   StringBuilder frameBottomParams = new StringBuilder().append("{");
   boolean login = StringUtil.getBooleanValue(request.getParameter("Login"));
@@ -101,7 +105,7 @@
 
   if (!"silverpeas-main.jsp".equalsIgnoreCase(helper.getMainFrame()) &&
       !"/admin/jsp/silverpeas-main.jsp".equalsIgnoreCase(helper.getMainFrame())) {
-    session.setAttribute("RedirectToSpaceId", spaceIdFromRedirect);
+    session.setAttribute(REDIRECT_TO_SPACE, spaceIdFromRedirect);
     String topLocation = gef.getLookFrame();
     if (!topLocation.startsWith("/")) {
       topLocation = "/admin/jsp/" + topLocation;
@@ -176,8 +180,8 @@
 </head>
 <body>
 <% if (attachmentId != null) {
-  session.setAttribute("RedirectToAttachmentId", null);
-  String mapping = (String) session.getAttribute("RedirectToMapping");
+  session.setAttribute(REDIRECT_TO_ATTACHMENT, null);
+  String mapping = (String) session.getAttribute(WebRedirection.REDIRECT_RESOURCE_TYPE);
 %>
 <script type="text/javascript">
   SP_openWindow('<%=m_sContext%>/<%=mapping%>/<%=attachmentId%>', 'Fichier', '800', '600',

--- a/core-web/src/main/java/org/silverpeas/core/web/authentication/AuthenticationServlet.java
+++ b/core-web/src/main/java/org/silverpeas/core/web/authentication/AuthenticationServlet.java
@@ -37,6 +37,7 @@ import org.silverpeas.core.security.authentication.verifier.AuthenticationUserVe
 import org.silverpeas.core.security.authentication.verifier.UserCanTryAgainToLoginVerifier;
 import org.silverpeas.core.security.authentication.verifier.UserMustAcceptTermsOfServiceVerifier;
 import org.silverpeas.core.util.*;
+import org.silverpeas.core.web.util.WebRedirection;
 import org.silverpeas.kernel.bundle.ResourceLocator;
 import org.silverpeas.kernel.bundle.SettingBundle;
 import org.silverpeas.kernel.logging.SilverLogger;
@@ -400,6 +401,7 @@ public class AuthenticationServlet extends SilverpeasHttpServlet {
       boolean secure) {
     String cookieValue = URLEncoder.encode(value, Charsets.UTF_8);
     Cookie cookie = new Cookie(name, cookieValue);
+    cookie.setHttpOnly(true);
     cookie.setSecure(secure);
     cookie.setMaxAge(duration);
     cookie.setPath("/");
@@ -410,7 +412,7 @@ public class AuthenticationServlet extends SilverpeasHttpServlet {
     HttpSession session = request.getSession(false);
     Map<String, Object> attrs = new HashMap<>();
     session.getAttributeNames().asIterator().forEachRemaining(a -> {
-      if (a.startsWith("Redirect") || a.equals("gotoNew")) {
+      if (a.startsWith("Redirect") || a.equals(WebRedirection.REDIRECT_URL)) {
         attrs.put(a, session.getAttribute(a));
       }
     });

--- a/core-web/src/main/java/org/silverpeas/core/web/session/HTTPSessionInfo.java
+++ b/core-web/src/main/java/org/silverpeas/core/web/session/HTTPSessionInfo.java
@@ -26,6 +26,7 @@ package org.silverpeas.core.web.session;
 import org.silverpeas.core.admin.user.model.User;
 import org.silverpeas.core.security.authentication.AuthenticationProtocol;
 import org.silverpeas.core.security.session.SessionInfo;
+import org.silverpeas.core.web.util.WebRedirection;
 import org.silverpeas.kernel.logging.SilverLogger;
 
 import javax.servlet.http.HttpSession;
@@ -86,7 +87,7 @@ public class HTTPSessionInfo extends SessionInfo {
         if (spName.startsWith("Silverpeas_") || spName.startsWith("WYSIWYG_")) {
           controllers.add(httpSession.getAttribute(spName));
         }
-        if (!spName.startsWith("Redirect") && !"gotoNew".equals(spName)
+        if (!spName.startsWith("Redirect") && !WebRedirection.REDIRECT_URL.equals(spName)
             && !AuthenticationProtocol.PASSWORD_CHANGE_ALLOWED.equals(spName)
             && !AuthenticationProtocol.PASSWORD_IS_ABOUT_TO_EXPIRE.equals(spName)) {
           httpSession.removeAttribute(spName);

--- a/core-web/src/main/java/org/silverpeas/core/web/util/WebRedirection.java
+++ b/core-web/src/main/java/org/silverpeas/core/web/util/WebRedirection.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2000 - 2024 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.web.util;
+
+import org.owasp.encoder.Encode;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+
+import static org.silverpeas.kernel.util.StringUtil.isDefined;
+
+/**
+ * Web redirection URL computer based upon the some request or session parameters. Those parameters
+ * are defined under the name whose definition is provided by this class.
+ *
+ * @author mmoquillon
+ */
+public final class WebRedirection {
+
+  /**
+   * Unique identifier of the attachment to redirect to.
+   */
+  public static final String REDIRECT_TO_ATTACHMENT = "RedirectToAttachmentId";
+
+  /**
+   * Unique identifier of the component instance to redirect to.
+   */
+  public static final String REDIRECT_TO_COMPONENT = "RedirectToComponentId";
+
+  /**
+   * Unique identifier of the workspace to redirect to.
+   */
+  public static final String REDIRECT_TO_SPACE = "RedirectToSpaceId";
+
+  /**
+   * The type of the resource targeted by a redirection. Usually used with a targeted attachment.
+   */
+  public static final String REDIRECT_RESOURCE_TYPE = "RedirectToMapping";
+
+  /**
+   * URL to which the web redirection has to be done.
+   */
+  public static final String REDIRECT_URL = "gotoNew";
+
+  /**
+   * Computes the redirection URL if some redirection properties have been set into the specified
+   * request (or in the user session).
+   * @param request the incoming HTTP request.
+   * @return the redirection URL or an empty string if there is no redirection properties set.
+   */
+  public String getRedirectionURL(final HttpServletRequest request) {
+    HttpSession session = request.getSession(false);
+    String gotoUrl = (String) session.getAttribute(REDIRECT_URL);
+    String componentId = (String) session.getAttribute(REDIRECT_TO_COMPONENT);
+    String spaceId = (String) session.getAttribute(REDIRECT_TO_SPACE);
+    StringBuilder builder = new StringBuilder();
+    if (isDefined(gotoUrl)) {
+      builder.append("goto=").append(Encode.forUriComponent(gotoUrl));
+    } else if (isDefined(componentId)) {
+      builder.append("ComponentId=").append(componentId);
+    } else if (isDefined(spaceId)) {
+      builder.append("SpaceId=").append(spaceId);
+    }
+    if (builder.length() > 0) {
+      builder.insert(0, "/autoRedirect.jsp?");
+    }
+    return builder.toString();
+  }
+}
+  


### PR DESCRIPTION
In anonymous mode, the redirection to the contribution referred by a notification wasn't done correctly when the user isn't authenticated:
* if the user isn't connected, it recieves an access forbidden (normal as it is not yet connected)
* and once he signs in, he's redirected into the main page instead of the contribution.

Now, when the user accesses from the notification (email) to Silverpeas, he's automatically redirected into the login page for authentication. Once authenticated, he's redirected into the page in which is displayed the contribution referred by the notification.
For doing, in the authentication process, in the session is opening, the computation of a possible redirection URL takes into account now of the parameters of redirection. Those parameters are set by AutoRedirectServlet when the user accesses first, from the notification (email), to Silverpeas. In our case, this is this servlet that redirects the user to the login page.