### PR TITLE
Bug #14471

### DIFF
--- a/core-api/src/main/java/org/silverpeas/core/ResourceReference.java
+++ b/core-api/src/main/java/org/silverpeas/core/ResourceReference.java
@@ -23,24 +23,27 @@
  */
 package org.silverpeas.core;
 
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
+import com.google.common.base.Objects;
 import org.silverpeas.core.contribution.model.ContributionIdentifier;
 
 import java.io.Serializable;
 import java.text.MessageFormat;
 
 /**
- * Reference to a resource managed by a component instance in Silverpeas. Such a reference is
- * a {@link ComponentResourceIdentifier} used to identify any kinds of resources in Silverpeas
- * without having knowledge on what this resource is. It is dedicated to be used to refer a given
- * resource without having to pass it explicitly; information about the resource can be then passed
- * from service to service without any coupling between them or with the underlying resource.
- *
+ * Reference to a resource managed by a component instance in Silverpeas. Such a reference is a
+ * {@link ComponentResourceIdentifier} used to identify any kinds of resources in Silverpeas without
+ * having knowledge on what this resource is. It is dedicated to be used to refer a given resource
+ * without having to pass it explicitly; information about the resource can be then passed from
+ * service to service without any coupling between them or with the underlying resource.
+ * <p>
+ * A resource is referred by such a reference by both its local identifier and the
+ * identifier of the component instance it belongs to.
+ * </p>
  * <p>
  * For compatibility reason, {@link ResourceReference} extends {@link WAPrimaryKey} but this
  * inheritance will be removed in the future.
  * </p>
+ *
  * @author Nicolas Eysseric
  * @author mmoquillon
  */
@@ -58,6 +61,7 @@ public class ResourceReference extends WAPrimaryKey
 
   /**
    * Constructs a new reference to the specified contribution.
+   *
    * @param identifier the unique identifier of a contribution.
    */
   public ResourceReference(ContributionIdentifier identifier) {
@@ -66,8 +70,9 @@ public class ResourceReference extends WAPrimaryKey
 
   /**
    * Constructs a new reference to a resource with the specified identifier. The resource doesn't
-   * belong to a component instance or that component instance isn't required to refer uniquely
-   * the resource.
+   * belong to a component instance or that component instance isn't required to refer uniquely the
+   * resource.
+   *
    * @param id the unique identifier of a resource from which it can be explicitly and uniquely
    * referred in the whole Silverpeas.
    */
@@ -78,6 +83,7 @@ public class ResourceReference extends WAPrimaryKey
   /**
    * Constructs a new reference to a resource with the specified identifier and that is managed by
    * the specified component instance.
+   *
    * @param id the identifier of the resource, unique in the given component instance.
    * @param componentInstanceId the unique identifier of the component instance.
    */
@@ -87,6 +93,7 @@ public class ResourceReference extends WAPrimaryKey
 
   /**
    * Constructs a new reference to a resource from the old and deprecated WAPrimaryKey object.
+   *
    * @param pk a WAPrimaryKey object used to identify uniquely a resource in Silverpeas.
    */
   public ResourceReference(WAPrimaryKey pk) {
@@ -95,6 +102,7 @@ public class ResourceReference extends WAPrimaryKey
 
   /**
    * Gets a reference to the specified resource managed by a component instance.
+   *
    * @param resource the unique identifier of a resource managed by a component.
    * @return a {@link ResourceReference} instance.
    */
@@ -103,7 +111,11 @@ public class ResourceReference extends WAPrimaryKey
   }
 
   /**
-   * Is the an another object is a {@link ResourceReference} instance and is equal to this object.
+   * Is this reference refers the same resource than the specified other reference? Two
+   * references refer the same resource if the pair local identifier of the referred
+   * resource and identifier of the application instance the resource belongs to are equal in the
+   * references.
+   *
    * @param other the object to compare to this reference.
    * @return true if other is equals to this reference. False otherwise.
    */
@@ -113,18 +125,19 @@ public class ResourceReference extends WAPrimaryKey
       return false;
     }
     final ResourceReference otherRef = (ResourceReference) other;
