### PR TITLE
Feature 14738

### DIFF
--- a/core-api/src/main/java/org/silverpeas/core/notification/system/AbstractResourceEvent.java
+++ b/core-api/src/main/java/org/silverpeas/core/notification/system/AbstractResourceEvent.java
@@ -28,10 +28,7 @@ import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import java.io.Serializable;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 /**
  * It is an abstract implementation of a notification event on a resource's state change. It defines
@@ -67,6 +64,7 @@ public abstract class AbstractResourceEvent<T extends Serializable> implements R
    * resource is expected:  the first being the resource before the update, the second being the
    * resource after the update (the result of the update).
    */
+  @SafeVarargs
   protected AbstractResourceEvent(Type type, @NotNull T... resource) {
     this.type = type;
     if (type == Type.CREATION) {
@@ -128,16 +126,11 @@ public abstract class AbstractResourceEvent<T extends Serializable> implements R
     }
 
     final AbstractResourceEvent<?> that = (AbstractResourceEvent<?>) o;
-    if (!transition.equals(that.transition)) {
-      return false;
-    }
-    return type == that.type;
+    return transition.equals(that.transition) && type == that.type;
   }
 
   @Override
   public int hashCode() {
-    int result = type.hashCode();
-    result = 31 * result + transition.hashCode();
-    return result;
+    return Objects.hash(this.type, this.transition);
   }
 }

--- a/core-api/src/main/java/org/silverpeas/core/notification/system/CDIAfterSuccessfulTransactionResourceEventListener.java
+++ b/core-api/src/main/java/org/silverpeas/core/notification/system/CDIAfterSuccessfulTransactionResourceEventListener.java
@@ -41,8 +41,8 @@ import static javax.enterprise.event.TransactionPhase.AFTER_SUCCESS;
  * some of the following methods to transparently receive the events on which they are interested:
  * </p>
  * <p>
