### PR TITLE
Bug #14802

### DIFF
--- a/core-web/src/main/java/org/silverpeas/core/webapi/socialnetwork/invitation/InvitationResource.java
+++ b/core-web/src/main/java/org/silverpeas/core/webapi/socialnetwork/invitation/InvitationResource.java
@@ -134,14 +134,10 @@ public class InvitationResource extends RESTWebService {
   }
 
   private void checkInvitationEntity(InvitationEntity invitationEntity) {
-    int senderId = invitationEntity.getSenderId();
+    int senderId = Integer.parseInt(getUser().getId());
     int receiverId = invitationEntity.getReceiverId();
     if (senderId == receiverId) {
       throw new WebApplicationException(Response.Status.BAD_REQUEST);
-    }
-    if (senderId != Integer.parseInt(getUser().getId())
-        || receiverId != Integer.parseInt(getUser().getId())) {
-      throw new WebApplicationException(Response.Status.FORBIDDEN);
     }
   }
 


### PR DESCRIPTION
The bug was caused by the fact the sender isn't specified by default in the invitation sending. In fact, this is normal as by default the sender is the current requester. We have just to check the destinator isn't the sender himself.