-    return new EqualsBuilder().append(this.getId(), otherRef.getId())
-        .append(getInstanceId(), otherRef.getInstanceId())
-        .build();
+    return Objects.equal(getLocalId(), otherRef.getLocalId())
+        && Objects.equal(getComponentInstanceId(), otherRef.getComponentInstanceId());
   }
 
   /**
-   * Gets the hash code of this reference.
-   * @return an integer
+   * Gets the hash code of this reference. It is computed on the local identifier of the referred
+   * resource and on the identifier of the component instance the resource belongs to.
+   *
+   * @return the hash code of this reference.
    */
   @Override
   public int hashCode() {
-    return new HashCodeBuilder().append(this.getId()).append(this.getInstanceId()).toHashCode();
+    return Objects.hashCode(getLocalId(), getComponentInstanceId());
   }
 
   @Override

--- a/core-library/src/integration-test/java/org/silverpeas/core/contribution/publication/service/PublicationDAOIT.java
+++ b/core-library/src/integration-test/java/org/silverpeas/core/contribution/publication/service/PublicationDAOIT.java
@@ -43,14 +43,12 @@ import org.silverpeas.core.test.util.RandomGenerator;
 import org.silverpeas.core.util.DateUtil;
 
 import java.sql.Connection;
-import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.Collection;
-import java.util.Date;
-import java.util.Iterator;
-import java.util.List;
+import java.util.*;
 
 import static junit.framework.TestCase.*;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.silverpeas.core.test.integration.rule.DbSetupRule.getSafeConnection;
 
 /**
@@ -147,6 +145,7 @@ public class PublicationDAOIT {
     try (Connection con = getSafeConnection()) {
       PublicationPK primaryKey = new PublicationPK("100", "kmelia200");
       PublicationDetail result = PublicationDAO.selectByPrimaryKey(con, primaryKey);
+      assertThat(result, is(notNullValue()));
       assertEquals(primaryKey, result.getPK());
       assertEquals("Homer Simpson", result.getAuthor());
       assertEquals("2009/10/18", DateUtil.formatDate(result.getBeginDate()));
@@ -294,11 +293,9 @@ public class PublicationDAOIT {
   public void testSelectByFatherPK_5args() throws Exception {
     try (Connection con = getSafeConnection()) {
       NodePK fatherPK = new NodePK("110", "kmelia200");
-      String sorting = null;
-      boolean filterOnVisibilityPeriod = false;
       String userId = "100";
-      Collection<PublicationDetail> result = PublicationDAO.selectByFatherPK(con, fatherPK, sorting,
-          filterOnVisibilityPeriod, userId);
+      Collection<PublicationDetail> result =
+          PublicationDAO.selectByFatherPK(con, fatherPK, null, false, userId);
       assertNotNull(result);
       assertEquals(1, result.size());
       Iterator<PublicationDetail> iter = result.iterator();
@@ -323,9 +320,7 @@ public class PublicationDAOIT {
       assertEquals("300", detail.getValidatorId());
       assertEquals("Publication 1", detail.getTitle());
 
-      filterOnVisibilityPeriod = true;
-      result = PublicationDAO.selectByFatherPK(con, fatherPK, sorting, filterOnVisibilityPeriod,
-          userId);
+      result = PublicationDAO.selectByFatherPK(con, fatherPK, null, true, userId);
       assertNotNull(result);
       assertEquals(1, result.size());
       iter = result.iterator();
@@ -367,7 +362,7 @@ public class PublicationDAOIT {
       List<PublicationDetail> result = PublicationDAO.selectByFatherIds(con, fatherIds, "kmelia200",
           sorting, status,
           filterOnVisibilityPeriod);
-      assertEquals(result.size(), 2);
+      assertThat(result.size(), is(2));
 
       // Test on an empty node
       fatherIds.clear();
@@ -375,7 +370,7 @@ public class PublicationDAOIT {
 
       result = PublicationDAO.selectByFatherIds(con, fatherIds, "kmelia200", sorting, status,
           filterOnVisibilityPeriod);
-      assertEquals(result.size(), 0);
+      assertThat(result.size(), is(0));
     }
   }
 
@@ -390,13 +385,13 @@ public class PublicationDAOIT {
           PublicationCriteria
               .excludingTrashNodeOnComponentInstanceIds("kmelia200")
               .ofStatus(status));
-      assertEquals(result.size(), 2);
+      assertThat(result.size(), is(2));
 
       status = "Draft";
       result = PublicationDAO.selectPublicationsByCriteria(con, PublicationCriteria
           .excludingTrashNodeOnComponentInstanceIds("kmelia200")
           .ofStatus(status));
-      assertEquals(result.size(), 0);
+      assertThat(result.size(), is(0));
     }
   }
 
@@ -414,20 +409,20 @@ public class PublicationDAOIT {
           PublicationCriteria
               .excludingTrashNodeOnComponentInstanceIds(componentIds)
               .ofStatus(status));
-      assertEquals(result.size(), 2);
+      assertThat(result.size(), is(2));
 
       status = "Draft";
       result = PublicationDAO.selectPublicationsByCriteria(con, PublicationCriteria
           .excludingTrashNodeOnComponentInstanceIds(componentIds)
           .ofStatus(status));
-      assertEquals(result.size(), 0);
+      assertThat(result.size(), is(0));
 
       status = "Valid";
       componentIds.remove("kmelia200");
       result = PublicationDAO.selectPublicationsByCriteria(con, PublicationCriteria
           .excludingTrashNodeOnComponentInstanceIds(componentIds)
           .ofStatus(status));
-      assertEquals(result.size(), 0);
+      assertThat(result.size(), is(0));
     }
   }
 
@@ -698,9 +693,9 @@ public class PublicationDAOIT {
       List<SocialInformationPublication> list101DOA =
           PublicationDAO.getAllPublicationsIDbyUserid(con,
               user101, begin, end);
-      assertTrue("Must be equal", list101.get(0).equals(list101DOA.get(0)));
+      assertThat(list101.get(0), is(list101DOA.get(0)));
 
-//who updated pub1 and pub2
+      //who updated pub1 and pub2
       begin = DateUtil.parse("2009/11/01");
       end = DateUtil.parse("2009/11/30");
       SocialInformationPublication sp1User200 = new SocialInformationPublication(
@@ -731,8 +726,7 @@ public class PublicationDAOIT {
       list200DOA = PublicationDAO.getSocialInformationsListOfMyContacts(con, myContactsIds,
           options, begin, end);
       assertNotNull("SocialInformationPublication of my contact must be not null", list200DOA);
-      assertTrue(
-          "SocialInformationPublication of my contact must be not empty", !list200DOA.isEmpty());
+      assertThat(list200DOA.isEmpty(), is(false));
     }
   }
 }

--- a/core-library/src/main/java/org/silverpeas/core/contribution/publication/model/PublicationDetail.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/publication/model/PublicationDetail.java
@@ -107,7 +107,20 @@ import static org.silverpeas.kernel.util.StringUtil.isDefined;
 import static org.silverpeas.kernel.util.StringUtil.split;
 
 /**
- * This object contains the description of a publication
+ * A publication is a contribution that contains both a localized content and attachments, and it
+ * can be subject of a validation process according to the application managing it. A publication
+ * can be also be exported through the Silverpeas XML export engine and its modifications are
+ * tracked.
+ * <p>
+ * Because a publication, according to the application managing it, can be located in different
+ * locations (either in the same application or in others ones), it is uniquely identified by its
+ * local identifier whatever the component instance (the application) it belongs to; this is why the
+ * local identifier of the publication is also its global identifier. This characteristic has to be
+ * taken with caution when comparing references to contributions between them
+ * ({@link ResourceReference} because this can cause unexpected behaviour, as by default two
+ * references are equal if they refer the same contribution (id est contributions having both same
+ * local identifier and same component instance identifier).
+ * </p>
  */
 @XmlRootElement(namespace = "http://www.silverpeas.org/exchange")
 @XmlAccessorType(XmlAccessType.NONE)