- * If the observation is performed into a transaction, all the events are performed just after a
- * successful commit.
+ * If the observation is performed within a transaction, all the events are then just received
+ * after a successful commit.
  * </p>
  * <ul>
  *   <li>{@code org.silverpeas.core.notification.system.ResourceEventListener#onCreation(ResourceEvent} to
@@ -72,7 +72,7 @@ public abstract class CDIAfterSuccessfulTransactionResourceEventListener<T exten
    * @param event an event.
    * @throws Exception if the processing of the event fails.
    */
-  public void onEvent(@Observes(during = AFTER_SUCCESS) T event) throws Exception {
+  public void onEvent(@Observes(during = AFTER_SUCCESS) T event) {
     Transaction.performInNew(() -> {
       try {
         dispatchEvent(event);

--- a/core-api/src/main/java/org/silverpeas/core/notification/system/CDIResourceEventListener.java
+++ b/core-api/src/main/java/org/silverpeas/core/notification/system/CDIResourceEventListener.java
@@ -64,7 +64,7 @@ public abstract class CDIResourceEventListener<T extends ResourceEvent<?>>
    * @param event an event.
    * @throws Exception if the processing of the event fails.
    */
-  public void onEvent(@Observes T event) throws Exception {
+  public void onEvent(@Observes T event) {
     dispatchEvent(event);
   }
 }

--- a/core-api/src/main/java/org/silverpeas/core/notification/system/ResourceEventListener.java
+++ b/core-api/src/main/java/org/silverpeas/core/notification/system/ResourceEventListener.java
@@ -53,9 +53,8 @@ public interface ResourceEventListener<T extends ResourceEvent<?>> {
    * nonrecoverable. By default, this method does nothing.
    *
    * @param event the event on the deletion of a resource.
-   * @throws java.lang.Exception if an error occurs while treating the event.
    */
-  default void onDeletion(final T event) throws Exception {
+  default void onDeletion(final T event) {
   }
 
   /**
@@ -63,9 +62,8 @@ public interface ResourceEventListener<T extends ResourceEvent<?>> {
    * and it is recoverable; it is usually put in a trash. By default, this method does nothing.
    *
    * @param event the event on the removing of a resource.
-   * @throws java.lang.Exception if an error occurs while treating the event.
    */
-  default void onRemoving(final T event) throws Exception {
+  default void onRemoving(final T event) {
   }
 
   /**
@@ -73,45 +71,40 @@ public interface ResourceEventListener<T extends ResourceEvent<?>> {
    * nothing.
    *
    * @param event the event on the removing of a resource.
-   * @throws java.lang.Exception if an error occurs while treating the event.
    */
-  default void onRecovery(final T event) throws Exception {
+  default void onRecovery(final T event) {
   }
 
   /**
    * An event on the update of a resource has be listened. By default, this method does nothing.
    *
    * @param event the event on the update of a resource.
-   * @throws java.lang.Exception if an error occurs while treating the event.
    */
-  default void onUpdate(final T event) throws Exception {
+  default void onUpdate(final T event) {
   }
 
   /**
    * An event on the move of a resource has be listened. By default, this method does nothing.
    *
    * @param event the event on the move of a resource.
-   * @throws java.lang.Exception if an error occurs while treating the event.
    */
-  default void onMove(final T event) throws Exception {
+  default void onMove(final T event) {
   }
 
   /**
    * An event on the creation of a resource has be listened. By default, this method does nothing.
    *
    * @param event the event on the creation of a resource.
-   * @throws java.lang.Exception if an error occurs while treating the event.
    */
-  default void onCreation(final T event) throws Exception {
+  default void onCreation(final T event) {
   }
 
   /**
    * An event on the unlock of a resource has be listened. By default, this method does nothing.
    *
    * @param event the event on the unlock of a resource.
-   * @throws java.lang.Exception if an error occurs while treating the event.
    */
-  default void onUnlock(final T event) throws Exception {
+  default void onUnlock(final T event) {
   }
 
   /**
@@ -135,9 +128,8 @@ public interface ResourceEventListener<T extends ResourceEvent<?>> {
    * </p>
    *
    * @param event the event to dispatch.
-   * @throws java.lang.Exception if an error occurs while treating the event.
    */
-  default void dispatchEvent(final T event) throws Exception {
+  default void dispatchEvent(final T event) {
     if (isEnabled()) {
       switch (event.getType()) {
         case CREATION:

--- a/core-library/src/integration-test/java/org/silverpeas/core/admin/user/notification/role/BaseUserRoleEventListenerTest.java
+++ b/core-library/src/integration-test/java/org/silverpeas/core/admin/user/notification/role/BaseUserRoleEventListenerTest.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright (C) 2000 - 2025 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.admin.user.notification.role;
+
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Before;
+import org.junit.Rule;
+import org.silverpeas.core.admin.service.AdminException;
+import org.silverpeas.core.admin.service.Administration;
+import org.silverpeas.core.admin.user.ProfileInstManager;
+import org.silverpeas.core.admin.user.model.ProfileInst;
+import org.silverpeas.core.admin.user.model.User;
+import org.silverpeas.core.admin.user.notification.role.test.Validator;
+import org.silverpeas.core.cache.service.CacheAccessorProvider;
+import org.silverpeas.core.cache.service.SessionCacheAccessor;
+import org.silverpeas.core.persistence.Transaction;
+import org.silverpeas.core.test.WarBuilder4LibCore;
+import org.silverpeas.core.test.integration.rule.DbSetupRule;
+import org.silverpeas.kernel.SilverpeasRuntimeException;
+
+import javax.inject.Inject;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Base class of the integration tests on the
+ * {@link org.silverpeas.core.admin.user.notification.role.UserRoleEvent} event listeners.
+ *
+ * @author mmoquillon
+ */
+public abstract class BaseUserRoleEventListenerTest {
+
+  public static final String VALIDATOR_ROLE = "validator";
+  public static final String READER_ROLE = "reader";
+  public static final List<String> NO_IDS = List.of();
+  public static final String INSTANCE_ID = "myComponent1";
+
+  @Rule
+  public DbSetupRule dbSetupRule = DbSetupRule.createTablesFrom("create_database.sql")
+      .loadInitialDataSetFrom("insert_dataset.sql");
+
+  @Inject
+  private ProfileInstManager profileInstManager;
+
+  @Inject
+  private Administration admin;
+
+  public static Archive<?> createTestArchiveFor(Class<? extends BaseUserRoleEventListenerTest> test) {
+    return WarBuilder4LibCore.onWarForTestClass(test)
+        .addSilverpeasExceptionBases()
+        .addAdministrationFeatures()
+        .addDatabaseToolFeatures()
+        .addJpaPersistenceFeatures()
+        .addPublicationTemplateFeatures()
+        .addAsResource("org/silverpeas/core/admin/user/notification/role")
+        .testFocusedOn(warBuilder ->
+            warBuilder.addPackages(true, test.getPackageName()))
+        .build();
+  }
+
+  @Before
+  public void setUpCurrentRequester() {
+    SessionCacheAccessor sessionCacheAccessor =
+        CacheAccessorProvider.getSessionCacheAccessor();
+    sessionCacheAccessor.newSessionCache(User.getById("1"));
+  }
+
+  @Before
+  public void reloadAdminCache() {
+    admin.reloadCache();
+  }
+
+  public ProfileInst getProfileInst(String roleName) {
+    String id;
+    switch (roleName) {
+      case "admin":
+        id = "1";
+        break;
+      case VALIDATOR_ROLE:
+        id = "2";
+        break;
+      default:
+        id = "3";
+        break;
+    }
+    return getProfileInstById(id);
+  }
+
+  public ProfileInst getProfileInstById(String id) {
+    return Transaction.performInOne(() -> {
+      try {
+        return profileInstManager.getProfileInst(id, false);
+      } catch (AdminException e) {
+        throw new SilverpeasRuntimeException(e);
+      }
+    });
+  }
+
+  public void updateProfileInst(ProfileInst profileInst) {
+    Transaction.performInOne(() -> {
+      try {
+        profileInstManager.updateProfileInst(profileInst);
+      } catch (AdminException e) {
+        throw new SilverpeasRuntimeException(e);
+      }
+      return null;
+    });
+  }
+
+  private String createProfileInst(ProfileInst profileInst) {
+    return Transaction.performInOne(() -> {
+      try {
+        return profileInstManager.createProfileInst(profileInst,
+            profileInst.getComponentFatherId());
+      } catch (AdminException e) {
+        throw new SilverpeasRuntimeException(e);
+      }
+    });
+  }
+
+  public void setUpProfileInstWith(String profileName, List<String> users, List<String> groups) {
+    ProfileInst initialProfile = getProfileInst(profileName);
+    initialProfile.getAllUsers().addAll(users);
+    initialProfile.getAllGroups().addAll(groups);
+    updateProfileInst(initialProfile);
+  }
+
+  public String setUpInheritedProfileInstWith(String profileName, List<String> users,
+      List<String> groups) {
+    ProfileInst initialProfile = new ProfileInst();
+    initialProfile.setComponentFatherId(1);
+    initialProfile.setInherited(true);
+    initialProfile.setName(profileName);
+    initialProfile.setLabel(profileName);
+    initialProfile.getAllUsers().addAll(users);
+    initialProfile.getAllGroups().addAll(groups);
+    return createProfileInst(initialProfile);
+  }
+
+  public static void assertValidatorsEquality(List<Validator> actualValidators,
+      List<Validator> expectedValidators) {
+      assertEquals(expectedValidators.size(), actualValidators.size());
+      assertTrue(actualValidators.containsAll(expectedValidators));
+  }
+
+  public static void assertValidatorIsRemoved(String validatorId,
+      List<Validator> actualValidators) {
+    assertTrue(actualValidators.stream()
+        .noneMatch(v -> v.getUserId().equals(validatorId)));
+  }
+}
+  

--- a/core-library/src/integration-test/java/org/silverpeas/core/admin/user/notification/role/GroupMembershipChangeIT.java
+++ b/core-library/src/integration-test/java/org/silverpeas/core/admin/user/notification/role/GroupMembershipChangeIT.java
@@ -1,0 +1,271 @@
+/*
+ * Copyright (C) 2000 - 2025 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.admin.user.notification.role;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.silverpeas.core.admin.service.AdminController;
+import org.silverpeas.core.admin.user.notification.role.test.ResourceValidators;
+import org.silverpeas.core.admin.user.notification.role.test.Validator;
+
+import javax.inject.Inject;
+import java.util.List;
+
+/**
+ * Integration test on the behaviour of the Resources Manager when a user doesn't belong anymore
+ * to a group playing a role in some Resources Manager applications.
+ *
+ * @author mmoquillon
+ */
+@RunWith(Arquillian.class)
+public class GroupMembershipChangeIT extends BaseUserRoleEventListenerTest {
+
+  @Inject
+  private ResourceValidators resourceValidators;
+
+  @Inject
+  private AdminController admin;
+
+  @Deployment
+  public static Archive<?> createTestArchive() {
+    return createTestArchiveFor(ProfileInstChangeIT.class);
+  }
+
+  /**
+   * Given a user is in a group G playing the manager role for some Resources Manager applications A
+   * and this user is a validator of some resources R in those applications A,
+   * When he's removed from the group G,
+   * Then he should be also removed from the validators of resources R in the applications A.
+   */
+  @Test
+  public void aValidatorHasBeenRemovedFromAGroupInManagersProfile() {
+    setUpProfileInstWith(VALIDATOR_ROLE, NO_IDS, List.of("1"));
+
+    admin.removeUserFromGroup("1", "1");
+
+    List<Validator> validators = resourceValidators.getAll(INSTANCE_ID);
+    assertValidatorIsRemoved("1", validators);
+  }
+
+  /**
+   * Given a user is in a group G playing the reader role for some Resources Manager applications A,
+   * When he's removed from the group G,
+   * Then nothing should be done with the validators of all the resources in the applications A.
+   */
+  @Test
+  public void aNonValidatorHasBeenRemovedFromAGroupInManagersProfile() {
+    setUpProfileInstWith(VALIDATOR_ROLE, NO_IDS, List.of("1"));
+    List<Validator> expectedValidators = resourceValidators.getAll(INSTANCE_ID);
+
+    admin.removeUserFromGroup("11", "1");
+
+    List<Validator> actualValidators = resourceValidators.getAll(INSTANCE_ID);
+    assertValidatorsEquality(actualValidators, expectedValidators);
+  }
+
+  /**
+   * Given a user is in a group G playing the reader role for some Resources Manager applications A
+   * and this user is also a validator of some resources R in those applications A,
+   * When he's removed from the group G,
+   * Then nothing should be done with the validators of the resources R in the applications A.
+   */
+  @Test
+  public void aValidatorHasBeenRemovedFromAGroupInReadersProfile() {
+    setUpProfileInstWith(READER_ROLE, NO_IDS, List.of("1"));
+    List<Validator> expectedValidators = resourceValidators.getAll(INSTANCE_ID);
+
+    admin.removeUserFromGroup("1", "1");
+
+    List<Validator> actualValidators = resourceValidators.getAll(INSTANCE_ID);
+    assertValidatorsEquality(actualValidators, expectedValidators);
+  }
+
+  /**
+   * Given a group G playing the manager role for some Resources Manager applications A,
+   * When a user is added into the group G,
+   * Then nothing should be done with the validators of all the resources in the applications A.
+   */
+  @Test
+  public void aValidatorHasBeenAddedInAGroupInManagersProfile() {
+    setUpProfileInstWith(VALIDATOR_ROLE, NO_IDS, List.of("2"));
+    List<Validator> expectedValidators = resourceValidators.getAll(INSTANCE_ID);
+
+    admin.addUserInGroup("1", "2");
+
+    List<Validator> actualValidators = resourceValidators.getAll(INSTANCE_ID);
+    assertValidatorsEquality(actualValidators, expectedValidators);
+  }
+
+  /**
+   * Given a user is in a subgroup G of a group playing the manager role for some Resources Manager
+   * applications A and this user is a validator of some resources R in those applications A,
+   * When he's removed from the subgroup G,
+   * Then he should be also removed from the validators of resources R in the applications A.
+   */
+  @Test
+  public void aValidatorHasBeenRemovedFromASubGroupOfAGroupInManagersProfile() {
+    setUpProfileInstWith(VALIDATOR_ROLE, NO_IDS, List.of("3"));
+
+    admin.removeUserFromGroup("1", "4");
+
+    List<Validator> validators = resourceValidators.getAll(INSTANCE_ID);
+    assertValidatorIsRemoved("1", validators);
+  }
+
+  /**
+   * Given a group G playing the publisher role for an applications other than Resources
+   * Manager and playing no role in any Resources Manager applications A,
+   * Given a user U being a validator for some resources in the applications A,
+   * When the user U is removed from the group G,
+   * Then nothing should be done with the validators of all the resources in the applications A.
+   */
+  @Test
+  public void aUserHasBeenRemovedFromAGroupInPublishersProfileInAnotherApplication() {
+    setUpProfileInstWith(VALIDATOR_ROLE, List.of("1"), NO_IDS);
+    List<Validator> expectedValidators = resourceValidators.getAll(INSTANCE_ID);
+
+    admin.removeUserFromGroup("1", "1");
+
+    List<Validator> actualValidators = resourceValidators.getAll(INSTANCE_ID);
+    assertValidatorsEquality(actualValidators, expectedValidators);
+  }
+
+  /**
+   * Given a group G playing the manager role in a Resources Manager applications A,
+   * Given a user U playing explicitly the manager role in the application A, belonging to the
+   * group G, and is a validator of some resources R in those applications A,
+   * When the user U is removed from the group G,
+   * Then nothing should be done with the validators of all the resources in the applications A.
+   */
+  @Test
+  public void aValidatorInManagersProfileHasBeenRemovedFromAGroupInManagersProfile() {
+    setUpProfileInstWith(VALIDATOR_ROLE, List.of("1"), List.of("1"));
+    List<Validator> expectedValidators = resourceValidators.getAll(INSTANCE_ID);
+
+    admin.removeUserFromGroup("1", "1");
+
+    List<Validator> actualValidators = resourceValidators.getAll(INSTANCE_ID);
+    assertValidatorsEquality(actualValidators, expectedValidators);
+  }
+
+  /**
+   * Given a group G playing the manager role in a Resources Manager applications A,
+   * Given a user U playing explicitly the manager role in the application A, belonging to a
+   * subgroup S of G, and is a validator of some resources R in those applications A,
+   * When the user U is removed from the subgroup S,
+   * Then nothing should be done with the validators of all the resources in the applications A.
+   */
+  @Test
+  public void aValidatorInManagersProfileHasBeenRemovedFromASubGroupInManagersProfile() {
+    setUpProfileInstWith(VALIDATOR_ROLE, List.of("1"), List.of("3"));
+    List<Validator> expectedValidators = resourceValidators.getAll(INSTANCE_ID);
+
+    admin.removeUserFromGroup("1", "4");
+
+    List<Validator> actualValidators = resourceValidators.getAll(INSTANCE_ID);
+    assertValidatorsEquality(actualValidators, expectedValidators);
+  }
+
+  /**
+   * Given a group G playing by rights inheritance the manager role in a Resources Manager
+   * applications A,
+   * Given a user U playing explicitly the manager role in the application A, belonging to the
+   * group G, and is a validator of some resources R in those applications A,
+   * When the user U is removed from the group G,
+   * Then nothing should be done with the validators of all the resources in the applications A.
+   */
+  @Test
+  public void aValidatorInManagersProfileHasBeenRemovedFromAGroupInInheritedManagersProfile() {
+    setUpInheritedProfileInstWith(VALIDATOR_ROLE, NO_IDS, List.of("1"));
+    setUpProfileInstWith(VALIDATOR_ROLE, List.of("1"), NO_IDS);
+    List<Validator> expectedValidators = resourceValidators.getAll(INSTANCE_ID);
+
+    admin.removeUserFromGroup("1", "1");
+
+    List<Validator> actualValidators = resourceValidators.getAll(INSTANCE_ID);
+    assertValidatorsEquality(actualValidators, expectedValidators);
+  }
+
+  /**
+   * Given a group G playing by rights inheritance the manager role in a Resources Manager
+   * applications A,
+   * Given a user U playing explicitly the manager role in the application A, belonging to the
+   * subgroup S of the group G, and is a validator of some resources R in those applications A,
+   * When the user U is removed from the subgroup S,
+   * Then nothing should be done with the validators of all the resources in the applications A.
+   */
+  @Test
+  public void aValidatorInManagersProfileHasBeenRemovedFromASubGroupInInheritedManagersProfile() {
+    setUpInheritedProfileInstWith(VALIDATOR_ROLE, NO_IDS, List.of("3"));
+    setUpProfileInstWith(VALIDATOR_ROLE, List.of("1"), NO_IDS);
+    List<Validator> expectedValidators = resourceValidators.getAll(INSTANCE_ID);
+
+    admin.removeUserFromGroup("1", "4");
+
+    List<Validator> actualValidators = resourceValidators.getAll(INSTANCE_ID);
+    assertValidatorsEquality(actualValidators, expectedValidators);
+  }
+
+  /**
+   * Given a group G playing the manager role in a Resources Manager applications A,
+   * Given a user U playing by inheritance the manager role in the application A, belonging to the
+   * group G, and is a validator of some resources R in those applications A,
+   * When the user U is removed from the group G,
+   * Then nothing should be done with the validators of all the resources in the applications A.
+   */
+  @Test
+  public void aValidatorInInheritedManagersProfileHasBeenRemovedFromAGroupInManagersProfile() {
+    setUpInheritedProfileInstWith(VALIDATOR_ROLE, List.of("1"), NO_IDS);
+    setUpProfileInstWith(VALIDATOR_ROLE, NO_IDS, List.of("1"));
+    List<Validator> expectedValidators = resourceValidators.getAll(INSTANCE_ID);
+
+    admin.removeUserFromGroup("1", "1");
+
+    List<Validator> actualValidators = resourceValidators.getAll(INSTANCE_ID);
+    assertValidatorsEquality(actualValidators, expectedValidators);
+  }
+
+  /**
+   * Given a group G playing the manager role in a Resources Manager applications A,
+   * Given a user U playing by inheritance the manager role in the application A, belonging to the
+   * subgroup S of the group G, and is a validator of some resources R in those applications A,
+   * When the user U is removed from the subgroup S,
+   * Then nothing should be done with the validators of all the resources in the applications A.
+   */
+  @Test
+  public void aValidatorInInheritedManagersProfileHasBeenRemovedFromASubGroupInManagersProfile() {
+    setUpInheritedProfileInstWith(VALIDATOR_ROLE, List.of("1"), NO_IDS);
+    setUpProfileInstWith(VALIDATOR_ROLE, NO_IDS, List.of("3"));
+    List<Validator> expectedValidators = resourceValidators.getAll(INSTANCE_ID);
+
+    admin.removeUserFromGroup("1", "4");
+
+    List<Validator> actualValidators = resourceValidators.getAll(INSTANCE_ID);
+    assertValidatorsEquality(actualValidators, expectedValidators);
+  }
+}

--- a/core-library/src/integration-test/java/org/silverpeas/core/admin/user/notification/role/ProfileInstChangeIT.java
+++ b/core-library/src/integration-test/java/org/silverpeas/core/admin/user/notification/role/ProfileInstChangeIT.java
@@ -1,0 +1,444 @@
+/*
+ * Copyright (C) 2000 - 2025 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.admin.user.notification.role;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.silverpeas.core.admin.user.model.ProfileInst;
+import org.silverpeas.core.admin.user.notification.role.test.ResourceValidators;
+import org.silverpeas.core.admin.user.notification.role.test.Validator;
+
+import javax.inject.Inject;
+import java.util.List;
+
+/**
+ * Integration test on the reception of the event notifying a user or a group of a user has been
+ * remove from a role playing in a given component instance.
+ *
+ * @author mmoquillon
+ */
+@RunWith(Arquillian.class)
+public class ProfileInstChangeIT extends BaseUserRoleEventListenerTest {
+
+  @Inject
+  private ResourceValidators resourceValidators;
+
+  @Deployment
+  public static Archive<?> createTestArchive() {
+    return createTestArchiveFor(ProfileInstChangeIT.class);
+  }
+
+  /**
+   * Given a user is playing the manager role for some Resources Manager applications A and this
+   * user is a validator of some resources R in those applications A, When he's removed from manager
+   * role, Then he should be also removed from the validators of resources R in the applications A.
+   */
+  @Test
+  public void aValidatorHasBeenRemovedFromManagersProfile() {
+    setUpProfileInstWith(VALIDATOR_ROLE, List.of("0", "1", "2"), NO_IDS);
+
+    ProfileInst profileToUpdate = getProfileInst(VALIDATOR_ROLE);
+    profileToUpdate.getAllUsers().remove("1");
+    updateProfileInst(profileToUpdate);
+
+    List<Validator> validators = resourceValidators.getAll(INSTANCE_ID);
+    assertValidatorIsRemoved("1", validators);
+  }
+
+  /**
+   * Given a user is playing the manager role for some Resources Manager applications A and this
+   * user is a validator of some resources R in those applications A, When he's removed from manager
+   * role, Then he should be also removed from the validators of resources R in the applications A.
+   */
+  @Test
+  public void aValidatorHasBeenRemovedFromInheritedManagersProfile() {
+    String profileId = setUpInheritedProfileInstWith(VALIDATOR_ROLE, List.of("0", "1", "2"),
+        NO_IDS);
+
+    ProfileInst profileToUpdate = getProfileInstById(profileId);
+    profileToUpdate.getAllUsers().remove("1");
+    updateProfileInst(profileToUpdate);
+
+    List<Validator> validators = resourceValidators.getAll(INSTANCE_ID);
+    assertValidatorIsRemoved("1", validators);
+  }
+
+  /**
+   * Given a user is playing the reader role for some Resources Manager applications A and this user
+   * is also a validator of some resources R in those applications A, When he's removed from the
+   * reader role, Then nothing should be done with the validators of the resources R in the
+   * applications A.
+   */
+  @Test
+  public void aValidatorHasBeenRemovedFromReadersProfile() {
+    setUpProfileInstWith(READER_ROLE, List.of("0", "1", "2"), NO_IDS);
+    List<Validator> expectedValidators = resourceValidators.getAll(INSTANCE_ID);
+
+    ProfileInst profileToUpdate = getProfileInst(READER_ROLE);
+    profileToUpdate.getAllUsers().remove("1");
+    updateProfileInst(profileToUpdate);
+
+    List<Validator> actualValidators = resourceValidators.getAll(INSTANCE_ID);
+    assertValidatorsEquality(actualValidators, expectedValidators);
+  }
+
+  /**
+   * Given a user is playing the manager role for some Resources Manager applications A and this
+   * user isn't a validator of any resources R in those applications A, When he's removed from the
+   * manager role, Then nothing should be done with the validators of the resources R in the
+   * applications A.
+   */
+  @Test
+  public void aNonValidatorHasBeenRemovedFromManagersProfile() {
+    setUpProfileInstWith(VALIDATOR_ROLE, List.of("0", "1", "2", "11"), NO_IDS);
+    List<Validator> expectedValidators = resourceValidators.getAll(INSTANCE_ID);
+
+    ProfileInst profileToUpdate = getProfileInst(VALIDATOR_ROLE);
+    profileToUpdate.getAllUsers().remove("11");
+    updateProfileInst(profileToUpdate);
+
+    List<Validator> actualValidators = resourceValidators.getAll(INSTANCE_ID);
+    assertValidatorsEquality(actualValidators, expectedValidators);
+  }
+
+  /**
+   * Given a user group G is playing the manager role for some Resources Manager applications A and
+   * some users U in this group are also validators of some resources R in those applications A,
+   * When the group G is removed from the manager role, Then the users U should be also removed from
+   * the validators of resources R in the applications A.
+   */
+  @Test
+  public void aGroupWithAValidatorHasBeenRemovedFromManagersProfile() {
+    // user 1 belongs to the user group 1
+    setUpProfileInstWith(VALIDATOR_ROLE, NO_IDS, List.of("1", "2"));
+
+    ProfileInst profileToUpdate = getProfileInst(VALIDATOR_ROLE);
+    profileToUpdate.getAllGroups().remove("1");
+    updateProfileInst(profileToUpdate);
+
+    List<Validator> validators = resourceValidators.getAll(INSTANCE_ID);
+    assertValidatorIsRemoved("1", validators);
+  }
+
+  /**
+   * Given a user group G is playing the manager role for some Resources Manager applications A and
+   * some users U in this group are also validators of some resources R in those applications A,
+   * When the group G is removed from the manager role, Then the users U should be also removed from
+   * the validators of resources R in the applications A.
+   */
+  @Test
+  public void aGroupWithAValidatorHasBeenRemovedFromInheritedManagersProfile() {
+    // user 1 belongs to the user group 1
+    String profileId = setUpInheritedProfileInstWith(VALIDATOR_ROLE, NO_IDS, List.of("1", "2"));
+
+    ProfileInst profileToUpdate = getProfileInstById(profileId);
+    profileToUpdate.getAllGroups().remove("1");
+    updateProfileInst(profileToUpdate);
+
+    List<Validator> validators = resourceValidators.getAll(INSTANCE_ID);
+    assertValidatorIsRemoved("1", validators);
+  }
+
+  /**
+   * Given a user group G is playing the reader role for some Resources Manager applications A and
+   * some users in the group G are also validators of resources R in those applications A, When the
+   * group G is removed from the reader role, Then nothing should be done with the validators of the
+   * resources R in the applications A.
+   */
+  @Test
+  public void aGroupWithoutAnyValidatorHasBeenRemovedFromReadersProfile() {
+    setUpProfileInstWith(READER_ROLE, NO_IDS, List.of("1", "2"));
+    List<Validator> expectedValidators = resourceValidators.getAll(INSTANCE_ID);
+
+    ProfileInst profileToUpdate = getProfileInst(READER_ROLE);
+    profileToUpdate.getAllGroups().remove("1");
+    updateProfileInst(profileToUpdate);
+
+    List<Validator> actualValidators = resourceValidators.getAll(INSTANCE_ID);
+    assertValidatorsEquality(actualValidators, expectedValidators);
+  }
+
+  /**
+   * Given a user group G is playing the manager role for some Resources Manager applications A and
+   * no users in the group G are validators of resources R in those applications A, When the group G
+   * is removed from the manager role, Then nothing should be done with the validators of the
+   * resources R in the applications A.
+   */
+  @Test
+  public void aGroupWithoutAnyValidatorHasBeenRemovedFromManagersProfile() {
+    // group 4 has no validators
+    setUpProfileInstWith(VALIDATOR_ROLE, NO_IDS, List.of("4", "5"));
+    List<Validator> expectedValidators = resourceValidators.getAll(INSTANCE_ID);
+
+    ProfileInst profileToUpdate = getProfileInst(VALIDATOR_ROLE);
+    profileToUpdate.getAllGroups().remove("5");
+    updateProfileInst(profileToUpdate);
+
+    List<Validator> actualValidators = resourceValidators.getAll(INSTANCE_ID);
+    assertValidatorsEquality(actualValidators, expectedValidators);
+  }
+
+  /**
+   * Given a user group G is playing the manager role for some Resources Manager applications A,
+   * Given a user U belonging to the group G is also playing explicitly the manager Role for those
+   * applications A and he's also validator of some resources R in those applications A, When the
+   * user U is removed from the manager role, Then nothing should be done with the validators of the
+   * resources R in the applications A.
+   */
+  @Test
+  public void aValidatorHasBeenDirectlyRemovedButItIsInGroupInManagersProfile() {
+    // user 1 belongs to user group 1
+    setUpProfileInstWith(VALIDATOR_ROLE, List.of("0", "1", "2"), List.of("1"));
+    List<Validator> expectedValidators = resourceValidators.getAll(INSTANCE_ID);
+
+    ProfileInst profileToUpdate = getProfileInst(VALIDATOR_ROLE);
+    profileToUpdate.getAllUsers().remove("1");
+    updateProfileInst(profileToUpdate);
+
+    List<Validator> actualValidators = resourceValidators.getAll(INSTANCE_ID);
+    assertValidatorsEquality(actualValidators, expectedValidators);
+  }
+
+  /**
+   * Given a user group G is playing buy inheritance the manager role for some Resources Manager
+   * applications A, Given a user U belonging to the group G is also playing explicitly the manager
+   * Role for those applications A and he's also validator of some resources R in those applications
+   * A, When the user U is removed from the manager role, Then nothing should be done with the
+   * validators of the resources R in the applications A.
+   */
+  @Test
+  public void aValidatorHasBeenDirectlyRemovedButItIsInGroupInInheritedManagersProfile() {
+    setUpInheritedProfileInstWith(VALIDATOR_ROLE, NO_IDS, List.of("1"));
+    setUpProfileInstWith(VALIDATOR_ROLE, List.of("0", "1", "2"), NO_IDS);
+    List<Validator> expectedValidators = resourceValidators.getAll(INSTANCE_ID);
+
+    ProfileInst profileToUpdate = getProfileInst(VALIDATOR_ROLE);
+    profileToUpdate.getAllUsers().remove("1");
+    updateProfileInst(profileToUpdate);
+
+    List<Validator> actualValidators = resourceValidators.getAll(INSTANCE_ID);
+    assertValidatorsEquality(actualValidators, expectedValidators);
+  }
+
+  /**
+   * Given a subgroup G of a user group playing the manager role for some Resources Manager
+   * applications A, Given a user U belonging to the subgroup G is also playing explicitly the
+   * manager Role for those applications A and he's also validator of some resources R in those
+   * applications A, When the user U is removed from the manager role, Then nothing should be done
+   * with the validators of the resources R in the applications A.
+   */
+  @Test
+  public void aValidatorHasBeenDirectlyRemovedButItIsInSubGroupInManagersProfile() {
+    setUpProfileInstWith(VALIDATOR_ROLE, List.of("0", "1", "2"), List.of("3"));
+    List<Validator> expectedValidators = resourceValidators.getAll(INSTANCE_ID);
+
+    ProfileInst profileToUpdate = getProfileInst(VALIDATOR_ROLE);
+    profileToUpdate.getAllUsers().remove("1");
+    updateProfileInst(profileToUpdate);
+
+    List<Validator> actualValidators = resourceValidators.getAll(INSTANCE_ID);
+    assertValidatorsEquality(actualValidators, expectedValidators);
+  }
+
+  /**
+   * Given a user group G is playing the manager role for some Resources Manager applications A,
+   * Given a user U is playing the manager Role for those applications A and he doesn't belong to
+   * the group G and he's also validator of some resources R in those applications A, When the user
+   * U is removed from the manager role, Then the users U should be also removed from the validators
+   * of resources R in the applications A.
+   */
+  @Test
+  public void aValidatorHasBeenDirectlyRemovedAndItIsNotInGroupInManagersProfile() {
+    setUpProfileInstWith(VALIDATOR_ROLE, List.of("0", "1", "2"), List.of("5"));
+
+    ProfileInst profileToUpdate = getProfileInst(VALIDATOR_ROLE);
+    profileToUpdate.getAllUsers().remove("1");
+    updateProfileInst(profileToUpdate);
+
+    List<Validator> validators = resourceValidators.getAll(INSTANCE_ID);
+    assertValidatorIsRemoved("1", validators);
+  }
+
+  /**
+   * Given a user group G is playing the manager role for some Resources Manager applications A,
+   * Given a user U is playing the manager Role for those applications A and he doesn't belong to
+   * the group G and he's also validator of some resources R in those applications A, When the user
+   * U is removed from the manager role, Then the users U should be also removed from the validators
+   * of resources R in the applications A.
+   */
+  @Test
+  public void aValidatorHasBeenDirectlyRemovedAndItIsNotInGroupInInheritedManagersProfile() {
+    setUpInheritedProfileInstWith(VALIDATOR_ROLE, NO_IDS, List.of("5"));
+    setUpProfileInstWith(VALIDATOR_ROLE, List.of("0", "1", "2"), NO_IDS);
+
+    ProfileInst profileToUpdate = getProfileInst(VALIDATOR_ROLE);
+    profileToUpdate.getAllUsers().remove("1");
+    updateProfileInst(profileToUpdate);
+
+    List<Validator> validators = resourceValidators.getAll(INSTANCE_ID);
+    assertValidatorIsRemoved("1", validators);
+  }
+
+  /**
+   * Given a group G is playing the manager role for some Resources Manager applications A and some
+   * users U in this group G are validators of some resources R in those applications A, When the
+   * group G is removed from the manager role for A, Then the users U should be also removed from
+   * the validators of R in the applications A.
+   */
+  @Test
+  public void aGroupInManagerProfileWithAValidatorHasBeenRemoved() {
+    setUpProfileInstWith(VALIDATOR_ROLE, NO_IDS, List.of("1"));
+
+    ProfileInst profileToUpdate = getProfileInst(VALIDATOR_ROLE);
+    profileToUpdate.getAllGroups().remove("1");
+    updateProfileInst(profileToUpdate);
+
+    List<Validator> validators = resourceValidators.getAll(INSTANCE_ID);
+    assertValidatorIsRemoved("1", validators);
+  }
+
+  /**
+   * Given a group G is playing the manager role for some Resources Manager applications A and some
+   * users U in this group G are validators of some resources R in those applications A, When the
+   * group G is removed from the manager role for A, Then the users U should be also removed from
+   * the validators of R in the applications A.
+   */
+  @Test
+  public void aGroupInInheritedManagerProfileWithAValidatorHasBeenRemoved() {
+    String profileId = setUpInheritedProfileInstWith(VALIDATOR_ROLE, NO_IDS, List.of("1"));
+
+    ProfileInst profileToUpdate = getProfileInstById(profileId);
+    profileToUpdate.getAllGroups().remove("1");
+    updateProfileInst(profileToUpdate);
+
+    List<Validator> validators = resourceValidators.getAll(INSTANCE_ID);
+    assertValidatorIsRemoved("1", validators);
+  }
+
+  /**
+   * Given a user group G is playing the manager role for some Resources Manager applications A,
+   * Given a user belonging to the group G is also playing explicitly the manager Role for those
+   * applications A and he's also validator of some resources R in those applications A, When the
+   * group G is removed from the manager role, Then nothing should be done with the validators of
+   * the resources R in the applications A.
+   */
+  @Test
+  public void aGroupWithAValidatorHasBeenRemovedButTheValidatorIsInManagersProfile() {
+    setUpProfileInstWith(VALIDATOR_ROLE, List.of("0", "1", "2"), List.of("1"));
+    List<Validator> expectedValidators = resourceValidators.getAll(INSTANCE_ID);
+
+    ProfileInst profileToUpdate = getProfileInst(VALIDATOR_ROLE);
+    profileToUpdate.getAllGroups().remove("1");
+    updateProfileInst(profileToUpdate);
+
+    List<Validator> actualValidators = resourceValidators.getAll(INSTANCE_ID);
+    assertValidatorsEquality(actualValidators, expectedValidators);
+  }
+
+  /**
+   * Given a user group G is playing the manager role for some Resources Manager applications A,
+   * Given a user belonging to the group G is also playing by inheritance the manager Role for those
+   * applications A and he's also validator of some resources R in those applications A, When the
+   * group G is removed from the manager role, Then nothing should be done with the validators of
+   * the resources R in the applications A.
+   */
+  @Test
+  public void aGroupWithAValidatorHasBeenRemovedButTheValidatorIsInInheritedManagersProfile() {
+    setUpInheritedProfileInstWith(VALIDATOR_ROLE, List.of("0", "1", "2"), NO_IDS);
+    setUpProfileInstWith(VALIDATOR_ROLE, NO_IDS, List.of("1"));
+    List<Validator> expectedValidators = resourceValidators.getAll(INSTANCE_ID);
+
+    ProfileInst profileToUpdate = getProfileInst(VALIDATOR_ROLE);
+    profileToUpdate.getAllGroups().remove("1");
+    updateProfileInst(profileToUpdate);
+
+    List<Validator> actualValidators = resourceValidators.getAll(INSTANCE_ID);
+    assertValidatorsEquality(actualValidators, expectedValidators);
+  }
+
+  /**
+   * Given two user groups are playing the manager role for some Resources Manager applications A,
+   * Given a user belonging to these two groups is also validator of some resources R in those
+   * applications A, When only one of these two groups is removed from the manager role, Then
+   * nothing should be done with the validators of the resources R in the applications A.
+   */
+  @Test
+  public void aGroupWithAValidatorHasBeenRemovedButTheValidatorIsAnotherGroupInManagersProfile() {
+    setUpProfileInstWith(VALIDATOR_ROLE, NO_IDS, List.of("1", "4"));
+    List<Validator> expectedValidators = resourceValidators.getAll(INSTANCE_ID);
+
+    ProfileInst profileToUpdate = getProfileInst(VALIDATOR_ROLE);
+    profileToUpdate.getAllGroups().remove("1");
+    updateProfileInst(profileToUpdate);
+
+    List<Validator> actualValidators = resourceValidators.getAll(INSTANCE_ID);
+    assertValidatorsEquality(actualValidators, expectedValidators);
+  }
+
+  /**
+   * Given two user groups G1 and G2 are playing the manager role for some Resources Manager
+   * applications A, Given a user is belonging to the group G1 and to a subgroup of G2, and he's
+   * also validator of some resources R in those applications A, When the group G1 is removed from
+   * the manager role, Then nothing should be done with the validators of the resources R in the
+   * applications A.
+   */
+  @Test
+  public void aGroupWithAValidatorHasBeenRemovedButTheValidatorIsInASubgroupInManagersProfile() {
+    setUpProfileInstWith(VALIDATOR_ROLE, NO_IDS, List.of("1", "3"));
+    List<Validator> expectedValidators = resourceValidators.getAll(INSTANCE_ID);
+
+    ProfileInst profileToUpdate = getProfileInst(VALIDATOR_ROLE);
+    profileToUpdate.getAllGroups().remove("1");
+    updateProfileInst(profileToUpdate);
+
+    List<Validator> actualValidators = resourceValidators.getAll(INSTANCE_ID);
+    assertValidatorsEquality(actualValidators, expectedValidators);
+  }
+
+  /**
+   * Given a user is playing the manager role for some Resources Manager applications A and this
+   * user is also a validator of some resources R in those applications A, When he's removed from
+   * the manager role whereas in the same time a group to which he belongs is added in the manager
+   * role, Then nothing should be done with the validators of the resources R in the applications
+   * A.
+   */
+  @Test
+  public void aValidatorHasBeenDirectlyRemovedButHeIsInSuperGroupAddedInManagersProfile() {
+    setUpProfileInstWith(VALIDATOR_ROLE, List.of("0", "1", "2"), NO_IDS);
+    List<Validator> expectedValidators = resourceValidators.getAll(INSTANCE_ID);
+
+    ProfileInst profileToUpdate = getProfileInst(VALIDATOR_ROLE);
+    profileToUpdate.getAllUsers().remove("1");
+    profileToUpdate.getAllGroups().add("4");
+    updateProfileInst(profileToUpdate);
+
+    List<Validator> actualValidators = resourceValidators.getAll(INSTANCE_ID);
+    assertValidatorsEquality(actualValidators, expectedValidators);
+  }
+}
+  

--- a/core-library/src/integration-test/java/org/silverpeas/core/admin/user/notification/role/test/Resource.java
+++ b/core-library/src/integration-test/java/org/silverpeas/core/admin/user/notification/role/test/Resource.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright (C) 2000 - 2025 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.admin.user.notification.role.test;
+
+import org.silverpeas.core.admin.user.model.User;
+import org.silverpeas.core.contribution.model.Contribution;
+import org.silverpeas.core.contribution.model.ContributionIdentifier;
+import org.silverpeas.core.persistence.Transaction;
+import org.silverpeas.core.persistence.datasource.model.identifier.UniqueLongIdentifier;
+import org.silverpeas.core.persistence.datasource.model.jpa.BasicJpaEntity;
+import org.silverpeas.core.persistence.datasource.model.jpa.EntityManagerProvider;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EntityManager;
+import javax.persistence.Table;
+import javax.validation.constraints.NotNull;
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * A resource managed by the component instance used in tests.
+ *
+ * @author mmoquillon
+ */
+@Entity
+@Table(name = "SC_MyComponent_Resources")
+public class Resource extends BasicJpaEntity<Resource, UniqueLongIdentifier>
+    implements Contribution {
+
+  @Column(nullable = false)
+  @NotNull
+  private String name;
+  @Column(nullable = false)
+  @NotNull
+  private String description = "";
+  @Column(nullable = false)
+  @NotNull
+  private Instant creationDate;
+  @Column(nullable = false)
+  @NotNull
+  private Instant updateDate;
+  @Column(nullable = false)
+  @NotNull
+  private String creator;
+  @Column(nullable = false)
+  @NotNull
+  private String updater;
+  private String validator;
+  private Instant validationDate;
+  @Column(nullable = false)
+  @NotNull
+  private String instanceId;
+
+
+  public static Optional<Resource> getById(String id) {
+    return Transaction.performInOne(() -> {
+      EntityManager em = EntityManagerProvider.get().getEntityManager();
+      return Optional.ofNullable(em.find(Resource.class, UniqueLongIdentifier.from(id)));
+    });
+  }
+
+  protected Resource() {
+    super();
+    // for JPA
+  }
+
+  public Resource(String instanceId, String name, String description) {
+    this.instanceId = instanceId;
+    this.name = name;
+    this.description = description;
+    this.creator = Optional.ofNullable(User.getCurrentRequester())
+        .map(User::getId)
+        .orElse(User.getSystemUser().getId());
+  }
+
+  @Override
+  public ContributionIdentifier getIdentifier() {
+    return ContributionIdentifier.from(instanceId, getId(), getClass().getSimpleName());
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  @Override
+  public String getDescription() {
+    return description;
+  }
+
+  public void setDescription(String description) {
+    this.description = description;
+  }
+
+  @Override
+  public Date getCreationDate() {
+    return Date.from(creationDate);
+  }
+
+  @Override
+  public Date getLastUpdateDate() {
+    return Date.from(updateDate);
+  }
+
+  @Override
+  public User getCreator() {
+    return User.getById(creator);
+  }
+
+  @Override
+  public User getLastUpdater() {
+    return User.getById(updater);
+  }
+
+  public User getValidator() {
+    return User.getById(validator);
+  }
+
+  public void setValidator(User validator) {
+    this.validator = validator.getId();
+  }
+
+  public Date getValidationDate() {
+    return Date.from(validationDate);
+  }
+
+  public void save() {
+    Transaction.performInOne(() -> {
+      EntityManager em = EntityManagerProvider.get().getEntityManager();
+      if (this.isPersisted()) {
+        em.persist(this);
+      } else {
+        em.merge(this);
+      }
+      return null;
+    });
+  }
+
+  public void validate() {
+    this.validationDate = Instant.now();
+    this.validator = Optional.ofNullable(User.getCurrentRequester())
+        .map(User::getId)
+        .orElse(User.getSystemUser().getId());
+    save();
+  }
+
+  public List<User> getPossibleValidators() {
+    if (isPersisted()) {
+      return getResourceValidators()
+          .stream()
+          .map(Validator::getUser)
+          .collect(Collectors.toList());
+    } else {
+      return List.of();
+    }
+  }
+
+  public void addAsValidator(User user) {
+    if (isPersisted()) {
+      Validator.newValidator(user)
+          .onResource(this)
+          .save();
+    }
+  }
+
+  public void removeFromValidators(User user) {
+    getResourceValidators().stream()
+        .filter(v -> v.getUserId().equals(user.getId()))
+        .findFirst()
+        .ifPresent(Validator::delete);
+  }
+
+  public boolean isValidated() {
+    return validationDate != null && validator != null;
+  }
+
+  @Override
+  protected void performBeforeUpdate() {
+    super.performBeforeUpdate();
+    this.updateDate = Instant.now();
+    this.updater = Optional.ofNullable(User.getCurrentRequester())
+        .map(User::getId)
+        .orElse(User.getSystemUser().getId());
+  }
+
+  @Override
+  protected void performBeforePersist() {
+    super.performBeforeUpdate();
+    this.creationDate = Instant.now();
+    this.creator = Optional.ofNullable(User.getCurrentRequester())
+        .map(User::getId)
+        .orElse(User.getSystemUser().getId());
+  }
+
+  private List<Validator> getResourceValidators() {
+    return Transaction.performInOne(() -> {
+      EntityManager em = EntityManagerProvider.get().getEntityManager();
+      return em.createNamedQuery("Validator.findAllByResource", Validator.class)
+          .setParameter("resource", this)
+          .getResultList();
+    });
+  }
+}
+  

--- a/core-library/src/integration-test/java/org/silverpeas/core/admin/user/notification/role/test/ResourceValidators.java
+++ b/core-library/src/integration-test/java/org/silverpeas/core/admin/user/notification/role/test/ResourceValidators.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2000 - 2024 Silverpeas
+ * Copyright (C) 2000 - 2025 Silverpeas
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -22,28 +22,32 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package org.silverpeas.core.workflow.engine.user;
+package org.silverpeas.core.admin.user.notification.role.test;
 
-import org.silverpeas.core.notification.system.AbstractResourceEvent;
-import org.silverpeas.core.workflow.api.user.Replacement;
+import org.silverpeas.core.annotation.Service;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import javax.transaction.Transactional;
+import java.util.List;
 
 /**
- * Event about the replacements of users in a given workflow. Such events are fired when an
- * operation was performed on a replacement such as the creation, the deletion, and so on.
+ * The validators registered for all the resources managed by the component instance used in tests.
+ *
  * @author mmoquillon
  */
-public class ReplacementEvent extends AbstractResourceEvent<Replacement<?>> {
+@Service
+public class ResourceValidators {
 
-  /**
-   * Constructs a new event about a given replacement.
-   * @param type the type of the event reflecting the cause of it (creation, deletion, ...)
-   * @param states the replacement concerned by the event as it was before the cause of that event
-   * and once the cause was done. If there is no state before the cause, then just passe
-   * the state after (case of the creation). If there is no state after the cause, then just passe
-   * the state before (case of the deletion).
-   */
-  public ReplacementEvent(final Type type, final Replacement<?>... states) {
-    super(type, states);
+  @PersistenceContext
+  private EntityManager entityManager;
+
+  @Transactional
+  public List<Validator> getAll(String instanceId) {
+    return entityManager.createNamedQuery("Validator.findAllByInstanceId", Validator.class)
+        .setParameter("instanceId", instanceId)
+        .getResultList();
   }
+
 }
   

--- a/core-library/src/integration-test/java/org/silverpeas/core/admin/user/notification/role/test/TestModelIT.java
+++ b/core-library/src/integration-test/java/org/silverpeas/core/admin/user/notification/role/test/TestModelIT.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright (C) 2000 - 2025 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.admin.user.notification.role.test;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.silverpeas.core.admin.user.model.User;
+import org.silverpeas.core.cache.service.CacheAccessorProvider;
+import org.silverpeas.core.cache.service.SessionCacheAccessor;
+import org.silverpeas.core.test.WarBuilder4LibCore;
+import org.silverpeas.core.test.integration.rule.DbSetupRule;
+
+import javax.inject.Inject;
+import java.util.List;
+import java.util.Optional;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Integration test to ensure the model used for tests works correctly.
+ *
+ * @author mmoquillon
+ */
+@RunWith(Arquillian.class)
+public class TestModelIT {
+
+  @Inject
+  private ResourceValidators resourceValidators;
+
+  @Rule
+  public DbSetupRule dbSetupRule =
+      DbSetupRule
+          .createTablesFrom(
+              "/org/silverpeas/core/admin/user/notification/role/create_database.sql")
+          .loadInitialDataSetFrom(
+              "/org/silverpeas/core/admin/user/notification/role/insert_dataset.sql");
+
+  @Deployment
+  public static Archive<?> createTestArchive() {
+    return WarBuilder4LibCore.onWarForTestClass(TestModelIT.class)
+        .addSilverpeasExceptionBases()
+        .addAdministrationFeatures()
+        .addDatabaseToolFeatures()
+        .addJpaPersistenceFeatures()
+        .addPublicationTemplateFeatures()
+        .addAsResource("org/silverpeas/core/admin/user/notification/role")
+        .testFocusedOn(warBuilder ->
+            warBuilder.addPackages(true, TestModelIT.class.getPackageName()))
+        .build();
+  }
+
+  @Before
+  public void setUpCurrentRequester() {
+    SessionCacheAccessor sessionCacheAccessor =
+        CacheAccessorProvider.getSessionCacheAccessor();
+    sessionCacheAccessor.newSessionCache(User.getById("1"));
+  }
+
+  @Test
+  public void existingResourceShouldBeFound() {
+    Optional<Resource> mayBeAResource = Resource.getById("1");
+    assertThat(mayBeAResource.isPresent(), is(true));
+
+    Resource resource = mayBeAResource.get();
+    assertThat(resource.getId(), is("1"));
+    assertThat(resource.getName(), is("Salle Chartreuse"));
+    assertThat(resource.getDescription().isEmpty(), is(true));
+    assertThat(resource.isValidated(), is(false));
+    assertThat(resource.getIdentifier().getComponentInstanceId(), is("myComponent1"));
+  }
+
+  @Test
+  public void existingResourceValidatorsShouldBeFound() {
+    Optional<Resource> mayBeAResource = Resource.getById("1");
+    assertThat(mayBeAResource.isPresent(), is(true));
+    List<String> expectedValidators = List.of("0", "1", "2");
+
+    Resource resource = mayBeAResource.get();
+    var validators = resource.getPossibleValidators();
+    assertThat(validators.size(), is(expectedValidators.size()));
+    validators.stream()
+        .map(User::getId)
+        .forEach(u -> assertThat(expectedValidators.contains(u), is(true)));
+  }
+
+  @Test
+  public void validatingAResourceValidateIt() {
+    Optional<Resource> mayBeAResource = Resource.getById("1");
+    assertThat(mayBeAResource.isPresent(), is(true));
+
+    Resource resource = mayBeAResource.get();
+    assertThat(resource.isValidated(), is(false));
+
+    resource.validate();
+
+    assertThat(resource.isValidated(), is(true));
+    assertThat(resource.getValidator().getId(), is("1"));
+
+    assertResourceChangeIsPersisted(resource);
+  }
+
+  @Test
+  public void addingAValidatorToAResourcePersistIt() {
+    User expectedUser = User.getById("10");
+
+    Optional<Resource> mayBeAResource = Resource.getById("1");
+    assertThat(mayBeAResource.isPresent(), is(true));
+
+    Resource resource = mayBeAResource.get();
+    assertThat(resource.getPossibleValidators().stream()
+        .map(User::getId)
+        .noneMatch(u -> u.equals(expectedUser.getId())), is(true));
+
+    resource.addAsValidator(expectedUser);
+
+    assertThat(resource.getPossibleValidators().stream()
+        .map(User::getId)
+        .anyMatch(u -> u.equals(expectedUser.getId())), is(true));
+
+    assertResourceChangeIsPersisted(resource);
+  }
+
+  @Test
+  public void allRegisteredValidatorsShouldBeFound() {
+    List<Validator> registeredValidators = resourceValidators.getAll("myComponent1");
+    assertThat(registeredValidators.size(), is(4));
+
+    assertThat(registeredValidators.get(0).getResource().getId(), is("1"));
+    assertThat(registeredValidators.get(0).getUser().getId(), is("0"));
+    assertThat(registeredValidators.get(1).getResource().getId(), is("1"));
+    assertThat(registeredValidators.get(1).getUser().getId(), is("1"));
+    assertThat(registeredValidators.get(2).getResource().getId(), is("1"));
+    assertThat(registeredValidators.get(2).getUser().getId(), is("2"));
+
+    assertThat(registeredValidators.get(3).getResource().getId(), is("3"));
+    assertThat(registeredValidators.get(3).getUser().getId(), is("0"));
+  }
+
+  private void assertResourceChangeIsPersisted(Resource expected) {
+    Optional<Resource> actualResource = Resource.getById(expected.getId());
+    assertThat(actualResource.isPresent(), is(true));
+
+    Resource actual = actualResource.get();
+    assertThat(actual.getId(), is(expected.getId()));
+    assertThat(actual.getName(), is(expected.getName()));
+    assertThat(actual.getDescription(), is(expected.getDescription()));
+    assertThat(actual.isValidated(), is(expected.isValidated()));
+    if (actual.isValidated()) {
+      assertThat(actual.getValidator().getId(), is(expected.getValidator().getId()));
+      assertThat(actual.getValidationDate(), is(expected.getValidationDate()));
+    }
+
+    assertThat(actual.getPossibleValidators(), is(expected.getPossibleValidators()));
+  }
+}

--- a/core-library/src/integration-test/java/org/silverpeas/core/admin/user/notification/role/test/Validator.java
+++ b/core-library/src/integration-test/java/org/silverpeas/core/admin/user/notification/role/test/Validator.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2000 - 2025 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.admin.user.notification.role.test;
+
+import org.silverpeas.core.admin.user.model.User;
+import org.silverpeas.core.persistence.Transaction;
+import org.silverpeas.core.persistence.datasource.model.CompositeEntityIdentifier;
+import org.silverpeas.core.persistence.datasource.model.jpa.BasicJpaEntity;
+import org.silverpeas.core.persistence.datasource.model.jpa.EntityManagerProvider;
+
+import javax.persistence.*;
+
+/**
+ * A possible validator of a resource managed by the component instance used in tests.
+ *
+ * @author mmoquillon
+ */
+@Entity
+@Table(name = "SC_MyComponent_Validators")
+@NamedQuery(name = "Validator.findAllByResource",
+    query = "select v from Validator v where v.resource = :resource order by v.id.validatorId")
+@NamedQuery(name = "Validator.findAllByInstanceId",
+    query = "select v from Validator v where v.resource.instanceId = :instanceId " +
+        "order by v.id.resourceId, v.id.validatorId")
+public class Validator extends BasicJpaEntity<Validator, ValidatorID> {
+
+  @ManyToOne(optional = false)
+  @JoinColumn(name = "resourceId", updatable = false, insertable = false,
+      referencedColumnName = "id")
+  private Resource resource;
+
+  protected Validator() {
+    // for JPA
+  }
+
+  protected Validator(User validator, Resource resource) {
+    this.resource = resource;
+    this.setId(validator.getId() + CompositeEntityIdentifier.COMPOSITE_SEPARATOR + resource.getId());
+  }
+
+  public static ValidatorBuilder newValidator(User user) {
+    return new ValidatorBuilder(user);
+  }
+
+  public String getUserId() {
+    return getNativeId().getValidatorId();
+  }
+
+  public Resource getResource() {
+    return resource;
+  }
+
+  public User getUser() {
+    return User.getById(getNativeId().getValidatorId());
+  }
+
+  public void save() {
+    Transaction.performInOne(() -> {
+      EntityManager em = EntityManagerProvider.get().getEntityManager();
+      if (this.isPersisted()) {
+        em.persist(this);
+      } else {
+        em.merge(this);
+      }
+      return null;
+    });
+  }
+
+  public void delete() {
+    if (isPersisted()) {
+      Transaction.performInOne(() -> {
+        EntityManager em = EntityManagerProvider.get().getEntityManager();
+        em.remove(this);
+        return null;
+      });
+    }
+  }
+
+  public static class ValidatorBuilder {
+
+    private final User validator;
+
+    private ValidatorBuilder(User validator) {
+      this.validator = validator;
+    }
+
+    public Validator onResource(Resource resource) {
+      return new Validator(validator, resource);
+    }
+  }
+}
+  

--- a/core-library/src/integration-test/java/org/silverpeas/core/admin/user/notification/role/test/ValidatorID.java
+++ b/core-library/src/integration-test/java/org/silverpeas/core/admin/user/notification/role/test/ValidatorID.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2000 - 2024 Silverpeas
+ * Copyright (C) 2000 - 2025 Silverpeas
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -22,28 +22,53 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package org.silverpeas.core.workflow.engine.user;
+package org.silverpeas.core.admin.user.notification.role.test;
 
-import org.silverpeas.core.notification.system.AbstractResourceEvent;
-import org.silverpeas.core.workflow.api.user.Replacement;
+import org.silverpeas.core.persistence.datasource.model.CompositeEntityIdentifier;
+
+import javax.persistence.Embeddable;
 
 /**
- * Event about the replacements of users in a given workflow. Such events are fired when an
- * operation was performed on a replacement such as the creation, the deletion, and so on.
+ * Composite identifier of a validator. A validator refers user playing the role of validator for a
+ * given resource.
+ *
  * @author mmoquillon
  */
-public class ReplacementEvent extends AbstractResourceEvent<Replacement<?>> {
+@SuppressWarnings("unused")
+@Embeddable
+public class ValidatorID implements CompositeEntityIdentifier {
 
-  /**
-   * Constructs a new event about a given replacement.
-   * @param type the type of the event reflecting the cause of it (creation, deletion, ...)
-   * @param states the replacement concerned by the event as it was before the cause of that event
-   * and once the cause was done. If there is no state before the cause, then just passe
-   * the state after (case of the creation). If there is no state after the cause, then just passe
-   * the state before (case of the deletion).
-   */
-  public ReplacementEvent(final Type type, final Replacement<?>... states) {
-    super(type, states);
+  private Long resourceId;
+
+  private String validatorId;
+
+  public ValidatorID() {
+    // for JPA
+  }
+
+  ValidatorID(String validatorId, Long resource) {
+    this.resourceId = resource;
+    this.validatorId = validatorId;
+  }
+
+  Long getResourceId() {
+    return resourceId;
+  }
+
+  String getValidatorId() {
+    return validatorId;
+  }
+
+  @Override
+  public CompositeEntityIdentifier fromString(String... values) {
+    this.validatorId = values[0];
+    this.resourceId = Long.parseLong(values[1]);
+    return this;
+  }
+
+  @Override
+  public String asString() {
+    return validatorId + COMPOSITE_SEPARATOR + resourceId;
   }
 }
   

--- a/core-library/src/integration-test/java/org/silverpeas/core/calendar/CalendarEventNotificationIT.java
+++ b/core-library/src/integration-test/java/org/silverpeas/core/calendar/CalendarEventNotificationIT.java
@@ -31,6 +31,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.silverpeas.core.admin.user.model.User;
+import org.silverpeas.core.annotation.Bean;
 import org.silverpeas.core.calendar.notification.AbstractNotifier;
 import org.silverpeas.core.calendar.notification.AttendeeLifeCycleEvent;
 import org.silverpeas.core.calendar.notification.AttendeeLifeCycleEventNotifier;
@@ -295,6 +296,7 @@ public class CalendarEventNotificationIT extends BaseCalendarTest {
   /**
    * Listens for change in the attendance in an event (or in a given event's occurrence).
    */
+  @Bean
   @Singleton
   public static class AttendanceNotificationListener extends
       AbstractNotifier<AttendeeLifeCycleEvent> {
@@ -338,6 +340,7 @@ public class CalendarEventNotificationIT extends BaseCalendarTest {
    * we send a notification about a change in the attendance in the event. This behaviour is
    * implemented by the attendee notification mechanism. We just simulate here this behaviour.
    */
+  @Bean
   @Singleton
   public static class CalendarEventNotificationListener extends
       AbstractNotifier<CalendarEventLifeCycleEvent> {
@@ -390,6 +393,7 @@ public class CalendarEventNotificationIT extends BaseCalendarTest {
    * this case, we send a notification about a change in the attendance in the event. This behaviour
    * is implemented by the attendee notification mechanism. We just simulate here this behaviour.
    */
+  @Bean
   @Singleton
   public static class CalendarEventOccurrenceNotificationListener
       extends AbstractNotifier<CalendarEventOccurrenceLifeCycleEvent> {

--- a/core-library/src/integration-test/java/org/silverpeas/core/notification/system/asynchronous/JMSQueueTestResourceEventListener.java
+++ b/core-library/src/integration-test/java/org/silverpeas/core/notification/system/asynchronous/JMSQueueTestResourceEventListener.java
@@ -52,25 +52,25 @@ public class JMSQueueTestResourceEventListener extends JMSResourceEventListener<
   }
 
   @Override
-  public void onDeletion(final TestResourceEvent event) throws Exception {
+  public void onDeletion(final TestResourceEvent event) {
     SilverLogger.getLogger(this).info("Deletion event reception...");
     this.bucket.pour(event);
   }
 
   @Override
-  public void onRemoving(final TestResourceEvent event) throws Exception {
+  public void onRemoving(final TestResourceEvent event) {
     SilverLogger.getLogger(this).info("Removing event reception...");
     this.bucket.pour(event);
   }
 
   @Override
-  public void onUpdate(final TestResourceEvent event) throws Exception {
+  public void onUpdate(final TestResourceEvent event) {
     SilverLogger.getLogger(this).info("Update event reception...");
     this.bucket.pour(event);
   }
 
   @Override
-  public void onCreation(final TestResourceEvent event) throws Exception {
+  public void onCreation(final TestResourceEvent event) {
     SilverLogger.getLogger(this).info("Creation event reception...");
     this.bucket.pour(event);
   }

--- a/core-library/src/integration-test/java/org/silverpeas/core/notification/system/asynchronous/JMSTopicTestResourceEventListener.java
+++ b/core-library/src/integration-test/java/org/silverpeas/core/notification/system/asynchronous/JMSTopicTestResourceEventListener.java
@@ -52,25 +52,25 @@ public class JMSTopicTestResourceEventListener extends JMSResourceEventListener<
   }
 
   @Override
-  public void onDeletion(final TestResourceEvent event) throws Exception {
+  public void onDeletion(final TestResourceEvent event) {
     SilverLogger.getLogger(this).info("Deletion event reception...");
     this.bucket.pour(event);
   }
 
   @Override
-  public void onRemoving(final TestResourceEvent event) throws Exception {
+  public void onRemoving(final TestResourceEvent event) {
     SilverLogger.getLogger(this).info("Removing event reception...");
     this.bucket.pour(event);
   }
 
   @Override
-  public void onUpdate(final TestResourceEvent event) throws Exception {
+  public void onUpdate(final TestResourceEvent event) {
     SilverLogger.getLogger(this).info("Update event reception...");
     this.bucket.pour(event);
   }
 
   @Override
-  public void onCreation(final TestResourceEvent event) throws Exception {
+  public void onCreation(final TestResourceEvent event) {
     SilverLogger.getLogger(this).info("Creation event reception...");
     this.bucket.pour(event);
   }

--- a/core-library/src/integration-test/java/org/silverpeas/core/notification/system/asynchronous/JMSTopicTestResourceEventListener2.java
+++ b/core-library/src/integration-test/java/org/silverpeas/core/notification/system/asynchronous/JMSTopicTestResourceEventListener2.java
@@ -52,25 +52,25 @@ public class JMSTopicTestResourceEventListener2 extends JMSResourceEventListener
   }
 
   @Override
-  public void onDeletion(final TestResourceEvent event) throws Exception {
+  public void onDeletion(final TestResourceEvent event) {
     SilverLogger.getLogger(this).info("Deletion event reception...");
     this.bucket.pour(event);
   }
 
   @Override
-  public void onRemoving(final TestResourceEvent event) throws Exception {
+  public void onRemoving(final TestResourceEvent event) {
     SilverLogger.getLogger(this).info("Removing event reception...");
     this.bucket.pour(event);
   }
 
   @Override
-  public void onUpdate(final TestResourceEvent event) throws Exception {
+  public void onUpdate(final TestResourceEvent event) {
     SilverLogger.getLogger(this).info("Update event reception...");
     this.bucket.pour(event);
   }
 
   @Override
-  public void onCreation(final TestResourceEvent event) throws Exception {
+  public void onCreation(final TestResourceEvent event) {
     SilverLogger.getLogger(this).info("Creation event reception...");
     this.bucket.pour(event);
   }

--- a/core-library/src/integration-test/java/org/silverpeas/core/notification/system/synchronous/SynchronousGenericResourceEventListener.java
+++ b/core-library/src/integration-test/java/org/silverpeas/core/notification/system/synchronous/SynchronousGenericResourceEventListener.java
@@ -41,8 +41,7 @@ public class SynchronousGenericResourceEventListener
   private GenericTestResource resource;
 
   @Override
-  public void onDeletion(final AbstractResourceEvent<? extends GenericTestResource> event)
-      throws Exception {
+  public void onDeletion(final AbstractResourceEvent<? extends GenericTestResource> event) {
     resource = event.getTransition().getBefore();
   }
 

--- a/core-library/src/integration-test/java/org/silverpeas/core/notification/system/synchronous/SynchronousTestResourceEventListener.java
+++ b/core-library/src/integration-test/java/org/silverpeas/core/notification/system/synchronous/SynchronousTestResourceEventListener.java
@@ -43,7 +43,7 @@ public class SynchronousTestResourceEventListener
   private TestResourceEventBucket bucket;
 
   @Override
-  public void onDeletion(final TestResourceEvent event) throws Exception {
+  public void onDeletion(final TestResourceEvent event) {
     pourEvent(event);
   }
 
@@ -53,12 +53,12 @@ public class SynchronousTestResourceEventListener
   }
 
   @Override
-  public void onUpdate(final TestResourceEvent event) throws Exception {
+  public void onUpdate(final TestResourceEvent event) {
     pourEvent(event);
   }
 
   @Override
-  public void onCreation(final TestResourceEvent event) throws Exception {
+  public void onCreation(final TestResourceEvent event) {
     pourEvent(event);
   }
 

--- a/core-library/src/integration-test/resources/org/silverpeas/core/admin/user/notification/role/create_database.sql
+++ b/core-library/src/integration-test/resources/org/silverpeas/core/admin/user/notification/role/create_database.sql
@@ -1,0 +1,249 @@
+CREATE TABLE ST_AccessLevel
+(
+    id   CHAR(1)      NOT NULL,
+    name VARCHAR(100) NOT NULL,
+    CONSTRAINT PK_AccessLevel PRIMARY KEY (id),
+    CONSTRAINT UN_AccessLevel_1 UNIQUE (name)
+);
+
+CREATE TABLE ST_User
+(
+    id                            INT                   NOT NULL,
+    domainId                      INT                   NOT NULL,
+    specificId                    VARCHAR(500)          NOT NULL,
+    firstName                     VARCHAR(100),
+    lastName                      VARCHAR(100)          NOT NULL,
+    email                         VARCHAR(100),
+    login                         VARCHAR(50)           NOT NULL,
+    loginMail                     VARCHAR(100),
+    accessLevel                   CHAR(1) DEFAULT 'U'   NOT NULL,
+    loginquestion                 VARCHAR(200),
+    loginanswer                   VARCHAR(200),
+    creationDate                  TIMESTAMP,
+    saveDate                      TIMESTAMP,
+    version                       INT     DEFAULT 0     NOT NULL,
+    tosAcceptanceDate             TIMESTAMP,
+    lastLoginDate                 TIMESTAMP,
+    nbSuccessfulLoginAttempts     INT     DEFAULT 0     NOT NULL,
+    lastLoginCredentialUpdateDate TIMESTAMP,
+    expirationDate                TIMESTAMP,
+    state                         VARCHAR(30)           NOT NULL,
+    stateSaveDate                 TIMESTAMP             NOT NULL,
+    notifManualReceiverLimit      INT,
+    sensitiveData                 BOOLEAN DEFAULT FALSE NOT NULL,
+    CONSTRAINT PK_User PRIMARY KEY (id),
+    CONSTRAINT UN_User_1 UNIQUE (specificId, domainId),
+    CONSTRAINT UN_User_2 UNIQUE (login, domainId),
+    CONSTRAINT FK_User_1 FOREIGN KEY (accessLevel) REFERENCES ST_AccessLevel (id)
+);
+
+CREATE TABLE ST_Group
+(
+    id            int          NOT NULL,
+    domainId      int          NOT NULL,
+    specificId    varchar(500) NOT NULL,
+    superGroupId  int,
+    name          varchar(100) NOT NULL,
+    description   varchar(400),
+    synchroRule   varchar(100),
+    creationDate  timestamp,
+    saveDate      timestamp,
+    state         varchar(30)  NOT NULL,
+    stateSaveDate timestamp    NOT NULL,
+    CONSTRAINT PK_Group PRIMARY KEY (id),
+    CONSTRAINT UN_Group_1 UNIQUE (specificId, domainId),
+    CONSTRAINT UN_Group_2 UNIQUE (superGroupId, name, domainId),
+    CONSTRAINT FK_Group_1 FOREIGN KEY (superGroupId) REFERENCES ST_Group (id)
+);
+
+CREATE TABLE ST_Group_User_Rel
+(
+    groupId int NOT NULL,
+    userId  int NOT NULL,
+    CONSTRAINT PK_Group_User_Rel PRIMARY KEY (groupId, userId),
+    CONSTRAINT FK_Group_User_Rel_1 FOREIGN KEY (groupId) REFERENCES ST_Group (id),
+    CONSTRAINT FK_Group_User_Rel_2 FOREIGN KEY (userId) REFERENCES ST_User (id)
+);
+
+CREATE TABLE ST_Space
+(
+    id                   INT             NOT NULL,
+    domainFatherId       INT,
+    name                 VARCHAR(100)    NOT NULL,
+    description          VARCHAR(400),
+    createdBy            INT,
+    firstPageType        INT             NOT NULL,
+    firstPageExtraParam  VARCHAR(400),
+    orderNum             INT DEFAULT (0) NOT NULL,
+    createTime           VARCHAR(20),
+    updateTime           VARCHAR(20),
+    removeTime           VARCHAR(20),
+    spaceStatus          CHAR(1),
+    updatedBy            INT,
+    removedBy            INT,
+    lang                 CHAR(2),
+    isInheritanceBlocked INT DEFAULT (0) NOT NULL,
+    look                 VARCHAR(50),
+    displaySpaceFirst    SMALLINT,
+    isPersonal           SMALLINT,
+    CONSTRAINT PK_Space PRIMARY KEY (id),
+    CONSTRAINT UN_Space_1 UNIQUE (domainFatherId, name),
+    CONSTRAINT FK_Space_1 FOREIGN KEY (createdBy) REFERENCES ST_User (id),
+    CONSTRAINT FK_Space_2 FOREIGN KEY (domainFatherId) REFERENCES ST_Space (id)
+);
+
+CREATE TABLE ST_SpaceI18N
+(
+    id          INT          NOT NULL,
+    spaceId     INT          NOT NULL,
+    lang        CHAR(2)      NOT NULL,
+    name        VARCHAR(100) NOT NULL,
+    description VARCHAR(400)
+);
+
+CREATE TABLE ST_ComponentInstance
+(
+    id                   INT             NOT NULL,
+    spaceId              INT             NOT NULL,
+    name                 VARCHAR(100)    NOT NULL,
+    componentName        VARCHAR(100)    NOT NULL,
+    description          VARCHAR(400),
+    createdBy            INT,
+    orderNum             INT DEFAULT (0) NOT NULL,
+    createTime           VARCHAR(20),
+    updateTime           VARCHAR(20),
+    removeTime           VARCHAR(20),
+    componentStatus      CHAR(1),
+    updatedBy            INT,
+    removedBy            INT,
+    isPublic             INT DEFAULT (0) NOT NULL,
+    isHidden             INT DEFAULT (0) NOT NULL,
+    lang                 CHAR(2),
+    isInheritanceBlocked INT DEFAULT (0) NOT NULL,
+    CONSTRAINT PK_ComponentInstance PRIMARY KEY (id),
+    CONSTRAINT UN_ComponentInstance_1 UNIQUE (spaceId, name),
+    CONSTRAINT FK_ComponentInstance_1 FOREIGN KEY (spaceId) REFERENCES ST_Space (id),
+    CONSTRAINT FK_ComponentInstance_2 FOREIGN KEY (createdBy) REFERENCES ST_User (id)
+);
+
+CREATE TABLE ST_ComponentInstanceI18N
+(
+    id          INT          NOT NULL,
+    componentId INT          NOT NULL,
+    lang        CHAR(2)      NOT NULL,
+    name        VARCHAR(100) NOT NULL,
+    description VARCHAR(400)
+);
+
+CREATE TABLE ST_Instance_Data
+(
+    id          INT          NOT NULL,
+    componentId INT          NOT NULL,
+    name        VARCHAR(100) NOT NULL,
+    label       VARCHAR(100) NOT NULL,
+    value       VARCHAR(400),
+    CONSTRAINT PK_Instance_Data PRIMARY KEY (id),
+    CONSTRAINT UN_Instance_Data_1 UNIQUE (componentId, name),
+    CONSTRAINT FK_Instance_Data_1 FOREIGN KEY (componentId) REFERENCES ST_ComponentInstance (id)
+);
+
+CREATE TABLE SB_ContentManager_Instance
+(
+    instanceId    int          NOT NULL,
+    componentId   varchar(100) NOT NULL,
+    containerType varchar(100) NOT NULL,
+    contentType   varchar(100) NOT NULL
+);
+
+CREATE TABLE ST_SpaceUserRole
+(
+    id          INT             NOT NULL,
+    spaceId     INT             NOT NULL,
+    name        VARCHAR(100)    NULL,
+    roleName    VARCHAR(100)    NOT NULL,
+    description VARCHAR(400),
+    isInherited INT DEFAULT (0) NOT NULL,
+    CONSTRAINT PK_SpaceUserRole PRIMARY KEY (id),
+    CONSTRAINT UN_SpaceUserRole_1 UNIQUE (spaceId, roleName, isInherited),
+    CONSTRAINT FK_SpaceUserRole_1 FOREIGN KEY (spaceId) REFERENCES ST_Space (id)
+);
+
+CREATE TABLE ST_SpaceUserRole_User_Rel
+(
+    spaceUserRoleId INT NOT NULL,
+    userId          INT NOT NULL,
+    CONSTRAINT PK_SpaceUserRole_User_Rel PRIMARY KEY (spaceUserRoleId, userId),
+    CONSTRAINT FK_SpaceUserRole_User_Rel_1 FOREIGN KEY (spaceUserRoleId) REFERENCES ST_SpaceUserRole (id),
+    CONSTRAINT FK_SpaceUserRole_User_Rel_2 FOREIGN KEY (userId) REFERENCES ST_User (id)
+);
+
+CREATE TABLE ST_SpaceUserRole_Group_Rel
+(
+    spaceUserRoleId INT NOT NULL,
+    groupId         INT NOT NULL,
+    CONSTRAINT PK_SpaceUserRole_Group_Rel PRIMARY KEY (spaceUserRoleId, groupId),
+    CONSTRAINT FK_SpaceUserRole_Group_Rel_1 FOREIGN KEY (spaceUserRoleId) REFERENCES ST_SpaceUserRole (id),
+    CONSTRAINT FK_SpaceUserRole_Group_Rel_2 FOREIGN KEY (groupId) REFERENCES ST_Group (id)
+);
+
+CREATE TABLE ST_UserRole
+(
+    id          INT             NOT NULL,
+    instanceId  INT             NOT NULL,
+    name        VARCHAR(100)    NULL,
+    roleName    VARCHAR(100)    NOT NULL,
+    description VARCHAR(400),
+    isInherited INT DEFAULT (0) NOT NULL,
+    objectId    INT,
+    objectType  VARCHAR(50),
+    CONSTRAINT PK_UserRole PRIMARY KEY (id),
+    CONSTRAINT UN_UserRole_1 UNIQUE (instanceId, roleName, isInherited, objectId),
+    CONSTRAINT FK_UserRole_1 FOREIGN KEY (instanceId) REFERENCES ST_ComponentInstance (id)
+);
+
+CREATE TABLE ST_UserRole_User_Rel
+(
+    userRoleId INT NOT NULL,
+    userId     INT NOT NULL,
+    CONSTRAINT PK_UserRole_User_Rel PRIMARY KEY (userRoleId, userId),
+    CONSTRAINT FK_UserRole_User_Rel_1 FOREIGN KEY (userRoleId) REFERENCES ST_UserRole (id),
+    CONSTRAINT FK_UserRole_User_Rel_2 FOREIGN KEY (userId) REFERENCES ST_User (id)
+);
+
+CREATE TABLE ST_UserRole_Group_Rel
+(
+    userRoleId INT NOT NULL,
+    groupId    INT NOT NULL,
+    CONSTRAINT PK_UserRole_Group_Rel PRIMARY KEY (userRoleId, groupId),
+    CONSTRAINT FK_UserRole_Group_Rel_1 FOREIGN KEY (userRoleId) REFERENCES ST_UserRole (id),
+    CONSTRAINT FK_UserRole_Group_Rel_2 FOREIGN KEY (groupId) REFERENCES ST_Group (id)
+);
+
+/*
+ * The SQL tables of a given component used in tests
+ */
+
+/* the resources managed by the instances of the component */
+CREATE TABLE SC_MyComponent_Resources
+(
+    id             BIGINT        NOT NULL,
+    instanceId     VARCHAR(50)   NOT NULL,
+    name           VARCHAR(128)  NOT NULL,
+    description    VARCHAR       NOT NULL DEFAULT '',
+    creationDate   DATETIME      NOT NULL,
+    updateDate     DATETIME      NOT NULL,
+    creator        VARCHAR(50)   NOT NULL,
+    updater        VARCHAR(50)   NOT NULL ,
+    validator      VARCHAR(50),
+    validationDate DATETIME,
+    CONSTRAINT PK_MyComponent_Resources PRIMARY KEY (id)
+);
+
+/* the list of the validators of a given resource of a component instance */
+CREATE TABLE SC_MyComponent_Validators
+(
+    resourceId  VARCHAR(50) NOT NULL,
+    validatorId VARCHAR(50) NOT NULL,
+    CONSTRAINT PK_MyComponent_Validator PRIMARY KEY (resourceId, validatorId),
+    CONSTRAINT FK_MyComponent_Resources FOREIGN KEY (resourceId) REFERENCES SC_MyComponent_Resources(id)
+);

--- a/core-library/src/integration-test/resources/org/silverpeas/core/admin/user/notification/role/insert_dataset.sql
+++ b/core-library/src/integration-test/resources/org/silverpeas/core/admin/user/notification/role/insert_dataset.sql
@@ -1,0 +1,78 @@
+INSERT INTO st_accesslevel (id, name) VALUES ('U', 'User');
+INSERT INTO st_accesslevel (id, name) VALUES ('A', 'Administrator');
+INSERT INTO st_accesslevel (id, name) VALUES ('G', 'Guest');
+INSERT INTO st_accesslevel (id, name) VALUES ('R', 'Removed');
+INSERT INTO st_accesslevel (id, name) VALUES ('K', 'KMManager');
+INSERT INTO st_accesslevel (id, name) VALUES ('D', 'DomainManager');
+
+INSERT INTO st_user (id, domainid, specificid, firstname, lastname, email, login, loginmail, accesslevel, state, stateSaveDate)
+VALUES
+    (0, 0, '0', '', 'Administrateur', 'ehu@silverpeas.com', 'SilverAdmin', '', 'A', 'VALID', '2012-01-01 00:00:00.0'),
+    (1, 0, '1', 'Bart', 'Simpson', 'ehu@silverpeas.com', 'user_a', '', 'U', 'VALID', '2012-01-01 00:00:00.0'),
+    (2, 0, '2', 'Homer', 'Simpson', 'homer@simpson.com', 'user_b', '', 'U', 'VALID', '2012-01-01 00:00:00.0'),
+    (10, 0, '10', 'Marge', 'Simpson', '', 'user_c', '', 'U', 'VALID', '2012-01-01 00:00:00.0'),
+    (11, 0, '11', 'Lisa', 'Simpson', 'lisa@simpson.com', 'user_d','', 'U', 'VALID', '2012-01-01 00:00:00.0');
+
+INSERT INTO st_group (id, domainid, specificid, name, supergroupid, state, stateSaveDate)
+VALUES
+    (1, -1, '1', 'G1', NULL, 'VALID', '2012-01-01 00:00:00.000'),
+    (2, -1, '2', 'G2', NULL, 'VALID', '2012-01-01 00:00:00.000'),
+    (3, -1, '3', 'G3', NULL, 'VALID', '2012-01-01 00:00:00.000'),
+    (4, -1, '4', 'G3-1', 3, 'VALID', '2012-01-01 00:00:00.000'),
+    (5, -1, '5', 'G3-2', 3, 'VALID', '2012-01-01 00:00:00.000');
+
+INSERT INTO st_group_user_rel (groupid, userid)
+VALUES (1, 1),
+       (1, 10),
+       (1, 11),
+       (2, 0),
+       (2, 11),
+       (4, 1),
+       (4, 2),
+       (5, 10),
+       (5, 11);
+
+INSERT INTO st_space (id, domainFatherId, name, firstpagetype, ordernum, isinheritanceblocked)
+VALUES
+    (1, NULL, 'Space-A_Level-1', 2, 0, 0),
+    (2, 1, 'Space-A_Level-2', 2, 0, 0),
+    (10, NULL, 'Space-B_Level-1', 2, 1, 0);
+
+INSERT INTO st_componentinstance (id, spaceid, componentname, ordernum, ispublic, name, isinheritanceblocked, ishidden)
+VALUES
+    (1, 1, 'myComponent', 0, 0, 'My Component', 0, 0),
+    (2, 2, 'myComponent', 0, 0, 'My Another Component', 1, 0);
+
+INSERT INTO st_spaceuserrole (id, spaceid, rolename, isinherited)
+VALUES
+    (1, 1, 'admin', 0),
+    (2, 1, 'publisher', 0),
+    (3, 1, 'writer', 0),
+    (4, 1, 'reader', 0);
+
+INSERT INTO st_userrole (id, instanceid, name, rolename, isinherited)
+VALUES
+    (1, 1,  'Managers','admin', 0),
+    (2, 1, 'Validators', 'validator', 0),
+    (3, 1, 'Readers', 'booker', 0),
+    (10, 2,  'Managers','admin', 1),
+    (11, 2, 'Validators', 'validator', 1),
+    (12, 2, 'Readers', 'reader', 1);
+
+INSERT INTO st_userrole_group_rel (userroleId, groupId)
+VALUES (11, 1);
+
+INSERT INTO SC_MyComponent_Resources (id, instanceId, name, creationDate, updateDate, creator, updater)
+VALUES
+    (1, 'myComponent1', 'Salle Chartreuse', '2025-03-03T14:40:21.440869Z', '2025-03-03T14:40:21.440869Z', '5', '5'),
+    (2, 'myComponent1', 'Salle Belledonne', '2025-03-03T14:40:21.440869Z', '2025-03-03T14:40:21.440869Z', '5', '5'),
+    (3, 'myComponent1', 'Twingo verte', '2025-03-03T14:40:21.440869Z', '2025-03-03T14:40:21.440869Z', '5', '5');
+
+INSERT INTO SC_MyComponent_Validators (resourceId, validatorid)
+VALUES (1, '0'),
+       (1, '1'),
+       (1, '2'),
+       (3, '0');
+
+INSERT INTO UniqueId (maxId, tableName)
+VALUES ('4', 'sc_mycomponent_resources');

--- a/core-library/src/integration-test/resources/xmlcomponents/myComponent.xml
+++ b/core-library/src/integration-test/resources/xmlcomponents/myComponent.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2000 - 2024 Silverpeas
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    As a special exception to the terms and conditions of version 3.0 of
+    the GPL, you may redistribute this Program in connection with Free/Libre
+    Open Source Software ("FLOSS") applications as described in Silverpeas's
+    FLOSS exception.  You should have received a copy of the text describing
+    the FLOSS exception, and it is also available here:
+    "https://www.silverpeas.org/docs/core/legal/floss_exception.html"
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+-->
+
+<WAComponent xmlns="http://silverpeas.org/xml/ns/component"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://silverpeas.org/xml/ns/component https://www.silverpeas.org/xsd/component.xsd">
+  <name>myComponent</name>
+  <label>
+    <message lang="fr">Gestion de ressources</message>
+    <message lang="en">Resources manager</message>
+    <message lang="de">Ressourcen-Manager</message>
+  </label>
+  <description>
+    <message lang="fr">L’application permet de gérer des ressources</message>
+    <message lang="en">This application allow to manage resources.</message>
+  </description>
+  <suite>
+    <message lang="fr">02 Gestion Collaborative</message>
+    <message lang="en">02 Collaborative Management</message>
+  </suite>
+  <visible>true</visible>
+  <portlet>false</portlet>
+  <profiles>
+    <profile name="manager">
+      <label>
+        <message lang="fr">Gestionnaires</message>
+        <message lang="en">Managers</message>
+        <message lang="de">Manager</message>
+      </label>
+      <help>
+        <message lang="fr">Les gestionnaires créent les ressources.</message>
+        <message lang="en">Managers create resources.</message>
+      </help>
+      <spaceMapping>
+        <profile>admin</profile>
+      </spaceMapping>
+    </profile>
+    <profile name="validator">
+      <label>
+        <message lang="fr">Validateurs</message>
+        <message lang="en">Validators</message>
+      </label>
+      <help>
+        <message lang="fr">Les validateurs valident les ressources.</message>
+        <message lang="en">Validators validate the resources.</message>
+      </help>
+      <spaceMapping>
+        <profile>publisher</profile>
+        <profile>writer</profile>
+      </spaceMapping>
+    </profile>
+    <profile name="reader">
+      <label>
+        <message lang="fr">Lecteurs</message>
+        <message lang="en">Readers</message>
+        <message lang="de">Leser</message>
+      </label>
+      <help>
+        <message lang="fr">Les lecteurs voient les ressources</message>
+        <message lang="en">Readers see the resources.</message>
+      </help>
+      <spaceMapping>
+        <profile>reader</profile>
+      </spaceMapping>
+    </profile>
+  </profiles>
+  <parameters>
+    <parameter>
+      <name>comments</name>
+      <label>
+        <message lang="fr">Commentaires</message>
+        <message lang="en">Comments</message>
+      </label>
+      <order>1</order>
+      <mandatory>true</mandatory>
+      <value>yes</value>
+      <type>checkbox</type>
+      <updatable>always</updatable>
+      <help>
+        <message lang="fr">
+          Les lecteurs peuvent laisser des commentaires sur les ressources.
+        </message>
+        <message lang="en">Readers are able to post comments on resource.</message>
+      </help>
+    </parameter>
+  </parameters>
+</WAComponent>

--- a/core-library/src/main/java/org/silverpeas/core/admin/BaseRightProfile.java
+++ b/core-library/src/main/java/org/silverpeas/core/admin/BaseRightProfile.java
@@ -27,6 +27,7 @@ package org.silverpeas.core.admin;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * @author mmoquillon
@@ -274,6 +275,18 @@ public abstract class BaseRightProfile implements RightProfile, Serializable {
    */
   public boolean isEmpty() {
     return this.groups.isEmpty() && this.users.isEmpty();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == null || getClass() != o.getClass()) return false;
+    BaseRightProfile that = (BaseRightProfile) o;
+    return Objects.equals(id, that.id);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(id);
   }
 }
   

--- a/core-library/src/main/java/org/silverpeas/core/admin/user/ProfileInstManager.java
+++ b/core-library/src/main/java/org/silverpeas/core/admin/user/ProfileInstManager.java
@@ -32,6 +32,7 @@ import org.silverpeas.core.admin.user.dao.RoleDAO;
 import org.silverpeas.core.admin.user.model.ProfileInst;
 import org.silverpeas.core.admin.user.notification.ProfileInstEventNotifier;
 import org.silverpeas.core.annotation.Service;
+import org.silverpeas.core.notification.system.ResourceEvent;
 import org.silverpeas.core.persistence.jdbc.DBUtil;
 import org.silverpeas.kernel.util.StringUtil;
 import org.silverpeas.kernel.logging.SilverLogger;

--- a/core-library/src/main/java/org/silverpeas/core/admin/user/ProfileInstManager.java
+++ b/core-library/src/main/java/org/silverpeas/core/admin/user/ProfileInstManager.java
@@ -32,7 +32,6 @@ import org.silverpeas.core.admin.user.dao.RoleDAO;
 import org.silverpeas.core.admin.user.model.ProfileInst;
 import org.silverpeas.core.admin.user.notification.ProfileInstEventNotifier;
 import org.silverpeas.core.annotation.Service;
-import org.silverpeas.core.notification.system.ResourceEvent;
 import org.silverpeas.core.persistence.jdbc.DBUtil;
 import org.silverpeas.kernel.util.StringUtil;
 import org.silverpeas.kernel.logging.SilverLogger;

--- a/core-library/src/main/java/org/silverpeas/core/admin/user/notification/GroupUserLinkEvent.java
+++ b/core-library/src/main/java/org/silverpeas/core/admin/user/notification/GroupUserLinkEvent.java
@@ -35,9 +35,6 @@ import java.io.Serializable;
  */
 public class GroupUserLinkEvent extends AbstractResourceEvent<GroupUserLink> {
 
-  protected GroupUserLinkEvent() {
-  }
-
   /**
    * @see AbstractResourceEvent#AbstractResourceEvent(Type, Serializable[])
    */

--- a/core-library/src/main/java/org/silverpeas/core/admin/user/notification/role/GroupUserUnlinkEventListener.java
+++ b/core-library/src/main/java/org/silverpeas/core/admin/user/notification/role/GroupUserUnlinkEventListener.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2000 - 2025 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.admin.user.notification.role;
+
+import org.silverpeas.core.admin.service.AdminController;
+import org.silverpeas.core.admin.user.model.ProfileInst;
+import org.silverpeas.core.admin.user.notification.GroupUserLink;
+import org.silverpeas.core.admin.user.notification.GroupUserLinkEvent;
+import org.silverpeas.core.annotation.Service;
+import org.silverpeas.core.notification.system.CDIAfterSuccessfulTransactionResourceEventListener;
+import org.silverpeas.core.notification.system.ResourceEvent;
+
+import javax.inject.Inject;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.*;
+
+/**
+ * Listens for events about the removing of a user from a given group, and for each such removal,
+ * find all the roles in the different component instances the user doesn't play anymore. For each
+ * found role, a notification about that is sent.
+ *
+ * @author mmoquillon
+ */
+@Service
+class GroupUserUnlinkEventListener
+    extends CDIAfterSuccessfulTransactionResourceEventListener<GroupUserLinkEvent> {
+
+  @Inject
+  private UserRoleChangeNotifier notifier;
+
+  @Inject
+  private AdminController admin;
+
+  @Override
+  public void onDeletion(GroupUserLinkEvent event) {
+    GroupUserLink link = event.getTransition().getBefore();
+    Map<String, Set<String>> profiles =
+        findComponentInstancesGroupedByNotAnymorePlayedRole(link.getUserId(), link.getGroupId());
+    profiles.forEach((key, value) -> {
+      UserRoleEvent evt = UserRoleEvent.builderFor(ResourceEvent.Type.DELETION)
+          .role(key)
+          .userId(link.getUserId())
+          .instanceIds(value)
+          .build();
+      notifier.notify(evt);
+    });
+  }
+
+  /**
+   * Finds all the component instances in which the specified group or its parent groups play a role
+   * and for which the specified user doesn't play anymore. The component instances are grouped by
+   * role name.
+   *
+   * @param userId the unique identifier of the user.
+   * @param groupId the unique identifier of the group.
+   * @return a dictionary with as key the role name and as value a set with the unique identifiers
+   * of the component instances in which the user doesn't play anymore a role.
+   */
+  private Map<String, Set<String>> findComponentInstancesGroupedByNotAnymorePlayedRole(String userId,
+      String groupId) {
+    Set<ProfileInst> userProfiles = Stream.of(admin.getProfileIds(userId))
+        .map(admin::getProfileInst)
+        .collect(toSet());
+    return Stream.concat(Stream.of(groupId),
+            admin.getPathToGroup(groupId).stream())
+        .map(admin::getGroupById)
+        .filter(g -> !List.of(g.getUserIds()).contains(userId))
+        .flatMap(g -> Stream.of(admin.getProfileIdsOfGroup(g.getId()))
+            .map(admin::getProfileInst)
+            .filter(p -> isNotInUserProfiles(p, userProfiles))
+            .filter(p -> isNotInOthersGroups(userId, g.getId(), p.getAllGroups())))
+        .collect(
+            groupingBy(ProfileInst::getName,
+                mapping(this::getComponentInst, toSet())));
+  }
+
+  private boolean isNotInUserProfiles(ProfileInst actualProfile, Set<ProfileInst> userProfiles) {
+    return userProfiles.stream()
+        .filter(p -> p.getComponentFatherId() == actualProfile.getComponentFatherId())
+        .noneMatch(p -> p.getName().equals(actualProfile.getName()));
+  }
+
+  private boolean isNotInOthersGroups(String userId, String groupId, List<String> groups) {
+    return groups.stream()
+        .filter(g -> !g.equalsIgnoreCase(groupId))
+        .map(g -> admin.getGroupById(g))
+        .noneMatch(g -> List.of(g.getUserIds()).contains(userId));
+  }
+
+  private String getComponentInst(ProfileInst profileInst) {
+    return admin.getComponentInst(String.valueOf(profileInst.getComponentFatherId())).getId();
+  }
+}
+  

--- a/core-library/src/main/java/org/silverpeas/core/admin/user/notification/role/ProfileInstUpdateEventListener.java
+++ b/core-library/src/main/java/org/silverpeas/core/admin/user/notification/role/ProfileInstUpdateEventListener.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2000 - 2025 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.admin.user.notification.role;
+
+import org.silverpeas.core.admin.component.model.ComponentInst;
+import org.silverpeas.core.admin.service.OrganizationController;
+import org.silverpeas.core.admin.user.model.Group;
+import org.silverpeas.core.admin.user.model.ProfileInst;
+import org.silverpeas.core.admin.user.notification.ProfileInstEvent;
+import org.silverpeas.core.annotation.Service;
+import org.silverpeas.core.notification.system.CDIResourceEventListener;
+import org.silverpeas.core.notification.system.ResourceEvent;
+
+import javax.inject.Inject;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Listens for events about a change in the lists of users and of groups of a given access right
+ * profile instance. For instance, the user groups removed from an access right profile instance
+ * aren't taken in charge, only the users. For all the users removed from the given profile
+ * instance, a notification about the fact these users don't play anymore the role is sent. The
+ * removed users shouldn't play the role in the concerned component instance neither directly nor by
+ * a group or a subgroup (in both the specific and inherited profile instances for the same role).
+ *
+ * @author mmoquillon
+ */
+@Service
+class ProfileInstUpdateEventListener extends CDIResourceEventListener<ProfileInstEvent> {
+
+  @Inject
+  private OrganizationController organization;
+
+  @Inject
+  private UserRoleChangeNotifier notifier;
+
+  @Override
+  public void onUpdate(ProfileInstEvent event) {
+    ProfileInst before = event.getTransition().getBefore();
+    ProfileInst after = event.getTransition().getAfter();
+    ComponentInst componentInst = getComponentInstanceId(before.getComponentFatherId());
+    Set<String> removedUsers = findRemovedUsersId(componentInst, before, after);
+    if (!removedUsers.isEmpty()) {
+      UserRoleEvent userRoleEvent = UserRoleEvent.builderFor(ResourceEvent.Type.DELETION)
+          .role(before.getName())
+          .instanceId(componentInst.getId())
+          .userIds(removedUsers)
+          .build();
+      notifier.notify(userRoleEvent);
+    }
+  }
+
+  /**
+   * Finds the users that were removed, either directly or through groups, from the specified access
+   * right profile of the underlying component instance. The users or the groups that are removed by
+   * the profile instance update are those present in the role profile before the update and that
+   * aren't anymore present in the role profile after the update.
+   *
+   * @param componentInst the component instance for which the right profile has been updated.
+   * @param before the state of the role profile before update.
+   * @param after the state of the role profile after update.
+   * @return a set with the unique identifiers of all of the users that were removed by the profile
+   * instance update.
+   */
+  private Set<String> findRemovedUsersId(ComponentInst componentInst, ProfileInst before,
+      ProfileInst after) {
+    List<String> usersAfter = after.getAllUsers();
+    List<String> groupsAfter = after.getAllGroups();
+    String roleName =  before.getName();
+    // get all the users directly removed from the profile instance and who don't play anymore
+    // the role for the application (they can be play another role)
+    Stream<String> removedUsers = before.getAllUsers().stream()
+        .filter(user -> !usersAfter.contains(user))
+        .filter(u -> Stream.of(organization.getUserProfiles(u, componentInst.getId()))
+            .noneMatch(p -> p.equalsIgnoreCase(roleName)));
+
+
+    // get all the users belonging to the groups removed from the profile instance and who's not
+    // anymore play the role for the application (can be play a role in an inherited or
+    // specific role other than the updated one)
+    Stream<String> removedUsersInGroups = before.getAllGroups().stream()
+        .filter(group -> !groupsAfter.contains(group))
+        .map(g -> organization.getGroup(g))
+        .flatMap(g -> Stream.of(((Group) g).getUserIds()))
+        .distinct()
+        .filter(u -> Stream.of(organization.getUserProfiles(u, componentInst.getId()))
+            .noneMatch(p -> p.equalsIgnoreCase(roleName)));
+
+    return Stream.concat(removedUsers, removedUsersInGroups).collect(Collectors.toSet());
+  }
+
+  private ComponentInst getComponentInstanceId(int localComponentId) {
+    return organization.getComponentInst(String.valueOf(localComponentId));
+  }
+}
+  

--- a/core-library/src/main/java/org/silverpeas/core/admin/user/notification/role/UserRoleChangeNotifier.java
+++ b/core-library/src/main/java/org/silverpeas/core/admin/user/notification/role/UserRoleChangeNotifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2000 - 2024 Silverpeas
+ * Copyright (C) 2000 - 2025 Silverpeas
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -22,28 +22,30 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package org.silverpeas.core.workflow.engine.user;
+package org.silverpeas.core.admin.user.notification.role;
 
-import org.silverpeas.core.notification.system.AbstractResourceEvent;
-import org.silverpeas.core.workflow.api.user.Replacement;
+import org.silverpeas.core.annotation.Bean;
+
+import javax.enterprise.event.Event;
+import javax.inject.Inject;
 
 /**
- * Event about the replacements of users in a given workflow. Such events are fired when an
- * operation was performed on a replacement such as the creation, the deletion, and so on.
+ * Bean in charge to notify a user or a user group doesn't play anymore a role in one or several
+ * component instances. This service is used by the more business services in charges to be
+ * informed about role change of users in order to notify all others business services for which
+ * this information is important.
+ *
  * @author mmoquillon
  */
-public class ReplacementEvent extends AbstractResourceEvent<Replacement<?>> {
+@Bean
+class UserRoleChangeNotifier {
 
-  /**
-   * Constructs a new event about a given replacement.
-   * @param type the type of the event reflecting the cause of it (creation, deletion, ...)
-   * @param states the replacement concerned by the event as it was before the cause of that event
-   * and once the cause was done. If there is no state before the cause, then just passe
-   * the state after (case of the creation). If there is no state after the cause, then just passe
-   * the state before (case of the deletion).
-   */
-  public ReplacementEvent(final Type type, final Replacement<?>... states) {
-    super(type, states);
+  @Inject
+  private Event<UserRoleEvent> notifEvent;
+
+  public void notify(final UserRoleEvent userRoleEvent) {
+    notifEvent.fire(userRoleEvent);
   }
+
 }
   

--- a/core-library/src/main/java/org/silverpeas/core/admin/user/notification/role/UserRoleEvent.java
+++ b/core-library/src/main/java/org/silverpeas/core/admin/user/notification/role/UserRoleEvent.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright (C) 2000 - 2025 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.admin.user.notification.role;
+
+import org.silverpeas.core.notification.system.AbstractResourceEvent;
+import org.silverpeas.core.notification.system.ResourceEvent;
+
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Event relating a change has been done in a the list of users and user groups of a given role in
+ * some component instances. For example, when a user doesn't play anymore a given role in a
+ * component instance.
+ *
+ * @author mmoquillon
+ */
+public class UserRoleEvent extends AbstractResourceEvent<UserRoleEvent.UserSet> {
+
+  private final Set<String> instanceIds = new HashSet<>();
+  private String role;
+
+  private UserRoleEvent(ResourceEvent.Type type, UserSet... users) {
+    super(type, users);
+  }
+
+  /**
+   * Gets all component instances for which the list of users of the underlying role has been
+   * modified.
+   *
+   * @return the set of unique identifiers of the component instances concerned by the role change.
+   */
+  public Set<String> getInstanceIds() {
+    return instanceIds;
+  }
+
+  /**
+   * Gets all the users concerned by the type of operation in the list of users of the underlying
+   * role. For example, the users who were removed from the role's list of users.
+   *
+   * @return a set of unique identifiers of the users targeted by the role change.
+   */
+  public Set<String> getUserIds() {
+    return getTransition().getBefore() == null ? getTransition().getAfter() :
+        getTransition().getBefore();
+  }
+
+  /**
+   * Gets the name of the role for which the list of users has been modified.
+   * @return the role name.
+   */
+  public String getRole() {
+    return role;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (!(o instanceof UserRoleEvent)) return false;
+    if (!super.equals(o)) return false;
+    UserRoleEvent that = (UserRoleEvent) o;
+    return Objects.equals(instanceIds, that.instanceIds) && Objects.equals(role, that.role);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), instanceIds, role);
+  }
+
+  /**
+   * Gets a builder of instances of {@link UserRoleEvent} for the specified notification type.
+   *
+   * @param type the type of the notification the event to build will carry.
+   * @return the builder.
+   */
+  static Builder builderFor(ResourceEvent.Type type) {
+    return new Builder(type);
+  }
+
+  /**
+   * The builder to facilitate the construction of a {@link UserRoleEvent} instance.
+   */
+  static class Builder {
+
+    private final UserRoleEvent event;
+
+    private Builder(ResourceEvent.Type type) {
+      UserSet users = new UserSet();
+      this.event = new UserRoleEvent(type, users, users);
+    }
+
+    /**
+     * Adds the user concerned by a modification of the users/groups list of a role.
+     *
+     * @param userId the unique identifier of the user.
+     * @return itself.
+     */
+    Builder userId(String userId) {
+      this.event.getUserIds().add(userId);
+      return this;
+    }
+
+    /**
+     * Adds the users concerned by a modification of the users/groups list of a role.
+     *
+     * @param userIds a collection of unique identifiers of the users.
+     * @return itself.
+     */
+    Builder userIds(Collection<String> userIds) {
+      this.event.getUserIds().addAll(userIds);
+      return this;
+    }
+
+    /**
+     * Sets the role for which the list of users/groups has been modified.
+     *
+     * @param role the name of the role.
+     * @return itself.
+     */
+    Builder role(String role) {
+      this.event.role = role;
+      return this;
+    }
+
+    /**
+     * Adds the component instance for which the list of users or groups playing the role has been
+     * modified.
+     *
+     * @param instanceId the unique identifier of a component instance.
+     * @return itself.
+     */
+    Builder instanceId(String instanceId) {
+      this.event.instanceIds.add(instanceId);
+      return this;
+    }
+
+    /**
+     * Adds the component instances for which the list of users or groups playing the role has been
+     * modified.
+     *
+     * @param instanceIds a collection of unique identifiers of component instances.
+     * @return itself.
+     */
+    Builder instanceIds(Collection<String> instanceIds) {
+      this.event.instanceIds.addAll(instanceIds);
+      return this;
+    }
+
+    /**
+     * Builds the {@link UserRoleEvent} instance with the information passed to the builder.
+     *
+     * @return a new {@link UserRoleEvent} instance.
+     */
+    UserRoleEvent build() {
+      return event;
+    }
+  }
+
+  /**
+   * Set of the users concerned by a change in the list of users of a given role.
+   */
+  public static class UserSet extends HashSet<String> implements Serializable {
+
+    private UserSet() {
+      super();
+    }
+  }
+}
+  

--- a/core-library/src/main/java/org/silverpeas/core/admin/user/notification/role/package-info.java
+++ b/core-library/src/main/java/org/silverpeas/core/admin/user/notification/role/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2000 - 2024 Silverpeas
+ * Copyright (C) 2000 - 2025 Silverpeas
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -22,28 +22,13 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package org.silverpeas.core.workflow.engine.user;
-
-import org.silverpeas.core.notification.system.AbstractResourceEvent;
-import org.silverpeas.core.workflow.api.user.Replacement;
-
 /**
- * Event about the replacements of users in a given workflow. Such events are fired when an
- * operation was performed on a replacement such as the creation, the deletion, and so on.
+ * Provides the event notification mechanism to inform a role played in some component instances by
+ * a user or a user group has changed. This is for applications requiring to be informed of such
+ * situations to update their data (for example to update the list of validators originally defined
+ * from a given access right profile). For instance, only the removal of users from played roles in
+ * some component instances is taken in charge.
+ *
  * @author mmoquillon
  */
-public class ReplacementEvent extends AbstractResourceEvent<Replacement<?>> {
-
-  /**
-   * Constructs a new event about a given replacement.
-   * @param type the type of the event reflecting the cause of it (creation, deletion, ...)
-   * @param states the replacement concerned by the event as it was before the cause of that event
-   * and once the cause was done. If there is no state before the cause, then just passe
-   * the state after (case of the creation). If there is no state after the cause, then just passe
-   * the state before (case of the deletion).
-   */
-  public ReplacementEvent(final Type type, final Replacement<?>... states) {
-    super(type, states);
-  }
-}
-  
+package org.silverpeas.core.admin.user.notification.role;

--- a/core-library/src/main/java/org/silverpeas/core/calendar/notification/CalendarComponentNotifier.java
+++ b/core-library/src/main/java/org/silverpeas/core/calendar/notification/CalendarComponentNotifier.java
@@ -24,7 +24,7 @@
 package org.silverpeas.core.calendar.notification;
 
 import org.silverpeas.core.admin.user.model.User;
-import org.silverpeas.core.annotation.Bean;
+import org.silverpeas.core.annotation.Service;
 import org.silverpeas.core.calendar.Attendee;
 import org.silverpeas.core.calendar.CalendarEvent;
 import org.silverpeas.core.calendar.CalendarEventOccurrence;
@@ -44,17 +44,16 @@ import java.util.Collections;
  * lifecycle events.
  * @author mmoquillon
  */
-@Bean
+@Service
 public class CalendarComponentNotifier extends AbstractNotifier<AttendeeLifeCycleEvent> {
 
   /**
    * An attendee has been removed. The attendee is informed about it (he shouldn't be the user
    * behind this attendance deletion).
    * @param event the lifecycle event on the deletion of an attendance.
-   * @throws Exception if an error occurs while notifying the attendee.
    */
   @Override
-  public void onDeletion(final AttendeeLifeCycleEvent event) throws Exception {
+  public void onDeletion(final AttendeeLifeCycleEvent event) {
     Attendee attendee = event.getTransition().getBefore();
     CalendarOperation operation =
         event.getSubType() == LifeCycleEventSubType.SINGLE ? CalendarOperation.ATTENDEE_REMOVING :
@@ -127,10 +126,9 @@ public class CalendarComponentNotifier extends AbstractNotifier<AttendeeLifeCycl
    * An attendee has been added among the attendees. The added attendee is
    * informed about it (he shouldn't be the user behind this attendance adding).
    * @param event the lifecycle event on the adding of the attendee.
-   * @throws Exception if an error occurs while notifying the attendee.
    */
   @Override
-  public void onCreation(final AttendeeLifeCycleEvent event) throws Exception {
+  public void onCreation(final AttendeeLifeCycleEvent event) {
     Attendee attendee = event.getTransition().getAfter();
     CalendarOperation operation =
         event.getSubType() == LifeCycleEventSubType.SINGLE ? CalendarOperation.ATTENDEE_ADDING :

--- a/core-library/src/main/java/org/silverpeas/core/calendar/notification/CalendarEventNotifier.java
+++ b/core-library/src/main/java/org/silverpeas/core/calendar/notification/CalendarEventNotifier.java
@@ -100,7 +100,7 @@ public class CalendarEventNotifier
   }
 
   @Override
-  public void onDeletion(final CalendarEventLifeCycleEvent event) throws Exception {
+  public void onDeletion(final CalendarEventLifeCycleEvent event) {
     final CalendarEvent deleted = event.getTransition().getBefore();
     final CalendarOperation operation = deleted.isRecurrent()
         ? CalendarOperation.SINCE_EVENT_DELETION

--- a/core-library/src/main/java/org/silverpeas/core/calendar/notification/CalendarEventOccurrenceNotifier.java
+++ b/core-library/src/main/java/org/silverpeas/core/calendar/notification/CalendarEventOccurrenceNotifier.java
@@ -62,7 +62,7 @@ public class CalendarEventOccurrenceNotifier
     extends AbstractNotifier<CalendarEventOccurrenceLifeCycleEvent> {
 
   @Override
-  public void onDeletion(final CalendarEventOccurrenceLifeCycleEvent event) throws Exception {
+  public void onDeletion(final CalendarEventOccurrenceLifeCycleEvent event) {
     final CalendarEventOccurrence deleted = event.getTransition().getBefore();
     CalendarOperation operation = CalendarOperation.EVENT_DELETION;
     if (event.getSubtype() == LifeCycleEventSubType.SINCE) {

--- a/core-library/src/main/java/org/silverpeas/core/calendar/notification/UserPreferenceEventListener.java
+++ b/core-library/src/main/java/org/silverpeas/core/calendar/notification/UserPreferenceEventListener.java
@@ -40,7 +40,7 @@ import org.silverpeas.core.personalization.notification.UserPreferenceEvent;
 public class UserPreferenceEventListener extends CDIResourceEventListener<UserPreferenceEvent> {
 
   @Override
-  public void onUpdate(final UserPreferenceEvent event) throws Exception {
+  public void onUpdate(final UserPreferenceEvent event) {
     UserPreferences previous = event.getTransition().getBefore();
     UserPreferences current = event.getTransition().getAfter();
     if (!previous.getZoneId().equals(current.getZoneId())) {

--- a/core-library/src/main/java/org/silverpeas/core/contribution/ContributionEventProcessor.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/ContributionEventProcessor.java
@@ -45,29 +45,25 @@ public class ContributionEventProcessor
     extends CDIResourceEventListener<AbstractResourceEvent<? extends Contribution>> {
 
   @Override
-  public void onUpdate(final AbstractResourceEvent<? extends Contribution> event)
-      throws Exception {
+  public void onUpdate(final AbstractResourceEvent<? extends Contribution> event) {
     ServiceProvider.getAllServices(ContributionModification.class).forEach(
         s -> s.update(event.getTransition().getBefore(), event.getTransition().getAfter()));
   }
 
   @Override
-  public void onMove(final AbstractResourceEvent<? extends Contribution> event)
-      throws Exception {
+  public void onMove(final AbstractResourceEvent<? extends Contribution> event) {
     ServiceProvider.getAllServices(ContributionMove.class).forEach(
         s -> s.move(event.getTransition().getBefore(), event.getTransition().getAfter()));
   }
 
   @Override
-  public void onDeletion(final AbstractResourceEvent<? extends Contribution> event)
-      throws Exception {
+  public void onDeletion(final AbstractResourceEvent<? extends Contribution> event) {
     ServiceProvider.getAllServices(ContributionDeletion.class)
         .forEach(s -> s.delete(event.getTransition().getBefore()));
   }
 
   @Override
-  public void onCreation(final AbstractResourceEvent<? extends Contribution> event)
-      throws Exception {
+  public void onCreation(final AbstractResourceEvent<? extends Contribution> event) {
     ServiceProvider.getAllServices(ContributionCreation.class)
         .forEach(s -> s.create(event.getTransition().getAfter()));
   }

--- a/core-library/src/main/java/org/silverpeas/core/contribution/publication/subscription/SubscriptionPublicationEventListener.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/publication/subscription/SubscriptionPublicationEventListener.java
@@ -54,7 +54,7 @@ public class SubscriptionPublicationEventListener
     extends AbstractProfiledResourceSubscriptionListener<PublicationDetail, PublicationEvent> {
 
   @Override
-  public void onDeletion(final PublicationEvent event) throws Exception {
+  public void onDeletion(final PublicationEvent event) {
     final PublicationDetail publication = event.getTransition().getBefore();
     final List<SubscriptionResource> toDelete = getSubscriptionService()
         .getByResource(PublicationAliasSubscriptionResource.from(new PublicationPK(publication.getId())))
@@ -67,7 +67,7 @@ public class SubscriptionPublicationEventListener
   }
 
   @Override
-  public void onUpdate(final PublicationEvent event) throws Exception {
+  public void onUpdate(final PublicationEvent event) {
     final PublicationDetail publication = event.getTransition().getBefore();
     OrganizationController.get().getComponentInstance(publication.getInstanceId())
         .filter(SilverpeasComponentInstance::isTopicTracker)

--- a/core-library/src/main/java/org/silverpeas/core/contribution/template/publication/PublicationTemplateUserEventListener.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/template/publication/PublicationTemplateUserEventListener.java
@@ -12,7 +12,7 @@ import org.silverpeas.core.notification.system.CDIResourceEventListener;
 public class PublicationTemplateUserEventListener extends CDIResourceEventListener<UserEvent> {
 
   @Override
-  public void onDeletion(final UserEvent event) throws Exception {
+  public void onDeletion(final UserEvent event) {
     UserDetail detail = event.getTransition().getBefore();
     PublicationTemplateManager templateManager = PublicationTemplateManager.getInstance();
     templateManager.deleteDirectoryData(detail.getId());

--- a/core-library/src/main/java/org/silverpeas/core/personalization/notification/PersonalizationSpaceEventListener.java
+++ b/core-library/src/main/java/org/silverpeas/core/personalization/notification/PersonalizationSpaceEventListener.java
@@ -41,7 +41,7 @@ public class PersonalizationSpaceEventListener extends CDIResourceEventListener<
   private PersonalizationService service;
 
   @Override
-  public void onRemoving(final SpaceEvent event) throws Exception {
+  public void onRemoving(final SpaceEvent event) {
     SpaceInst space = event.getTransition().getBefore();
     service.resetDefaultSpace(space.getId());
   }

--- a/core-library/src/main/java/org/silverpeas/core/reminder/UserReminderListener.java
+++ b/core-library/src/main/java/org/silverpeas/core/reminder/UserReminderListener.java
@@ -36,7 +36,7 @@ import org.silverpeas.kernel.logging.SilverLogger;
 public class UserReminderListener extends CDIResourceEventListener<UserEvent> {
 
   @Override
-  public void onDeletion(final UserEvent event) throws Exception {
+  public void onDeletion(final UserEvent event) {
     try {
       Reminder.getByUser(event.getTransition().getBefore()).forEach(Reminder::unschedule);
     } catch (Exception e) {

--- a/core-library/src/main/java/org/silverpeas/core/socialnetwork/SocialNetworkUserListener.java
+++ b/core-library/src/main/java/org/silverpeas/core/socialnetwork/SocialNetworkUserListener.java
@@ -52,13 +52,13 @@ public class SocialNetworkUserListener extends CDIResourceEventListener<UserEven
   private RelationShipService relationShipService;
 
   @Override
-  public void onDeletion(final UserEvent event) throws Exception {
+  public void onDeletion(final UserEvent event) {
     UserDetail user = event.getTransition().getBefore();
     SilverLogger.getLogger(this)
         .debug("Delete all the social network data of user {0}", user.getId());
 
     List<RelationShip> relationShips =
-        relationShipService.getAllMyRelationShips(Integer.valueOf(user.getId()));
+        relationShipService.getAllMyRelationShips(Integer.parseInt(user.getId()));
     relationShips.forEach(
         relationShip -> relationShipService.removeRelationShip(relationShip.getUser1Id(),
             relationShip.getUser2Id()));

--- a/core-library/src/main/java/org/silverpeas/core/subscription/AbstractProfiledResourceSubscriptionListener.java
+++ b/core-library/src/main/java/org/silverpeas/core/subscription/AbstractProfiledResourceSubscriptionListener.java
@@ -44,14 +44,14 @@ public abstract class AbstractProfiledResourceSubscriptionListener<R extends Ser
   private SubscriptionService subscriptionService;
 
   @Override
-  public void onDeletion(final T event) throws Exception {
+  public void onDeletion(final T event) {
     final R object = event.getTransition().getBefore();
     final SubscriptionResource resource = getSubscriptionResource(object);
     subscriptionService.unsubscribeByResource(resource);
   }
 
   @Override
-  public void onUpdate(final T event) throws Exception {
+  public void onUpdate(final T event) {
     final R object = event.getTransition().getAfter();
     final boolean isEnabled = isSubscriptionEnabled(object);
     if (!isEnabled) {

--- a/core-library/src/main/java/org/silverpeas/core/subscription/SubscriptionGroupEventListener.java
+++ b/core-library/src/main/java/org/silverpeas/core/subscription/SubscriptionGroupEventListener.java
@@ -40,7 +40,7 @@ public class SubscriptionGroupEventListener extends CDIResourceEventListener<Gro
   private SubscriptionService subscriptionService;
 
   @Override
-  public void onDeletion(final GroupEvent event) throws Exception {
+  public void onDeletion(final GroupEvent event) {
     subscriptionService.unsubscribeBySubscriber(
         GroupSubscriptionSubscriber.from(event.getTransition().getBefore().getId()));
   }

--- a/core-library/src/main/java/org/silverpeas/core/subscription/SubscriptionUserEventListener.java
+++ b/core-library/src/main/java/org/silverpeas/core/subscription/SubscriptionUserEventListener.java
@@ -40,7 +40,7 @@ public class SubscriptionUserEventListener extends CDIResourceEventListener<User
   private SubscriptionService subscriptionService;
 
   @Override
-  public void onDeletion(final UserEvent event) throws Exception {
+  public void onDeletion(final UserEvent event) {
     subscriptionService.unsubscribeBySubscriber(
         UserSubscriptionSubscriber.from(event.getTransition().getBefore().getId()));
   }

--- a/core-library/src/test/java/org/silverpeas/core/admin/component/WAComponentRegistryTest.java
+++ b/core-library/src/test/java/org/silverpeas/core/admin/component/WAComponentRegistryTest.java
@@ -297,7 +297,6 @@ class WAComponentRegistryTest {
     assertThat(frComponent.getLabel(), is(label));
     assertThat(frComponent.getDescription(), is(description));
     assertThat(frComponent.getSuite(), is(suite));
-    assertThat(registry.getAllWAComponents().size(), is(7));
     assertThat(Files.exists(expectedDescriptor), is(true));
     assertThat(streamComponentDescriptors(componentName).count(), is(1L));
 

--- a/core-services/comment/src/main/java/org/silverpeas/core/comment/service/notification/CommentUserNotificationService.java
+++ b/core-services/comment/src/main/java/org/silverpeas/core/comment/service/notification/CommentUserNotificationService.java
@@ -76,7 +76,7 @@ public class CommentUserNotificationService extends CDIResourceEventListener<Com
   private CommentService commentService;
 
   @Override
-  public void onCreation(final CommentEvent event) throws Exception {
+  public void onCreation(final CommentEvent event) {
     Comment comment = event.getTransition().getAfter();
     String componentInstanceId = comment.getComponentInstanceId();
     if (isDefined(componentInstanceId)) {
@@ -118,7 +118,7 @@ public class CommentUserNotificationService extends CDIResourceEventListener<Com
    * @param commentAuthorId the identifier of the author of the comment that is concerned by the
    * notification.
    * @param contribution the content that was commented by the specified comment.
-   * @return a list with the identifier of the interested users.
+   * @return a set with the identifier of the interested users.
    */
   private Set<String> getInterestedUsers(final String commentAuthorId, Contribution contribution) {
     Set<String> interestedUsers = new LinkedHashSet<>();

--- a/core-services/mylinks/src/main/java/org/silverpeas/core/mylinks/MyLinksUserEventListener.java
+++ b/core-services/mylinks/src/main/java/org/silverpeas/core/mylinks/MyLinksUserEventListener.java
@@ -41,7 +41,7 @@ public class MyLinksUserEventListener extends CDIResourceEventListener<UserEvent
   private MyLinksService service;
 
   @Override
-  public void onDeletion(final UserEvent event) throws Exception {
+  public void onDeletion(final UserEvent event) {
     service.deleteUserData(event.getTransition().getBefore().getId());
   }
 }

--- a/core-services/pdc/src/main/java/org/silverpeas/core/pdc/pdc/service/PdcGroupEventListener.java
+++ b/core-services/pdc/src/main/java/org/silverpeas/core/pdc/pdc/service/PdcGroupEventListener.java
@@ -26,6 +26,8 @@ package org.silverpeas.core.pdc.pdc.service;
 import org.silverpeas.core.admin.user.notification.GroupEvent;
 import org.silverpeas.core.annotation.Bean;
 import org.silverpeas.core.notification.system.CDIResourceEventListener;
+import org.silverpeas.core.pdc.pdc.model.PdcException;
+import org.silverpeas.kernel.SilverpeasRuntimeException;
 
 import javax.inject.Inject;
 
@@ -39,7 +41,11 @@ public class PdcGroupEventListener extends CDIResourceEventListener<GroupEvent> 
   private PdcManager pdcManager;
 
   @Override
-  public void onDeletion(final GroupEvent event) throws Exception {
-    pdcManager.deleteGroupManager(event.getTransition().getBefore().getId());
+  public void onDeletion(final GroupEvent event) {
+    try {
+      pdcManager.deleteGroupManager(event.getTransition().getBefore().getId());
+    } catch (PdcException e) {
+      throw new SilverpeasRuntimeException(e);
+    }
   }
 }

--- a/core-services/pdc/src/main/java/org/silverpeas/core/pdc/pdc/service/PdcNodeEventListener.java
+++ b/core-services/pdc/src/main/java/org/silverpeas/core/pdc/pdc/service/PdcNodeEventListener.java
@@ -42,7 +42,7 @@ public class PdcNodeEventListener extends CDIResourceEventListener<NodeEvent> {
   private PdcClassificationService service;
 
   @Override
-  public void onDeletion(final NodeEvent event) throws Exception {
+  public void onDeletion(final NodeEvent event) {
     NodePK nodePK = event.getTransition().getBefore().getNodePK();
     service.deletePreDefinedClassification(nodePK.getId(), nodePK.getInstanceId());
   }

--- a/core-services/pdc/src/main/java/org/silverpeas/core/pdc/pdc/service/PdcUserEventListener.java
+++ b/core-services/pdc/src/main/java/org/silverpeas/core/pdc/pdc/service/PdcUserEventListener.java
@@ -26,6 +26,8 @@ package org.silverpeas.core.pdc.pdc.service;
 import org.silverpeas.core.admin.user.notification.UserEvent;
 import org.silverpeas.core.annotation.Bean;
 import org.silverpeas.core.notification.system.CDIResourceEventListener;
+import org.silverpeas.core.pdc.pdc.model.PdcException;
+import org.silverpeas.kernel.SilverpeasRuntimeException;
 
 import javax.inject.Inject;
 
@@ -39,7 +41,11 @@ public class PdcUserEventListener extends CDIResourceEventListener<UserEvent> {
   private PdcManager pdcManager;
 
   @Override
-  public void onDeletion(final UserEvent event) throws Exception {
-    pdcManager.deleteManager(event.getTransition().getBefore().getId());
+  public void onDeletion(final UserEvent event) {
+    try {
+      pdcManager.deleteManager(event.getTransition().getBefore().getId());
+    } catch (PdcException e) {
+      throw new SilverpeasRuntimeException(e);
+    }
   }
 }

--- a/core-services/workflow/src/main/java/org/silverpeas/core/workflow/api/user/Replacement.java
+++ b/core-services/workflow/src/main/java/org/silverpeas/core/workflow/api/user/Replacement.java
@@ -203,7 +203,7 @@ public interface Replacement<T extends Replacement<T>> extends Entity<T, UuidIde
    * @param replacement the attendees to compare with.
    * @return true if the given replacement is the same has the current one.
    */
-  default boolean isSameAs(Replacement<T> replacement) {
+  default boolean isSameAs(Replacement<?> replacement) {
     return Objects.equals(getIncumbent().getUserId(), replacement.getIncumbent().getUserId()) &&
         Objects.equals(getSubstitute().getUserId(), replacement.getSubstitute().getUserId()) &&
         Objects.equals(getPeriod(), replacement.getPeriod());

--- a/core-war/src/main/java/org/silverpeas/web/sharing/control/AttachmentSharingListener.java
+++ b/core-war/src/main/java/org/silverpeas/web/sharing/control/AttachmentSharingListener.java
@@ -42,7 +42,7 @@ public class AttachmentSharingListener extends CDIResourceEventListener<Attachme
   private SharingTicketService service;
 
   @Override
-  public void onDeletion(final AttachmentEvent event) throws Exception {
+  public void onDeletion(final AttachmentEvent event) {
     AttachmentRef attachment = event.getTransition().getBefore();
     if (attachment != null) {
       service.deleteTicketsForSharedObject(attachment.getOldSilverpeasId(), Ticket.FILE_TYPE);

--- a/core-war/src/main/java/org/silverpeas/web/sharing/control/NodeSharingListener.java
+++ b/core-war/src/main/java/org/silverpeas/web/sharing/control/NodeSharingListener.java
@@ -43,7 +43,7 @@ public class NodeSharingListener extends CDIResourceEventListener<NodeEvent> {
   private SharingTicketService service;
 
   @Override
-  public void onDeletion(final NodeEvent event) throws Exception {
+  public void onDeletion(final NodeEvent event) {
     NodePK nodePK = event.getTransition().getBefore().getNodePK();
     service.deleteTicketsForSharedObject(Long.parseLong(nodePK.getId()), Ticket.NODE_TYPE);
   }

--- a/core-war/src/main/java/org/silverpeas/web/sharing/control/PublicationSharingListener.java
+++ b/core-war/src/main/java/org/silverpeas/web/sharing/control/PublicationSharingListener.java
@@ -42,7 +42,7 @@ public class PublicationSharingListener extends CDIResourceEventListener<Publica
   private SharingTicketService service;
 
   @Override
-  public void onDeletion(final PublicationEvent event) throws Exception {
+  public void onDeletion(final PublicationEvent event) {
     String id = event.getTransition().getBefore().getId();
     service.deleteTicketsForSharedObject(Long.parseLong(id), Ticket.PUBLICATION_TYPE);
   }


### PR DESCRIPTION
Add a new system event notification to inform about changes in the list of users of the roles in the component instances. For instance, only users removed from the list of users of a role in one or more component instances are taken in charge: those users are removed either explicitly from the list of users or indirectly by leaving a user group playing some roles in some component instances.

Don't forget to merge also the PR https://github.com/Silverpeas/Silverpeas-Components/pull/894 which is based upon this one.