### PR TITLE
Bug #13273

### DIFF
--- a/core-library/src/integration-test/java/org/silverpeas/core/admin/SpacesAndComponentsIT.java
+++ b/core-library/src/integration-test/java/org/silverpeas/core/admin/SpacesAndComponentsIT.java
@@ -873,8 +873,8 @@ public class SpacesAndComponentsIT {
     assertThat(fullSpace.getAllSpaceProfilesInst(), hasSize(3));
     assertThat(fullSpace.getProfiles(), hasSize(2));
     assertThat(fullSpace.getInheritedProfiles(), hasSize(1));
-    assertThat(fullSpace.getSpaceProfileInst(SilverpeasRole.PUBLISHER.getName()).getNumUser(), is(1));
-    assertThat(fullSpace.getSpaceProfileInst(SilverpeasRole.READER.getName()).getNumUser(), is(1));
+    assertThat(fullSpace.getDirectSpaceProfileInst(SilverpeasRole.PUBLISHER.getName()).getNumUser(), is(1));
+    assertThat(fullSpace.getDirectSpaceProfileInst(SilverpeasRole.READER.getName()).getNumUser(), is(1));
     assertThat(fullSpace.getInheritedSpaceProfileInst(SilverpeasRole.PUBLISHER.getName()).getNumUser(),
         is(1));
 
@@ -935,8 +935,8 @@ public class SpacesAndComponentsIT {
     assertThat(fullSpace.getAllSpaceProfilesInst(), hasSize(1));
     assertThat(fullSpace.getProfiles(), hasSize(0));
     assertThat(fullSpace.getInheritedProfiles(), hasSize(1));
-    assertThat(fullSpace.getSpaceProfileInst(SilverpeasRole.PUBLISHER.getName()), is(nullValue()));
-    assertThat(fullSpace.getSpaceProfileInst(SilverpeasRole.READER.getName()), is(nullValue()));
+    assertThat(fullSpace.getDirectSpaceProfileInst(SilverpeasRole.PUBLISHER.getName()), is(nullValue()));
+    assertThat(fullSpace.getDirectSpaceProfileInst(SilverpeasRole.READER.getName()), is(nullValue()));
     assertThat(fullSpace.getInheritedSpaceProfileInst(SilverpeasRole.PUBLISHER.getName()).getNumUser(),
         is(1));
     // check GED rights
@@ -963,8 +963,8 @@ public class SpacesAndComponentsIT {
     assertThat(fullSpace.getAllSpaceProfilesInst(), hasSize(0));
     assertThat(fullSpace.getProfiles(), hasSize(0));
     assertThat(fullSpace.getInheritedProfiles(), hasSize(0));
-    assertThat(fullSpace.getSpaceProfileInst(SilverpeasRole.PUBLISHER.getName()), is(nullValue()));
-    assertThat(fullSpace.getSpaceProfileInst(SilverpeasRole.READER.getName()), is(nullValue()));
+    assertThat(fullSpace.getDirectSpaceProfileInst(SilverpeasRole.PUBLISHER.getName()), is(nullValue()));
+    assertThat(fullSpace.getDirectSpaceProfileInst(SilverpeasRole.READER.getName()), is(nullValue()));
     assertThat(fullSpace.getInheritedSpaceProfileInst(SilverpeasRole.PUBLISHER.getName()),
         is(nullValue()));
 

--- a/core-library/src/main/java/org/silverpeas/core/admin/service/Administration.java
+++ b/core-library/src/main/java/org/silverpeas/core/admin/service/Administration.java
@@ -968,8 +968,8 @@ public interface Administration {
       throws AdminException;
 
   /**
-   * Gets the space profile instance which provides all user and group identifiers through simple
-   * methods.
+   * Gets the space profile instance which provides all user and group identifiers playing the
+   * given role, either directly or by space profile inheritance.
    * @param spaceId the identifier of aimed space.
    * @param role the aimed technical role name.
    * @return the {@link SpaceProfile} instance.

--- a/core-library/src/main/java/org/silverpeas/core/admin/service/SpaceProfile.java
+++ b/core-library/src/main/java/org/silverpeas/core/admin/service/SpaceProfile.java
@@ -34,15 +34,16 @@ import java.util.List;
 import java.util.Set;
 
 /**
- * Getting user identifiers and group identifiers of behind a Silverpeas profiles linked to a
- * space.
+ * The user and user group profiles in a given space including inherited roles from the parent
+ * space. It decorates a specified space profile instance by taking into account the inherited
+ * roles from the same profile but of the parent space.
  * @author Nicolas Eysseric
  */
 public class SpaceProfile {
 
   private SpaceProfileInst profile;
-  private Set<String> inheritedUserIds = new HashSet<>();
-  private Set<String> inheritedGroupIds = new HashSet<>();
+  private final Set<String> inheritedUserIds = new HashSet<>();
+  private final Set<String> inheritedGroupIds = new HashSet<>();
 
   public void setProfile(SpaceProfileInst profile) {
     this.profile = profile;
@@ -96,11 +97,10 @@ public class SpaceProfile {
     return ids;
   }
 
-  @SuppressWarnings("unchecked")
   private List<String> getAllUserIdsOfGroup(String groupId) {
     List<String> userIds = new ArrayList<>();
     Group group = Group.getById(groupId);
-    List<User> users = (List<User>) group.getAllUsers();
+    List<User> users = group.getAllUsers();
     for (User user : users) {
       userIds.add(user.getId());
     }

--- a/core-library/src/main/java/org/silverpeas/core/admin/space/SpaceInst.java
+++ b/core-library/src/main/java/org/silverpeas/core/admin/space/SpaceInst.java
@@ -25,12 +25,7 @@ package org.silverpeas.core.admin.space;
 
 import org.silverpeas.core.BasicIdentifier;
 import org.silverpeas.core.Identifiable;
-import org.silverpeas.core.admin.component.model.ComponentInst;
-import org.silverpeas.core.admin.component.model.PersonalComponent;
-import org.silverpeas.core.admin.component.model.PersonalComponentInstance;
-import org.silverpeas.core.admin.component.model.SilverpeasComponentInstance;
-import org.silverpeas.core.admin.component.model.SilverpeasPersonalComponentInstance;
-import org.silverpeas.core.admin.component.model.SilverpeasSharedComponentInstance;
+import org.silverpeas.core.admin.component.model.*;
 import org.silverpeas.core.admin.quota.constant.QuotaType;
 import org.silverpeas.core.admin.quota.exception.QuotaException;
 import org.silverpeas.core.admin.quota.exception.QuotaRuntimeException;
@@ -52,6 +47,7 @@ import org.silverpeas.core.util.URLUtil;
 import org.silverpeas.core.util.UnitUtil;
 import org.silverpeas.core.util.memory.MemoryUnit;
 import org.silverpeas.kernel.annotation.NonNull;
+import org.silverpeas.kernel.annotation.Nullable;
 import org.silverpeas.kernel.bundle.ResourceLocator;
 import org.silverpeas.kernel.cache.model.SimpleCache;
 import org.silverpeas.kernel.util.StringUtil;
@@ -417,17 +413,33 @@ public class SpaceInst extends AbstractI18NBean<SpaceI18N>
   }
 
   /**
-   * Get a space profile from space profiles list, given its name (WARNING : if more than one space
-   * profile match the given name, the first one will be returned)
-   *
-   * @param sSpaceProfileName name of requested space profile
+   * Gets both the inherited and the direct space profile instances with the specified role name.
+   * @param spaceProfileName the name of the space profile to get.
+   * @return a list of either no profile instances (the profile is inherited and not yet cached)
+   * or of one or two profile instances whose one is the space-specific profile and the other is the
+   * inherited one from the parent spaces.
    */
-  public SpaceProfileInst getSpaceProfileInst(String sSpaceProfileName) {
-    return getSpaceProfileInst(sSpaceProfileName, false);
+  public List<SpaceProfileInst> getSpaceProfileInst(String spaceProfileName) {
+    return data.safeRead(d ->
+        d.streamProfiles()
+            .filter(i -> i.getName().equals(spaceProfileName))
+            .collect(Collectors.toList()));
   }
 
-  public SpaceProfileInst getInheritedSpaceProfileInst(String sSpaceProfileName) {
-    return getSpaceProfileInst(sSpaceProfileName, true);
+  /**
+   * Get a non inherited space profile from space profiles list, given its name (WARNING: if more
+   * than one space profile match the given name, the first one will be returned).
+   * @param spaceProfileName name of requested space profile
+   * @return a space profile instance or null if no such profile exists.
+   */
+  @Nullable
+  public SpaceProfileInst getDirectSpaceProfileInst(String spaceProfileName) {
+    return getSpaceProfileInst(spaceProfileName, false);
+  }
+
+  @Nullable
+  public SpaceProfileInst getInheritedSpaceProfileInst(String spaceProfileName) {
+    return getSpaceProfileInst(spaceProfileName, true);
   }
 
   private SpaceProfileInst getSpaceProfileInst(String spaceProfileName, boolean inherited) {

--- a/core-library/src/main/java/org/silverpeas/core/admin/user/model/UserDetail.java
+++ b/core-library/src/main/java/org/silverpeas/core/admin/user/model/UserDetail.java
@@ -44,7 +44,8 @@ import org.silverpeas.core.socialnetwork.invitation.InvitationService;
 import org.silverpeas.core.socialnetwork.relationship.RelationShipService;
 import org.silverpeas.core.socialnetwork.status.StatusService;
 import org.silverpeas.core.ui.DisplayI18NHelper;
-import org.silverpeas.core.util.*;
+import org.silverpeas.core.util.DateUtil;
+import org.silverpeas.core.util.ServiceProvider;
 import org.silverpeas.core.util.comparator.AbstractComplexComparator;
 import org.silverpeas.core.util.file.FileRepositoryManager;
 import org.silverpeas.core.util.file.FileServerUtils;
@@ -62,7 +63,6 @@ import java.util.*;
 
 import static org.silverpeas.core.notification.user.client.NotificationManagerSettings.getUserManualNotificationRecipientLimit;
 import static org.silverpeas.core.notification.user.client.NotificationManagerSettings.isUserManualNotificationRecipientLimitEnabled;
-import static org.silverpeas.kernel.util.StringUtil.areStringEquals;
 import static org.silverpeas.kernel.util.StringUtil.isDefined;
 
 public class UserDetail implements User {
@@ -648,30 +648,21 @@ public class UserDetail implements User {
   public boolean equals(Object other) {
     if (other instanceof UserDetail) {
       UserDetail cmpUser = (UserDetail) other;
-      return areStringEquals(id, cmpUser.getId()) &&
-          areStringEquals(specificId, cmpUser.getSpecificId()) &&
-          areStringEquals(domainId, cmpUser.getDomainId()) &&
-          areStringEquals(login, cmpUser.getLogin()) &&
-          areStringEquals(firstName, cmpUser.getFirstName()) &&
-          areStringEquals(lastName, cmpUser.getLastName()) &&
-          areStringEquals(eMail, cmpUser.getEmailAddress()) &&
-          accessLevel.equals(cmpUser.getAccessLevel());
+      return Objects.equals(id, cmpUser.getId()) &&
+          Objects.equals(specificId, cmpUser.getSpecificId()) &&
+          Objects.equals(domainId, cmpUser.getDomainId()) &&
+          Objects.equals(login, cmpUser.getLogin()) &&
+          Objects.equals(firstName, cmpUser.getFirstName()) &&
+          Objects.equals(lastName, cmpUser.getLastName()) &&
+          Objects.equals(eMail, cmpUser.getEmailAddress()) &&
+          Objects.equals(accessLevel, cmpUser.getAccessLevel());
     }
     return false;
   }
 
   @Override
   public int hashCode() {
-    int hash = 3;
-    hash = 41 * hash + (this.id != null ? this.id.hashCode() : 0);
-    hash = 41 * hash + (this.specificId != null ? this.specificId.hashCode() : 0);
-    hash = 41 * hash + (this.domainId != null ? this.domainId.hashCode() : 0);
-    hash = 41 * hash + (this.login != null ? this.login.hashCode() : 0);
-    hash = 41 * hash + (this.firstName != null ? this.firstName.hashCode() : 0);
-    hash = 41 * hash + (this.lastName != null ? this.lastName.hashCode() : 0);
-    hash = 41 * hash + (this.eMail != null ? this.eMail.hashCode() : 0);
-    hash = 41 * hash + (this.accessLevel != null ? this.accessLevel.hashCode() : 0);
-    return hash;
+    return Objects.hash(id, specificId, domainId, login, firstName, lastName, eMail, accessLevel);
   }
 
   /**

--- a/core-war/src/main/java/org/silverpeas/web/jobstartpage/control/JobStartPagePeasSessionController.java
+++ b/core-war/src/main/java/org/silverpeas/web/jobstartpage/control/JobStartPagePeasSessionController.java
@@ -679,7 +679,7 @@ public class JobStartPagePeasSessionController extends AbstractAdminComponentSes
   public void updateSpaceRole(String role, List<String> userIds, List<String> groupIds) {
     // Update the profile
     SpaceInst spaceint1 = getSpaceInstById();
-    SpaceProfileInst spaceProfileInst = spaceint1.getSpaceProfileInst(role);
+    SpaceProfileInst spaceProfileInst = spaceint1.getDirectSpaceProfileInst(role);
     if (spaceProfileInst == null) {
       spaceProfileInst = new SpaceProfileInst();
       spaceProfileInst.setName(role);

--- a/core-war/src/main/webapp/jobStartPagePeas/jsp/startPageInfo.jsp
+++ b/core-war/src/main/webapp/jobStartPagePeas/jsp/startPageInfo.jsp
@@ -132,19 +132,18 @@
       }
     </style>
     <script type="text/javascript">
-      //<!--
-      var currentLanguage = "${space.language}";
+      const currentLanguage = "${space.language}";
 
       function openPopup(action, larg, haut) {
-        windowName = "actionWindow";
-        windowParams = "directories=0,menubar=0,toolbar=0,alwaysRaised,scrollbars,resizable";
-        actionWindow = SP_openWindow(action, windowName, larg, haut, windowParams, false);
+        const windowName = "actionWindow";
+        const windowParams = "directories=0,menubar=0,toolbar=0,alwaysRaised,scrollbars,resizable";
+        SP_openWindow(action, windowName, larg, haut, windowParams, false);
       }
       <c:if test="${m_SpaceExtraInfos.admin}">
         <c:if test="${isUserAdmin && !empty m_SpaceName}">
           function deleteSpace() {
             jQuery.popup.confirm(
-                '${FullMessageSuppressionSpaceLabel}',
+                "${FullMessageSuppressionSpaceLabel}",
                 function() {
                   $('#spaceForm').attr('action', 'DeleteSpace');
                   $('#Id').val('${space.id}');
@@ -180,34 +179,35 @@
       function showPasteOptions() {
         // Display copy options only if there is at least one copied compliant app (ignore cut/paste)
         new Promise(function(resolve, reject) {
-          <c:if test="${empty copiedComponentNames}">
-            resolve();
-          </c:if>
-
-          <c:if test="${not empty copiedComponentNames}">
-            <c:forEach items="${copiedComponentNames}" var="componentName">
-              $.ajax({
-                url: webContext+'/${componentName}/jsp/copyApplicationDialog.jsp',
-                type: "GET",
-                dataType: "html",
-                success: function(data) {
-                  $('#pasteOptions').html(data);
-                  resolve();
-                },
-                error: function() {
-                  resolve();
-                }
-              });
-            </c:forEach>
-          </c:if>
-        }).then(function() {
+          <c:choose>
+          <c:when test="${empty copiedComponentNames}">
+          resolve();
+          </c:when>
+          <c:otherwise>
+          <c:forEach items="${copiedComponentNames}" var="componentName">
+          $.ajax({
+            url: webContext + '/${componentName}/jsp/copyApplicationDialog.jsp',
+            type: "GET",
+            dataType: "html",
+            success: function (data) {
+              $('#pasteOptions').html(data);
+              resolve();
+            },
+            error: function () {
+              resolve();
+            }
+          });
+          </c:forEach>
+          </c:otherwise>
+          </c:choose>
+        }).then(function () {
           if ($('#pasteOptions').is(':empty')) {
             $.progressMessage();
-            location.href="Paste";
+            location.href = "Paste";
           } else {
             $('#pasteOptionsDialog').popup('validation', {
-              title : "${CopyDialogOptionsLabel}",
-              callback : function() {
+              title: "${CopyDialogOptionsLabel}",
+              callback: function () {
                 $.progressMessage();
                 document.pasteForm.submit();
                 return true;
@@ -216,7 +216,6 @@
           }
         });
       }
-      //-->
     </script>
   </view:sp-head-part>
   <view:sp-body-part cssClass="startPageInfo page_content_admin">
@@ -273,10 +272,10 @@
           <fmt:message key="JSPP.publisher" var="publisher" />
           <fmt:message key="JSPP.writer" var="writer" />
           <fmt:message key="JSPP.reader" var="reader" />
-          <c:set var="adminAction" value="SpaceManager?Role=admin"></c:set>
-          <c:set var="publisherAction" value="SpaceManager?Role=publisher"></c:set>
-          <c:set var="writerAction" value="SpaceManager?Role=writer"></c:set>
-          <c:set var="readerAction" value="SpaceManager?Role=reader"></c:set>
+          <c:set var="adminAction" value="SpaceManager?Role=admin"/>
+          <c:set var="publisherAction" value="SpaceManager?Role=publisher"/>
+          <c:set var="writerAction" value="SpaceManager?Role=writer"/>
+          <c:set var="readerAction" value="SpaceManager?Role=reader"/>
           <view:tab label="${admin}" action="${adminAction}" selected="false" />
           <view:tab label="${publisher}" action="${publisherAction}" selected="false" />
           <view:tab label="${writer}" action="${writerAction}" selected="false" />

--- a/core-war/src/main/webapp/util/javaScript/silverpeas-responsibles.js
+++ b/core-war/src/main/webapp/util/javaScript/silverpeas-responsibles.js
@@ -22,38 +22,36 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-(function($) {
+(function ($) {
 
   // Web Context
   if (!webContext) {
-    var webContext = '/silverpeas';
+    window.webContext = '/silverpeas';
   }
 
   // Web Service Context
-  var webServiceContext = webContext + '/services';
-
-  var cache = [];
+  const webServiceContext = webContext + '/services';
 
   $.responsibles = {
     labels: {
       platformResponsible: '',
       sendMessage: ''
     },
-    renderSpaceResponsibles: function(target, userId, spaceId, onlySpaceManagers) {
-      __loadMissingPlugins(false).then(function() {
+    renderSpaceResponsibles: function (target, userId, spaceId, onlySpaceManagers) {
+      __loadMissingPlugins(false).then(function () {
         $(target).empty();
-        __getResponsibles(true, spaceId).then(function(data) {
+        __getResponsibles(true, spaceId).then(function (data) {
           __prepareContent($(target), userId, true, data.usersAndGroupsRoles, onlySpaceManagers);
         });
       });
     },
-    displaySpaceResponsibles: function(userId, spaceId) {
-      __loadMissingPlugins(true).then(function() {
+    displaySpaceResponsibles: function (userId, spaceId) {
+      __loadMissingPlugins(true).then(function () {
         __display(userId, true, spaceId);
       });
     },
-    displayComponentResponsibles: function(userId, componentId) {
-      __loadMissingPlugins(true).then(function() {
+    displayComponentResponsibles: function (userId, componentId) {
+      __loadMissingPlugins(true).then(function () {
         __display(userId, false, componentId);
       });
     }
@@ -67,13 +65,13 @@
    * @private
    */
   function __display(userId, isSpace, id) {
-    var $display = $('#responsible-popup-content');
-    __getResponsibles(isSpace, id).then(function(data) {
+    const $display = $('#responsible-popup-content');
+    __getResponsibles(isSpace, id).then(function (data) {
       if (!isSpace && !__userAndGroupRolesAreDefined(data)) {
         // No responsible founded, so searching on space on which component is attached ...
-        __getJSonData(data.parentURI).then(function(spaceOfComponent) {
+        __getJSonData(data.parentURI).then(function (spaceOfComponent) {
           if (spaceOfComponent && spaceOfComponent.id) {
-            __getResponsibles(true, spaceOfComponent.id).then(function(data) {
+            __getResponsibles(true, spaceOfComponent.id).then(function (data) {
               __render($display, data, true, userId);
             });
           } else {
@@ -87,8 +85,9 @@
   }
 
   function __render($display, data, isSpace, userId) {
-    var title = $('<div>').append($('.space-or-component-responsibles-operation').text() +
-        " ").append($('<b>').append(data.label)).html();
+    const title = $('<div>')
+        .append($('.space-or-component-responsibles-operation').text() + " ")
+        .append($('<b>').append(data.label)).html();
     if ($display.length !== 0) {
       $display.dialog('destroy');
       $display.remove();
@@ -112,22 +111,18 @@
    * @private
    */
   function __getResponsibles(isSpace, id) {
-    var result = cache[(isSpace ? 'space-' : 'component-') + id];
-    if (!result) {
-      return __getJSonData(
-          webServiceContext + '/' + (isSpace ? 'spaces' : 'components') + '/' + id).then(
-          function(spaceOrComponent) {
-            return __getJSonData(spaceOrComponent.usersAndGroupsRolesURI + '?roles=' +
-                (isSpace ? 'Manager' : 'admin')).then(function(usersAndGroupsRoles) {
-              result = {
-                usersAndGroupsRoles : usersAndGroupsRoles
-              };
-              $.extend(result, spaceOrComponent);
-              return result;
-            });
+    return __getJSonData(
+        webServiceContext + '/' + (isSpace ? 'spaces' : 'components') + '/' + id).then(
+        function (spaceOrComponent) {
+          return __getJSonData(spaceOrComponent.usersAndGroupsRolesURI + '?roles=' +
+              (isSpace ? 'Manager' : 'admin')).then(function (usersAndGroupsRoles) {
+            result = {
+              usersAndGroupsRoles: usersAndGroupsRoles
+            };
+            $.extend(result, spaceOrComponent);
+            return result;
           });
-    }
-    return sp.promise.resolveDirectlyWith(result);
+        });
   }
 
   /**
@@ -140,16 +135,16 @@
    * @private
    */
   function __prepareContent($target, userId, isSpace, usersAndGroupsRoles, onlySpaceManagers) {
-    var aimedRoles = ['Manager', 'admin'];
-    var promises = [];
-    var $newLine = null;
-    $.each(aimedRoles, function(index, role) {
-      var usersAndGroups = usersAndGroupsRoles[role];
-      var userPromise = __getAllDataOfUsers(usersAndGroups).then(function(dataOfUsers) {
+    const aimedRoles = ['Manager', 'admin'];
+    const promises = [];
+    let $newLine = null;
+    $.each(aimedRoles, function (index, role) {
+      const usersAndGroups = usersAndGroupsRoles[role];
+      const userPromise = __getAllDataOfUsers(usersAndGroups).then(function (dataOfUsers) {
         if (dataOfUsers.length > 0) {
           $target.append($newLine);
           if (isSpace) {
-            var $div = $('<div>', {'id':'space-admins'});
+            const $div = $('<div>', {'id': 'space-admins'});
             $target.append($div);
             $div.append($('<h5>', {
               'class': 'textePetitBold title-list-responsible-user'
@@ -164,26 +159,26 @@
       promises.push(userPromise);
     });
     if (!onlySpaceManagers && isSpace) {
-      var adminPromise = User.get({
-        accessLevel : ['ADMINISTRATOR']
-      }).then(function(users) {
-        var administrators = [];
-        $(users).each(function(index, administrator) {
+      const adminPromise = User.get({
+        accessLevel: ['ADMINISTRATOR']
+      }).then(function (users) {
+        const administrators = [];
+        $(users).each(function (index, administrator) {
           administrators.push(administrator);
         });
         if (administrators.length > 0) {
-          var $div = $('<div>', {'id' : 'global-admins'});
+          const $div = $('<div>', {'id': 'global-admins'});
           $target.append($div);
           $div.append($newLine);
           $div.append($('<h5>',
-              {'class' : 'textePetitBold title-list-responsible-user'}).append($.responsibles.labels.platformResponsible));
+              {'class': 'textePetitBold title-list-responsible-user'}).append($.responsibles.labels.platformResponsible));
           __prepareRoleResponsibles($div, userId, administrators);
           $newLine = $('<br/>');
         }
       });
       promises.push(adminPromise);
     }
-    return sp.promise.whenAllResolved(promises).then(function() {
+    return sp.promise.whenAllResolved(promises).then(function () {
       __loadUserZoomPlugins();
     });
   }
@@ -197,28 +192,31 @@
    */
   function __prepareRoleResponsibles($target, userId, dataOfUsers) {
     if ($.isArray(dataOfUsers) && dataOfUsers.length > 0) {
-      var $users = $('<ul>', {'class': 'list-responsible-user'});
-      $.each(dataOfUsers, function(index, user) {
-        var $user = $('<span>').append(' ' + user.fullName);
+      const $users = $('<ul>', {'class': 'list-responsible-user'});
+      $.each(dataOfUsers, function (index, user) {
+        const $user = $('<span>').append(' ' + user.fullName);
         if (userId !== user.id && !user.anonymous) {
           $user.addClass('userToZoom');
           $user.attr('rel', user.id);
         }
-        var $photoProfil = $('<div>', {'class': 'profilPhoto'}).append($('<a>').append($('<img>',
-                {'class': 'avatar', src: user.avatar})));
-        var $userName = $('<div>', {'class': 'userName'});
-        var $action = null;
+        const $photoProfil = $('<div>', {'class': 'profilPhoto'}).append($('<a>').append($('<img>',
+            {'alt': user.fullName + ' avatar', 'class': 'avatar', src: user.avatar})));
+        const $userName = $('<div>', {'class': 'userName'});
+        let $action = null;
         if (userId !== user.id && !user.anonymous) {
           $userName.append($('<a>', {'class': 'userToZoom', rel: user.id}).append(user.fullName));
           $action = $('<div>', {'class': 'action'}).append($('<a>',
-                  {href: '#', 'class': 'link notification'}).append($.responsibles.labels.sendMessage)).click(function() {
+              {
+                href: '#',
+                'class': 'link notification'
+              }).append($.responsibles.labels.sendMessage)).click(function () {
             sp.messager.open(null, {recipientUsers: user.id, recipientEdition: false});
           });
         } else {
           $userName.append($('<a>').append(user.fullName));
         }
         $users.append($('<li>', {'class': 'intfdcolor'}).append($('<div>',
-                {'class': 'content'}).append($photoProfil).append($userName).append($action)));
+            {'class': 'content'}).append($photoProfil).append($userName).append($action)));
       });
       $target.append($users);
     }
@@ -231,26 +229,26 @@
    */
   function __getAllDataOfUsers(usersAndGroups) {
     if (usersAndGroups) {
-      var promises = [];
-      var dataOfUsers = [];
-      var uriOfUsers = [];
+      const promises = [];
+      const dataOfUsers = [];
+      const uriOfUsers = [];
 
       // Users
       if (usersAndGroups.users && usersAndGroups.users.length > 0) {
-        var userPromises = [];
-        promises.push(new Promise(function(resolve, reject) {
-          $.each(usersAndGroups.users, function(index, userUri) {
+        const userPromises = [];
+        promises.push(new Promise(function (resolve, reject) {
+          $.each(usersAndGroups.users, function (index, userUri) {
             if ($.inArray(userUri, uriOfUsers) < 0) {
               uriOfUsers.push(userUri);
-              userPromises.push(new Promise(function(resolve, reject) {
-                __getJSonData(userUri).then(function(user) {
+              userPromises.push(new Promise(function (resolve, reject) {
+                __getJSonData(userUri).then(function (user) {
                   dataOfUsers.push(user);
                   resolve();
                 });
               }));
             }
           });
-          sp.promise.whenAllResolved(userPromises).then(function() {
+          sp.promise.whenAllResolved(userPromises).then(function () {
             resolve();
           });
         }));
@@ -258,14 +256,14 @@
 
       // Groups
       if (usersAndGroups.groups && usersAndGroups.groups.length > 0) {
-        var groupPromises = [];
-        promises.push(new Promise(function(resolve, reject) {
-          $.each(usersAndGroups.groups, function(index, groupUri) {
-            groupPromises.push(new Promise(function(resolve, reject) {
-              __getJSonData(groupUri).then(function(group) {
+        const groupPromises = [];
+        promises.push(new Promise(function (resolve, reject) {
+          $.each(usersAndGroups.groups, function (index, groupUri) {
+            groupPromises.push(new Promise(function (resolve, reject) {
+              __getJSonData(groupUri).then(function (group) {
                 if (group) {
-                  __getJSonData(group.usersUri).then(function(users) {
-                    $.each(users, function(index, user) {
+                  __getJSonData(group.usersUri).then(function (users) {
+                    $.each(users, function (index, user) {
                       if ($.inArray(user.uri, uriOfUsers) < 0) {
                         uriOfUsers.push(user.uri);
                         dataOfUsers.push(user);
@@ -279,14 +277,14 @@
               })
             }));
           });
-          sp.promise.whenAllResolved(groupPromises).then(function() {
+          sp.promise.whenAllResolved(groupPromises).then(function () {
             resolve();
           });
         }));
       }
 
       // Sorting users by their names
-      return sp.promise.whenAllResolved(promises).then(function() {
+      return sp.promise.whenAllResolved(promises).then(function () {
         dataOfUsers.sort(__sortByName);
         return dataOfUsers;
       });
@@ -297,7 +295,7 @@
   function __userAndGroupRolesAreDefined(data) {
     let roles = data.usersAndGroupsRoles;
     if (typeof roles === 'object') {
-      for(let roleName in roles) {
+      for (let roleName in roles) {
         let role = roles[roleName];
         if ((Array.isArray(role.users) && role.users.length > 0) ||
             (Array.isArray(role.groups) && role.groups.length > 0)) {
@@ -316,8 +314,8 @@
    * @private
    */
   function __sortByName(a, b) {
-    var aName = a.fullName.toLowerCase();
-    var bName = b.fullName.toLowerCase();
+    const aName = a.fullName.toLowerCase();
+    const bName = b.fullName.toLowerCase();
     return ((aName < bName) ? -1 : ((aName > bName) ? 1 : 0));
   }
 
@@ -326,18 +324,18 @@
    * @private
    */
   function __loadMissingPlugins(isPopup) {
-    var promises = [];
+    const promises = [];
     if (isPopup && !$.popup) {
-      promises.push(new Promise(function(resolve, reject) {
-        $.getScript(webContext + "/util/javaScript/silverpeas-popup.js", function() {
+      promises.push(new Promise(function (resolve, reject) {
+        $.getScript(webContext + "/util/javaScript/silverpeas-popup.js", function () {
           resolve();
         });
       }));
     }
     if (typeof User === 'undefined') {
-      promises.push(new Promise(function(resolve, reject) {
+      promises.push(new Promise(function (resolve, reject) {
         $.getScript(webContext + "/util/javaScript/angularjs/services/silverpeas-profile.js",
-            function() {
+            function () {
               resolve();
             });
       }));
@@ -369,15 +367,15 @@
    * request.
    */
   function __performAjaxRequest(settings) {
-    return new Promise(function(resolve, reject) {
+    return new Promise(function (resolve, reject) {
       // Default options.
       // url, type, dataType are missing.
-      var options = {
-        cache : false,
-        success : function(data) {
+      let options = {
+        cache: false,
+        success: function (data) {
           resolve(data);
         },
-        error : function(jqXHR, textStatus, errorThrown) {
+        error: function (jqXHR, textStatus, errorThrown) {
           reject();
           window.console &&
           window.console.log('Silverpeas Responsible JQuery Plugin - ERROR - ' + errorThrown);

--- a/core-web/src/main/java/org/silverpeas/core/web/look/DefaultSpaceHomePage.java
+++ b/core-web/src/main/java/org/silverpeas/core/web/look/DefaultSpaceHomePage.java
@@ -28,17 +28,17 @@ import org.silverpeas.core.admin.space.SpaceInstLight;
 import org.silverpeas.core.admin.user.model.UserDetail;
 import org.silverpeas.core.contribution.publication.model.PublicationDetail;
 
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.List;
 
 public class DefaultSpaceHomePage {
 
   private SpaceInstLight space;
-  private List<SpaceInstLight> subSpaces = Collections.EMPTY_LIST;
-  private List<UserDetail> admins = Collections.EMPTY_LIST;
-  private List<ComponentInstLight> apps = Collections.EMPTY_LIST;
-  private List<PublicationDetail> publications = Collections.EMPTY_LIST;
-  private List<PublicationDetail> news = Collections.EMPTY_LIST;
+  private List<SpaceInstLight> subSpaces = new ArrayList<>();
+  private List<UserDetail> admins = new ArrayList<>();
+  private List<ComponentInstLight> apps = new ArrayList<>();
+  private List<PublicationDetail> publications = new ArrayList<>();
+  private List<PublicationDetail> news = new ArrayList<>();
   private String nextEventsURL;
 
   public SpaceInstLight getSpace() {


### PR DESCRIPTION
Rename SpaceInst#getSpaceProfileInst to
SpaceProfilInst#getDirectSpaceProfileInst because this method returns only the direct space profile instance with the specified name and not all the profile instances (both inherited and not inherited).

Add new method to get both the inherited and direct space profiles with a specified name: SpaceInst#getSpaceProfileInst(String)

In DefaultAdministration:
- when a new space is created, in the case of a inherited rights access, the inherited space manager profile is now taken into account in same way than the others inherited space profiles.
- when getting the space profile of a given space and with the specified role name, take into account the inherited space manager profile has been previously cached

In SpaceResource, when getting the space profiles of a given space with requesting role names, invokes, through the OrganizationController, for each role, the Administration#getSpaceProfile(String, SilverpeasRole) method.

The changes impact Silverpeas-Components for which a PR has been created: https://github.com/Silverpeas/Silverpeas-Components/pull/874