@@ -185,6 +198,7 @@ public class PublicationDetail extends AbstractI18NBean<PublicationI18N>
    * Gets a builder of {@link PublicationDetail} instances for the default language as defined in
    * {@link I18n#getDefaultLanguage()}. All the textual properties (name, description and keywords)
    * will be related to this language.
+   *
    * @return a {@link Builder} instance
    */
   public static Builder builder() {
@@ -194,6 +208,7 @@ public class PublicationDetail extends AbstractI18NBean<PublicationI18N>
   /**
    * Gets a builder of {@link PublicationDetail} instances for the specified language. All the
    * textual properties (name, description and keywords) will be related to this language.
+   *
    * @param language a ISO 639-1 code of a supported language.
    * @return a {@link Builder} instance
    */
@@ -380,6 +395,7 @@ public class PublicationDetail extends AbstractI18NBean<PublicationI18N>
    * <p>
    * The corresponding {@link ThumbnailDetail} is loaded once and cached into publication instance.
    * </p>
+   *
    * @return the {@link ThumbnailDetail} instance if any.
    */
   @Override
@@ -618,7 +634,8 @@ public class PublicationDetail extends AbstractI18NBean<PublicationI18N>
       } catch (Exception e) {
         SilverLogger.getLogger(this)
             .warn(failureOnGetting("field value with",
-                MessageFormat.format("pubid {0} and fieldName {1}", getPK().getId(), fieldName)),
+                    MessageFormat.format("pubid {0} and fieldName {1}", getPK().getId(),
+                        fieldName)),
                 e);
       }
 
