### PR TITLE
Bug #14806

### DIFF
--- a/core-library/src/main/java/org/silverpeas/core/contribution/content/form/FieldTemplate.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/content/form/FieldTemplate.java
@@ -28,6 +28,7 @@ import org.silverpeas.core.contribution.content.form.record.Parameter;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * A FieldTemplate describes a specific field of a DataRecord. A FieldTemplate gives the field name,
@@ -109,5 +110,7 @@ public interface FieldTemplate extends Serializable {
   int getMaximumNumberOfOccurrences();
 
   boolean isRepeatable();
+
+  Set<FieldValueTemplate> getFieldValueTemplate(String language);
 
 }

--- a/core-library/src/main/java/org/silverpeas/core/contribution/content/form/FieldValueTemplate.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/content/form/FieldValueTemplate.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2000 - 2025 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have received a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "https://www.silverpeas.org/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.core.contribution.content.form;
+
+/**
+ * Template of a field value in a given language.
+ *
+ * @author mmoquillon
+ */
+public class FieldValueTemplate {
+
+  private final String key;
+  private final String value;
+  private final String language;
+
+  public FieldValueTemplate(String key, String value, String language) {
+    this.key = key;
+    this.value = value;
+    this.language = language;
+  }
+
+  public String getKey() {
+    return key;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  public String getLanguage() {
+    return language;
+  }
+}
+  

--- a/core-library/src/main/java/org/silverpeas/core/contribution/content/form/dummy/DummyFieldTemplate.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/content/form/dummy/DummyFieldTemplate.java
@@ -25,22 +25,21 @@ package org.silverpeas.core.contribution.content.form.dummy;
 
 import org.silverpeas.core.contribution.content.form.Field;
 import org.silverpeas.core.contribution.content.form.FieldTemplate;
-import org.silverpeas.core.contribution.content.form.FormException;
+import org.silverpeas.core.contribution.content.form.FieldValueTemplate;
 import org.silverpeas.core.contribution.content.form.field.TextFieldImpl;
 import org.silverpeas.core.contribution.content.form.record.Parameter;
 import org.silverpeas.core.util.ArrayUtil;
 
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * A dummy FieldTemplate.
  */
 public class DummyFieldTemplate implements FieldTemplate {
 
-  private Field field;
+  private final Field field;
 
   public DummyFieldTemplate() {
     field = new TextFieldImpl();
@@ -136,12 +135,17 @@ public class DummyFieldTemplate implements FieldTemplate {
    */
   @Override
   public Map<String, String> getParameters(String language) {
-    return new HashMap<>();
+    return Map.of();
   }
 
   @Override
   public List<Parameter> getParametersObj() {
-    return new ArrayList<>();
+    return List.of();
+  }
+
+  @Override
+  public Set<FieldValueTemplate> getFieldValueTemplate(String language) {
+    return Set.of();
   }
 
   /**
@@ -177,7 +181,7 @@ public class DummyFieldTemplate implements FieldTemplate {
   }
 
   @Override
-  public Field getEmptyField(int occurrence) throws FormException {
+  public Field getEmptyField(int occurrence) {
     return field;
   }
 

--- a/core-library/src/main/java/org/silverpeas/core/contribution/content/form/record/GenericFieldTemplate.java
+++ b/core-library/src/main/java/org/silverpeas/core/contribution/content/form/record/GenericFieldTemplate.java
@@ -23,12 +23,8 @@
  */
 package org.silverpeas.core.contribution.content.form.record;
 
+import org.silverpeas.core.contribution.content.form.*;
 import org.silverpeas.kernel.SilverpeasRuntimeException;
-import org.silverpeas.core.contribution.content.form.Field;
-import org.silverpeas.core.contribution.content.form.FieldTemplate;
-import org.silverpeas.core.contribution.content.form.FormException;
-import org.silverpeas.core.contribution.content.form.FormFatalException;
-import org.silverpeas.core.contribution.content.form.TypeManager;
 import org.silverpeas.core.util.ArrayUtil;
 
 import javax.xml.bind.annotation.XmlAccessType;
@@ -36,12 +32,8 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import java.lang.reflect.Constructor;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.StringTokenizer;
+import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * A generic FieldTemplate implementation.
@@ -321,6 +313,14 @@ public class GenericFieldTemplate implements FieldTemplate {
       addParameter(parameter.getName(), parameter.getValue(language));
     }
     return parameters;
+  }
+
+  @Override
+  public Set<FieldValueTemplate> getFieldValueTemplate(String language) {
+    var keyValuePairs = getKeyValuePairs(language);
+    return keyValuePairs.entrySet().stream()
+        .map(e -> new FieldValueTemplate(e.getKey(), e.getValue(), language))
+        .collect(Collectors.toSet());
   }
 
   public Map<String, String> getKeyValuePairs(String language) {

--- a/core-services/workflow/src/main/java/org/silverpeas/core/workflow/engine/datarecord/ProcessInstanceFieldTemplate.java
+++ b/core-services/workflow/src/main/java/org/silverpeas/core/workflow/engine/datarecord/ProcessInstanceFieldTemplate.java
@@ -23,13 +23,11 @@
  */
 package org.silverpeas.core.workflow.engine.datarecord;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import org.silverpeas.core.contribution.content.form.Field;
 import org.silverpeas.core.contribution.content.form.FieldTemplate;
+import org.silverpeas.core.contribution.content.form.FieldValueTemplate;
 import org.silverpeas.core.contribution.content.form.FormException;
 import org.silverpeas.core.contribution.content.form.record.Parameter;
 import org.silverpeas.core.workflow.api.instance.ProcessInstance;
@@ -38,7 +36,7 @@ import org.silverpeas.core.workflow.api.instance.ProcessInstance;
  * A ProcessInstanceFieldTemplate describes a field of a process instance.
  */
 public abstract class ProcessInstanceFieldTemplate implements FieldTemplate {
-  public ProcessInstanceFieldTemplate(String fieldName, String typeName,
+  protected ProcessInstanceFieldTemplate(String fieldName, String typeName,
       String displayerName, String label) {
     this.fieldName = fieldName;
     this.typeName = typeName;
@@ -121,12 +119,17 @@ public abstract class ProcessInstanceFieldTemplate implements FieldTemplate {
    * (max-size, length ...).
    */
   public Map<String, String> getParameters(String language) {
-    return new HashMap<>();
+    return Map.of();
   }
 
   @Override
   public List<Parameter> getParametersObj() {
-    return new ArrayList<>();
+    return List.of();
+  }
+
+  @Override
+  public Set<FieldValueTemplate> getFieldValueTemplate(String language) {
+    return Set.of();
   }
 
   /**


### PR DESCRIPTION
Add FieldValueTemplate to model the template of a field value in a RecordTemplate of a form. This is to avoid to parse template parameters for both keys and values of fields in a FieldTemplate; the way they are encoded in the FieldTemplate has to be encapsulated and not exposed.