### PR TITLE
Bug #14869

### DIFF
--- a/core-library/src/main/java/org/silverpeas/core/admin/service/Administration.java
+++ b/core-library/src/main/java/org/silverpeas/core/admin/service/Administration.java
@@ -35,6 +35,7 @@ import org.silverpeas.core.admin.space.SpaceInstLight;
 import org.silverpeas.core.admin.space.SpaceProfileInst;
 import org.silverpeas.core.admin.user.constant.GroupState;
 import org.silverpeas.core.admin.user.model.*;
+import org.silverpeas.kernel.annotation.NonNull;
 import org.silverpeas.kernel.util.Pair;
 import org.silverpeas.core.util.ServiceProvider;
 import org.silverpeas.core.util.SilverpeasList;
@@ -333,8 +334,9 @@ public interface Administration {
    * Get the profile instance corresponding to the given id
    * @param sProfileId the unique identifier of the profile.
    * @return the role profile
-   * @throws AdminException if an error occurs
+   * @throws AdminException if an error occurs or if the profile instance isn't found
    */
+  @NonNull
   ProfileInst getProfileInst(String sProfileId) throws AdminException;
 
   /**

--- a/core-library/src/main/java/org/silverpeas/core/admin/service/ComponentInstManager.java
+++ b/core-library/src/main/java/org/silverpeas/core/admin/service/ComponentInstManager.java
@@ -24,13 +24,7 @@
 package org.silverpeas.core.admin.service;
 
 import org.silverpeas.core.admin.component.dao.ComponentDAO;
-import org.silverpeas.core.admin.component.model.ComponentI18N;
-import org.silverpeas.core.admin.component.model.ComponentInst;
-import org.silverpeas.core.admin.component.model.ComponentInstLight;
-import org.silverpeas.core.admin.component.model.LocalizedParameter;
-import org.silverpeas.core.admin.component.model.Parameter;
-import org.silverpeas.core.admin.component.model.SilverpeasSharedComponentInstance;
-import org.silverpeas.core.admin.component.model.WAComponent;
+import org.silverpeas.core.admin.component.model.*;
 import org.silverpeas.core.admin.component.notification.ComponentInstanceEventNotifier;
 import org.silverpeas.core.admin.persistence.ComponentInstanceI18NRow;
 import org.silverpeas.core.admin.persistence.ComponentInstanceRow;
@@ -40,13 +34,12 @@ import org.silverpeas.core.admin.user.model.ProfileInst;
 import org.silverpeas.core.annotation.Service;
 import org.silverpeas.core.i18n.AbstractI18NBean;
 import org.silverpeas.core.i18n.I18NHelper;
-import org.silverpeas.core.notification.system.ResourceEvent;
 import org.silverpeas.core.persistence.jdbc.DBUtil;
 import org.silverpeas.core.util.ArrayUtil;
-import org.silverpeas.kernel.util.Pair;
 import org.silverpeas.core.util.ServiceProvider;
-import org.silverpeas.kernel.util.StringUtil;
 import org.silverpeas.kernel.logging.SilverLogger;
+import org.silverpeas.kernel.util.Pair;
+import org.silverpeas.kernel.util.StringUtil;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -54,12 +47,7 @@ import javax.transaction.Transactional;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.text.MessageFormat;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyList;
@@ -271,7 +259,9 @@ public class ComponentInstManager {
         // Insert the profileInst in the componentInst
         for (int nI = 0; asProfileIds != null && nI < asProfileIds.length; nI++) {
           final ProfileInst profileInst = profileInstManager.getProfileInst(asProfileIds[nI], false);
-          componentInst.addProfileInst(profileInst);
+          if (profileInst != null) {
+            componentInst.addProfileInst(profileInst);
+          }
         }
         componentInst.setLanguage(instance.lang);
         // translations
@@ -358,16 +348,6 @@ public class ComponentInstManager {
       organizationSchema.instance().updateComponentOrder(compLocalId, orderNum);
     } catch (Exception e) {
       throw new AdminException(failureOnUpdate("order of component", compLocalId), e);
-    }
-  }
-
-  public void updateComponentInheritance(int compLocalId, boolean inheritanceBlocked)
-      throws AdminException {
-    try {
-      organizationSchema.instance().updateComponentInheritance(compLocalId,
-          inheritanceBlocked);
-    } catch (Exception e) {
-      throw new AdminException(failureOnUpdate(COMPONENT, compLocalId), e);
     }
   }
 
@@ -501,22 +481,6 @@ public class ComponentInstManager {
       return compoIds;
     } catch (Exception e) {
       throw new AdminException(failureOnGetting("instances of component", sComponentName), e);
-    }
-  }
-
-  public String[] getComponentIdsInSpace(int spaceId) throws AdminException {
-    Connection con = null;
-    try {
-      con = DBUtil.openConnection();
-
-      // getting all componentIds available for user
-      List<String> componentIds = ComponentDAO.getComponentIdsInSpace(con, spaceId);
-      return componentIds.toArray(new String[0]);
-
-    } catch (Exception e) {
-      throw new AdminException(failureOnGetting("component instances in space", spaceId), e);
-    } finally {
-      DBUtil.close(con);
     }
   }
 

--- a/core-library/src/main/java/org/silverpeas/core/admin/service/DefaultAdministration.java
+++ b/core-library/src/main/java/org/silverpeas/core/admin/service/DefaultAdministration.java
@@ -1618,12 +1618,15 @@ class DefaultAdministration implements Administration {
         .orElse(profileName);
   }
 
+  @Nonnull
   @Override
   public ProfileInst getProfileInst(String sProfileId) throws AdminException {
     final ProfileInst profileInst;
     Optional<ProfileInst> optionalProfile = cache.getProfileInst(sProfileId);
     if (optionalProfile.isEmpty()) {
-      profileInst = profileManager.getProfileInst(sProfileId, false);
+      profileInst = Optional.ofNullable(profileManager.getProfileInst(sProfileId, false))
+              .orElseThrow(() ->
+                  new AdminException("Profile instance" + sProfileId + " not found"));
       cache.putProfileInst(profileInst);
     } else {
       profileInst = optionalProfile.get();
@@ -1751,6 +1754,9 @@ class DefaultAdministration implements Administration {
   @Override
   public String deleteProfileInst(String profileId, String userId) throws AdminException {
     ProfileInst profile = profileManager.getProfileInst(profileId, true);
+    if (profile == null) {
+      throw new AdminNotFoundException("Profile instance " + profileId + " not found");
+    }
     try {
       profileManager.deleteProfileInst(profile);
       if (StringUtil.isDefined(userId) &&
@@ -5229,7 +5235,9 @@ class DefaultAdministration implements Administration {
         ProfileInst profile = profileManager.getProfileInst(profileId,
             includeRemovedUsersAndGroups);
         // add users directly attach to profile
-        addAllUsersInProfile(profile, userIds);
+        if (profile != null) {
+          addAllUsersInProfile(profile, userIds);
+        }
       }
     } catch (Exception e) {
       throw new AdminException("Fail to search user ids by some profiles", e);

--- a/core-library/src/main/java/org/silverpeas/core/admin/service/DefaultOrganizationController.java
+++ b/core-library/src/main/java/org/silverpeas/core/admin/service/DefaultOrganizationController.java
@@ -934,7 +934,7 @@ public class DefaultOrganizationController implements OrganizationController {
       List<ProfileInst> profiles = getAdminService().getProfilesByObject(objectId, componentId);
       List<String> profileIds = new ArrayList<>();
       for (ProfileInst profile : profiles) {
-        if (profile != null && profileNames.contains(profile.getName())) {
+        if (profileNames.contains(profile.getName())) {
           profileIds.add(profile.getId());
         }
       }

--- a/core-library/src/main/java/org/silverpeas/core/admin/user/ProfileInstManager.java
+++ b/core-library/src/main/java/org/silverpeas/core/admin/user/ProfileInstManager.java
@@ -28,25 +28,22 @@ import org.silverpeas.core.admin.ProfiledObjectType;
 import org.silverpeas.core.admin.persistence.OrganizationSchema;
 import org.silverpeas.core.admin.persistence.UserRoleRow;
 import org.silverpeas.core.admin.service.AdminException;
+import org.silverpeas.core.admin.service.AdminNotFoundException;
 import org.silverpeas.core.admin.user.dao.RoleDAO;
 import org.silverpeas.core.admin.user.model.ProfileInst;
 import org.silverpeas.core.admin.user.notification.ProfileInstEventNotifier;
 import org.silverpeas.core.annotation.Service;
 import org.silverpeas.core.persistence.jdbc.DBUtil;
-import org.silverpeas.kernel.util.StringUtil;
+import org.silverpeas.kernel.annotation.Nullable;
 import org.silverpeas.kernel.logging.SilverLogger;
+import org.silverpeas.kernel.util.StringUtil;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import javax.transaction.Transactional;
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import static java.util.Collections.singleton;
 import static java.util.stream.Collectors.*;
@@ -116,6 +113,7 @@ public class ProfileInstManager {
    * @return the corresponding {@link ProfileInst} if any, null otherwise.
    * @throws AdminException if an error occurred.
    */
+  @Nullable
   public ProfileInst getProfileInst(String sProfileId, final boolean includeRemovedUsersAndGroups)
       throws AdminException {
     ProfileInst profileInst = null;
@@ -211,7 +209,9 @@ public class ProfileInstManager {
    */
   public String updateProfileInst(ProfileInst profileInstNew) throws AdminException {
     ProfileInst profileInst = getProfileInst(profileInstNew.getId(), false);
-
+    if (profileInst == null) {
+      throw new AdminNotFoundException("Profile instance " + profileInstNew.getId() + " not found");
+    }
     try {
       // the groups in the previous state of the profile
       List<String> alOldProfileGroup = profileInst.getAllGroups();

--- a/core-library/src/main/java/org/silverpeas/core/admin/user/ProfiledObjectManager.java
+++ b/core-library/src/main/java/org/silverpeas/core/admin/user/ProfiledObjectManager.java
@@ -74,7 +74,7 @@ public class ProfiledObjectManager {
       throws AdminException {
     List<ProfileInst> profiles = new ArrayList<>();
 
-    String[] asProfileIds = null;
+    String[] asProfileIds;
     try {
       // Get the profiles
       int objectId = Integer.parseInt(objectRef.getId());
@@ -88,7 +88,9 @@ public class ProfiledObjectManager {
     // Insert the profileInst in the componentInst
     for (int nI = 0; asProfileIds != null && nI < asProfileIds.length; nI++) {
       ProfileInst profileInst = profileInstManager.getProfileInst(asProfileIds[nI], false);
-      profiles.add(profileInst);
+      if (profileInst != null) {
+        profiles.add(profileInst);
+      }
     }
 
     return profiles;
@@ -151,7 +153,7 @@ public class ProfiledObjectManager {
       throws AdminException {
     List<ProfileInst> profiles = new ArrayList<>();
 
-    String[] asProfileIds = null;
+    String[] asProfileIds;
     try {
       // Get the profiles
       asProfileIds = organizationSchema.userRole()

--- a/core-library/src/main/java/org/silverpeas/core/node/service/DefaultNodeService.java
+++ b/core-library/src/main/java/org/silverpeas/core/node/service/DefaultNodeService.java
@@ -517,7 +517,7 @@ public class DefaultNodeService implements NodeService, ComponentInstanceDeletio
 
   @Override
   @Transactional
-  public NodePK createNode(NodeDetail node) {
+  public NodeDetail createNode(NodeDetail node) {
     NodePK parentPK = node.getFatherPK();
     if (parentPK != null) {
       NodeDetail parent = getHeader(parentPK);
@@ -535,7 +535,7 @@ public class DefaultNodeService implements NodeService, ComponentInstanceDeletio
       NodePK newNodePK = save(node);
       NodeDetail newNode = getDetail(newNodePK);
       createIndex(newNode, false);
-      return newNode.getNodePK();
+      return newNode;
     } catch (Exception e) {
       throw new NodeRuntimeException(e);
     }
@@ -551,7 +551,7 @@ public class DefaultNodeService implements NodeService, ComponentInstanceDeletio
    * @since 1.0
    */
   @Override
-  public NodePK createNode(NodeDetail nd, NodeDetail fatherDetail) {
+  public NodeDetail createNode(NodeDetail nd, NodeDetail fatherDetail) {
     try {
       if (!NodeDetail.FILE_LINK_TYPE.equals(nd.getNodeType())) {
         nd.setPath(fatherDetail.getPath() + fatherDetail.getNodePK().getId() + "/");
@@ -566,7 +566,7 @@ public class DefaultNodeService implements NodeService, ComponentInstanceDeletio
       NodeDetail newNode = getDetail(newNodePK);
 
       createIndex(newNode, false);
-      return newNode.getNodePK();
+      return newNode;
     } catch (Exception re) {
       throw new NodeRuntimeException(re);
     }

--- a/core-library/src/main/java/org/silverpeas/core/node/service/NodeService.java
+++ b/core-library/src/main/java/org/silverpeas/core/node/service/NodeService.java
@@ -209,18 +209,18 @@ public interface NodeService {
 
   /**
    * Creates a new node in Silverpeas.
-   * @param nodeDetail the details of the node to save.
-   * @param fatherDetail the parent of the node to save.
-   * @return the unique identifier of the new node.
+   * @param nodeDetail details about the node to save.
+   * @param fatherDetail the parent of the node.
+   * @return the new node.
    */
-  NodePK createNode(NodeDetail nodeDetail, NodeDetail fatherDetail);
+  NodeDetail createNode(NodeDetail nodeDetail, NodeDetail fatherDetail);
 
   /**
    * Creates a new node in Silverpeas.
-   * @param nodeDetail the details of the node to save.
-   * @return the unique identifier of the new node.
+   * @param nodeDetail details about the node to save.
+   * @return the new node.
    */
-  NodePK createNode(NodeDetail nodeDetail);
+  NodeDetail createNode(NodeDetail nodeDetail);
 
   /**
    * Removes a node and its descendants
@@ -272,7 +272,6 @@ public interface NodeService {
    * Gets the identifiers of all of the descendants of the specified node.
    * @param nodePK the unique identifier of a node.
    * @return A collection of {@link NodePK} instances.
-   * @return A collection of NodePK
    * @see NodePK
    */
   Collection<NodePK> getDescendantPKs(NodePK nodePK);
@@ -281,7 +280,6 @@ public interface NodeService {
    * Gets all the descendants of the specified node.
    * @param nodePK the unique identifier of a node.
    * @return A collection of {@link NodePK} instances.
-   * @return A collection of NodePK
    * @see NodeDetail
    */
   List<NodeDetail> getDescendantDetails(NodePK nodePK);
@@ -290,7 +288,6 @@ public interface NodeService {
    * Gets all the descendants of the specified node.
    * @param node a node.
    * @return A collection of {@link NodePK} instances.
-   * @return A collection of NodePK
    * @see NodeDetail
    */
   List<NodeDetail> getDescendantDetails(NodeDetail node);

--- a/core-services/importExport/src/main/java/org/silverpeas/core/importexport/control/GEDImportExport.java
+++ b/core-services/importExport/src/main/java/org/silverpeas/core/importexport/control/GEDImportExport.java
@@ -611,15 +611,15 @@ public abstract class GEDImportExport extends ComponentImportExport {
             newNode.setNodePK(new NodePK("unknown", componentId));
             newNode.setFatherPK(new NodePK(parentId, componentId));
             newNode.setCreatorId(userId);
-            NodePK newNodePK;
+            NodeDetail createdNode;
             try {
-              newNodePK = getNodeService().createNode(newNode);
+              createdNode = getNodeService().createNode(newNode);
             } catch (Exception e) {
               SilverLogger.getLogger(this)
                   .error(e);
               return new ArrayList<>();
             }
-            parentId = newNodePK.getId();
+            parentId = createdNode.getId();
           }
         }
         node.setId(Integer.parseInt(parentId));
@@ -663,7 +663,7 @@ public abstract class GEDImportExport extends ComponentImportExport {
    * @return un objet cle primaire du nouveau theme cree.
    * @throws ImportExportException en cas d'anomalie lors de la creation du noeud.
    */
-  protected abstract NodePK addSubTopicToTopic(NodeDetail nodeDetail, int topicId,
+  protected abstract NodeDetail addSubTopicToTopic(NodeDetail nodeDetail, int topicId,
       MassiveReport massiveReport) throws ImportExportException;
 
   /**
@@ -740,8 +740,7 @@ public abstract class GEDImportExport extends ComponentImportExport {
     try {
       String directoryName = directory.getName();
       NodeDetail nodeDetail = new NodeDetail("unknow", directoryName, directoryName, 0, "useless");
-      nodeDetail.setNodePK(addSubTopicToTopic(nodeDetail, topicId, massiveReport));
-      return nodeDetail;
+      return addSubTopicToTopic(nodeDetail, topicId, massiveReport);
     } catch (Exception ex) {
       throw new ImportExportException("GEDImportExport.addSubTopicToTopic",
           "importExport.EX_NODE_CREATE", ex);

--- a/core-services/importExport/src/main/java/org/silverpeas/core/importexport/coordinates/CoordinateImportExport.java
+++ b/core-services/importExport/src/main/java/org/silverpeas/core/importexport/coordinates/CoordinateImportExport.java
@@ -283,17 +283,12 @@ public class CoordinateImportExport {
     position.getNodePK().setComponentName(componentId);
     position.setCreationDate(new Date());
     NodeDetail fatherDetail;
-    NodePK positionPK;
-    NodeDetail positionDetail;
     try {
       fatherDetail = getNodeHeader(axisId, componentId);
-      positionPK = getNodeService().createNode(position, fatherDetail);
-
-      positionDetail = getNodeHeader(positionPK);
+      return getNodeService().createNode(position, fatherDetail);
     } catch (Exception e) {
       throw new CoordinateRuntimeException("Adding position failure", e);
     }
-    return positionDetail;
   }
 
   /**


### PR DESCRIPTION
NodeService#createNode methods return now the new NodeDetails instead of the NodePK of the created node.

Check directly the nullity of the returned ProfileInst object after the invocation of ProfileManager#getProfileInst(...) method in order to avoid to spread the nullity possibility of the ProfileInst object up to the chain of call.