@@ -741,11 +758,6 @@ public class PublicationDetail extends AbstractI18NBean<PublicationI18N>
     indexOperation = i;
   }
 
-  public String getDefaultUrl(String componentName) {
-    return "/R" + componentName + "/" + getPK().getInstanceId() +
-        "/searchResult?Type=Publication&Id=" + getPK().getId();
-  }
-
   public boolean isStatusMustBeChecked() {
     return statusMustBeChecked;
   }
@@ -762,20 +774,6 @@ public class PublicationDetail extends AbstractI18NBean<PublicationI18N>
     this.targetValidatorId = targetValidatorId;
   }
 
-  public String getTargetValidatorNames() {
-    StringBuilder validatorNames = new StringBuilder();
-    String[] validatorIds = getTargetValidatorIds();
-    if (validatorIds != null) {
-      for (String valId : validatorIds) {
-        if (validatorNames.length() > 0) {
-          validatorNames.append(", ");
-        }
-        validatorNames.append(User.getById(valId).getDisplayedName());
-      }
-    }
-    return validatorNames.toString();
-  }
-
   public String[] getTargetValidatorIds() {
     return split(getTargetValidatorId(), ',');
   }
@@ -789,8 +787,8 @@ public class PublicationDetail extends AbstractI18NBean<PublicationI18N>
   }
 
   public boolean haveGotClone() {
-    return cloneId != null && !"-1".equals(cloneId) && !"null".equals(cloneId) &&
-        cloneId.length() > 0;
+    return cloneId != null && !"-1".equals(cloneId) && !"null".equals(cloneId)
+        && !cloneId.isEmpty();
   }
 
   public boolean isClone() {
@@ -859,12 +857,13 @@ public class PublicationDetail extends AbstractI18NBean<PublicationI18N>
   /**
    * Indicates if the update data MUST be set.
    * <p>
-   *   The update data are:
+   * The update data are:
    *   <ul>
    *     <li>the last update date</li>
    *     <li>the last updater</li>
    *   </ul>
    * </p>
+   *
    * @return true if update data MUST be set, false otherwise.
    */
   public boolean isUpdateDataMustBeSet() {
@@ -948,6 +947,7 @@ public class PublicationDetail extends AbstractI18NBean<PublicationI18N>
    * A user can access a publication if he has enough rights to access both the application instance
    * in which is managed this publication and one of the nodes to which this publication belongs
    * to.
+   *
    * @param user a user in Silverpeas.
    * @return true if the user can access this publication, false otherwise.
    */
@@ -962,6 +962,7 @@ public class PublicationDetail extends AbstractI18NBean<PublicationI18N>
    * A user can access a publication on persist context if he has enough rights to access both the
    * application instance in which is managed this publication and one of the nodes to which this
    * publication belongs to.
+   *
    * @param user a user in Silverpeas.
    * @return true if the user can access this publication, false otherwise.
    */
@@ -974,6 +975,7 @@ public class PublicationDetail extends AbstractI18NBean<PublicationI18N>
 
   /**
    * Is the specified user can file in this publication attachments?
+   *
    * @param user a user in Silverpeas.
    * @return true if the user has modification rights on this publication. In this case, he can
    * attach documents to this publication. False otherwise.
@@ -985,6 +987,7 @@ public class PublicationDetail extends AbstractI18NBean<PublicationI18N>
 
   /**
    * The type of this resource
+   *
    * @return the same value returned by getContributionType()
    */
   public static String getResourceType() {
@@ -1006,6 +1009,7 @@ public class PublicationDetail extends AbstractI18NBean<PublicationI18N>
 
   /**
    * Gets the rating informations linked with the current publication.
+   *
    * @return the rating of the publication.
    */
   @Override
@@ -1033,6 +1037,7 @@ public class PublicationDetail extends AbstractI18NBean<PublicationI18N>
    * <p>
    * Giving a null location means that alias data MUST be cleared.
    * </p>
+   *
    * @param location a {@link Location} instance.
    */
   public void setAuthorizedLocation(final Location location) {
@@ -1095,6 +1100,7 @@ public class PublicationDetail extends AbstractI18NBean<PublicationI18N>
    * Is this publication a new one? A publication is considered as a new one when it was created or
    * updated before a given amount of day. This amount is a parameter that is set in the
    * <code>publicationSettings.properties</code> properties file.
+   *
    * @return true of this publication was created or updated recently. False otherwise
    */
   public boolean isNew() {
@@ -1113,8 +1119,9 @@ public class PublicationDetail extends AbstractI18NBean<PublicationI18N>
     }
 
     /**
-     * Builds a {@link PublicationDetail} instance from the properties that were previously set
-     * with this builder.
+     * Builds a {@link PublicationDetail} instance from the properties that were previously set with
+     * this builder.
+     *
      * @return a {@link PublicationDetail} instance.
      */
     public PublicationDetail build() {
@@ -1126,6 +1133,7 @@ public class PublicationDetail extends AbstractI18NBean<PublicationI18N>
 
     /**
      * Sets the unique identifier of the {@link PublicationDetail} instance to build.
+     *
      * @param pk a unique identifier of a publication.
      * @return itself.
      */
@@ -1136,6 +1144,7 @@ public class PublicationDetail extends AbstractI18NBean<PublicationI18N>
 
     /**
      * Sets the creation properties of the {@link PublicationDetail} instance to build.
+     *
      * @param creationDate the date at which the publication was created.
      * @param creatorId the identifier of the user that created the publication.
      * @return itself.
@@ -1148,6 +1157,7 @@ public class PublicationDetail extends AbstractI18NBean<PublicationI18N>
 
     /**
      * Sets the update properties of the {@link PublicationDetail} instance to build.
+     *
      * @param updateDate the date at which the publication was lastly updated.
      * @param updaterId the identifier of the user that lastly updated the publication.
      * @return itself.
@@ -1160,6 +1170,7 @@ public class PublicationDetail extends AbstractI18NBean<PublicationI18N>
 
     /**
      * Sets the validation properties of the {@link PublicationDetail} instance to build.
+     *
      * @param validateDate the date at which the publication was validated.
      * @param validatorId the identifier of the user that validated the publication.
      * @return itself.
@@ -1171,7 +1182,9 @@ public class PublicationDetail extends AbstractI18NBean<PublicationI18N>
     }
 
     /**
-     * Sets the visibility begin date properties of the {@link PublicationDetail} instance to build.
+     * Sets the visibility begin date properties of the {@link PublicationDetail} instance to
+     * build.
+     *
      * @param date the day at which the publication begins to be visible.
      * @param hour the hour at which the publication begins to be visible.
      * @return itself.
@@ -1184,6 +1197,7 @@ public class PublicationDetail extends AbstractI18NBean<PublicationI18N>
 
     /**
      * Sets the visibility end date properties of the {@link PublicationDetail} instance to build.
+     *
      * @param date the day at which the publication ends to be visible.
      * @param hour the hour at which the publication ends to be visible.
      * @return itself.
@@ -1196,6 +1210,7 @@ public class PublicationDetail extends AbstractI18NBean<PublicationI18N>
 
     /**
      * Sets the importance of the {@link PublicationDetail} instance to build.
+     *
      * @param importance the importance of the publication. Lower value means more importance.
      * @return itself.
      */
@@ -1206,6 +1221,7 @@ public class PublicationDetail extends AbstractI18NBean<PublicationI18N>
 
     /**
      * Sets the keywords of the {@link PublicationDetail} instance to build.
+     *
      * @param keywords the keywords of the publication.
      * @return itself.
      */
@@ -1215,8 +1231,9 @@ public class PublicationDetail extends AbstractI18NBean<PublicationI18N>
     }
 
     /**
-     * Sets the URL path where is located the content of the {@link PublicationDetail} instance
-     * to build.
+     * Sets the URL path where is located the content of the {@link PublicationDetail} instance to
+     * build.
+     *
      * @param contentPagePath the path of the content of the publication.
      * @return itself.
      */
@@ -1227,6 +1244,7 @@ public class PublicationDetail extends AbstractI18NBean<PublicationI18N>
 
     /**
      * Sets the version of the {@link PublicationDetail} instance to build.
+     *
      * @param version the version of the publication.
      * @return itself.
      */
@@ -1237,6 +1255,7 @@ public class PublicationDetail extends AbstractI18NBean<PublicationI18N>
 
     /**
      * Sets in the default language the given name and description of the publication to build.
+     *
      * @param name the name of the publication.
      * @param description the description of the publication.
      * @return itself.

--- a/core-library/src/main/java/org/silverpeas/core/contribution/publication/model/PublicationIdentifier.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/publication/model/PublicationIdentifier.java
@@ -27,7 +27,15 @@ package org.silverpeas.core.contribution.publication.model;
 import org.silverpeas.core.ResourceReference;
 import org.silverpeas.core.contribution.model.ContributionIdentifier;
 
+import java.util.Objects;
+
 /**
+ * Unique identifier of a publication. As a publication can be located in different locations in
+ * different component instances, it is always uniquely identified by its alone local identifier and
+ * not by the pair local identifier/component instance identifier like with any others
+ * contributions. This is why, the equality and the hash computation is done only on its local
+ * unique identifier.
+ *
  * @author silveryocha
  */
 class PublicationIdentifier extends ContributionIdentifier {
@@ -41,5 +49,19 @@ class PublicationIdentifier extends ContributionIdentifier {
   @Override
   public ResourceReference toReference() {
     return new PublicationPK(getLocalId(), getComponentInstanceId());
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o instanceof PublicationIdentifier) {
+      PublicationIdentifier that = (PublicationIdentifier) o;
+      return Objects.equals(that.getLocalId(), getLocalId());
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getLocalId());
   }
 }

--- a/core-library/src/main/java/org/silverpeas/core/contribution/publication/model/PublicationPK.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/publication/model/PublicationPK.java
@@ -27,9 +27,11 @@ package org.silverpeas.core.contribution.publication.model;
 import org.silverpeas.core.ResourceReference;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 /**
- * It's the Publication PrimaryKey object It identify a Publication
+ * A reference to a publication in Silverpeas.
+ *
  * @author Nicolas Eysseric
  * @version 1.0
  */
@@ -55,6 +57,7 @@ public class PublicationPK extends ResourceReference implements Serializable {
 
   /**
    * Return the object root table name
+   *
    * @return the root table name of the object
    * @since 1.0
    */
@@ -65,6 +68,7 @@ public class PublicationPK extends ResourceReference implements Serializable {
 
   /**
    * Return the object table name
+   *
    * @return the table name of the object
    * @since 1.0
    */
@@ -74,7 +78,11 @@ public class PublicationPK extends ResourceReference implements Serializable {
   }
 
   /**
-   * Check if an another object is equal to this object
+   * Check if this reference refers the same publication than the specified one. A publication is
+   * uniquely identified by its identifier, whatever the component instance it belongs to. Two
+   * instances in different component instances but with the same identifier refer the same
+   * publication; this means the same publication can be referred from different location.
+   *
    * @param obj the object to compare to this PublicationPK
    * @return true if other is equals to this object
    * @see java.lang.Object#equals(java.lang.Object)
@@ -91,19 +99,18 @@ public class PublicationPK extends ResourceReference implements Serializable {
       return false;
     }
     PublicationPK other = (PublicationPK) obj;
-    if (id == null) {
-      return (other.id == null);
-    }
-    return (id.equals(other.id));
+    return Objects.equals(id, other.id);
   }
 
   /**
-   * Returns a hash code for the key
+   * Returns a hash code for the key. In opposite to the default behavior of the
+   * {@link ResourceReference}, it is computed only on the publication identifier.
+   *
    * @return A hash code for this object
    * @see java.lang.Object#hashCode()
    */
   @Override
   public int hashCode() {
-    return id.hashCode();
+    return Objects.hash(id);
   }
 }

--- a/core-library/src/test/java/org/silverpeas/core/security/authorization/PublicationDetail4Test.java
+++ b/core-library/src/test/java/org/silverpeas/core/security/authorization/PublicationDetail4Test.java
@@ -79,4 +79,12 @@ class PublicationDetail4Test extends PublicationDetail {
   List<Location> getLocations() {
     return locations;
   }
+
+  @Override
+  public String toString() {
+    return "PublicationDetail4Test{" +
+        "id=" + getId() +
+        ", instanceId=" + getInstanceId() +
+        '}';
+  }
 }


### PR DESCRIPTION
A publication is a peculiar contribution in Silverpeas as it can be located in several locations in the same or in different component instances. In this case, we have the original publication along with its all aliases. This capability is used in the Kmelia application. As consequence, the publication is only referred uniquely by its local identifier (its local identifier is its global one), whereas the others types of contributions are identified uniquely by their global identifier that is made up of their local identifier and of the identifier of the application instance they belong to.

Despite this peculiarity, the indexation, the search and the access rights computation treat the publications only by their local identifier, and this can cause troubles when the aliases of a publication (with the original one) are implied. For example, if an alias was removed, then the index in which the alias is referred is simply deleted, despite the fact there is others aliases or, worse, there is the original publication referred by the index.

In the fix, we ensure now that all the treatments are done on both the local identifier of the publication and the identifier of the application instance it belongs to. And, in the management of the indexes of the publications, they are deleted only if there is no more publications (original one/aliases) referred by them. And, in the access rights computation, in the case of a search, we look for the access rights of nodes with specific rights in which is linked the in-checking alias.

The following PR is related to this one: https://github.com/Silverpeas/Silverpeas-Components/pull/864