### PR TITLE
Bug #14926

### DIFF
--- a/core-api/src/main/java/org/silverpeas/core/notification/message/MessageContainer.java
+++ b/core-api/src/main/java/org/silverpeas/core/notification/message/MessageContainer.java
@@ -24,6 +24,7 @@
 package org.silverpeas.core.notification.message;
 
 import org.silverpeas.core.ui.DisplayI18NHelper;
+import org.silverpeas.kernel.annotation.NonNull;
 import org.silverpeas.kernel.bundle.LocalizationBundle;
 import org.silverpeas.kernel.bundle.ResourceLocator;
 
@@ -83,6 +84,7 @@ public class MessageContainer {
     }
   }
 
+  @NonNull
   public Set<Message> getMessages() {
     return messages;
   }

--- a/core-api/src/main/java/org/silverpeas/core/notification/message/MessageManager.java
+++ b/core-api/src/main/java/org/silverpeas/core/notification/message/MessageManager.java
@@ -63,7 +63,10 @@ import org.silverpeas.kernel.logging.SilverLogger;
  */
 public class MessageManager {
 
-  private static SimpleCache applicationCache =
+  private MessageManager() {
+  }
+
+  private static final SimpleCache applicationCache =
       CacheAccessorProvider.getApplicationCacheAccessor().getCache();
 
   public static String initialize() {
@@ -161,16 +164,15 @@ public class MessageManager {
         StringUtil.isDefined(language) ? language : container.getLanguage());
   }
 
-
   public static MessageContainer getMessageContainer(String registredKey) {
-    try {
-      return applicationCache.get(registredKey, MessageContainer.class);
-    } catch (NullPointerException e) {
-      SilverLogger.getLogger(MessageManager.class)
-          .silent(e)
+      var container = applicationCache
+          .get(StringUtil.defaultStringIfNotDefined(registredKey), MessageContainer.class);
+      if (container == null) {
+        SilverLogger.getLogger(MessageManager.class)
           .debug("No Message Container registered with key ''{0}''!", registredKey);
-      return null;
-    }
+        return null;
+      }
+      return container;
   }
 
   /**

--- a/core-api/src/test/java/org/silverpeas/core/notification/message/MessageManagerTest.java
+++ b/core-api/src/test/java/org/silverpeas/core/notification/message/MessageManagerTest.java
@@ -45,13 +45,13 @@ import static org.hamcrest.Matchers.*;
 class MessageManagerTest {
 
   @BeforeEach
-  public void setup() {
+  void setup() {
     MessageManager.initialize();
     assertThat(getMessageContainer().getMessages(), emptyIterable());
   }
 
   @AfterEach
-  public void tearDown() {
+  void tearDown() {
     MessageManager.clear(MessageManager.getRegistredKey());
     MessageManager.destroy();
   }

--- a/core-configuration/src/main/config/properties/org/silverpeas/util/security.properties
+++ b/core-configuration/src/main/config/properties/org/silverpeas/util/security.properties
@@ -50,7 +50,7 @@ security.web.protection.injection.xss = true
 # A REGEXP that permits to identify the parameter names for which the XSS injection verification must be skipped.
 # So, without deactivating entirely the security, it permits to add or remove parameter names to skip from XSS verification
 # If no parameters must be skip, please fill no value
-security.web.protection.injection.xss.skipped.parameters = (?i)^(editor.*|Content)
+security.web.protection.injection.xss.skipped.parameters = (?i)^(editor.*|Content|context)
 # Indicates whether the content (and by extension the XSS) injection security mechanism must be
 # activated. This property enable the Content Security Policy
 # (see https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP). It enforces the XSS protection

--- a/core-services/workflow/src/main/java/org/silverpeas/core/workflow/api/ProcessModelManager.java
+++ b/core-services/workflow/src/main/java/org/silverpeas/core/workflow/api/ProcessModelManager.java
@@ -63,9 +63,8 @@ public interface ProcessModelManager {
   /**
    * Create a new ProcessModel descriptor that is not yet saved in a XML file.
    * @return ProcessModel object
-   * @throws WorkflowException when something goes wrong
    */
-  ProcessModel createProcessModelDescriptor() throws WorkflowException;
+  ProcessModel createProcessModelDescriptor();
 
   /**
    * Delete a ProcessModel with given model id

--- a/core-services/workflow/src/main/java/org/silverpeas/core/workflow/api/model/Action.java
+++ b/core-services/workflow/src/main/java/org/silverpeas/core/workflow/api/model/Action.java
@@ -23,10 +23,12 @@
  */
 package org.silverpeas.core.workflow.api.model;
 
+import java.io.Serializable;
+
 /**
  * Interface describing a representation of the &lt;action&gt; element of a Process Model.
  **/
-public interface Action {
+public interface Action extends Serializable {
   /**
    * Get the name of this action
    * @return action's name

--- a/core-services/workflow/src/main/java/org/silverpeas/core/workflow/api/model/Actions.java
+++ b/core-services/workflow/src/main/java/org/silverpeas/core/workflow/api/model/Actions.java
@@ -68,7 +68,6 @@ public interface Actions extends Serializable {
   /**
    * Remove an action from the collection
    * @param strActionName the name of the action to be removed.
-   * @throws WorkflowException when the action cannot be found
    */
-  void removeAction(String strActionName) throws WorkflowException;
+  void removeAction(String strActionName);
 }

--- a/core-services/workflow/src/main/java/org/silverpeas/core/workflow/api/model/AllowedAction.java
+++ b/core-services/workflow/src/main/java/org/silverpeas/core/workflow/api/model/AllowedAction.java
@@ -23,10 +23,12 @@
  */
 package org.silverpeas.core.workflow.api.model;
 
+import java.io.Serializable;
+
 /**
  * Interface describing a representation of the &lt;allowedAction&gt; element of a Process Model.
  */
-public interface AllowedAction {
+public interface AllowedAction extends Serializable {
 
   /**
    * Get the allowed action

--- a/core-services/workflow/src/main/java/org/silverpeas/core/workflow/api/model/Column.java
+++ b/core-services/workflow/src/main/java/org/silverpeas/core/workflow/api/model/Column.java
@@ -23,10 +23,12 @@
  */
 package org.silverpeas.core.workflow.api.model;
 
+import java.io.Serializable;
+
 /**
  * Interface describing a representation of the &lt;column&gt; element of a Process Model.
  **/
-public interface Column {
+public interface Column extends Serializable {
   /**
    * Get the item to show in this column
    * @return the item

--- a/core-services/workflow/src/main/java/org/silverpeas/core/workflow/api/model/Columns.java
+++ b/core-services/workflow/src/main/java/org/silverpeas/core/workflow/api/model/Columns.java
@@ -23,13 +23,14 @@
  */
 package org.silverpeas.core.workflow.api.model;
 
+import java.io.Serializable;
 import java.util.Iterator;
 import java.util.List;
 
 /**
  * Interface describing a representation of the &lt;columns&gt; element of a Process Model.
  */
-public interface Columns {
+public interface Columns extends Serializable {
 
   /**
    * Get the referenced Column objects as a list

--- a/core-services/workflow/src/main/java/org/silverpeas/core/workflow/api/model/Consequence.java
+++ b/core-services/workflow/src/main/java/org/silverpeas/core/workflow/api/model/Consequence.java
@@ -23,12 +23,13 @@
  */
 package org.silverpeas.core.workflow.api.model;
 
+import java.io.Serializable;
 import java.util.List;
 
 /**
  * Interface describing a representation of the &lt;consequence&gt; element of a Process Model.
  */
-public interface Consequence {
+public interface Consequence extends Serializable {
   /**
    * Get the item on which the comparison will be processed
    * @return the item name

--- a/core-services/workflow/src/main/java/org/silverpeas/core/workflow/api/model/Consequences.java
+++ b/core-services/workflow/src/main/java/org/silverpeas/core/workflow/api/model/Consequences.java
@@ -23,13 +23,14 @@
  */
 package org.silverpeas.core.workflow.api.model;
 
+import java.io.Serializable;
 import java.util.List;
 import java.util.Iterator;
 
 /**
  * Interface describing a representation of the &lt;consequences&gt; element of a Process Model.
  */
-public interface Consequences {
+public interface Consequences extends Serializable {
   /**
    * Get the target consequences
    * @return the target consequences as a Vector

--- a/core-services/workflow/src/main/java/org/silverpeas/core/workflow/api/model/ContextualDesignations.java
+++ b/core-services/workflow/src/main/java/org/silverpeas/core/workflow/api/model/ContextualDesignations.java
@@ -23,8 +23,6 @@
  */
 package org.silverpeas.core.workflow.api.model;
 
-import org.silverpeas.core.workflow.api.WorkflowException;
-
 import java.io.Serializable;
 import java.util.Iterator;
 
@@ -57,10 +55,8 @@ public interface ContextualDesignations extends Serializable {
    * Remove a matching contextualDesignation from the collection. The collection shall be searched
    * for a Designation with the same language and role.
    * @param contextualDesignation a model of the contextualDesignation to be removed.
-   * @throws WorkflowException when a matching contextualDescription could not be found.
    */
-  void removeContextualDesignation(ContextualDesignation contextualDesignation) throws
-      WorkflowException;
+  void removeContextualDesignation(ContextualDesignation contextualDesignation);
 
   /**
    * Get the designation for the given role and language; make an exact match, do not fall-back to

--- a/core-services/workflow/src/main/java/org/silverpeas/core/workflow/api/model/Form.java
+++ b/core-services/workflow/src/main/java/org/silverpeas/core/workflow/api/model/Form.java
@@ -112,7 +112,7 @@ public interface Form extends Serializable {
    * Remove the input specified by the index
    * @param idx the index
    */
-  void removeInput(int idx) throws WorkflowException;
+  void removeInput(int idx);
 
   /**
    * Get all the titles

--- a/core-services/workflow/src/main/java/org/silverpeas/core/workflow/api/model/Forms.java
+++ b/core-services/workflow/src/main/java/org/silverpeas/core/workflow/api/model/Forms.java
@@ -23,8 +23,6 @@
  */
 package org.silverpeas.core.workflow.api.model;
 
-import org.silverpeas.core.workflow.api.WorkflowException;
-
 import java.io.Serializable;
 import java.util.Iterator;
 
@@ -72,7 +70,6 @@ public interface Forms extends Serializable {
    * Remove the form identified by name and role
    * @param strName the form name
    * @param strRole the name of the role, may be <code>null</code>
-   * @throws WorkflowException if the role cannot be found
    */
-  void removeForm(String strName, String strRole) throws WorkflowException;
+  void removeForm(String strName, String strRole);
 }

--- a/core-services/workflow/src/main/java/org/silverpeas/core/workflow/api/model/Item.java
+++ b/core-services/workflow/src/main/java/org/silverpeas/core/workflow/api/model/Item.java
@@ -23,8 +23,6 @@
  */
 package org.silverpeas.core.workflow.api.model;
 
-import org.silverpeas.core.workflow.api.WorkflowException;
-
 import java.io.Serializable;
 import java.util.Iterator;
 import java.util.Map;
@@ -167,9 +165,8 @@ public interface Item extends Serializable {
   /**
    * Remove the parameter specified by its name
    * @param strName the name of the parameter
-   * @throws WorkflowException when the parameter cannot be found
    */
-  void removeParameter(String strName) throws WorkflowException;
+  void removeParameter(String strName);
 
   /**
    * Gets the parameters as a dictionary of keys to values.

--- a/core-services/workflow/src/main/java/org/silverpeas/core/workflow/api/model/Participant.java
+++ b/core-services/workflow/src/main/java/org/silverpeas/core/workflow/api/model/Participant.java
@@ -23,10 +23,12 @@
  */
 package org.silverpeas.core.workflow.api.model;
 
+import java.io.Serializable;
+
 /**
  * Interface describing a representation of the &lt;participant&gt; element of a Process Model.
  */
-public interface Participant {
+public interface Participant extends Serializable {
   /**
    * Get the name of this participant
    * @return participant's name

--- a/core-services/workflow/src/main/java/org/silverpeas/core/workflow/api/model/Participants.java
+++ b/core-services/workflow/src/main/java/org/silverpeas/core/workflow/api/model/Participants.java
@@ -23,8 +23,6 @@
  */
 package org.silverpeas.core.workflow.api.model;
 
-import org.silverpeas.core.workflow.api.WorkflowException;
-
 import java.io.Serializable;
 import java.util.Iterator;
 
@@ -67,7 +65,6 @@ public interface Participants extends Serializable {
   /**
    * Remove an participant from the collection
    * @param strParticipantName the name of the participant to be removed.
-   * @throws WorkflowException when the participant could not be deleted.
    */
-  void removeParticipant(String strParticipantName) throws WorkflowException;
+  void removeParticipant(String strParticipantName);
 }

--- a/core-services/workflow/src/main/java/org/silverpeas/core/workflow/api/model/Presentation.java
+++ b/core-services/workflow/src/main/java/org/silverpeas/core/workflow/api/model/Presentation.java
@@ -23,8 +23,6 @@
  */
 package org.silverpeas.core.workflow.api.model;
 
-import org.silverpeas.core.workflow.api.WorkflowException;
-
 import java.io.Serializable;
 import java.util.Iterator;
 
@@ -85,7 +83,6 @@ public interface Presentation extends Serializable {
   /**
    * Delete the Columns object with the given name
    * @param strRoleName the name of the Columns object (a role name)
-   * @throws WorkflowException when the Columns for the given name have not been found.
    */
-  void deleteColumns(String strRoleName) throws WorkflowException;
+  void deleteColumns(String strRoleName);
 }

--- a/core-services/workflow/src/main/java/org/silverpeas/core/workflow/api/model/QualifiedUsers.java
+++ b/core-services/workflow/src/main/java/org/silverpeas/core/workflow/api/model/QualifiedUsers.java
@@ -23,8 +23,7 @@
  */
 package org.silverpeas.core.workflow.api.model;
 
-import org.silverpeas.core.workflow.api.WorkflowException;
-
+import java.io.Serializable;
 import java.util.Iterator;
 
 /**
@@ -34,7 +33,7 @@ import java.util.Iterator;
  * <li>&lt;interestedUsers&gt;</li>
  * </ul>
  */
-public interface QualifiedUsers {
+public interface QualifiedUsers extends Serializable {
   /**
    * Get the userInRoles
    * @return the userInRoles as an array
@@ -61,8 +60,8 @@ public interface QualifiedUsers {
 
   /**
    * Get the userInRoles
-   * @param strRoleName
-   * @return the userInRoles as a Vector
+   * @param strRoleName the role
+   * @return the user playing the role
    */
   UserInRole getUserInRole(String strRoleName);
 
@@ -99,9 +98,8 @@ public interface QualifiedUsers {
   /**
    * Remove a RelatedUser from the collection
    * @param reference the reference of the RelatedUser to be removed
-   * @throws WorkflowException when something goes wrong
    */
-  void removeRelatedUser(RelatedUser reference) throws WorkflowException;
+  void removeRelatedUser(RelatedUser reference);
 
   /**
    * Get the related groups
@@ -135,7 +133,7 @@ public interface QualifiedUsers {
 
   /**
    * Get the user id used as sender for message.
-   * @return
+   * @return the identifier of the message sender
    */
   String getSenderId();
 

--- a/core-services/workflow/src/main/java/org/silverpeas/core/workflow/api/model/RelatedUser.java
+++ b/core-services/workflow/src/main/java/org/silverpeas/core/workflow/api/model/RelatedUser.java
@@ -23,10 +23,12 @@
  */
 package org.silverpeas.core.workflow.api.model;
 
+import java.io.Serializable;
+
 /**
  * Interface describing a representation of the &lt;relatedUser&gt; element of a Process Model.
  */
-public interface RelatedUser {
+public interface RelatedUser extends Serializable {
   /**
    * Get the referred participant
    * @return Participant object

--- a/core-services/workflow/src/main/java/org/silverpeas/core/workflow/api/model/Role.java
+++ b/core-services/workflow/src/main/java/org/silverpeas/core/workflow/api/model/Role.java
@@ -23,10 +23,12 @@
  */
 package org.silverpeas.core.workflow.api.model;
 
+import java.io.Serializable;
+
 /**
  * Interface describing a representation of the &lt;role&gt; element of a Process Model.
  */
-public interface Role {
+public interface Role extends Serializable {
   /**
    * Get the name of the Role
    * @return role's name

--- a/core-services/workflow/src/main/java/org/silverpeas/core/workflow/api/model/Roles.java
+++ b/core-services/workflow/src/main/java/org/silverpeas/core/workflow/api/model/Roles.java
@@ -23,8 +23,6 @@
  */
 package org.silverpeas.core.workflow.api.model;
 
-import org.silverpeas.core.workflow.api.WorkflowException;
-
 import java.io.Serializable;
 import java.util.Iterator;
 
@@ -66,7 +64,6 @@ public interface Roles extends Serializable {
   /**
    * Remove an role from the collection
    * @param strRoleName the name of the role to be removed.
-   * @throws WorkflowException if the role cannot be found.
    */
-  void removeRole(String strRoleName) throws WorkflowException;
+  void removeRole(String strRoleName);
 }

--- a/core-services/workflow/src/main/java/org/silverpeas/core/workflow/api/model/State.java
+++ b/core-services/workflow/src/main/java/org/silverpeas/core/workflow/api/model/State.java
@@ -23,10 +23,12 @@
  */
 package org.silverpeas.core.workflow.api.model;
 
+import java.io.Serializable;
+
 /**
  * Interface describing a representation of the &lt;state&gt; element of a Process Model.
  */
-public interface State {
+public interface State extends Serializable {
   /**
    * Get the name of this state
    * @return state's name

--- a/core-services/workflow/src/main/java/org/silverpeas/core/workflow/api/model/TimeOutAction.java
+++ b/core-services/workflow/src/main/java/org/silverpeas/core/workflow/api/model/TimeOutAction.java
@@ -23,10 +23,12 @@
  */
 package org.silverpeas.core.workflow.api.model;
 
+import java.io.Serializable;
+
 /**
  * Interface describing a representation of the &lt;timeoutAction&gt; element of a Process Model.
  */
-public interface TimeOutAction {
+public interface TimeOutAction extends Serializable {
 
   /**
    * Get timeoutAction order. As several timeout might be defined, an order is set.

--- a/core-services/workflow/src/main/java/org/silverpeas/core/workflow/api/model/TimeOutActions.java
+++ b/core-services/workflow/src/main/java/org/silverpeas/core/workflow/api/model/TimeOutActions.java
@@ -23,10 +23,12 @@
  */
 package org.silverpeas.core.workflow.api.model;
 
+import java.io.Serializable;
+
 /**
  * Interface describing a representation of the &lt;timeoutActions&gt; element of a Process Model.
  */
-public interface TimeOutActions {
+public interface TimeOutActions extends Serializable {
 
   /**
    * Get timeout actions

--- a/core-services/workflow/src/main/java/org/silverpeas/core/workflow/api/model/Trigger.java
+++ b/core-services/workflow/src/main/java/org/silverpeas/core/workflow/api/model/Trigger.java
@@ -26,11 +26,12 @@ package org.silverpeas.core.workflow.api.model;
 import org.silverpeas.core.workflow.external.impl.ExternalActionImpl;
 
 import javax.inject.Named;
+import java.io.Serializable;
 
 /**
  * Interface describing a representation of the &lt;trigger&gt; element of a Process Model.
  */
-public interface Trigger {
+public interface Trigger extends Serializable {
   /**
    * Get the name of the Trigger
    * @return parameter's name

--- a/core-services/workflow/src/main/java/org/silverpeas/core/workflow/api/model/Triggers.java
+++ b/core-services/workflow/src/main/java/org/silverpeas/core/workflow/api/model/Triggers.java
@@ -23,12 +23,13 @@
  */
 package org.silverpeas.core.workflow.api.model;
 
+import java.io.Serializable;
 import java.util.Iterator;
 
 /**
  * Interface describing a representation of the &lt;triggers&gt; element of a Process Model.
  */
-public interface Triggers {
+public interface Triggers extends Serializable {
 
   /**
    * Iterate through the Trigger objects

--- a/core-services/workflow/src/main/java/org/silverpeas/core/workflow/engine/model/ActionImpl.java
+++ b/core-services/workflow/src/main/java/org/silverpeas/core/workflow/engine/model/ActionImpl.java
@@ -23,7 +23,6 @@
  */
 package org.silverpeas.core.workflow.engine.model;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -47,7 +46,7 @@ import javax.xml.bind.annotation.XmlRootElement;
  **/
 @XmlRootElement(name = "action")
 @XmlAccessorType(XmlAccessType.NONE)
-public class ActionImpl implements Action, Serializable {
+public class ActionImpl implements Action {
   private static final long serialVersionUID = -6984785710903135661L;
   @XmlID
   @XmlAttribute
@@ -82,129 +81,77 @@ public class ActionImpl implements Action, Serializable {
     kind = "update";
   }
 
-  /*
-   * (non-Javadoc)
-   * @see Action#getLabels()
-   */
+  @Override
   public ContextualDesignations getLabels() {
     return new SpecificLabelListHelper(labels);
   }
 
-  /*
-   * (non-Javadoc)
-   * @see Action#getLabel(java.lang.String, java.lang.String)
-   */
+  @Override
   public String getLabel(String role, String language) {
     return getLabels().getLabel(role, language);
   }
 
-  /**
-   * Get all the users allowed to execute this action
-   * @return object containing QualifiedUsers
-   */
+  @Override
   public QualifiedUsers getAllowedUsers() {
     return allowedUsers;
   }
 
-  /**
-   * Get all the consequences of this action
-   * @return Consequences objects
-   */
+  @Override
   public Consequences getConsequences() {
     return consequences;
   }
 
-  /**
-   * Get the form associated with this action
-   * @return form object
-   */
+  @Override
   public Form getForm() {
     return form;
   }
 
-  /**
-   * Get the name of this action
-   * @return action's name
-   */
+  @Override
   public String getName() {
     return name;
   }
 
-  /**
-   * Get the kind of this action (update, create or delete)
-   * @return action's kind
-   */
+  @Override
   public String getKind() {
     return kind;
   }
 
-  /*
-   * (non-Javadoc)
-   * @see Action#getDescriptions()
-   */
+  @Override
   public ContextualDesignations getDescriptions() {
     return new SpecificLabelListHelper(descriptions);
   }
 
-  /*
-   * (non-Javadoc)
-   * @see Action#getDescription(java.lang.String,
-   * java.lang.String)
-   */
+  @Override
   public String getDescription(String role, String language) {
     return getDescriptions().getLabel(role, language);
   }
 
-  /**
-   * Create and return an object implementing QalifiedUsers
-   */
-  public QualifiedUsers createQualifiedUsers() {
-    return new QualifiedUsersImpl();
-  }
-
-  /**
-   * Set the list of users allowed to execute this action
-   * @param allowedUsers allowed users
-   **/
+  @Override
   public void setAllowedUsers(QualifiedUsers allowedUsers) {
     this.allowedUsers = allowedUsers;
   }
 
-  /**
-   * Create and return and object implementing Consequences
-   */
+  @Override
   public Consequences createConsequences() {
     return new ConsequencesImpl();
   }
 
-  /**
-   * Set the consequences of this action
-   * @param consequences
-   */
+  @Override
   public void setConsequences(Consequences consequences) {
     this.consequences = consequences;
   }
 
-  /**
-   * Set the form associated to this action
-   * @param form associated form
-   **/
+  @Override
   public void setForm(Form form) {
     this.form = (FormImpl) form;
   }
 
-  /**
-   * Set the name of this action
-   * @param name action's name
-   */
+  @Override
   public void setName(String name) {
     this.name = name;
   }
 
-  /**
-   * Set the kind of this action
-   * @param kind action's kind
-   */
+  @Override
   public void setKind(String kind) {
     this.kind = kind;
   }
@@ -214,7 +161,7 @@ public class ActionImpl implements Action, Serializable {
    * @return unique key
    */
   public String getKey() {
-    return name;
+    return getName();
   }
 
 }

--- a/core-services/workflow/src/main/java/org/silverpeas/core/workflow/engine/model/ActionRef.java
+++ b/core-services/workflow/src/main/java/org/silverpeas/core/workflow/engine/model/ActionRef.java
@@ -23,8 +23,6 @@
  */
 package org.silverpeas.core.workflow.engine.model;
 
-import java.io.Serializable;
-
 import org.silverpeas.core.workflow.api.model.Action;
 import org.silverpeas.core.workflow.api.model.AllowedAction;
 import org.silverpeas.core.workflow.engine.AbstractReferrableObject;
@@ -38,7 +36,7 @@ import javax.xml.bind.annotation.XmlIDREF;
  * Class implementing the representation of the &lt;allow&gt; element of a Process Model.
  **/
 @XmlAccessorType(XmlAccessType.NONE)
-public class ActionRef extends AbstractReferrableObject implements Serializable, AllowedAction {
+public class ActionRef extends AbstractReferrableObject implements AllowedAction {
   private static final long serialVersionUID = -8866828437819862983L;
 
   @XmlIDREF
@@ -46,17 +44,12 @@ public class ActionRef extends AbstractReferrableObject implements Serializable,
   // The reference to the allowed action
   private ActionImpl action;
 
-  /**
-   * Get the referred action
-   */
+  @Override
   public Action getAction() {
     return action;
   }
 
-  /**
-   * Set the referred action
-   * @param action action to refer
-   */
+  @Override
   public void setAction(Action action) {
     this.action = (ActionImpl) action;
   }
@@ -68,10 +61,7 @@ public class ActionRef extends AbstractReferrableObject implements Serializable,
     return null;
   }
 
-  /*
-   * (non-Javadoc)
-   * @see AbstractReferrableObject#getKey()
-   */
+  @Override
   public String getKey() {
     if (getAction() != null) {
       return getAction().getName();

--- a/core-services/workflow/src/main/java/org/silverpeas/core/workflow/engine/model/ActionRefs.java
+++ b/core-services/workflow/src/main/java/org/silverpeas/core/workflow/engine/model/ActionRefs.java
@@ -53,38 +53,21 @@ public class ActionRefs implements Serializable, AllowedActions {
     actionRefList = new ArrayList<>();
   }
 
-  /*
-   * (non-Javadoc)
-   * @seecom.silverpeas.workflow.api.model.AllowedActions#addAllowedAction(com.
-   * silverpeas.workflow.api.model.AllowedAction)
-   */
   @Override
   public void addAllowedAction(AllowedAction allowedAction) {
     actionRefList.add(allowedAction);
   }
 
-  /*
-   * (non-Javadoc)
-   * @see AllowedActions#createAllowedAction()
-   */
   @Override
   public AllowedAction createAllowedAction() {
     return new ActionRef();
   }
 
-  /*
-   * (non-Javadoc)
-   * @see AllowedActions#iterateAllowedAction()
-   */
   @Override
   public Iterator<AllowedAction> iterateAllowedAction() {
     return actionRefList.iterator();
   }
 
-  /*
-   * (non-Javadoc)
-   * @see AllowedActions#getAllowedActions()
-   */
   @Override
   public Action[] getAllowedActions() {
     if (actionRefList == null) {
@@ -100,10 +83,6 @@ public class ActionRefs implements Serializable, AllowedActions {
     return result;
   }
 
-  /*
-   * (non-Javadoc)
-   * @see AllowedActions#getAllowedAction(java. lang.String)
-   */
   @Override
   public AllowedAction getAllowedAction(String strActionName) {
     AllowedAction allowedAction = new ActionRef();

--- a/core-services/workflow/src/main/java/org/silverpeas/core/workflow/engine/model/ActionsImpl.java
+++ b/core-services/workflow/src/main/java/org/silverpeas/core/workflow/engine/model/ActionsImpl.java
@@ -54,29 +54,16 @@ public class ActionsImpl implements Serializable, Actions {
     actionList = new ArrayList<>();
   }
 
-  /*
-   * (non-Javadoc)
-   * @see Actions#addAction(com.silverpeas.workflow
-   * .api.model.Action)
-   */
   @Override
   public void addAction(Action action) {
     actionList.add(action);
   }
 
-  /*
-   * (non-Javadoc)
-   * @see Actions#createAction()
-   */
   @Override
   public Action createAction() {
     return new ActionImpl();
   }
 
-  /*
-   * (non-Javadoc)
-   * @see Actions#getAction(java.lang.String)
-   */
   @Override
   public Action getAction(String name) throws WorkflowException {
     for (Action action : actionList) {
@@ -88,43 +75,24 @@ public class ActionsImpl implements Serializable, Actions {
         "WorkflowEngine.EX_ERR_ACTION_NOT_FOUND_IN_MODEL", name);
   }
 
-  /*
-   * (non-Javadoc)
-   * @see Actions#getActions()
-   */
   @Override
   public Action[] getActions() {
     if (actionList == null) {
       return new Action[0];
     }
-    return actionList.toArray(new Action[actionList.size()]);
+    return actionList.toArray(new Action[0]);
   }
 
-  /*
-   * (non-Javadoc)
-   * @see Actions#iterateAction()
-   */
   @Override
   public Iterator<Action> iterateAction() {
     return actionList.iterator();
   }
 
-  /*
-   * (non-Javadoc)
-   * @see Actions#removeAction(java.lang.String)
-   */
   @Override
-  public void removeAction(String strActionName) throws WorkflowException {
+  public void removeAction(String strActionName) {
     if (actionList == null) {
       return;
     }
-    Action action = createAction();
-    action.setName(strActionName);
-
-    if (!actionList.remove(action)) {
-      throw new WorkflowException("ActionsImpl.removeAction()",
-          "workflowEngine.EX_ERR_ACTION_NOT_FOUND_IN_MODEL",
-          strActionName == null ? "<null>" : strActionName);
-    }
+    actionList.removeIf(action -> action.getName().equals(strActionName));
   }
 }

--- a/core-services/workflow/src/main/java/org/silverpeas/core/workflow/engine/model/ColumnImpl.java
+++ b/core-services/workflow/src/main/java/org/silverpeas/core/workflow/engine/model/ColumnImpl.java
@@ -26,19 +26,14 @@ package org.silverpeas.core.workflow.engine.model;
 import org.silverpeas.core.workflow.api.model.Column;
 import org.silverpeas.core.workflow.api.model.Item;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlIDREF;
-import javax.xml.bind.annotation.XmlRootElement;
-import java.io.Serializable;
+import javax.xml.bind.annotation.*;
 
 /**
  * Class implementing the representation of the &lt;column&gt; element of a Process Model.
  **/
 @XmlRootElement(name = "column")
 @XmlAccessorType(XmlAccessType.NONE)
-public class ColumnImpl implements Column, Serializable {
+public class ColumnImpl implements Column {
   private static final long serialVersionUID = 3766121048611753846L;
 
   @XmlIDREF

--- a/core-services/workflow/src/main/java/org/silverpeas/core/workflow/engine/model/ColumnsImpl.java
+++ b/core-services/workflow/src/main/java/org/silverpeas/core/workflow/engine/model/ColumnsImpl.java
@@ -23,26 +23,22 @@
  */
 package org.silverpeas.core.workflow.engine.model;
 
-import org.silverpeas.kernel.util.StringUtil;
 import org.silverpeas.core.workflow.api.model.Column;
 import org.silverpeas.core.workflow.api.model.Columns;
+import org.silverpeas.kernel.util.StringUtil;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import java.io.Serializable;
+import javax.xml.bind.annotation.*;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Class implementing the representation of the &lt;columns&gt; element of a Process Model.
  **/
 @XmlRootElement(name = "columns")
 @XmlAccessorType(XmlAccessType.NONE)
-public class ColumnsImpl implements Serializable, Columns {
+public class ColumnsImpl implements Columns {
   private static final long serialVersionUID = -179308759997989687L;
 
   @XmlElement(name = "column", type = ColumnImpl.class)
@@ -106,10 +102,8 @@ public class ColumnsImpl implements Serializable, Columns {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-
     final ColumnsImpl columns = (ColumnsImpl) o;
-
-    return roleName != null ? roleName.equals(columns.roleName) : columns.roleName == null;
+    return Objects.equals(roleName, columns.roleName);
   }
 
   @Override

--- a/core-services/workflow/src/main/java/org/silverpeas/core/workflow/engine/model/ConsequencesImpl.java
+++ b/core-services/workflow/src/main/java/org/silverpeas/core/workflow/engine/model/ConsequencesImpl.java
@@ -23,9 +23,6 @@
  */
 package org.silverpeas.core.workflow.engine.model;
 
-import java.io.Serializable;
-import java.util.Iterator;
-
 import org.silverpeas.core.workflow.api.model.Consequence;
 import org.silverpeas.core.workflow.api.model.Consequences;
 
@@ -34,6 +31,7 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -41,7 +39,7 @@ import java.util.List;
  */
 @XmlRootElement(name = "consequences")
 @XmlAccessorType(XmlAccessType.NONE)
-public class ConsequencesImpl implements Consequences, Serializable {
+public class ConsequencesImpl implements Consequences {
   private static final long serialVersionUID = 931366159263133929L;
   @XmlElement(name = "consequence", type = ConsequenceImpl.class)
   private List<Consequence> consequenceList;

--- a/core-services/workflow/src/main/java/org/silverpeas/core/workflow/engine/model/DataFolderImpl.java
+++ b/core-services/workflow/src/main/java/org/silverpeas/core/workflow/engine/model/DataFolderImpl.java
@@ -65,7 +65,7 @@ public class DataFolderImpl implements DataFolder, Serializable {
    */
   @Override
   public Item[] getItems() {
-    return itemList.toArray(new Item[itemList.size()]);
+    return itemList.toArray(new Item[0]);
   }
 
   /*
@@ -134,11 +134,6 @@ public class DataFolderImpl implements DataFolder, Serializable {
     }
   }
 
-  /**
-   * Converts this object in a RecordTemplate object
-   * @param readonly
-   * @return the resulting RecordTemplate
-   */
   @Override
   public RecordTemplate toRecordTemplate(String role, String lang, boolean readonly) throws
       WorkflowException {
@@ -149,37 +144,42 @@ public class DataFolderImpl implements DataFolder, Serializable {
 
     try {
       // Add all fields description in the RecordTemplate
-      for (Item item : itemList) {
-        // if item is map to a userfull detail, it must not be shown in userinfo form
-        if (item.getMapTo() == null || item.getMapTo().length() == 0) {
-          // create a new FieldTemplate and set attributes
-          GenericFieldTemplate ft = new GenericFieldTemplate(item.getName(), item.getType());
-
-          // add parameters to new FieldTemplate
-          Iterator<Parameter> parameters = item.iterateParameter();
-          while (parameters.hasNext()) {
-            Parameter parameter = parameters.next();
-            if (parameter != null) {
-              ft.addParameter(parameter.getName(), parameter.getValue());
-            }
-          }
-
-          if (role != null && lang != null) {
-            ft.setReadOnly(readonly);
-            ft.setMandatory(!readonly);
-
-            ft.addLabel(item.getLabel(role, lang), lang);
-          }
-
-          // add the new FieldTemplate in RecordTemplate
-          rt.addFieldTemplate(ft);
-        }
-      }
+      addFieldDescription(rt, role, lang, readonly);
     } catch (FormException fe) {
       throw new WorkflowException("DataFolderImpl.toRecordTemplate",
           "workflowEngine.EX_ERR_BUILD_FIELD_TEMPLATE", fe);
     }
 
     return rt;
+  }
+
+  private void addFieldDescription(GenericRecordTemplate rt, String role, String lang,
+      boolean readonly) throws FormException {
+    for (Item item : itemList) {
+      // if item is map to a userfull detail, it must not be shown in userinfo form
+      if (item.getMapTo() == null || item.getMapTo().isEmpty()) {
+        // create a new FieldTemplate and set attributes
+        GenericFieldTemplate ft = new GenericFieldTemplate(item.getName(), item.getType());
+
+        // add parameters to new FieldTemplate
+        Iterator<Parameter> parameters = item.iterateParameter();
+        while (parameters.hasNext()) {
+          Parameter parameter = parameters.next();
+          if (parameter != null) {
+            ft.addParameter(parameter.getName(), parameter.getValue());
+          }
+        }
+
+        if (role != null && lang != null) {
+          ft.setReadOnly(readonly);
+          ft.setMandatory(!readonly);
+
+          ft.addLabel(item.getLabel(role, lang), lang);
+        }
+
+        // add the new FieldTemplate in RecordTemplate
+        rt.addFieldTemplate(ft);
+      }
+    }
   }
 }

--- a/core-services/workflow/src/main/java/org/silverpeas/core/workflow/engine/model/FormImpl.java
+++ b/core-services/workflow/src/main/java/org/silverpeas/core/workflow/engine/model/FormImpl.java
@@ -43,6 +43,7 @@ import org.silverpeas.core.workflow.api.model.Form;
 import org.silverpeas.core.workflow.api.model.Input;
 import org.silverpeas.core.workflow.api.model.Item;
 import org.silverpeas.core.workflow.api.model.Parameter;
+import org.silverpeas.kernel.annotation.NonNull;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -85,63 +86,40 @@ public class FormImpl implements Form, Serializable {
     inputList = new Vector<>();
   }
 
-  /**
-   * Get the name of this form
-   * @return form's name
-   */
+  @Override
   public String getName() {
     return this.name;
   }
 
-  /*
-   * (non-Javadoc)
-   * @see Form#getRole()
-   */
+  @Override
   public String getRole() {
     return role;
   }
 
-  /**
-   * Get the name of HTML file to show this form if no HTML file is defined, XMLForm will be used to
-   * create the form
-   * @return form's name
-   */
+  @Override
   public String getHTMLFileName() {
     return this.htmlFileName;
   }
 
-  /**
-   * Set the name of HTML file to show this form if no HTML file is defined, XMLForm will be used to
-   * display the form
-   * @return form's name
-   */
+  @Override
   public void setHTMLFileName(String htmlFileName) {
     this.htmlFileName = htmlFileName;
   }
 
-  /**
-   * Get the inputs
-   * @return the inputs as an array
-   */
+  @Override
   public Input[] getInputs() {
     if (inputList == null) {
       return new Input[0];
     }
-    return inputList.toArray(new ItemRef[0]);
+    return inputList.toArray(new Input[0]);
   }
 
-  /*
-   * (non-Javadoc)
-   * @see Form#getInput(int)
-   */
+  @Override
   public Input getInput(int idx) {
     return inputList.get(idx);
   }
 
-  /*
-   * (non-Javadoc)
-   * @see Form#getInput(com.silverpeas.workflow .api.model.Input)
-   */
+  @Override
   public Input getInput(Input reference) {
     int idx = inputList.indexOf(reference);
 
@@ -152,88 +130,58 @@ public class FormImpl implements Form, Serializable {
     }
   }
 
-  /*
-   * (non-Javadoc)
-   * @see Form#addInput(com.silverpeas.workflow .api.model.Input)
-   */
+  @Override
   public void addInput(Input input) {
     inputList.add(input);
   }
 
-  /*
-   * (non-Javadoc)
-   * @see Form#iterateInput()
-   */
+  @Override
   public Iterator<Input> iterateInput() {
     return inputList.iterator();
   }
 
-  /*
-   * (non-Javadoc)
-   * @see Form#createInput()
-   */
+  @Override
   public Input createInput() {
     return new ItemRef();
   }
 
-  /*
-   * (non-Javadoc)
-   * @see Form#removeInput(int)
-   */
-  public void removeInput(int idx) throws WorkflowException {
+  @Override
+  public void removeInput(int idx) {
     inputList.remove(idx);
   }
 
-  /*
-   * (non-Javadoc)
-   * @see Form#getTitles()
-   */
+  @Override
   public ContextualDesignations getTitles() {
     return new SpecificLabelListHelper(titles);
   }
 
-  /*
-   * (non-Javadoc)
-   * @see Form#getTitle(java.lang.String, java.lang.String)
-   */
+  @Override
   public String getTitle(String role, String language) {
     return getTitles().getLabel(role, language);
   }
 
-  /**
-   * Set the name of this form
-   * @param name form's name
-   **/
+  @Override
   public void setName(String name) {
     this.name = name;
   }
 
-  /*
-   * (non-Javadoc)
-   * @see Form#setRole(java.lang.String)
-   */
+  @Override
   public void setRole(String role) {
     this.role = role;
   }
 
-  /**
-   * Converts this object in a RecordTemplate object
-   * @return the resulting RecordTemplate
-   */
+  @Override
   public RecordTemplate toRecordTemplate(String role, String lang)
       throws WorkflowException {
     return toRecordTemplate(role, lang, false);
   }
 
-  /**
-   * Converts this object in a DataRecord object
-   * @return the resulting DataRecord object with the default values set
-   */
+  @Override
   public DataRecord getDefaultRecord(String role, String lang, DataRecord data)
       throws WorkflowException {
     try {
-      String fieldName = "";
-      String value = "";
+      String fieldName;
+      String value;
       DataRecord defaultRecord = this.toRecordTemplate(role, lang).getEmptyRecord();
 
       if (inputList == null) {
@@ -242,10 +190,8 @@ public class FormImpl implements Form, Serializable {
 
       // Add all fields description in the RecordTemplate
       int count = 0;
-      for (int i = 0; i < inputList.size(); i++) {
+      for (Input input : inputList) {
         // Get the input
-        Input input = inputList.get(i);
-
         // Get the item name referenced by this input
         Item item = input.getItem();
         if (item == null) {
@@ -273,26 +219,19 @@ public class FormImpl implements Form, Serializable {
     }
   }
 
-  /**
-   * Converts this object in a RecordTemplate object
-   * @return the resulting RecordTemplate
-   */
+  @Override
   public RecordTemplate toRecordTemplate(String role, String lang,
       boolean readOnly) throws WorkflowException {
     GenericRecordTemplate rt = new GenericRecordTemplate();
-    String label = "";
-
     if (inputList == null) {
       return rt;
     }
 
-    int count = 0;
-
     try {
       // Add all fields description in the RecordTemplate
-      for (int i = 0; i < inputList.size(); i++) {
+      int count = 0;
+      for (Input input : inputList) {
         // Get the item definition
-        Input input = inputList.get(i);
         ItemImpl item = (ItemImpl) input.getItem();
         if (item == null) {
           item = new ItemImpl();
@@ -302,38 +241,12 @@ public class FormImpl implements Form, Serializable {
         }
 
         // create a new FieldTemplate and set attributes
-        GenericFieldTemplate ft = new GenericFieldTemplate(item.getName(), item
-            .getType());
-        if (readOnly) {
-          ft.setReadOnly(true);
-        } else {
-          ft.setReadOnly(input.isReadonly());
-        }
-        ft.setMandatory(input.isMandatory());
-        ft.setTemplateName("form:"+name);
-        if (input.getDisplayerName() != null
-            && input.getDisplayerName().length() > 0) {
-          ft.setDisplayerName(input.getDisplayerName());
-        }
+        GenericFieldTemplate ft = createNewFieldTemplate(input, item, readOnly);
 
-        if (role != null && lang != null) {
-          label = input.getLabel(role, lang);
-          if (label == null || label.length() == 0) {
-            ft.addLabel(item.getLabel(role, lang), lang);
-          } else {
-            ft.addLabel(label, lang);
-          }
-        }
+        setRoleInFieldTemplate(ft, input, item, role, lang);
 
         // add parameters
-        Iterator<Parameter> parameters = item.iterateParameter();
-        Parameter param = null;
-        while (parameters.hasNext()) {
-          param = parameters.next();
-          if (param != null) {
-            ft.addParameter(param.getName(), param.getValue());
-          }
-        }
+        addParametersInFieldTemplate(ft, item);
 
         // add the new FieldTemplate in RecordTemplate
         rt.addFieldTemplate(ft);
@@ -344,6 +257,48 @@ public class FormImpl implements Form, Serializable {
       throw new WorkflowException("FormImpl.toRecordTemplate()",
           "workflowEngine.EX_ERR_BUILD_FIELD_TEMPLATE", fe);
     }
+  }
+
+  private static void addParametersInFieldTemplate(GenericFieldTemplate ft, ItemImpl item) {
+    Iterator<Parameter> parameters = item.iterateParameter();
+    Parameter param;
+    while (parameters.hasNext()) {
+      param = parameters.next();
+      if (param != null) {
+        ft.addParameter(param.getName(), param.getValue());
+      }
+    }
+  }
+
+  private static void setRoleInFieldTemplate(GenericFieldTemplate ft, Input input, ItemImpl item,
+      String role, String lang) {
+    String label;
+    if (role != null && lang != null) {
+      label = input.getLabel(role, lang);
+      if (label == null || label.isEmpty()) {
+        ft.addLabel(item.getLabel(role, lang), lang);
+      } else {
+        ft.addLabel(label, lang);
+      }
+    }
+  }
+
+  @NonNull
+  private GenericFieldTemplate createNewFieldTemplate(Input input, ItemImpl item, boolean readOnly)
+      throws FormException {
+    GenericFieldTemplate ft = new GenericFieldTemplate(item.getName(), item.getType());
+    if (readOnly) {
+      ft.setReadOnly(true);
+    } else {
+      ft.setReadOnly(input.isReadonly());
+    }
+    ft.setMandatory(input.isMandatory());
+    ft.setTemplateName("form:" + name);
+    if (input.getDisplayerName() != null
+        && !input.getDisplayerName().isEmpty()) {
+      ft.setDisplayerName(input.getDisplayerName());
+    }
+    return ft;
   }
 
 }

--- a/core-services/workflow/src/main/java/org/silverpeas/core/workflow/engine/model/FormsImpl.java
+++ b/core-services/workflow/src/main/java/org/silverpeas/core/workflow/engine/model/FormsImpl.java
@@ -23,20 +23,17 @@
  */
 package org.silverpeas.core.workflow.engine.model;
 
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-
-import org.silverpeas.core.workflow.api.WorkflowException;
 import org.silverpeas.core.workflow.api.model.Form;
 import org.silverpeas.core.workflow.api.model.Forms;
-import org.silverpeas.core.exception.SilverpeasException;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
 
 /**
  * Class implementing the representation of the &lt;forms&gt; element of a Process Model.
@@ -96,13 +93,12 @@ public class FormsImpl implements Serializable, Forms {
   public Form getForm(String name, String role) {
     Form form2Return = null;
     for (Form form : formList) {
-      if (name.equals(form.getName())) {
-        if (role != null && role.equalsIgnoreCase(form.getRole())) {
-          form2Return = form;
-        } else if (form.getRole() == null && form2Return == null) {
+      if (name.equals(form.getName()) &&
+          (role != null && role.equalsIgnoreCase(form.getRole()) ||
+            form.getRole() == null && form2Return == null)) {
           form2Return = form;
         }
-      }
+
     }
 
     return form2Return;
@@ -122,7 +118,7 @@ public class FormsImpl implements Serializable, Forms {
    * @see Forms#removeForm(java.lang.String, java.lang.String)
    */
   @Override
-  public void removeForm(String strName, String strRole) throws WorkflowException {
+  public void removeForm(String strName, String strRole) {
     Iterator<Form> iter = formList.iterator();
     while (iter.hasNext()) {
       Form form = iter.next();
@@ -132,8 +128,5 @@ public class FormsImpl implements Serializable, Forms {
         return;
       }
     }
-    throw new WorkflowException("FormsImpl.removeForm", SilverpeasException.ERROR,
-        "workflowEngine.EX_FORM_NOT_FOUND");
-
   }
 }

--- a/core-services/workflow/src/main/java/org/silverpeas/core/workflow/engine/model/ItemRef.java
+++ b/core-services/workflow/src/main/java/org/silverpeas/core/workflow/engine/model/ItemRef.java
@@ -28,13 +28,7 @@ import org.silverpeas.core.workflow.api.model.ContextualDesignations;
 import org.silverpeas.core.workflow.api.model.Input;
 import org.silverpeas.core.workflow.api.model.Item;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlIDREF;
-import javax.xml.bind.annotation.XmlRootElement;
-import java.io.Serializable;
+import javax.xml.bind.annotation.*;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -43,7 +37,7 @@ import java.util.List;
  **/
 @XmlRootElement(name = "input")
 @XmlAccessorType(XmlAccessType.NONE)
-public class ItemRef implements Input, Serializable {
+public class ItemRef implements Input {
   private static final long serialVersionUID = 4356623937044121281L;
   @XmlIDREF
   @XmlAttribute
@@ -117,6 +111,7 @@ public class ItemRef implements Input, Serializable {
    * Get default value
    * @return default value
    */
+  @Override
   public String getValue() {
     return this.value;
   }

--- a/core-services/workflow/src/main/java/org/silverpeas/core/workflow/engine/model/ParameterImpl.java
+++ b/core-services/workflow/src/main/java/org/silverpeas/core/workflow/engine/model/ParameterImpl.java
@@ -24,6 +24,7 @@
 package org.silverpeas.core.workflow.engine.model;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 import org.silverpeas.core.workflow.api.model.Parameter;
 
@@ -64,6 +65,7 @@ public class ParameterImpl implements Parameter, Serializable {
    * Get the name of the Parameter
    * @return parameter's name
    */
+  @Override
   public String getName() {
     return this.name;
   }
@@ -72,6 +74,7 @@ public class ParameterImpl implements Parameter, Serializable {
    * Set the name of the Parameter
    * @param name parameter's name
    */
+  @Override
   public void setName(String name) {
     this.name = name;
   }
@@ -80,6 +83,7 @@ public class ParameterImpl implements Parameter, Serializable {
    * Get the value of the Parameter
    * @return parameter's value
    */
+  @Override
   public String getValue() {
     return this.value;
   }
@@ -88,6 +92,7 @@ public class ParameterImpl implements Parameter, Serializable {
    * Set the value of the Parameter
    * @param value parameter's value
    */
+  @Override
   public void setValue(String value) {
     this.value = value;
   }
@@ -100,10 +105,8 @@ public class ParameterImpl implements Parameter, Serializable {
     if (!(o instanceof ParameterImpl)) {
       return false;
     }
-
     final ParameterImpl parameter = (ParameterImpl) o;
-
-    return name != null ? name.equals(parameter.name) : parameter.name == null;
+    return Objects.equals(name, parameter.name);
   }
 
   @Override

--- a/core-services/workflow/src/main/java/org/silverpeas/core/workflow/engine/model/ParticipantImpl.java
+++ b/core-services/workflow/src/main/java/org/silverpeas/core/workflow/engine/model/ParticipantImpl.java
@@ -23,27 +23,20 @@
  */
 package org.silverpeas.core.workflow.engine.model;
 
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.List;
-
 import org.silverpeas.core.workflow.api.model.ContextualDesignation;
 import org.silverpeas.core.workflow.api.model.ContextualDesignations;
 import org.silverpeas.core.workflow.api.model.Participant;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlID;
-import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.*;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Class implementing the representation of the &lt;participant&gt; element of a Process Model.
  **/
 @XmlRootElement(name = "participant")
 @XmlAccessorType(XmlAccessType.NONE)
-public class ParticipantImpl implements Participant, Serializable {
+public class ParticipantImpl implements Participant {
   private static final long serialVersionUID = -6272061474366848845L;
   @XmlID
   @XmlAttribute
@@ -79,14 +72,12 @@ public class ParticipantImpl implements Participant, Serializable {
    * given language, if not found again, return the default description in default language, if not
    * found again, return empty string.
    */
+  @Override
   public String getDescription(String role, String language) {
     return getDescriptions().getLabel(role, language);
   }
 
-  /*
-   * (non-Javadoc)
-   * @see Participant#getDescriptions()
-   */
+  @Override
   public ContextualDesignations getDescriptions() {
     return new SpecificLabelListHelper(descriptions);
   }
@@ -100,46 +91,32 @@ public class ParticipantImpl implements Participant, Serializable {
    * found again, return the default label in default language, if not found again, return empty
    * string.
    */
+  @Override
   public String getLabel(String role, String language) {
     return getLabels().getLabel(role, language);
   }
 
-  /*
-   * (non-Javadoc)
-   * @see Participant#getLabels()
-   */
+  @Override
   public ContextualDesignations getLabels() {
     return new SpecificLabelListHelper(labels);
   }
 
-  /**
-   * Get the name of this participant
-   * @return participant's name
-   */
+  @Override
   public String getName() {
     return this.name;
   }
 
-  /**
-   * Get the state that defined participant has resolved
-   * @return state that defined participant has resolved
-   */
+  @Override
   public String getResolvedState() {
     return this.resolvedState;
   }
 
-  /*
-   * (non-Javadoc)
-   * @see Participant#setName(java.lang.String)
-   */
+  @Override
   public void setName(String name) {
     this.name = name;
   }
 
-  /*
-   * (non-Javadoc)
-   * @see Participant#setResolvedState(java.lang .String)
-   */
+  @Override
   public void setResolvedState(String resolvedState) {
     this.resolvedState = resolvedState;
   }

--- a/core-services/workflow/src/main/java/org/silverpeas/core/workflow/engine/model/ParticipantsImpl.java
+++ b/core-services/workflow/src/main/java/org/silverpeas/core/workflow/engine/model/ParticipantsImpl.java
@@ -23,12 +23,6 @@
  */
 package org.silverpeas.core.workflow.engine.model;
 
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-
-import org.silverpeas.core.workflow.api.WorkflowException;
 import org.silverpeas.core.workflow.api.model.Participant;
 import org.silverpeas.core.workflow.api.model.Participants;
 
@@ -36,6 +30,10 @@ import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
 
 /**
  * Class implementing the representation of the &lt;participants&gt; element of a Process Model.
@@ -83,7 +81,7 @@ public class ParticipantsImpl implements Serializable, Participants {
     if (participantList == null) {
       return new Participant[0];
     }
-    return participantList.toArray(new Participant[participantList.size()]);
+    return participantList.toArray(new Participant[0]);
   }
 
   /**
@@ -118,16 +116,10 @@ public class ParticipantsImpl implements Serializable, Participants {
    * @see Participants#removeParticipant(java.lang .String)
    */
   @Override
-  public void removeParticipant(String strParticipantName) throws WorkflowException {
-    Participant participant = createParticipant();
-    participant.setName(strParticipantName);
+  public void removeParticipant(String strParticipantName) {
     if (participantList == null) {
       return;
     }
-    if (!participantList.remove(participant)) {
-      throw new WorkflowException("ParticipantsImpl.removeParticipant()",
-          "workflowEngine.EX_PARTICIPANT_NOT_FOUND",
-          strParticipantName == null ? "<null>" : strParticipantName);
-    }
+    participantList.removeIf(p -> p.getName().equals(strParticipantName));
   }
 }

--- a/core-services/workflow/src/main/java/org/silverpeas/core/workflow/engine/model/PresentationImpl.java
+++ b/core-services/workflow/src/main/java/org/silverpeas/core/workflow/engine/model/PresentationImpl.java
@@ -23,18 +23,12 @@
  */
 package org.silverpeas.core.workflow.engine.model;
 
-import org.silverpeas.core.workflow.api.WorkflowException;
-import org.silverpeas.core.workflow.api.model.Column;
-import org.silverpeas.core.workflow.api.model.Columns;
-import org.silverpeas.core.workflow.api.model.ContextualDesignation;
-import org.silverpeas.core.workflow.api.model.ContextualDesignations;
-import org.silverpeas.core.workflow.api.model.Presentation;
+import org.silverpeas.core.workflow.api.model.*;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -45,7 +39,7 @@ import java.util.Vector;
  **/
 @XmlRootElement(name = "presentation")
 @XmlAccessorType(XmlAccessType.NONE)
-public class PresentationImpl implements Presentation, Serializable {
+public class PresentationImpl implements Presentation {
 
   private static final long serialVersionUID = 8175832964614235239L;
   @XmlElement(name = "title", type = SpecificLabel.class)
@@ -61,23 +55,12 @@ public class PresentationImpl implements Presentation, Serializable {
     columnsList = new Vector<>();
   }
 
-  // //////////////////
-  // titles
-  // //////////////////
-
-  /*
-   * (non-Javadoc)
-   * @see Presentation#getTitles()
-   */
+  @Override
   public ContextualDesignations getTitles() {
     return new SpecificLabelListHelper(titles);
   }
 
-  /*
-   * (non-Javadoc)
-   * @see Presentation#getTitle(java.lang.String,
-   * java.lang.String)
-   */
+  @Override
   public String getTitle(String role, String language) {
     return getTitles().getLabel(role, language);
   }
@@ -88,6 +71,7 @@ public class PresentationImpl implements Presentation, Serializable {
    * @param strRoleName the name of the role
    * @return the contents of 'Columns' as an array of 'Column'
    */
+  @Override
   public Column[] getColumns(String strRoleName) {
     Columns columns = getColumnsByRole(strRoleName);
     if (columns == null) {
@@ -96,10 +80,7 @@ public class PresentationImpl implements Presentation, Serializable {
     return columns.getColumnList().toArray(new Column[0]);
   }
 
-  /*
-   * (non-Javadoc)
-   * @see Presentation#getColumnsByRole(java.lang .String)
-   */
+  @Override
   public Columns getColumnsByRole(String strRoleName) {
     Columns search;
     int index;
@@ -126,42 +107,26 @@ public class PresentationImpl implements Presentation, Serializable {
     }
   }
 
-  /*
-   * (non-Javadoc)
-   * @see Presentation#createColumns()
-   */
+  @Override
   public Columns createColumns() {
     return new ColumnsImpl();
   }
 
-  /*
-   * (non-Javadoc)
-   * @see Presentation#addColumns(com.silverpeas
-   * .workflow.api.model.Columns)
-   */
+  @Override
   public void addColumns(Columns columns) {
     columnsList.add(columns);
   }
 
-  /*
-   * (non-Javadoc)
-   * @see Presentation#iterateColumns()
-   */
+  @Override
   public Iterator<Columns> iterateColumns() {
     return columnsList.iterator();
   }
 
-  /*
-   * (non-Javadoc)
-   * @see Presentation#deleteColumns(java.lang. String)
-   */
-  public void deleteColumns(String strRoleName) throws WorkflowException {
-    Columns search = createColumns();
-    search.setRoleName(strRoleName);
-    if (!columnsList.remove(search)) {
-      throw new WorkflowException("PresentationImpl.deleteColumns",
-          "workflowEngine.EX_COLUMNS_NOT_FOUND",
-          "Columns role name=" + (strRoleName == null ? "<null>" : strRoleName));
+  @Override
+  public void deleteColumns(String strRoleName) {
+    if (columnsList == null) {
+      return;
     }
+    columnsList.removeIf(c -> c.getRoleName().equals(strRoleName));
   }
 }

--- a/core-services/workflow/src/main/java/org/silverpeas/core/workflow/engine/model/ProcessModelImpl.java
+++ b/core-services/workflow/src/main/java/org/silverpeas/core/workflow/engine/model/ProcessModelImpl.java
@@ -115,68 +115,45 @@ public class ProcessModelImpl implements ProcessModel, Serializable {
     labels = new ArrayList<>();
     descriptions = new ArrayList<>();
     presentation = createPresentation();
+    dataFolder = new DataFolderImpl();
   }
 
-  /**
-   * Get the id of this process model
-   * @return process model id
-   */
+  @Override
   public String getModelId() {
     return this.modelId;
   }
 
-  /**
-   * Set the id of this process model
-   * @param modelId process model id
-   */
+  @Override
   public void setModelId(String modelId) {
     this.modelId = modelId;
   }
 
-  /**
-   * Get the name of this process model
-   * @return process model's name
-   */
+  @Override
   public String getName() {
     return this.name;
   }
 
-  /**
-   * Set the name of this process model
-   * @param name process model's name
-   */
+  @Override
   public void setName(String name) {
     this.name = name;
   }
 
-  /**
-   * Get the presentation configuration
-   * @return presentation configuration
-   */
+  @Override
   public Presentation getPresentation() {
     return presentation;
   }
 
-  /**
-   * Set the presentation's configuration
-   * @param presentation presentation's configuration
-   */
+  @Override
   public void setPresentation(Presentation presentation) {
     this.presentation = presentation;
   }
 
-  /*
-   * (non-Javadoc)
-   * @see ProcessModel#createPresentation()
-   */
+  @Override
   public Presentation createPresentation() {
     return new PresentationImpl();
   }
 
-  /**
-   * Get the participants definition
-   * @return participants definition
-   */
+  @Override
   public Participant[] getParticipants() {
     if (participants == null) {
       return new Participant[0];
@@ -184,34 +161,22 @@ public class ProcessModelImpl implements ProcessModel, Serializable {
     return participants.getParticipants();
   }
 
-  /*
-   * (non-Javadoc)
-   * @see ProcessModel#getAllParticipants()
-   */
+  @Override
   public Participants getParticipantsEx() {
     return participants;
   }
 
-  /**
-   * Set the participants definition
-   * @param participants participants definition
-   */
+  @Override
   public void setParticipants(Participants participants) {
     this.participants = participants;
   }
 
-  /*
-   * (non-Javadoc)
-   * @see ProcessModel#createParticipants()
-   */
+  @Override
   public Participants createParticipants() {
     return new ParticipantsImpl();
   }
 
-  /**
-   * Get the roles definition
-   * @return roles definition
-   */
+  @Override
   public Role[] getRoles() {
     if (roles == null) {
       return new Role[0];
@@ -219,11 +184,7 @@ public class ProcessModelImpl implements ProcessModel, Serializable {
     return roles.getRoles();
   }
 
-  /**
-   * Get the role definition with given name
-   * @param name role name
-   * @return wanted role definition
-   */
+  @Override
   public Role getRole(String name) {
     if (roles == null) {
       return null;
@@ -231,34 +192,22 @@ public class ProcessModelImpl implements ProcessModel, Serializable {
     return roles.getRole(name);
   }
 
-  /*
-   * (non-Javadoc)
-   * @see ProcessModel#getAllRoles()
-   */
+  @Override
   public Roles getRolesEx() {
     return roles;
   }
 
-  /**
-   * Set the roles definition
-   * @param roles roles definition
-   */
+  @Override
   public void setRoles(Roles roles) {
     this.roles = roles;
   }
 
-  /*
-   * (non-Javadoc)
-   * @see ProcessModel#createRoles()
-   */
+  @Override
   public Roles createRoles() {
     return new RolesImpl();
   }
 
-  /**
-   * Get the states defined for this process model
-   * @return states defined for this process model
-   */
+  @Override
   public State[] getStates() {
     if (states == null) {
       return new State[0];
@@ -266,19 +215,12 @@ public class ProcessModelImpl implements ProcessModel, Serializable {
     return states.getStates();
   }
 
-  /*
-   * (non-Javadoc)
-   * @see ProcessModel#getAllStates()
-   */
+  @Override
   public States getStatesEx() {
     return states;
   }
 
-  /**
-   * Get the state with the given name
-   * @param name state name
-   * @return wanted state
-   */
+  @Override
   public State getState(String name) {
     if (states == null) {
       return null;
@@ -286,26 +228,17 @@ public class ProcessModelImpl implements ProcessModel, Serializable {
     return states.getState(name);
   }
 
-  /**
-   * Set the states defined for this process model
-   * @param states states defined for this process model
-   */
+  @Override
   public void setStates(States states) {
     this.states = states;
   }
 
-  /*
-   * (non-Javadoc)
-   * @see ProcessModel#createStates()
-   */
+  @Override
   public States createStates() {
     return new StatesImpl();
   }
 
-  /**
-   * Get the actions defined for this process model
-   * @return actions defined for this process model
-   */
+  @Override
   public Action[] getActions() {
     if (actions == null) {
       return new Action[0];
@@ -313,19 +246,12 @@ public class ProcessModelImpl implements ProcessModel, Serializable {
     return actions.getActions();
   }
 
-  /*
-   * (non-Javadoc)
-   * @see ProcessModel#getAllActions()
-   */
+  @Override
   public Actions getActionsEx() {
     return actions;
   }
 
-  /**
-   * Get the action with the given name
-   * @param name action name
-   * @return the wanted action
-   */
+  @Override
   public Action getAction(String name) throws WorkflowException {
     if (actions == null) {
       return null;
@@ -333,86 +259,52 @@ public class ProcessModelImpl implements ProcessModel, Serializable {
     return actions.getAction(name);
   }
 
-  /**
-   * Set the actions defined for this process model
-   * @param actions actions defined for this process model
-   */
+  @Override
   public void setActions(Actions actions) {
     this.actions = actions;
   }
 
-  /*
-   * (non-Javadoc)
-   * @see ProcessModel#createActions()
-   */
+  @Override
   public Actions createActions() {
     return new ActionsImpl();
   }
 
-  /**
-   * Get the data folder defined for this process model
-   * @return data folder defined for this process model. it contains all the items declarations
-   */
+  @Override
   public DataFolder getDataFolder() {
     return dataFolder;
   }
 
-  /**
-   * Set the data folder defined for this process model
-   * @param dataFolder data folder defined for this process model. it contains all the items
-   * declarations
-   */
+  @Override
   public void setDataFolder(DataFolder dataFolder) {
     this.dataFolder = dataFolder;
   }
 
-  /*
-   * (non-Javadoc)
-   * @see ProcessModel#createDataFolder()
-   */
+  @Override
   public DataFolder createDataFolder() {
     return new DataFolderImpl();
   }
 
-  /**
-   * Get the user infos defined for this process model It contains all the items necessary about
-   * user to allow him to use the instance
-   * @return user infos defined for this process model.
-   */
+  @Override
   public DataFolder getUserInfos() {
     return userInfos;
   }
 
-  /**
-   * Set the user infos defined for this process model It contains all the items necessary about
-   * user to allow him to use the instance
-   * @param userInfos user infos defined for this process model.
-   */
+  @Override
   public void setUserInfos(DataFolder userInfos) {
     this.userInfos = userInfos;
   }
 
-  /*
-   * (non-Javadoc)
-   * @see ProcessModel#getAllForms()
-   */
+  @Override
   public Forms getForms() {
     return forms;
   }
 
-  /**
-   * Get the form with the given name
-   * @param name form name
-   * @return the wanted form
-   */
+  @Override
   public Form getForm(String name) {
     return getForm(name, null);
   }
 
-  /*
-   * (non-Javadoc)
-   * @see ProcessModel#getForm(java.lang.String, java.lang.String)
-   */
+  @Override
   public Form getForm(String name, String role) {
     if (forms == null) {
       return null;
@@ -420,98 +312,57 @@ public class ProcessModelImpl implements ProcessModel, Serializable {
     return forms.getForm(name, role);
   }
 
-  /**
-   * Set the forms defined for this process model
-   * @param forms forms defined for this process model.
-   */
+  @Override
   public void setForms(Forms forms) {
     this.forms = forms;
   }
 
-  /*
-   * (non-Javadoc)
-   * @see ProcessModel#createForms()
-   */
+  @Override
   public Forms createForms() {
     return new FormsImpl();
   }
 
-  /*
-   * (non-Javadoc)
-   * @see ProcessModel#getLabels()
-   */
+  @Override
   public ContextualDesignations getLabels() {
     return new SpecificLabelListHelper(labels);
   }
 
-  /**
-   * Get label in specific language for the given role
-   * @param role role for which the label is
-   * @param language label's language
-   * @return wanted label as a String object. If label is not found, search label with given role
-   * and default language, if not found again, return the default label in given language, if not
-   * found again, return the default label in default language, if not found again, return empty
-   * string.
-   */
+  @Override
   public String getLabel(String role, String language) {
     return getLabels().getLabel(role, language);
   }
 
-  /*
-   * (non-Javadoc)
-   * @see ProcessModel#getDescriptions()
-   */
+  @Override
   public ContextualDesignations getDescriptions() {
     return new SpecificLabelListHelper(descriptions);
   }
 
-  /**
-   * Get description in specific language for the given role
-   * @param role role for which the description is
-   * @param language description's language
-   * @return wanted description as a String object. If description is not found, search description
-   * with given role and default language, if not found again, return the default description in
-   * given language, if not found again, return the default description in default language, if not
-   * found again, return empty string.
-   */
+  @Override
   public String getDescription(String role, String language) {
     return getDescriptions().getLabel(role, language);
   }
 
-  /*
-   * (non-Javadoc)
-   * @see ProcessModel#createQualifiedUsers()
-   */
+  @Override
   public QualifiedUsers createQualifiedUsers() {
     return new QualifiedUsersImpl();
   }
 
-  /*
-   * (non-Javadoc)
-   * @see ProcessModel#createRelatedUser()
-   */
+  @Override
   public RelatedUser createRelatedUser() {
     return new RelatedUserImpl();
   }
 
-  /**
-   * Returns the name of the record set where are saved all the folder of the instance built from
-   * this model.
-   */
+  @Override
   public String getFolderRecordSetName() {
     return modelId + ":" + "folder";
   }
 
-  /**
-   * Returns the name of the record set where are saved all the data of the named form.
-   */
+  @Override
   public String getFormRecordSetName(String formName) {
     return modelId + ":" + "form:" + formName;
   }
 
-  /**
-   * Returns the record set where are saved all the folder of the instance built from this model.
-   */
+  @Override
   public RecordSet getFolderRecordSet() throws WorkflowException {
     // Now, the folder is read from xml file and no more in database
     // This permit to add items to the folder
@@ -533,9 +384,7 @@ public class ProcessModelImpl implements ProcessModel, Serializable {
     return new GenericRecordSet(idTemplate);
   }
 
-  /**
-   * Returns the record set where are saved all the data of the named form.
-   */
+  @Override
   public RecordSet getFormRecordSet(String formName) throws WorkflowException {
     try {
       RecordSet recordSet =
@@ -586,19 +435,13 @@ public class ProcessModelImpl implements ProcessModel, Serializable {
     }
   }
 
-  /**
-   * Returns the form (if any) associated to the named action. Returns null if the action has no
-   * form. Throws a WorkflowException if the action is unknown.
-   */
+  @Override
   public Form getActionForm(String actionName) throws WorkflowException {
     Action action = getAction(actionName);
     return action.getForm();
   }
 
-  /**
-   * Returns the action of kind create Throws a WorkflowException if there is no action of type
-   * create
-   */
+  @Override
   public Action getCreateAction(String role) throws WorkflowException {
     Action[] someActions = getActions();
 
@@ -619,11 +462,7 @@ public class ProcessModelImpl implements ProcessModel, Serializable {
     throw new WorkflowException(PROCESS_MODEL, "workflowEngine.ERR_NO_CREATE_ACTION_DEFINED");
   }
 
-  /**
-   * Returns the Form which be used to publish the form associated to the named
-   * action. Returns null if the action has no form. Throws a WorkflowException if the action is
-   * unknown.
-   */
+  @Override
   public org.silverpeas.core.contribution.content.form.Form getPublicationForm(String actionName, String roleName,
       String lang) throws WorkflowException {
     Action action = getAction(actionName);
@@ -634,10 +473,7 @@ public class ProcessModelImpl implements ProcessModel, Serializable {
     return getConcreteForm(action.getForm(), roleName, lang, false);
   }
 
-  /**
-   * Returns the Form which be used to publish the form associated to the named
-   * action or form. Returns null if the action has no form.
-   */
+  @Override
   public org.silverpeas.core.contribution.content.form.Form getPresentationForm(String name, String roleName, String lang)
       throws WorkflowException {
     Action action = null;
@@ -694,6 +530,7 @@ public class ProcessModelImpl implements ProcessModel, Serializable {
    * @param roleName  Role of the current user
    * @param lang Lang of the current user
    */
+  @Override
   public DataRecord getNewActionRecord(String actionName, String roleName, String lang,
       DataRecord data) throws WorkflowException {
     Action action = getAction(actionName);
@@ -709,6 +546,7 @@ public class ProcessModelImpl implements ProcessModel, Serializable {
    * @param roleName Role of the current user
    * @param lang Lang of the current user
    */
+  @Override
   public DataRecord getNewUserInfosRecord(String roleName, String lang) throws WorkflowException {
     try {
       return this.getUserInfos().toRecordTemplate(roleName, lang, false).getEmptyRecord();
@@ -721,6 +559,7 @@ public class ProcessModelImpl implements ProcessModel, Serializable {
   /**
    * Returns the roles under which an user can create a new instance
    */
+  @Override
   public String[] getCreationRoles() throws WorkflowException {
     try {
       List<String> someRoles = new ArrayList<>();
@@ -754,6 +593,7 @@ public class ProcessModelImpl implements ProcessModel, Serializable {
    * @param role Role of the current user
    * @param lang Lang of the current user
    */
+  @Override
   public RecordTemplate getAllDataTemplate(String role, String lang) {
     RecordTemplate template = instanceDataTemplates.get(role + "\n" + lang);
 
@@ -772,6 +612,7 @@ public class ProcessModelImpl implements ProcessModel, Serializable {
    * @param role Role of the current user
    * @param lang Lang of the current user
    */
+  @Override
   public RecordTemplate getRowTemplate(String role, String lang) {
     RecordTemplate template = rowTemplates.get(role + "\n" + lang);
 
@@ -791,6 +632,7 @@ public class ProcessModelImpl implements ProcessModel, Serializable {
    * @param lang Lang of the current user
    * @param isProcessIdVisible Case if id is deplayed or not
    */
+  @Override
   public RecordTemplate getRowTemplate(String role, String lang, boolean isProcessIdVisible) {
     RecordTemplate template = rowTemplates.get(role + "\n" + lang);
     if (template == null) {

--- a/core-services/workflow/src/main/java/org/silverpeas/core/workflow/engine/model/ProcessModelManagerImpl.java
+++ b/core-services/workflow/src/main/java/org/silverpeas/core/workflow/engine/model/ProcessModelManagerImpl.java
@@ -73,7 +73,7 @@ public class ProcessModelManagerImpl implements ProcessModelManager {
   /**
    * ResourceLocator object to retrieve settings in a properties file
    */
-  private static SettingBundle settings =
+  private static final SettingBundle settings =
       ResourceLocator.getSettingBundle("org.silverpeas.workflow.engine.settings");
 
   /**
@@ -110,7 +110,7 @@ public class ProcessModelManagerImpl implements ProcessModelManager {
    * Recursive method to retrieve all process models in and below the given directory
    * @param strProcessModelDir the directory to start with
    * @return a list of strings containing the relative path and file name of the model
-   * @throws IOException
+   * @throws IOException if an IO error occurs
    */
   private List<String> findProcessModels(String strProcessModelDir) throws IOException {
     Iterator<File> subFoldersIterator =
@@ -186,7 +186,7 @@ public class ProcessModelManagerImpl implements ProcessModelManager {
    * @see ProcessModelManager#createProcessModelDescriptor ()
    */
   @Override
-  public ProcessModel createProcessModelDescriptor() throws WorkflowException {
+  public ProcessModel createProcessModelDescriptor() {
     return new ProcessModelImpl();
   }
 
@@ -362,7 +362,7 @@ public class ProcessModelManagerImpl implements ProcessModelManager {
   @Override
   public String getProcessModelDir() {
     String dir = FileUtil.convertPathToServerOS(settings.getString("ProcessModelDir", null));
-    if (dir != null && !dir.endsWith(File.separator)) {
+    if (!dir.endsWith(File.separator)) {
       dir = dir + File.separatorChar;
     }
     return dir;
@@ -384,7 +384,7 @@ public class ProcessModelManagerImpl implements ProcessModelManager {
       while (rs.next()) {
         peasIds.add(rs.getString(1));
       }
-      return peasIds.toArray(new String[peasIds.size()]);
+      return peasIds.toArray(new String[0]);
     } catch (SQLException se) {
       throw new WorkflowException("ProcessModelManagerImpl.getAllPeasId",
           "workflowEngine.EX_ERR_GET_ALL_PEAS_IDS",
@@ -444,7 +444,7 @@ public class ProcessModelManagerImpl implements ProcessModelManager {
   protected String getProcessPath(String processFileName) {
     String processModelDir = settings.getString("ProcessModelDir");
     processModelDir = processModelDir.replace('\\', '/');
-    if (processModelDir.length() > 0 && !processModelDir.endsWith("/")) {
+    if (!processModelDir.isEmpty() && !processModelDir.endsWith("/")) {
       processModelDir = processModelDir + '/';
     }
     return processModelDir + processFileName;

--- a/core-services/workflow/src/main/java/org/silverpeas/core/workflow/engine/model/QualifiedUsersImpl.java
+++ b/core-services/workflow/src/main/java/org/silverpeas/core/workflow/engine/model/QualifiedUsersImpl.java
@@ -23,7 +23,6 @@
  */
 package org.silverpeas.core.workflow.engine.model;
 
-import org.silverpeas.core.workflow.api.WorkflowException;
 import org.silverpeas.core.workflow.api.model.QualifiedUsers;
 import org.silverpeas.core.workflow.api.model.RelatedGroup;
 import org.silverpeas.core.workflow.api.model.RelatedUser;
@@ -33,7 +32,6 @@ import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
-import java.io.Serializable;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Vector;
@@ -43,7 +41,7 @@ import java.util.Vector;
  * &lt;notifiedUsers&gt; and &lt;interestedUsers&gt; elements of a Process Model.
  **/
 @XmlAccessorType(XmlAccessType.NONE)
-public class QualifiedUsersImpl implements QualifiedUsers, Serializable {
+public class QualifiedUsersImpl implements QualifiedUsers {
 
   private static final long serialVersionUID = -6137211965745730173L;
   @XmlElement(name = "userInRole", type = UserInRoleImpl.class)
@@ -74,6 +72,7 @@ public class QualifiedUsersImpl implements QualifiedUsers, Serializable {
    * Get the userInRoles
    * @return the userInRoles as a Vector
    */
+  @Override
   public UserInRole getUserInRole(String strRoleName) {
     UserInRole userInRole = new UserInRoleImpl();
     userInRole.setRoleName(strRoleName);
@@ -91,7 +90,7 @@ public class QualifiedUsersImpl implements QualifiedUsers, Serializable {
    */
   @Override
   public UserInRole[] getUserInRoles() {
-    return userInRoleList.toArray(new UserInRole[userInRoleList.size()]);
+    return userInRoleList.toArray(new UserInRole[0]);
   }
 
   /*
@@ -137,7 +136,7 @@ public class QualifiedUsersImpl implements QualifiedUsers, Serializable {
    */
   @Override
   public RelatedUser[] getRelatedUsers() {
-    return relatedUserList.toArray(new RelatedUser[relatedUserList.size()]);
+    return relatedUserList.toArray(new RelatedUser[0]);
   }
 
   /**
@@ -187,12 +186,8 @@ public class QualifiedUsersImpl implements QualifiedUsers, Serializable {
    * @see QualifiedUsers#removeRelatedUser(RelatedUser )
    */
   @Override
-  public void removeRelatedUser(RelatedUser reference) throws WorkflowException {
-    if (!relatedUserList.remove(reference)) {
-      throw new WorkflowException("QualifiedUsersImpl.removeRelatedUser()",
-          "workflowEngine.EX_RELATED_USER_NOT_FOUND", reference == null ? "<null>" : reference.
-          getRelation() + ", " + reference.getRole());
-    }
+  public void removeRelatedUser(RelatedUser reference) {
+    relatedUserList.remove(reference);
   }
 
   /**

--- a/core-services/workflow/src/main/java/org/silverpeas/core/workflow/engine/model/RelatedGroupImpl.java
+++ b/core-services/workflow/src/main/java/org/silverpeas/core/workflow/engine/model/RelatedGroupImpl.java
@@ -32,6 +32,7 @@ import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlIDREF;
 import javax.xml.bind.annotation.XmlRootElement;
 import java.io.Serializable;
+import java.util.Objects;
 
 /**
  * Class implementing the representation of the &lt;relatedUser&gt; element of a Process Model.
@@ -47,33 +48,22 @@ public class RelatedGroupImpl implements RelatedGroup, Serializable {
   @XmlAttribute
   private String role;
 
-  /**
-   * Get the referred item
-   */
+  @Override
   public Item getFolderItem() {
     return folderItem;
   }
 
-  /**
-   * Set the referred item
-   * @param folderItem item to refer
-   */
+  @Override
   public void setFolderItem(Item folderItem) {
     this.folderItem = (ItemImpl) folderItem;
   }
 
-  /**
-   * Get the role to which the related user will be affected
-   * @return the role name
-   */
+  @Override
   public String getRole() {
     return this.role;
   }
 
-  /**
-   * Set the role to which the related user will be affected
-   * @param role role as a String
-   */
+  @Override
   public void setRole(String role) {
     this.role = role;
   }
@@ -88,11 +78,7 @@ public class RelatedGroupImpl implements RelatedGroup, Serializable {
     }
 
     final RelatedGroupImpl that = (RelatedGroupImpl) o;
-
-    if (folderItem != null ? !folderItem.equals(that.folderItem) : that.folderItem != null) {
-      return false;
-    }
-    return role != null ? role.equals(that.role) : that.role == null;
+    return Objects.equals(folderItem, that.folderItem) && Objects.equals(role, that.role);
   }
 
   @Override

--- a/core-services/workflow/src/main/java/org/silverpeas/core/workflow/engine/model/RelatedUserImpl.java
+++ b/core-services/workflow/src/main/java/org/silverpeas/core/workflow/engine/model/RelatedUserImpl.java
@@ -27,19 +27,15 @@ import org.silverpeas.core.workflow.api.model.Item;
 import org.silverpeas.core.workflow.api.model.Participant;
 import org.silverpeas.core.workflow.api.model.RelatedUser;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlIDREF;
-import javax.xml.bind.annotation.XmlRootElement;
-import java.io.Serializable;
+import javax.xml.bind.annotation.*;
+import java.util.Objects;
 
 /**
  * Class implementing the representation of the &lt;relatedUser&gt; element of a Process Model.
  **/
 @XmlRootElement(name = "relatedUser")
 @XmlAccessorType(XmlAccessType.NONE)
-public class RelatedUserImpl implements RelatedUser, Serializable {
+public class RelatedUserImpl implements RelatedUser {
   private static final long serialVersionUID = -7371460894690406952L;
   @XmlIDREF
   @XmlAttribute
@@ -52,64 +48,42 @@ public class RelatedUserImpl implements RelatedUser, Serializable {
   @XmlAttribute
   private String role;
 
-  /**
-   * Get the referred participant
-   */
+  @Override
   public Participant getParticipant() {
     return participant;
   }
 
-  /*
-   * (non-Javadoc)
-   * @see RelatedUser#setParticipant(com.silverpeas
-   * .workflow.api.model.Participant)
-   */
+  @Override
   public void setParticipant(Participant participant) {
     this.participant = (ParticipantImpl) participant;
   }
 
-  /**
-   * Get the referred item
-   */
+  @Override
   public Item getFolderItem() {
     return folderItem;
   }
 
-  /**
-   * Set the referred item
-   * @param folderItem item to refer
-   */
+  @Override
   public void setFolderItem(Item folderItem) {
     this.folderItem = (ItemImpl) folderItem;
   }
 
-  /**
-   * Get the relation between user and participant
-   */
+  @Override
   public String getRelation() {
     return this.relation;
   }
 
-  /**
-   * Set the relation between user and participant
-   * @param relation relation as a String
-   */
+  @Override
   public void setRelation(String relation) {
     this.relation = relation;
   }
 
-  /**
-   * Get the role to which the related user will be affected
-   * @return the role name
-   */
+  @Override
   public String getRole() {
     return this.role;
   }
 
-  /**
-   * Set the role to which the related user will be affected
-   * @param role role as a String
-   */
+  @Override
   public void setRole(String role) {
     this.role = role;
   }
@@ -124,17 +98,10 @@ public class RelatedUserImpl implements RelatedUser, Serializable {
     }
 
     final RelatedUserImpl that = (RelatedUserImpl) o;
-
-    if (participant != null ? !participant.equals(that.participant) : that.participant != null) {
-      return false;
-    }
-    if (folderItem != null ? !folderItem.equals(that.folderItem) : that.folderItem != null) {
-      return false;
-    }
-    if (relation != null ? !relation.equals(that.relation) : that.relation != null) {
-      return false;
-    }
-    return role != null ? role.equals(that.role) : that.role == null;
+    return Objects.equals(participant, that.participant) &&
+        Objects.equals(folderItem, that.folderItem) &&
+        Objects.equals(relation, that.relation) &&
+        Objects.equals(role, that.role);
   }
 
   @Override

--- a/core-services/workflow/src/main/java/org/silverpeas/core/workflow/engine/model/RoleImpl.java
+++ b/core-services/workflow/src/main/java/org/silverpeas/core/workflow/engine/model/RoleImpl.java
@@ -23,26 +23,20 @@
  */
 package org.silverpeas.core.workflow.engine.model;
 
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.List;
-
 import org.silverpeas.core.workflow.api.model.ContextualDesignation;
 import org.silverpeas.core.workflow.api.model.ContextualDesignations;
 import org.silverpeas.core.workflow.api.model.Role;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.*;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Class implementing the representation of the &lt;role&gt; element of a Process Model.
  **/
 @XmlRootElement(name = "role")
 @XmlAccessorType(XmlAccessType.NONE)
-public class RoleImpl implements Role, Serializable {
+public class RoleImpl implements Role {
   private static final long serialVersionUID = 1005254939500303606L;
   @XmlAttribute
   private String name;
@@ -67,59 +61,37 @@ public class RoleImpl implements Role, Serializable {
     descriptions = new ArrayList<>();
   }
 
-  /**
-   * Get the name of the Role
-   * @return role's name
-   */
+  @Override
   public String getName() {
     return this.name;
   }
 
-  /*
-   * (non-Javadoc)
-   * @see Role#setName(java.lang.String)
-   */
+  @Override
   public void setName(String name) {
     this.name = name;
   }
 
-  /*
-   * (non-Javadoc)
-   * @see Role#getLabels()
-   */
+  @Override
   public ContextualDesignations getLabels() {
     return new SpecificLabelListHelper(labels);
   }
 
-  /*
-   * (non-Javadoc)
-   * @see Role#getLabel(java.lang.String, java.lang.String)
-   */
+  @Override
   public String getLabel(String role, String language) {
     return getLabels().getLabel(role, language);
   }
 
-  /*
-   * (non-Javadoc)
-   * @see Role#addLabel(com.silverpeas.workflow
-   * .api.model.ContextualDesignation)
-   */
+  @Override
   public void addLabel(ContextualDesignation label) {
     labels.add(label);
   }
 
-  /*
-   * (non-Javadoc)
-   * @see Role#getDescriptions()
-   */
+  @Override
   public ContextualDesignations getDescriptions() {
     return new SpecificLabelListHelper(descriptions);
   }
 
-  /*
-   * (non-Javadoc)
-   * @see Role#getDescription(java.lang.String, java.lang.String)
-   */
+  @Override
   public String getDescription(String role, String language) {
     return getDescriptions().getLabel(role, language);
   }

--- a/core-services/workflow/src/main/java/org/silverpeas/core/workflow/engine/model/RolesImpl.java
+++ b/core-services/workflow/src/main/java/org/silverpeas/core/workflow/engine/model/RolesImpl.java
@@ -23,12 +23,6 @@
  */
 package org.silverpeas.core.workflow.engine.model;
 
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-
-import org.silverpeas.core.workflow.api.WorkflowException;
 import org.silverpeas.core.workflow.api.model.Role;
 import org.silverpeas.core.workflow.api.model.Roles;
 
@@ -36,6 +30,10 @@ import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
 
 /**
  * Class implementing the representation of the &lt;roles&gt; element of a Process Model.
@@ -99,7 +97,7 @@ public class RolesImpl implements Serializable, Roles {
     if (roleList == null) {
       return new Role[0];
     }
-    return roleList.toArray(new Role[roleList.size()]);
+    return roleList.toArray(new Role[0]);
   }
 
   /*
@@ -116,16 +114,10 @@ public class RolesImpl implements Serializable, Roles {
    * @see Roles#removeRole(java.lang.String)
    */
   @Override
-  public void removeRole(String strRoleName) throws WorkflowException {
-    Role role = createRole();
-    role.setName(strRoleName);
+  public void removeRole(String strRoleName) {
     if (roleList == null) {
       return;
     }
-
-    if (!roleList.remove(role)) {
-      throw new WorkflowException("RolesImpl.removeRole()", "workflowEngine.EX_ROLE_NOT_FOUND",
-          strRoleName == null ? "<null>" : strRoleName);
-    }
+    roleList.removeIf(r -> r.getName().equals(strRoleName));
   }
 }

--- a/core-services/workflow/src/main/java/org/silverpeas/core/workflow/engine/model/SpecificLabel.java
+++ b/core-services/workflow/src/main/java/org/silverpeas/core/workflow/engine/model/SpecificLabel.java
@@ -23,15 +23,9 @@
  */
 package org.silverpeas.core.workflow.engine.model;
 
-import java.io.Serializable;
-
 import org.silverpeas.core.workflow.api.model.ContextualDesignation;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlValue;
+import javax.xml.bind.annotation.*;
 
 /**
  * Class implementing the representation of the following elements of a Process Model:
@@ -44,7 +38,7 @@ import javax.xml.bind.annotation.XmlValue;
  **/
 @XmlRootElement
 @XmlAccessorType(XmlAccessType.NONE)
-public class SpecificLabel implements Serializable, ContextualDesignation {
+public class SpecificLabel implements ContextualDesignation {
 
   private static final long serialVersionUID = 3151220585995921545L;
   @XmlValue
@@ -69,47 +63,32 @@ public class SpecificLabel implements Serializable, ContextualDesignation {
     this.role = role;
   }
 
-  /**
-   * Get the content of specific label
-   */
+  @Override
   public String getContent() {
     return this.content;
   }
 
-  /**
-   * Get the language of specific label
-   */
+  @Override
   public String getLanguage() {
     return this.language;
   }
 
-  /**
-   * Get the role for which this specific label is
-   */
+  @Override
   public String getRole() {
     return this.role;
   }
 
-  /**
-   * Set the content of specific label
-   * @param content content of specific label
-   */
+  @Override
   public void setContent(String content) {
     this.content = content;
   }
 
-  /**
-   * Set the language of specific label
-   * @param language language of specific label
-   */
+  @Override
   public void setLanguage(String language) {
     this.language = language;
   }
 
-  /**
-   * Set the role for which this specific label is
-   * @param role role
-   */
+  @Override
   public void setRole(String role) {
     this.role = role;
   }

--- a/core-services/workflow/src/main/java/org/silverpeas/core/workflow/engine/model/SpecificLabelListHelper.java
+++ b/core-services/workflow/src/main/java/org/silverpeas/core/workflow/engine/model/SpecificLabelListHelper.java
@@ -23,14 +23,12 @@
  */
 package org.silverpeas.core.workflow.engine.model;
 
-import org.silverpeas.core.workflow.api.WorkflowException;
 import org.silverpeas.core.workflow.api.model.ContextualDesignation;
 import org.silverpeas.core.workflow.api.model.ContextualDesignations;
 
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import java.io.Serializable;
-import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
@@ -44,13 +42,6 @@ public class SpecificLabelListHelper implements ContextualDesignations, Serializ
 
   @XmlElement(type = SpecificLabel.class)
   private List<ContextualDesignation> labels;
-
-  /**
-   * Constructor
-   */
-  public SpecificLabelListHelper() {
-    this.labels = new ArrayList<>();
-  }
 
   /**
    * Constructor
@@ -94,9 +85,9 @@ public class SpecificLabelListHelper implements ContextualDesignations, Serializ
    */
   @Override
   public ContextualDesignation getSpecificLabel(String role, String language) {
-    SpecificLabel label = null;
-    for (int l = 0; l < labels.size(); l++) {
-      label = (SpecificLabel) labels.get(l);
+    SpecificLabel label;
+    for (ContextualDesignation contextualDesignation : labels) {
+      label = (SpecificLabel) contextualDesignation;
       if (role != null && role.equals(label.getRole()) && language != null
           && language.equals(label.getLanguage())) {
         return label;
@@ -145,17 +136,12 @@ public class SpecificLabelListHelper implements ContextualDesignations, Serializ
    */
   @Override
   public void removeContextualDesignation(
-      ContextualDesignation contextualDesignation) throws WorkflowException {
+      ContextualDesignation contextualDesignation) {
     if (labels == null) {
       return;
     }
-    if (!labels.removeIf(d ->
+    labels.removeIf(d ->
         d.getRole().equals(contextualDesignation.getRole()) &&
-        d.getLanguage().equals(contextualDesignation.getLanguage()))) {
-      throw new WorkflowException("SpecificLabelListHelper.removeContextualDesignation()",
-          //$NON-NLS-1$
-          "workflowEngine.EX_DESIGNATION_NOT_FOUND", // $NON-NLS-1$
-          contextualDesignation == null ? "<null>" : contextualDesignation.getContent());
-    }
+        d.getLanguage().equals(contextualDesignation.getLanguage()));
   }
 }

--- a/core-services/workflow/src/main/java/org/silverpeas/core/workflow/engine/model/StateImpl.java
+++ b/core-services/workflow/src/main/java/org/silverpeas/core/workflow/engine/model/StateImpl.java
@@ -23,32 +23,19 @@
  */
 package org.silverpeas.core.workflow.engine.model;
 
-import org.silverpeas.core.workflow.api.model.Action;
-import org.silverpeas.core.workflow.api.model.AllowedActions;
-import org.silverpeas.core.workflow.api.model.ContextualDesignation;
-import org.silverpeas.core.workflow.api.model.ContextualDesignations;
-import org.silverpeas.core.workflow.api.model.QualifiedUsers;
-import org.silverpeas.core.workflow.api.model.State;
-import org.silverpeas.core.workflow.api.model.TimeOutAction;
-import org.silverpeas.core.workflow.api.model.TimeOutActions;
+import org.silverpeas.core.workflow.api.model.*;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlID;
-import javax.xml.bind.annotation.XmlIDREF;
-import javax.xml.bind.annotation.XmlRootElement;
-import java.io.Serializable;
+import javax.xml.bind.annotation.*;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Class implementing the representation of the &lt;state&gt; element of a Process Model.
  **/
 @XmlRootElement(name = "state")
 @XmlAccessorType(XmlAccessType.NONE)
-public class StateImpl implements State, Serializable {
+public class StateImpl implements State {
   private static final long serialVersionUID = -3019436287850255663L;
 
   @XmlAttribute
@@ -114,70 +101,32 @@ public class StateImpl implements State, Serializable {
   // labels
   // //////////////////
 
-  /*
-   * (non-Javadoc)
-   * @see State#getLabels()
-   */
+  @Override
   public ContextualDesignations getLabels() {
     return new SpecificLabelListHelper(labels);
   }
 
-  /*
-   * (non-Javadoc)
-   * @see State#getLabel(java.lang.String, java.lang.String)
-   */
+  @Override
   public String getLabel(String role, String language) {
     return getLabels().getLabel(role, language);
   }
 
-  // //////////////////
-  // activities
-  // //////////////////
-
-  /*
-   * (non-Javadoc)
-   * @see State#getActivities()
-   */
+  @Override
   public ContextualDesignations getActivities() {
     return new SpecificLabelListHelper(activities);
   }
 
-  /*
-   * (non-Javadoc)
-   * @see State#getActivity(java.lang.String, java.lang.String)
-   */
-  public String getActivity(String role, String language) {
-    return getActivities().getLabel(role, language);
-  }
-
-  // //////////////////
-  // descriptions
-  // //////////////////
-
-  /*
-   * (non-Javadoc)
-   * @see State#getDescriptions()
-   */
+  @Override
   public ContextualDesignations getDescriptions() {
     return new SpecificLabelListHelper(descriptions);
   }
 
-  /*
-   * (non-Javadoc)
-   * @see State#getDescription(java.lang.String, java.lang.String)
-   */
+  @Override
   public String getDescription(String role, String language) {
     return getDescriptions().getLabel(role, language);
   }
 
-  // //////////////////
-  // Miscellaneous
-  // //////////////////
-
-  /**
-   * Get actions available in this state
-   * @return allowedActions allowed actions
-   */
+  @Override
   public Action[] getAllowedActions() {
     // check for allowedActions attribute
     if (allowedActions == null) {
@@ -186,10 +135,7 @@ public class StateImpl implements State, Serializable {
     return allowedActions.getAllowedActions();
   }
 
-  /**
-   * Get timeout actions for this state
-   * @return timeout actions
-   */
+  @Override
   public TimeOutAction[] getTimeOutActions() {
     if (timeOutActions == null) {
       return new TimeOutAction[0];
@@ -198,18 +144,17 @@ public class StateImpl implements State, Serializable {
     return timeOutActions.getTimeOutActions();
   }
 
-  /*
-   * (non-Javadoc)
-   * @see State#getAllAllowedActions()
-   */
+  @Override
   public AllowedActions getAllowedActionsEx() {
     return allowedActions;
   }
 
+  @Override
   public AllowedActions createAllowedActions() {
     return new ActionRefs();
   }
 
+  @Override
   public Action[] getFilteredActions() {
     if (filteredActions == null) {
       return new Action[0];
@@ -223,135 +168,77 @@ public class StateImpl implements State, Serializable {
     filteredActions = allowedActions;
   }
 
-  /*
-   * (non-Javadoc)
-   * @see State#getInterestedUsers()
-   */
+  @Override
   public QualifiedUsers getInterestedUsers() {
-    if (interestedUsers == null) {
-      return new QualifiedUsersImpl();
-    } else {
-      return this.interestedUsers;
-    }
+    return Objects.requireNonNullElseGet(interestedUsers, QualifiedUsersImpl::new);
   }
 
-  /*
-   * (non-Javadoc)
-   * @see State#getInterestedUsersEx()
-   */
+  @Override
   public QualifiedUsers getInterestedUsersEx() {
     return interestedUsers;
   }
 
-  /**
-   * Get the name of this state
-   * @return state's name
-   */
+  @Override
   public String getName() {
     return this.name;
   }
 
-  /*
-   * (non-Javadoc)
-   * @see State#getWorkingUsers()
-   */
+  @Override
   public QualifiedUsers getWorkingUsers() {
-    if (workingUsers == null) {
-      return new QualifiedUsersImpl();
-    } else {
-      return this.workingUsers;
-    }
+    return Objects.requireNonNullElseGet(workingUsers, QualifiedUsersImpl::new);
   }
 
-  /*
-   * (non-Javadoc)
-   * @see State#getWorkingUsersEx()
-   */
+  @Override
   public QualifiedUsers getWorkingUsersEx() {
     return workingUsers;
   }
 
-  /*
-   * (non-Javadoc)
-   *
-   * State#setAllowedActions(com.silverpeas.workflow.api.model
-   * .AllowedActions)
-   */
+  @Override
   public void setAllowedActions(AllowedActions allowedActions) {
     this.allowedActions = allowedActions;
   }
 
-  /**
-   * Set all the users interested by this state
-   * @param interestedUsers object containing interested users
-   */
+  @Override
   public void setInterestedUsers(QualifiedUsers interestedUsers) {
     this.interestedUsers = interestedUsers;
   }
 
-  /*
-   * (non-Javadoc)
-   * @see State#setName(java.lang.String)
-   */
+  @Override
   public void setName(String name) {
     this.name = name;
   }
 
-  /**
-   * Set all the users who can act in this state
-   * @param workingUsers object containing these users
-   */
+  @Override
   public void setWorkingUsers(QualifiedUsers workingUsers) {
     this.workingUsers = workingUsers;
   }
 
-  /*
-   * (non-Javadoc)
-   * @see State#getTimeoutInterval()
-   */
+  @Override
   public int getTimeoutInterval() {
     return timeoutInterval;
   }
 
-  /*
-   * (non-Javadoc)
-   * @see State#setTimeoutInterval(int)
-   */
+  @Override
   public void setTimeoutInterval(int hours) {
     timeoutInterval = hours;
   }
 
-  /**
-   * Get the timeout action of this state Action that will played if timeout is triggered
-   * @return timeout action
-   */
+  @Override
   public Action getTimeoutAction() {
     return timeOutAction;
   }
 
-  /*
-   * (non-Javadoc)
-   *
-   * State#setTimeoutAction(com.silverpeas.workflow.api.model.
-   * Action)
-   */
+  @Override
   public void setTimeoutAction(Action timeoutAction) {
     this.timeOutAction = (ActionImpl) timeoutAction;
   }
 
-  /**
-   * Get flag for admin notification if true, the timeout manager will send a notification to all
-   * supervisors
-   * @return admin notification flag
-   */
+  @Override
   public boolean getTimeoutNotifyAdmin() {
     return timeoutNotifyAdmin;
   }
 
-  /*
-   * (non-Javadoc)
-   * @see State#setTimeoutNotifyAdmin(boolean)
-   */
+  @Override
   public void setTimeoutNotifyAdmin(boolean timeoutAction) {
     this.timeoutNotifyAdmin = timeoutAction;
   }
@@ -366,7 +253,6 @@ public class StateImpl implements State, Serializable {
     }
 
     final StateImpl state = (StateImpl) o;
-
     return name.equals(state.name);
   }
 

--- a/core-services/workflow/src/main/java/org/silverpeas/core/workflow/engine/model/StateRef.java
+++ b/core-services/workflow/src/main/java/org/silverpeas/core/workflow/engine/model/StateRef.java
@@ -44,17 +44,12 @@ public class StateRef implements Serializable, StateSetter {
   @XmlAttribute
   private StateImpl state;
 
-  /**
-   * Get the referred state
-   */
+  @Override
   public State getState() {
     return this.state;
   }
 
-  /**
-   * Set the referred state
-   * @param state state to refer
-   */
+  @Override
   public void setState(State state) {
     this.state = (StateImpl) state;
   }

--- a/core-services/workflow/src/main/java/org/silverpeas/core/workflow/engine/model/StatesImpl.java
+++ b/core-services/workflow/src/main/java/org/silverpeas/core/workflow/engine/model/StatesImpl.java
@@ -23,11 +23,6 @@
  */
 package org.silverpeas.core.workflow.engine.model;
 
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-
 import org.silverpeas.core.workflow.api.WorkflowException;
 import org.silverpeas.core.workflow.api.model.State;
 import org.silverpeas.core.workflow.api.model.States;
@@ -36,13 +31,16 @@ import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
 
 /**
  * Class implementing the representation of the &lt;states&gt; element of a Process Model.
  **/
 @XmlRootElement(name = "states")
 @XmlAccessorType(XmlAccessType.NONE)
-public class StatesImpl implements Serializable, States {
+public class StatesImpl implements States {
 
   private static final long serialVersionUID = -2580715672830095678L;
   @XmlElement(name = "state", type = StateImpl.class)
@@ -65,10 +63,7 @@ public class StatesImpl implements Serializable, States {
     stateList.add(state);
   }
 
-  /*
-   * (non-Javadoc)
-   * @see States#createState()
-   */
+  @Override
   public State createState() {
     return new StateImpl();
   }
@@ -96,13 +91,10 @@ public class StatesImpl implements Serializable, States {
     if (stateList == null) {
       return new State[0];
     }
-    return stateList.toArray(new State[stateList.size()]);
+    return stateList.toArray(new State[0]);
   }
 
-  /*
-   * (non-Javadoc)
-   * @see States#iterateState()
-   */
+  @Override
   public Iterator<State> iterateState() {
     return stateList.iterator();
   }

--- a/core-services/workflow/src/main/java/org/silverpeas/core/workflow/engine/model/TimeOutActionImpl.java
+++ b/core-services/workflow/src/main/java/org/silverpeas/core/workflow/engine/model/TimeOutActionImpl.java
@@ -23,17 +23,11 @@
  */
 package org.silverpeas.core.workflow.engine.model;
 
-import java.io.Serializable;
-
 import org.silverpeas.core.workflow.api.model.Action;
 import org.silverpeas.core.workflow.api.model.Item;
 import org.silverpeas.core.workflow.api.model.TimeOutAction;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlIDREF;
-import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.*;
 
 /**
  * Representation of the &lt;timeoutAction&gt; element of a Process Model.
@@ -41,7 +35,7 @@ import javax.xml.bind.annotation.XmlRootElement;
  */
 @XmlRootElement(name = "timeOutAction")
 @XmlAccessorType(XmlAccessType.NONE)
-public class TimeOutActionImpl implements TimeOutAction, Serializable {
+public class TimeOutActionImpl implements TimeOutAction {
 
   private static final long serialVersionUID = -7434214806057433378L;
   @XmlIDREF

--- a/core-services/workflow/src/main/java/org/silverpeas/core/workflow/engine/model/TimeOutActionsImpl.java
+++ b/core-services/workflow/src/main/java/org/silverpeas/core/workflow/engine/model/TimeOutActionsImpl.java
@@ -23,8 +23,6 @@
  */
 package org.silverpeas.core.workflow.engine.model;
 
-import java.io.Serializable;
-
 import org.silverpeas.core.workflow.api.model.TimeOutAction;
 import org.silverpeas.core.workflow.api.model.TimeOutActions;
 
@@ -40,7 +38,7 @@ import java.util.List;
  **/
 @XmlRootElement(name = "timeOutActions")
 @XmlAccessorType(XmlAccessType.NONE)
-public class TimeOutActionsImpl implements Serializable, TimeOutActions {
+public class TimeOutActionsImpl implements TimeOutActions {
   private static final long serialVersionUID = 7973279591384251532L;
   @XmlElement(name = "timeOutAction", type = TimeOutActionImpl.class)
   private List<TimeOutAction> timeoutActionList;
@@ -52,15 +50,12 @@ public class TimeOutActionsImpl implements Serializable, TimeOutActions {
     timeoutActionList = new ArrayList<>();
   }
 
-  /*
-   * (non-Javadoc)
-   * @see AllowedActions#getAllowedActions()
-   */
+  @Override
   public TimeOutAction[] getTimeOutActions() {
     if (timeoutActionList == null) {
       return new TimeOutAction[0];
     }
-    return timeoutActionList.toArray(new TimeOutAction[timeoutActionList.size()]);
+    return timeoutActionList.toArray(new TimeOutAction[0]);
   }
 
 }

--- a/core-services/workflow/src/main/java/org/silverpeas/core/workflow/engine/model/TriggerImpl.java
+++ b/core-services/workflow/src/main/java/org/silverpeas/core/workflow/engine/model/TriggerImpl.java
@@ -27,12 +27,7 @@ import org.silverpeas.core.workflow.api.model.Parameter;
 import org.silverpeas.core.workflow.api.model.Trigger;
 import org.silverpeas.core.workflow.engine.AbstractReferrableObject;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import java.io.Serializable;
+import javax.xml.bind.annotation.*;
 import java.util.List;
 import java.util.Vector;
 
@@ -41,7 +36,7 @@ import java.util.Vector;
  **/
 @XmlRootElement(name = "trigger")
 @XmlAccessorType(XmlAccessType.NONE)
-public class TriggerImpl extends AbstractReferrableObject implements Trigger, Serializable {
+public class TriggerImpl extends AbstractReferrableObject implements Trigger {
   private static final long serialVersionUID = -5923330362725539310L;
   @XmlAttribute
   private String name;

--- a/core-services/workflow/src/main/java/org/silverpeas/core/workflow/engine/model/TriggersImpl.java
+++ b/core-services/workflow/src/main/java/org/silverpeas/core/workflow/engine/model/TriggersImpl.java
@@ -23,10 +23,6 @@
  */
 package org.silverpeas.core.workflow.engine.model;
 
-import java.io.Serializable;
-import java.util.Iterator;
-import java.util.List;
-
 import org.silverpeas.core.workflow.api.model.Trigger;
 import org.silverpeas.core.workflow.api.model.Triggers;
 
@@ -35,13 +31,15 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
 
 /**
  * Class implementing the representation of the &lt;triggers&gt; element of a Process Model.
  **/
 @XmlRootElement(name = "triggers")
 @XmlAccessorType(XmlAccessType.NONE)
-public class TriggersImpl implements Serializable, Triggers {
+public class TriggersImpl implements Triggers {
   private static final long serialVersionUID = -2251572849084710965L;
 
   @XmlElement(name = "trigger", type = TriggerImpl.class)

--- a/core-services/workflow/src/main/java/org/silverpeas/core/workflow/engine/model/UserInRoleImpl.java
+++ b/core-services/workflow/src/main/java/org/silverpeas/core/workflow/engine/model/UserInRoleImpl.java
@@ -23,21 +23,20 @@
  */
 package org.silverpeas.core.workflow.engine.model;
 
-import java.io.Serializable;
-
 import org.silverpeas.core.workflow.api.model.UserInRole;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlRootElement;
+import java.util.Objects;
 
 /**
  * Class implementing the representation of the &lt;userInRole&gt; element of a Process Model.
  **/
 @XmlRootElement(name = "userInRole")
 @XmlAccessorType(XmlAccessType.NONE)
-public class UserInRoleImpl implements UserInRole, Serializable {
+public class UserInRoleImpl implements UserInRole {
   private static final long serialVersionUID = -6419166381111612814L;
   @XmlAttribute(name = "name")
   private String roleName;
@@ -49,17 +48,12 @@ public class UserInRoleImpl implements UserInRole, Serializable {
     super();
   }
 
-  /**
-   * Get name of the role
-   */
+  @Override
   public String getRoleName() {
     return this.roleName;
   }
 
-  /**
-   * Set name of the role
-   * @param roleName
-   */
+  @Override
   public void setRoleName(String roleName) {
     this.roleName = roleName;
   }
@@ -74,8 +68,7 @@ public class UserInRoleImpl implements UserInRole, Serializable {
     }
 
     final UserInRoleImpl that = (UserInRoleImpl) o;
-
-    return roleName != null ? roleName.equals(that.roleName) : that.roleName == null;
+    return Objects.equals(roleName, that.roleName);
   }
 
   @Override

--- a/core-war/src/main/java/org/silverpeas/web/token/SessionSynchronizerTokenValidator.java
+++ b/core-war/src/main/java/org/silverpeas/web/token/SessionSynchronizerTokenValidator.java
@@ -26,21 +26,15 @@ package org.silverpeas.web.token;
 import org.silverpeas.core.security.session.SessionInfo;
 import org.silverpeas.core.security.session.SessionManagement;
 import org.silverpeas.core.security.token.exception.TokenValidationException;
-import org.silverpeas.kernel.bundle.ResourceLocator;
-import org.silverpeas.kernel.util.StringUtil;
-import org.silverpeas.kernel.logging.SilverLogger;
 import org.silverpeas.core.util.security.SecuritySettings;
 import org.silverpeas.core.web.rs.UserPrivilegeValidation;
 import org.silverpeas.core.web.token.SynchronizerTokenService;
+import org.silverpeas.kernel.bundle.ResourceLocator;
+import org.silverpeas.kernel.logging.SilverLogger;
+import org.silverpeas.kernel.util.StringUtil;
 
 import javax.inject.Inject;
-import javax.servlet.Filter;
-import javax.servlet.FilterChain;
-import javax.servlet.FilterConfig;
-import javax.servlet.RequestDispatcher;
-import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
+import javax.servlet.*;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
@@ -51,9 +45,8 @@ import static org.silverpeas.core.util.URLUtil.getApplicationURL;
 /**
  * A validator of a session token for each incoming request. For each protected web resources, the
  * requests are expected to carry a synchronizer token that must match the token mapped with the
- * user session. The request validation is in fact delegated to a
- * {@link SynchronizerTokenService} instance; this object just process the
- * status of the validation.
+ * user session. The request validation is in fact delegated to a {@link SynchronizerTokenService}
+ * instance; this object just process the status of the validation.
  *
  * @author mmoquillon
  */
@@ -76,12 +69,12 @@ public class SessionSynchronizerTokenValidator implements Filter {
    * If the request is sent within an opened user session but it doesn't carry a valid session
    * synchronizer token, then it is rejected and a forbidden status is sent back.
    * </p>
+   *
    * @param request The servlet request to validate.
    * @param response The servlet response to sent back.
    * @param chain The filter chain we are processing
-   *
-   * @exception IOException if an input/output error occurs
-   * @exception ServletException if a servlet error occurs
+   * @throws IOException if an input/output error occurs
+   * @throws ServletException if a servlet error occurs
    */
   @Override
   public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
@@ -161,11 +154,15 @@ public class SessionSynchronizerTokenValidator implements Filter {
   }
 
   private boolean isProtectedResource(HttpServletRequest request) {
-    return tokenService.isAProtectedResource(request, false) && !isFileDragAndDrop(request) &&
-        !isCredentialManagement(request) && !isSsoAuthentication(request) &&
-        !isWebServiceRequested(request) &&
-        !isWebBrowserEditionResource(request) && !isCMISResource(request) &&
-        !isDragAndDropWebEditionResource(request);
+    return tokenService.isAProtectedResource(request, false)
+        && !(isFileDragAndDrop(request) ||
+            isCredentialManagement(request) ||
+            isSsoAuthentication(request) ||
+            isWebServiceRequested(request) ||
+            isWebBrowserEditionResource(request) ||
+            isCMISResource(request) ||
+            isDragAndDropWebEditionResource(request) ||
+            isWorkflowDesignerResource(request));
   }
 
   private boolean isWebDAVResource(HttpServletRequest request) {
@@ -195,6 +192,10 @@ public class SessionSynchronizerTokenValidator implements Filter {
 
   private boolean isDragAndDropWebEditionResource(HttpServletRequest request) {
     return request.getRequestURI().contains(getApplicationURL() + "/Rddwe/");
+  }
+
+  private boolean isWorkflowDesignerResource(HttpServletRequest request) {
+    return request.getRequestURI().contains(getApplicationURL() + "/RworkflowDesigner/");
   }
 
   private static class UnauthenticatedRequestException extends Exception {

--- a/core-war/src/main/java/org/silverpeas/web/workflowdesigner/control/WorkflowDesignerSessionController.java
+++ b/core-war/src/main/java/org/silverpeas/web/workflowdesigner/control/WorkflowDesignerSessionController.java
@@ -36,7 +36,7 @@ import org.silverpeas.core.template.SilverpeasTemplate;
 import org.silverpeas.core.template.SilverpeasTemplateFactory;
 import org.silverpeas.core.util.ArrayUtil;
 import org.silverpeas.core.util.Charsets;
-import org.silverpeas.kernel.util.StringUtil;
+import org.silverpeas.core.util.URLEncoder;
 import org.silverpeas.core.util.file.FileServerUtils;
 import org.silverpeas.core.util.file.FileUtil;
 import org.silverpeas.core.web.mvc.controller.AbstractAdminComponentSessionController;
@@ -50,6 +50,8 @@ import org.silverpeas.core.workflow.engine.WorkflowHub;
 import org.silverpeas.core.workflow.engine.model.ProcessModelManagerImpl;
 import org.silverpeas.core.workflow.engine.model.SpecificLabel;
 import org.silverpeas.core.workflow.util.WorkflowUtil;
+import org.silverpeas.kernel.logging.SilverLogger;
+import org.silverpeas.kernel.util.StringUtil;
 import org.silverpeas.web.workflowdesigner.model.WorkflowDesignerException;
 
 import java.io.File;
@@ -100,12 +102,11 @@ public class WorkflowDesignerSessionController extends AbstractAdminComponentSes
   // process model is referenced
 
   /**
-* Standard Session Controller Constructeur
-*
-* @param mainSessionCtrl The user's profile
-* @param componentContext The component's profile
-*
-*/
+   * Standard Session Controller Constructeur
+   *
+   * @param mainSessionCtrl The user's profile
+   * @param componentContext The component's profile
+   */
   public WorkflowDesignerSessionController(
       MainSessionController mainSessionCtrl, ComponentContext componentContext) {
     super(mainSessionCtrl, componentContext,
@@ -115,11 +116,11 @@ public class WorkflowDesignerSessionController extends AbstractAdminComponentSes
   }
 
   /**
-* Get the list of all process models available for edition
-*
-* @return A list of Strings containing relative paths to process model file names.
-* @throws WorkflowDesignerException
-*/
+   * Get the list of all process models available for edition
+   *
+   * @return A list of Strings containing relative paths to process model file names.
+   * @throws WorkflowDesignerException if an error occurs while getting the process models
+   */
   public List<String> listProcessModels() throws WorkflowDesignerException {
     try {
       return Workflow.getProcessModelManager().listProcessModels();
@@ -130,30 +131,24 @@ public class WorkflowDesignerSessionController extends AbstractAdminComponentSes
   }
 
   /**
-* Create a new ProcessModel descriptor that is not yet saved in a XML file.
-*
-* @return ProcessModel object
-*/
-  public ProcessModel createProcessModel() throws WorkflowDesignerException {
-    try {
-      processModel = Workflow.getProcessModelManager().createProcessModelDescriptor();
-      processModelFileName = NEW_ELEMENT_NAME;
-      referencedInComponent = null;
-      return processModel;
-    } catch (WorkflowException e) {
-      throw new WorkflowDesignerException("WorkflowDesignerSessionController.createPorcesModel",
-          SilverpeasException.ERROR, "workflowDesigner.EX_CREATING_PROCESS_DESCRIPTIOR_FAILED", e);
-    }
+   * Create a new ProcessModel descriptor that is not yet saved in a XML file.
+   *
+   * @return ProcessModel object
+   */
+  public ProcessModel createProcessModel() {
+    processModel = Workflow.getProcessModelManager().createProcessModelDescriptor();
+    processModelFileName = NEW_ELEMENT_NAME;
+    referencedInComponent = null;
+    return processModel;
   }
 
   /**
-* Load the process model from the specified file, cache it before returning.
-*
-* @param strProcessFileName relative path and the file name
-* @return An object implementing the ProcessModel interface
-* @throws WorkflowDesignerException
-*/
-  public ProcessModel loadProcessModel(String strProcessFileName)
+   * Load the process model from the specified file, cache it before returning.
+   *
+   * @param strProcessFileName relative path and the file name
+   * @throws WorkflowDesignerException if an error occurs while loading the process model
+   */
+  public void loadProcessModel(String strProcessFileName)
       throws WorkflowDesignerException {
     try {
       // Load the process model from the XML file
@@ -166,7 +161,6 @@ public class WorkflowDesignerSessionController extends AbstractAdminComponentSes
       //
       referencedInComponent = findComponentDescriptor(processModelFileName);
 
-      return processModel;
     } catch (WorkflowException e) {
       throw new WorkflowDesignerException("WorkflowDesignerSessionController.loadProcesModel",
           SilverpeasException.ERROR, "workflowDesigner.EX_LOADING_PROCES_MODEL_FAILED", e);
@@ -175,6 +169,7 @@ public class WorkflowDesignerSessionController extends AbstractAdminComponentSes
 
   /**
    * Save the currently cached process model in a XML file
+   *
    * @throws WorkflowDesignerException when the saving goes wrong...
    */
   public void saveProcessModel()
@@ -205,11 +200,11 @@ public class WorkflowDesignerSessionController extends AbstractAdminComponentSes
   }
 
   /**
-* Removes the process model descriptor file from the filesystem
-*
-* @param strProcessModelFileName the relative path to the process file name
-* @throws WorkflowDesignerException when something goes wrong
-*/
+   * Removes the process model descriptor file from the filesystem
+   *
+   * @param strProcessModelFileName the relative path to the process file name
+   * @throws WorkflowDesignerException when something goes wrong
+   */
   public void removeProcessModel(String strProcessModelFileName)
       throws WorkflowDesignerException {
     try {
@@ -220,7 +215,7 @@ public class WorkflowDesignerSessionController extends AbstractAdminComponentSes
       String componentName = findComponentDescriptor(strProcessModelFileName);
       if (componentName != null) {
         WAComponentRegistry registry = WAComponentRegistry.get();
-        registry.getWAComponent(componentName).ifPresent(wa -> registry.removeWorkflow(wa));
+        registry.getWAComponent(componentName).ifPresent(registry::removeWorkflow);
       }
     } catch (Exception e) {
       throw new WorkflowDesignerException("WorkflowDesignerSessionController.removeProcesModel",
@@ -229,52 +224,52 @@ public class WorkflowDesignerSessionController extends AbstractAdminComponentSes
   }
 
   /**
-* An object implementing the ProcessModel interface containing the currently loaded model or null
-* if none.
-*/
+   * An object implementing the ProcessModel interface containing the currently loaded model or null
+   * if none.
+   */
   public ProcessModel getProcessModel() {
     return processModel;
   }
 
   /**
-* Is it a new Process Model that has not yet been saved to a file?
-*/
+   * Is it a new Process Model that has not yet been saved to a file?
+   */
   public Boolean isNewProcessModel() {
     return NEW_ELEMENT_NAME.equals(processModelFileName);
   }
 
   /**
-* The relative path and file name of the currently loaded model or null if none.
-*/
+   * The relative path and file name of the currently loaded model or null if none.
+   */
   public String getProcessFileName() {
     return processModelFileName;
   }
 
   /**
-* The name of the component descriptor that references this process model definition
-*
-* @return the component descriptor file name (without .xml) or <code>null</code> if no components
-* reference this process model.
-*/
+   * The name of the component descriptor that references this process model definition
+   *
+   * @return the component descriptor file name (without .xml) or <code>null</code> if no components
+   * reference this process model.
+   */
   public String getComponentDescriptorName() {
     return referencedInComponent;
   }
 
   /**
-* Update the header of the cached process model
-*
-* @param processModel the reference object
-*/
+   * Update the header of the cached process model
+   *
+   * @param processModel the reference object
+   */
   public void updateProcessModelHeader(ProcessModel processModel) {
     // Update the current process Model
     this.processModel.setName(processModel.getName());
   }
 
   /**
-* Create a new columns object to be added to the model
-*
-* @return an object implementing Columns
-*/
+   * Create a new columns object to be added to the model
+   *
+   * @return an object implementing Columns
+   */
   public Columns addColumns() {
     Columns columns = processModel.getPresentation().createColumns();
 
@@ -283,11 +278,11 @@ public class WorkflowDesignerSessionController extends AbstractAdminComponentSes
   }
 
   /**
-* Update or insert a new columns section of the presentation element of the cached process model
-*
-* @param source the reference object
-* @throws WorkflowDesignerException
-*/
+   * Update or insert a new columns section of the presentation element of the cached process model
+   *
+   * @param source the reference object
+   * @throws WorkflowDesignerException if an error occurs while updaring the columns.
+   */
   public void updateColumns(Columns source, String strRoleOriginal)
       throws WorkflowDesignerException {
     Columns check = processModel.getPresentation().getColumnsByRole(source.getRoleName());
@@ -302,34 +297,27 @@ public class WorkflowDesignerSessionController extends AbstractAdminComponentSes
         throw new WorkflowDesignerException("WorkflowDesignerSessionController.updateColumns",
             SilverpeasException.ERROR, "workflowDesigner.EX_COLUMNS_ALREADY_EXISTS");
       }
-    }
-    else
+    } else {
       deleteColumns(strRoleOriginal);
+    }
 
     processModel.getPresentation().addColumns(source);
   }
 
   /**
-* Removes the 'columns' object specified by the role name
-*
-* @param strRoleName the value of the role attribute
-* @throws WorkflowDesignerException when something goes wrong
-*/
-  public void deleteColumns(String strRoleName)
-      throws WorkflowDesignerException {
-    try {
-      processModel.getPresentation().deleteColumns(strRoleName);
-    } catch (WorkflowException e) {
-      throw new WorkflowDesignerException("WorkflowDesignerSessionController.deleteColumns",
-          SilverpeasException.ERROR, "workflowDesigner.EX_DELETING_COLUMNS_FAILED", e);
-    }
+   * Removes the 'columns' object specified by the role name
+   *
+   * @param strRoleName the value of the role attribute
+   */
+  public void deleteColumns(String strRoleName) {
+    processModel.getPresentation().deleteColumns(strRoleName);
   }
 
   /**
-* Create a new role object to be added to the model
-*
-* @return an object implementing Role
-*/
+   * Create a new role object to be added to the model
+   *
+   * @return an object implementing Role
+   */
   public Role createRole() {
     Roles roles = processModel.getRolesEx();
     if (roles == null) {
@@ -343,12 +331,12 @@ public class WorkflowDesignerSessionController extends AbstractAdminComponentSes
   }
 
   /**
-* Update or insert a new role element of the cached process model
-*
-* @param source the data carrier object
-* @param strNameOriginal the original name of the object
-* @throws WorkflowDesignerException if another object with the same name already exists
-*/
+   * Update or insert a new role element of the cached process model
+   *
+   * @param source the data carrier object
+   * @param strNameOriginal the original name of the object
+   * @throws WorkflowDesignerException if another object with the same name already exists
+   */
   public void updateRole(Role source, String strNameOriginal)
       throws WorkflowDesignerException {
     Role check = processModel.getRolesEx().getRole(source.getName());
@@ -389,11 +377,11 @@ public class WorkflowDesignerSessionController extends AbstractAdminComponentSes
   }
 
   /**
-* Remove the role specified
-*
-* @param strRoleName the name of the role
-* @throws WorkflowDesignerException if the role cannot be found or is referenced elsewhere.
-*/
+   * Remove the role specified
+   *
+   * @param strRoleName the name of the role
+   * @throws WorkflowDesignerException if the role cannot be found or is referenced elsewhere.
+   */
   public void removeRole(String strRoleName) throws WorkflowDesignerException {
     Map<ContextualDesignations, String> mapDesignations = collectContextualDesignations();
     Iterator<ContextualDesignations> iterKeys = mapDesignations.keySet().iterator();
@@ -483,30 +471,24 @@ public class WorkflowDesignerSessionController extends AbstractAdminComponentSes
           throw new WorkflowDesignerException("WorkflowDesignerSessionController.removeRole",
               SilverpeasException.ERROR, "workflowDesigner.EX_ELEMENT_REFERENCED",
               mapQualifiedUsers.get(qualifiedUsers) + " (relatedUser: ["
-                + (relatedUser.getParticipant() == null ? "" : (" participant: '" + relatedUser
+                  + (relatedUser.getParticipant() == null ? "" : (" participant: '" + relatedUser
                   .getParticipant().getName() + "'"))
-                + (relatedUser.getFolderItem() == null ? "" : (" folderItem: '"
+                  + (relatedUser.getFolderItem() == null ? "" : (" folderItem: '"
                   + relatedUser.getFolderItem().getName() + "'"))
-                + (relatedUser.getRelation() == null ? "" : (" relation: '"
+                  + (relatedUser.getRelation() == null ? "" : (" relation: '"
                   + relatedUser.getRelation() + "'")) + " role: '" + strRoleName + "'" + " ])");
         }
       }
     }
 
-    try {
-      processModel.getRolesEx().removeRole(strRoleName);
-      processModel.setRoles(null);
-    } catch (WorkflowException e) {
-      throw new WorkflowDesignerException("WorkflowDesignerSessionController.removeRole",
-          SilverpeasException.ERROR, "workflowDesigner.EX_ROLE_NOT_FOUND");
-    }
+    processModel.getRolesEx().removeRole(strRoleName);
   }
 
   /**
-* Create a new participant object to be added to the model
-*
-* @return an object implementing Participant
-*/
+   * Create a new participant object to be added to the model
+   *
+   * @return an object implementing Participant
+   */
   public Participant createParticipant() {
     Participants participants = processModel.getParticipantsEx();
     Participant participant;
@@ -522,11 +504,11 @@ public class WorkflowDesignerSessionController extends AbstractAdminComponentSes
   }
 
   /**
-* Update or insert a new participant element of the cached process model
-*
-* @param source the reference object
-* @throws WorkflowDesignerException
-*/
+   * Update or insert a new participant element of the cached process model
+   *
+   * @param source the reference object
+   * @throws WorkflowDesignerException if an error occurs while updating the participant
+   */
   public void updateParticipant(Participant source, String strNameOriginal)
       throws WorkflowDesignerException {
     Participant check = processModel.getParticipantsEx().getParticipant(
@@ -568,12 +550,12 @@ public class WorkflowDesignerSessionController extends AbstractAdminComponentSes
   }
 
   /**
-* Remove the participant specified
-*
-* @param strParticipantName the name of the participant
-* @throws WorkflowDesignerException if the participant cannot be found or is referenced
-* elsewhere.
-*/
+   * Remove the participant specified
+   *
+   * @param strParticipantName the name of the participant
+   * @throws WorkflowDesignerException if the participant cannot be found or is referenced
+   * elsewhere.
+   */
   public void removeParticipant(String strParticipantName) throws WorkflowDesignerException {
     Participant reference = processModel.getParticipantsEx().getParticipant(strParticipantName);
 
@@ -611,20 +593,14 @@ public class WorkflowDesignerSessionController extends AbstractAdminComponentSes
       }
     }
 
-    try {
-      processModel.getParticipantsEx().removeParticipant(strParticipantName);
-      processModel.setParticipants(null);
-    } catch (WorkflowException e) {
-      throw new WorkflowDesignerException("WorkflowDesignerSessionController.removeParticipant",
-          SilverpeasException.ERROR, "workflowDesigner.EX_PARTICIPANT_NOT_FOUND");
-    }
+    processModel.getParticipantsEx().removeParticipant(strParticipantName);
   }
 
   /**
-* Create a new state object to be added to the model
-*
-* @return an object implementing State
-*/
+   * Create a new state object to be added to the model
+   *
+   * @return an object implementing State
+   */
   public State createState() {
     States states = processModel.getStatesEx();
     State state;
@@ -640,11 +616,11 @@ public class WorkflowDesignerSessionController extends AbstractAdminComponentSes
   }
 
   /**
-* Update or insert a new state element of the cached process model
-*
-* @param source the reference object
-* @throws WorkflowDesignerException
-*/
+   * Update or insert a new state element of the cached process model
+   *
+   * @param source the reference object
+   * @throws WorkflowDesignerException if an error occurs while updating state
+   */
   public void updateState(State source, String strNameOriginal)
       throws WorkflowDesignerException {
     State check = processModel.getStatesEx().getState(source.getName()), state;
@@ -686,11 +662,11 @@ public class WorkflowDesignerSessionController extends AbstractAdminComponentSes
   }
 
   /**
-* Remove the state specified
-*
-* @param strStateName the name of the state
-* @throws WorkflowDesignerException if the state cannot be found or is referenced elsewhere.
-*/
+   * Remove the state specified
+   *
+   * @param strStateName the name of the state
+   * @throws WorkflowDesignerException if the state cannot be found or is referenced elsewhere.
+   */
   public void removeState(String strStateName) throws WorkflowDesignerException {
     Actions actions = processModel.getActionsEx();
     Participants participants = processModel.getParticipantsEx();
@@ -727,8 +703,8 @@ public class WorkflowDesignerSessionController extends AbstractAdminComponentSes
 
       while (iterParticipant.hasNext()) {
         Participant participant = iterParticipant.next();
-
-        if (participant.getResolvedState().equals(strStateName)) {
+        String resolvedState = participant.getResolvedState();
+        if (StringUtil.isDefined(resolvedState) && resolvedState.equals(strStateName)) {
           throw new WorkflowDesignerException("WorkflowDesignerSessionController.removeState",
               SilverpeasException.ERROR,
               "workflowDesigner.EX_ELEMENT_REFERENCED", "participant : '"
@@ -747,14 +723,14 @@ public class WorkflowDesignerSessionController extends AbstractAdminComponentSes
   }
 
   /**
-* Update Qualified Users referenced by the context, create the object if it was <code>null</code>
-* before.
-*
-* @param source the new Qualified Users
-* @param strContext the context of the QualifiedUsers being updated
-* @throws WorkflowException when the update goes wrong
-* @throws WorkflowDesignerException when the update goes wrong
-*/
+   * Update Qualified Users referenced by the context, create the object if it was <code>null</code>
+   * before.
+   *
+   * @param source the new Qualified Users
+   * @param strContext the context of the QualifiedUsers being updated
+   * @throws WorkflowException when the update goes wrong
+   * @throws WorkflowDesignerException when the update goes wrong
+   */
   public void updateQualifiedUsers(QualifiedUsers source, String strContext)
       throws WorkflowException, WorkflowDesignerException {
     QualifiedUsers qualifiedUsers = findQualifiedUsers(strContext);
@@ -775,16 +751,16 @@ public class WorkflowDesignerSessionController extends AbstractAdminComponentSes
   }
 
   /**
-* Find a related user corresponding to the criteria given
-*
-* @param strContext the context
-* @param strParticipant the name of the participant, may be <code>null</code>
-* @param strFolderItem the name of the data folder item, may be <code>null</code>
-* @param strRelation the relation, may be <code>null</code>
-* @param strRole the name of the role, may be <code>null</code>
-* @return an object implementing RelatedUser
-* @throws WorkflowException when something goes wrong
-*/
+   * Find a related user corresponding to the criteria given
+   *
+   * @param strContext the context
+   * @param strParticipant the name of the participant, may be <code>null</code>
+   * @param strFolderItem the name of the data folder item, may be <code>null</code>
+   * @param strRelation the relation, may be <code>null</code>
+   * @param strRole the name of the role, may be <code>null</code>
+   * @return an object implementing RelatedUser
+   * @throws WorkflowException when something goes wrong
+   */
   public RelatedUser findRelatedUser(String strContext, String strParticipant,
       String strFolderItem, String strRelation, String strRole)
       throws WorkflowException {
@@ -820,18 +796,17 @@ public class WorkflowDesignerSessionController extends AbstractAdminComponentSes
   }
 
   /**
-* Update a related user corresponding to the criteria given
-*
-* @param strContext the context
-* @param strParticipantOriginal the original name of the participant, may be <code>null</code>
-* @param strFolderItemOriginal the original name of the data folder item, may be
-* <code>null</code>
-* @param strRelationOriginal the original relation, may be <code>null</code>
-* @param strRoleOriginal the original name of the role, may be <code>null</code>
-* @return an object implementing RelatedUser
-* @throws WorkflowDesignerException when something goes wrong
-* @throws WorkflowException when something goes wrong
-*/
+   * Update a related user corresponding to the criteria given
+   *
+   * @param strContext the context
+   * @param strParticipantOriginal the original name of the participant, may be <code>null</code>
+   * @param strFolderItemOriginal the original name of the data folder item, may be
+   * <code>null</code>
+   * @param strRelationOriginal the original relation, may be <code>null</code>
+   * @param strRoleOriginal the original name of the role, may be <code>null</code>
+   * @throws WorkflowDesignerException when something goes wrong
+   * @throws WorkflowException when something goes wrong
+   */
   public void updateRelatedUser(RelatedUser source, String strContext,
       String strParticipantOriginal, String strFolderItemOriginal,
       String strRelationOriginal, String strRoleOriginal)
@@ -913,13 +888,12 @@ public class WorkflowDesignerSessionController extends AbstractAdminComponentSes
   }
 
   /**
-* Remove the related user specified
-*
-* @param reference the reference for the related user to remove
-* @param strContext the context
-* @throws WorkflowException if the related user cannot be found or when something goes
-* wrong
-*/
+   * Remove the related user specified
+   *
+   * @param reference the reference for the related user to remove
+   * @param strContext the context
+   * @throws WorkflowException if the related user cannot be found or when something goes wrong
+   */
   public void removeRelatedUser(RelatedUser reference, String strContext)
       throws WorkflowException {
     QualifiedUsers qualifiedUsers = findQualifiedUsers(strContext);
@@ -927,10 +901,10 @@ public class WorkflowDesignerSessionController extends AbstractAdminComponentSes
   }
 
   /**
-* Create a new action object to be added to the model
-*
-* @return an object implementing Action
-*/
+   * Create a new action object to be added to the model
+   *
+   * @return an object implementing Action
+   */
   public Action createAction() {
     Actions actions = processModel.getActionsEx();
     Action action;
@@ -946,13 +920,13 @@ public class WorkflowDesignerSessionController extends AbstractAdminComponentSes
   }
 
   /**
-* Update or insert a new action element of the cached process model
-*
-* @param source the reference object
-* @param strNameOriginal
-* @throws WorkflowDesignerException when something goes wrong
-* @throws WorkflowException when something goes wrong
-*/
+   * Update or insert a new action element of the cached process model
+   *
+   * @param source the reference object
+   * @param strNameOriginal the original name of the action
+   * @throws WorkflowDesignerException when something goes wrong
+   * @throws WorkflowException when something goes wrong
+   */
   public void updateAction(Action source, String strNameOriginal)
       throws WorkflowDesignerException, WorkflowException {
     Action check = null, action;
@@ -1002,14 +976,12 @@ public class WorkflowDesignerSessionController extends AbstractAdminComponentSes
   }
 
   /**
-* Remove the action specified
-*
-* @param strActionName the name of the action
-* @throws WorkflowException if the action cannot be found
-* @throws WorkflowDesignerException if the action is referenced elsewhere
-*/
-  public void removeAction(String strActionName)
-      throws WorkflowException, WorkflowDesignerException {
+   * Remove the action specified
+   *
+   * @param strActionName the name of the action
+   * @throws WorkflowDesignerException if the action is referenced elsewhere
+   */
+  public void removeAction(String strActionName) throws WorkflowDesignerException {
     States states = processModel.getStatesEx();
 
     // check if this action is referenced in states
@@ -1046,22 +1018,16 @@ public class WorkflowDesignerSessionController extends AbstractAdminComponentSes
     }
 
     processModel.getActionsEx().removeAction(strActionName);
-
-    // Was this the last action defined?
-    //
-    if (!processModel.getActionsEx().iterateAction().hasNext()) {
-      processModel.setActions(null);
-    }
   }
 
   /**
-* Update or insert a new consequence element of the cached process model
-*
-* @param source the reference object
-* @param strContext the context of Consequence
-* @throws WorkflowDesignerException when something goes wrong
-* @throws WorkflowException when something goes wrong
-*/
+   * Update or insert a new consequence element of the cached process model
+   *
+   * @param source the reference object
+   * @param strContext the context of Consequence
+   * @throws WorkflowDesignerException when something goes wrong
+   * @throws WorkflowException when something goes wrong
+   */
   public void updateConsequence(Consequence source, String strContext)
       throws WorkflowDesignerException, WorkflowException {
     Action action = findAction(strContext);
@@ -1118,13 +1084,13 @@ public class WorkflowDesignerSessionController extends AbstractAdminComponentSes
   }
 
   /**
-* Move the consequence specified by the context inside the collection
-*
-* @param strContext the context of the consequence
-* @param iConsequence the current index of the consequence in the collection
-* @param nDirection the offset and the direction to move by
-* @throws WorkflowDesignerException if the consequence cannot be found.
-*/
+   * Move the consequence specified by the context inside the collection
+   *
+   * @param strContext the context of the consequence
+   * @param iConsequence the current index of the consequence in the collection
+   * @param nDirection the offset and the direction to move by
+   * @throws WorkflowDesignerException if the consequence cannot be found.
+   */
   public void moveConsequence(String strContext, int iConsequence, int nDirection) throws
       WorkflowDesignerException {
     try {
@@ -1145,11 +1111,11 @@ public class WorkflowDesignerSessionController extends AbstractAdminComponentSes
   }
 
   /**
-* Remove the consequence specified by the context
-*
-* @param strContext the context of the consequence
-* @throws WorkflowDesignerException if the consequence cannot be found.
-*/
+   * Remove the consequence specified by the context
+   *
+   * @param strContext the context of the consequence
+   * @throws WorkflowDesignerException if the consequence cannot be found.
+   */
   public void removeConsequence(String strContext)
       throws WorkflowDesignerException {
     try {
@@ -1170,10 +1136,10 @@ public class WorkflowDesignerSessionController extends AbstractAdminComponentSes
   }
 
   /**
-* Create a new form object to be added to the model
-*
-* @return an object implementing Form
-*/
+   * Create a new form object to be added to the model
+   *
+   * @return an object implementing Form
+   */
   public Form createForm() {
     Forms forms = processModel.getForms();
     Form form;
@@ -1189,11 +1155,11 @@ public class WorkflowDesignerSessionController extends AbstractAdminComponentSes
   }
 
   /**
-* Find the form by context
-*
-* @param strContext the context
-* @return a Form object
-*/
+   * Find the form by context
+   *
+   * @param strContext the context
+   * @return a Form object
+   */
   public Form findForm(String strContext) {
     String[] astrElements;
     String strRoleName;
@@ -1209,7 +1175,6 @@ public class WorkflowDesignerSessionController extends AbstractAdminComponentSes
           } else {
             strRoleName = astrElements[2];
           }
-
           form = processModel.getForms().getForm(astrElements[1], strRoleName);
         }
       } catch (RuntimeException e) {
@@ -1221,16 +1186,16 @@ public class WorkflowDesignerSessionController extends AbstractAdminComponentSes
   }
 
   /**
-* Update Form referenced by the context.
-*
-* @param source the object carrying the new values
-* @param strContext the context of the form being updated
-* @param strNameOriginal the original name of the form
-* @throws WorkflowDesignerException when the update goes wrong
-*/
+   * Update Form referenced by the context.
+   *
+   * @param source the object carrying the new values
+   * @param strContext the context of the form being updated
+   * @param strNameOriginal the original name of the form
+   * @throws WorkflowDesignerException when the update goes wrong
+   */
   public void updateForm(Form source, String strContext,
       String strNameOriginal, String strRoleOriginal) throws WorkflowDesignerException {
-    Form form = null;
+    Form form;
 
     Form check = processModel.getForms().getForm(source.getName(),
         source.getRole());
@@ -1295,12 +1260,12 @@ public class WorkflowDesignerSessionController extends AbstractAdminComponentSes
   }
 
   /**
-* Remove the form described by the context
-*
-* @param strContext the context
-* @throws WorkflowException if the form cannot be found
-* @throws WorkflowDesignerException if the form is referenced elsewhere
-*/
+   * Remove the form described by the context
+   *
+   * @param strContext the context
+   * @throws WorkflowException if the form cannot be found
+   * @throws WorkflowDesignerException if the form is referenced elsewhere
+   */
   public void removeForm(String strContext) throws WorkflowException,
       WorkflowDesignerException {
     String[] astrElements;
@@ -1337,12 +1302,6 @@ public class WorkflowDesignerSessionController extends AbstractAdminComponentSes
           }
 
           processModel.getForms().removeForm(astrElements[1], strRoleName);
-
-          // Was this the last form?
-          //
-          if (!processModel.getForms().iterateForm().hasNext()) {
-            processModel.setForms(null);
-          }
         }
       } catch (ArrayIndexOutOfBoundsException e) {
         // Thrown when no token was found where expected
@@ -1355,11 +1314,11 @@ public class WorkflowDesignerSessionController extends AbstractAdminComponentSes
   }
 
   /**
-* Find the input by context
-*
-* @param strContext the context
-* @return a Input object
-*/
+   * Find the input by context
+   *
+   * @param strContext the context
+   * @return a Input object
+   */
   public Input findInput(String strContext) {
     String[] astrElements;
     Input input = null;
@@ -1369,13 +1328,10 @@ public class WorkflowDesignerSessionController extends AbstractAdminComponentSes
       astrElements = strContext.split("[,/\\[\\]]", -2);
 
       try {
-        if (astrElements[5].length() > 0) {
+        if (!astrElements[5].isEmpty()) {
           input = form.getInput(Integer.parseInt(astrElements[5]));
         }
-      } catch (ArrayIndexOutOfBoundsException e) {
-        // Thrown when no token was found where expected
-        // do nothing, just return null...
-      } catch (NumberFormatException e) {
+      } catch (ArrayIndexOutOfBoundsException | NumberFormatException e) {
         // Thrown when no token was found where expected
         // do nothing, just return null...
       }
@@ -1384,12 +1340,12 @@ public class WorkflowDesignerSessionController extends AbstractAdminComponentSes
   }
 
   /**
-* Update or insert a new input element of the cached process model
-*
-* @param source the reference object
-* @param strContext the context of Input
-* @throws WorkflowDesignerException when something goes wrong
-*/
+   * Update or insert a new input element of the cached process model
+   *
+   * @param source the reference object
+   * @param strContext the context of Input
+   * @throws WorkflowDesignerException when something goes wrong
+   */
   public void updateInput(Input source, String strContext)
       throws WorkflowDesignerException {
     Form form = findForm(strContext);
@@ -1436,14 +1392,12 @@ public class WorkflowDesignerSessionController extends AbstractAdminComponentSes
   }
 
   /**
-* Remove the input specified by the context
-*
-* @param strContext the context of the input
-* @throws WorkflowDesignerException if the input cannot be found.
-* @throws WorkflowException if the input cannot be found
-*/
-  public void removeInput(String strContext) throws WorkflowDesignerException,
-      WorkflowException {
+   * Remove the input specified by the context
+   *
+   * @param strContext the context of the input
+   * @throws WorkflowDesignerException if the input cannot be found.
+   */
+  public void removeInput(String strContext) throws WorkflowDesignerException {
     Form form = findForm(strContext);
     String[] astrElements;
 
@@ -1451,7 +1405,7 @@ public class WorkflowDesignerSessionController extends AbstractAdminComponentSes
       astrElements = strContext.split("[,/\\[\\]]", -2);
 
       try {
-        if (astrElements[5].length() > 0) {
+        if (!astrElements[5].isEmpty()) {
           form.removeInput(Integer.parseInt(astrElements[5]));
           return;
         }
@@ -1469,10 +1423,10 @@ public class WorkflowDesignerSessionController extends AbstractAdminComponentSes
   }
 
   /**
-* Create a new ContextualDesignation object to be added to the model
-*
-* @return an object implementing ContextualDesignation
-*/
+   * Create a new ContextualDesignation object to be added to the model
+   *
+   * @return an object implementing ContextualDesignation
+   */
   public ContextualDesignation createDesignation() {
     ContextualDesignation designation = new SpecificLabel();
 
@@ -1480,15 +1434,6 @@ public class WorkflowDesignerSessionController extends AbstractAdminComponentSes
     return designation;
   }
 
-  /**
-* Update or insert a new ContextualDesignation element of the cached process model
-*
-* @param strContext
-* @param source the reference object
-* @param strLangOriginal
-* @param strRoleOriginal
-* @throws WorkflowDesignerException
-*/
   public void updateContextualDesignations(String strContext,
       ContextualDesignation source, String strLangOriginal,
       String strRoleOriginal) throws WorkflowDesignerException {
@@ -1538,14 +1483,14 @@ public class WorkflowDesignerSessionController extends AbstractAdminComponentSes
   }
 
   /**
-* Finds the contextual designation with the given attributes in the specified context
-*
-* @param strContext the context of the designation
-* @param strLanguage the language
-* @param strRole the role name
-* @return contextual designation of the given role & name or <code>null</code>
-* @throws WorkflowDesignerException if something goes wrong
-*/
+   * Finds the contextual designation with the given attributes in the specified context
+   *
+   * @param strContext the context of the designation
+   * @param strLanguage the language
+   * @param strRole the role name
+   * @return contextual designation of the given role & name or <code>null</code>
+   * @throws WorkflowDesignerException if something goes wrong
+   */
   public ContextualDesignation findContextualDesignation(String strContext,
       String strRole, String strLanguage) throws WorkflowDesignerException {
     return findContextualDesignations(strContext).getSpecificLabel(strRole,
@@ -1553,33 +1498,27 @@ public class WorkflowDesignerSessionController extends AbstractAdminComponentSes
   }
 
   /**
-* Removes the contextual designation with the attributes as the reference object in the specified
-* context
-*
-* @param strContext the context of the designation
-* @param contextualDesignation the reference object
-* @throws WorkflowDesignerException when something goes wrong e.g. designation not found
-*/
+   * Removes the contextual designation with the attributes as the reference object in the specified
+   * context
+   *
+   * @param strContext the context of the designation
+   * @param contextualDesignation the reference object
+   * @throws WorkflowDesignerException when something goes wrong e.g. designation not found
+   */
   public void removeContextualDesignation(String strContext,
       ContextualDesignation contextualDesignation)
       throws WorkflowDesignerException {
-    try {
-      findContextualDesignations(strContext).removeContextualDesignation(
-          contextualDesignation);
-    } catch (WorkflowException e) {
-      throw new WorkflowDesignerException(
-          "WorkflowDesignerSessionController.removeContextualDesignation",
-          SilverpeasException.ERROR, "workflowDesigner.EX_CONTEXTUAL_DESIGNATION_NOT_FOUND");
-    }
+    findContextualDesignations(strContext).removeContextualDesignation(
+        contextualDesignation);
   }
 
   /**
-* Finds the contextual designations object in the specified context
-*
-* @param strContext the context of the designations
-* @return ContextualDesignations collection or <code>null</code> if nothing found
-* @throws WorkflowDesignerException when something goes wrong
-*/
+   * Finds the contextual designations object in the specified context
+   *
+   * @param strContext the context of the designations
+   * @return ContextualDesignations collection or <code>null</code> if nothing found
+   * @throws WorkflowDesignerException when something goes wrong
+   */
   private ContextualDesignations findContextualDesignations(String strContext)
       throws WorkflowDesignerException {
     StringTokenizer strtok;
@@ -1721,13 +1660,13 @@ public class WorkflowDesignerSessionController extends AbstractAdminComponentSes
   }
 
   /**
-* Collect all the object of the type ContextualDesignations instantiated in the Process Model
-*
-* @return a map, where the key is the reference to the object and the value is a textual
-* description of the object location
-*/
+   * Collect all the object of the type ContextualDesignations instantiated in the Process Model
+   *
+   * @return a map, where the key is the reference to the object and the value is a textual
+   * description of the object location
+   */
   private Map<ContextualDesignations, String> collectContextualDesignations() {
-    Map<ContextualDesignations, String> map = new IdentityHashMap<ContextualDesignations, String>();
+    Map<ContextualDesignations, String> map = new IdentityHashMap<>();
     Roles roles = processModel.getRolesEx();
 
     // Process Model Labels & Descriptions
@@ -1843,10 +1782,10 @@ public class WorkflowDesignerSessionController extends AbstractAdminComponentSes
   }
 
   /**
-* Create a new item object to be added to the model
-*
-* @return an object implementing Item
-*/
+   * Create a new item object to be added to the model
+   *
+   * @return an object implementing Item
+   */
   public Item createItem(String strContext) {
     Item item = null;
     if (strContext != null) {
@@ -1875,11 +1814,11 @@ public class WorkflowDesignerSessionController extends AbstractAdminComponentSes
   }
 
   /**
-* Find the Item specified by the context
-*
-* @param strContext the context
-* @return an Item object or <code>null</code>
-*/
+   * Find the Item specified by the context
+   *
+   * @param strContext the context
+   * @return an Item object or <code>null</code>
+   */
   public Item findItem(String strContext) {
     Item item = null;
     if (strContext != null) {
@@ -1896,19 +1835,20 @@ public class WorkflowDesignerSessionController extends AbstractAdminComponentSes
       } catch (NoSuchElementException e) {
         // Thrown when no token was found where expected
         // do nothing, just return null...
+        SilverLogger.getLogger(this).error(e.getMessage());
       }
     }
     return item;
   }
 
   /**
-* Update Item referenced by the context.
-*
-* @param source the object carrying the new values
-* @param strContext the context of the item being updated
-* @param strNameOriginal the original name of the item
-* @throws WorkflowDesignerException when the update goes wrong
-*/
+   * Update Item referenced by the context.
+   *
+   * @param source the object carrying the new values
+   * @param strContext the context of the item being updated
+   * @param strNameOriginal the original name of the item
+   * @throws WorkflowDesignerException when the update goes wrong
+   */
   public void updateItem(Item source, String strContext, String strNameOriginal)
       throws WorkflowDesignerException {
     Item item, check = null;
@@ -1971,15 +1911,15 @@ public class WorkflowDesignerSessionController extends AbstractAdminComponentSes
   }
 
   /**
-* Remove the item described by the context
-*
-* @param strContext the context
-* @throws WorkflowException when the item cannot be found
-* @throws WorkflowDesignerException when the item is referenced elsewhere
-*/
+   * Remove the item described by the context
+   *
+   * @param strContext the context
+   * @throws WorkflowException when the item cannot be found
+   * @throws WorkflowDesignerException when the item is referenced elsewhere
+   */
   public void removeItem(String strContext) throws WorkflowException,
       WorkflowDesignerException {
-    String strItemName = null;
+    String strItemName;
     DataFolder items;
 
     if (strContext == null) {
@@ -2002,8 +1942,7 @@ public class WorkflowDesignerSessionController extends AbstractAdminComponentSes
       } else {
         throw new WorkflowException("WorkflowDesignerSessionController.removeItem()",
             "workflowEngine.EX_ITEM_NOT_FOUND", // $NON-NLS-1$
-            strItemName == null ? "<null>"
-                : strItemName);
+            "<null>");
       }
     } catch (NoSuchElementException e) {
       throw new WorkflowException("WorkflowDesignerSessionController.removeItem()",
@@ -2178,13 +2117,13 @@ public class WorkflowDesignerSessionController extends AbstractAdminComponentSes
   }
 
   /**
-* Update Parameter referenced by the context and parameter name.
-*
-* @param source the object carrying the new values
-* @param strContext the context of the item being updated
-* @param strNameOriginal the original name of the parameter
-* @throws WorkflowDesignerException when the update goes wrong
-*/
+   * Update Parameter referenced by the context and parameter name.
+   *
+   * @param source the object carrying the new values
+   * @param strContext the context of the item being updated
+   * @param strNameOriginal the original name of the parameter
+   * @throws WorkflowDesignerException when the update goes wrong
+   */
   public void updateParameter(Parameter source, String strContext,
       String strNameOriginal) throws WorkflowDesignerException {
     Item item = findItem(strContext);
@@ -2221,23 +2160,22 @@ public class WorkflowDesignerSessionController extends AbstractAdminComponentSes
   }
 
   /**
-* Remove the parameter described by the context and name
-*
-* @param strContext the context
-* @param strName the name of the parameter
-* @throws WorkflowException
-*/
-  public void removeParameter(String strContext, String strName) throws WorkflowException {
+   * Remove the parameter described by the context and name
+   *
+   * @param strContext the context
+   * @param strName the name of the parameter
+   */
+  public void removeParameter(String strContext, String strName) {
     Item item = findItem(strContext);
     item.removeParameter(strName);
   }
 
   /**
-* Find the QualifiedUsers specified by the context
-*
-* @param strContext the context
-* @return a QualifiedUsers object or <code>null</code>
-*/
+   * Find the QualifiedUsers specified by the context
+   *
+   * @param strContext the context
+   * @return a QualifiedUsers object or <code>null</code>
+   */
   public QualifiedUsers findQualifiedUsers(String strContext)
       throws WorkflowException {
     StringTokenizer strtok;
@@ -2291,34 +2229,27 @@ public class WorkflowDesignerSessionController extends AbstractAdminComponentSes
                 List<QualifiedUsers> qualifiedUsersList = consequence.getNotifiedUsers();
                 if (i != -1 && qualifiedUsersList != null && !qualifiedUsersList.isEmpty()) {
                   qualifiedUsers = qualifiedUsersList.get(i);
-                } else {
-                  qualifiedUsers = null;
                 }
               }
             }
           }
         }
-      } catch (NoSuchElementException e) {
+      } catch (NoSuchElementException | NumberFormatException | ArrayIndexOutOfBoundsException e) {
         // Thrown when no token was found where expected
         // do nothing, just return null...
-      } catch (ArrayIndexOutOfBoundsException e) {
-        // Thrown when no consequence was found at the specified index
-        // do nothing, just return null...
-      } catch (NumberFormatException e) {
-        // Thrown when no token was found where expected
-        // do nothing, just return null...
-      }
+      } // Thrown when no consequence was found at the specified index
+
     }
     return qualifiedUsers;
   }
 
   /**
-* Set the QualifiedUsers specified by the context to the given value
-*
-* @param qualifiedUsers the new value of qualified users
-* @param strContext the context
-* @throws WorkflowDesignerException When the qualified users' parent could not be found
-*/
+   * Set the QualifiedUsers specified by the context to the given value
+   *
+   * @param qualifiedUsers the new value of qualified users
+   * @param strContext the context
+   * @throws WorkflowDesignerException When the qualified users' parent could not be found
+   */
   public void setQualifiedUsers(QualifiedUsers qualifiedUsers, String strContext)
       throws WorkflowException, WorkflowDesignerException {
     if (strContext != null) {
@@ -2382,13 +2313,13 @@ public class WorkflowDesignerSessionController extends AbstractAdminComponentSes
   }
 
   /**
-* Collect all the objects of the type QalifiedUsers instantiated in the Process Model
-*
-* @return a map, where the key is the reference to the object and the value is a textual
-* description of the object location
-*/
+   * Collect all the objects of the type QalifiedUsers instantiated in the Process Model
+   *
+   * @return a map, where the key is the reference to the object and the value is a textual
+   * description of the object location
+   */
   private Map<QualifiedUsers, String> collectQualifiedUsers() {
-    Map<QualifiedUsers, String> map = new IdentityHashMap<QualifiedUsers, String>();
+    Map<QualifiedUsers, String> map = new IdentityHashMap<>();
 
     // States
     //
@@ -2446,11 +2377,11 @@ public class WorkflowDesignerSessionController extends AbstractAdminComponentSes
   }
 
   /**
-* Get the Action specified by the context
-*
-* @param strContext the context
-* @return an Action object or <code>null</code>
-*/
+   * Get the Action specified by the context
+   *
+   * @param strContext the context
+   * @return an Action object or <code>null</code>
+   */
   public Action findAction(String strContext) throws WorkflowException {
     StringTokenizer strtok;
     String strElement;
@@ -2475,11 +2406,11 @@ public class WorkflowDesignerSessionController extends AbstractAdminComponentSes
   }
 
   /**
-* Find the Consequence specified by the context
-*
-* @param strContext the context
-* @return an Consequence object or <code>null</code>
-*/
+   * Find the Consequence specified by the context
+   *
+   * @param strContext the context
+   * @return an Consequence object or <code>null</code>
+   */
   public Consequence findConsequence(String strContext)
       throws WorkflowException {
     StringTokenizer strtok;
@@ -2492,12 +2423,13 @@ public class WorkflowDesignerSessionController extends AbstractAdminComponentSes
 
       try {
         if (action != null) {
-          strElement = strtok.nextToken(); // actions/
-          strElement = strtok.nextToken(); // <name>
-          strElement = strtok.nextToken(); // consequences/
+          strtok.nextToken(); // actions/
+          strtok.nextToken(); // <name>
+          strtok.nextToken(); // consequences/
           strElement = strtok.nextToken(); // <consequence-no>
 
-          consequence = action.getConsequences().getConsequenceList().get(Integer.parseInt(strElement));
+          consequence =
+              action.getConsequences().getConsequenceList().get(Integer.parseInt(strElement));
         }
       } catch (NoSuchElementException e) {
         // Thrown when no token was found where expected
@@ -2514,14 +2446,14 @@ public class WorkflowDesignerSessionController extends AbstractAdminComponentSes
   }
 
   /**
-* Returns the language codes as configured in the properties
-*
-* @param fDefault if <code>true</code> the 'default' option shall be included
-* @return an array of language codes
-*/
+   * Returns the language codes as configured in the properties
+   *
+   * @param fDefault if <code>true</code> the 'default' option shall be included
+   * @return an array of language codes
+   */
   public String[] retrieveLanguageCodes(boolean fDefault) {
     StringTokenizer strtok = new StringTokenizer(getSettings().getString("languages"), ",");
-    List<String> list = new ArrayList<String>(strtok.countTokens() + 1);
+    List<String> list = new ArrayList<>(strtok.countTokens() + 1);
     if (fDefault) {
       list.add("default");
     }
@@ -2533,16 +2465,16 @@ public class WorkflowDesignerSessionController extends AbstractAdminComponentSes
   }
 
   /**
-* Returns names of available languages as configured in the properties, localised for the current
-* user
-*
-* @param fDefault if <code>true</code> the 'default' option shall be included
-* @return an array of language names
-*/
+   * Returns names of available languages as configured in the properties, localised for the current
+   * user
+   *
+   * @param fDefault if <code>true</code> the 'default' option shall be included
+   * @return an array of language names
+   */
   public String[] retrieveLanguageNames(boolean fDefault) {
     StringTokenizer strtok = new StringTokenizer(getSettings().getString("languages"), ",");
     Locale locale = new Locale(getLanguage());
-    List<String> list = new ArrayList<String>(strtok.countTokens() + 1);
+    List<String> list = new ArrayList<>(strtok.countTokens() + 1);
     if (fDefault) {
       list.add(getString("workflowDesigner.default"));
     }
@@ -2555,11 +2487,11 @@ public class WorkflowDesignerSessionController extends AbstractAdminComponentSes
   }
 
   /**
-* Returns the item type codes as configured in the properties
-*
-* @param fNone if <code>true</code> the 'None' option shall be included
-* @return an array of codes
-*/
+   * Returns the item type codes as configured in the properties
+   *
+   * @param fNone if <code>true</code> the 'None' option shall be included
+   * @return an array of codes
+   */
   public String[] retrieveItemTypeCodes(boolean fNone) {
     String[] types = TypeManager.getInstance().getTypeNames();
     if (fNone) {
@@ -2569,14 +2501,14 @@ public class WorkflowDesignerSessionController extends AbstractAdminComponentSes
   }
 
   /**
-* Returns a list of comparison operators as configured in the properties,
-*
-* @param fNone if <code>true</code> the 'none' option shall be included
-* @return an array of operators
-*/
+   * Returns a list of comparison operators as configured in the properties,
+   *
+   * @param fNone if <code>true</code> the 'none' option shall be included
+   * @return an array of operators
+   */
   public String[] retrieveOperators(boolean fNone) {
     StringTokenizer strtok = new StringTokenizer(getSettings().getString("operators"), ",");
-    List<String> list = new ArrayList<String>(strtok.countTokens() + 1);
+    List<String> list = new ArrayList<>(strtok.countTokens() + 1);
 
     if (fNone) {
       list.add("");
@@ -2590,13 +2522,13 @@ public class WorkflowDesignerSessionController extends AbstractAdminComponentSes
   }
 
   /**
-* Returns the action kind codes as configured in the properties retrieve
-*
-* @return an array of codes
-*/
+   * Returns the action kind codes as configured in the properties retrieve
+   *
+   * @return an array of codes
+   */
   public String[] retrieveActionKindCodes() {
     StringTokenizer strtok = new StringTokenizer(getSettings().getString("actionKinds"), ",");
-    List<String> list = new ArrayList<String>(strtok.countTokens());
+    List<String> list = new ArrayList<>(strtok.countTokens());
     while (strtok.hasMoreTokens()) {
       list.add(strtok.nextToken());
     }
@@ -2609,13 +2541,13 @@ public class WorkflowDesignerSessionController extends AbstractAdminComponentSes
   }
 
   /**
-* Produce a list of action names
-*
-* @param fNone if <code>true</code> the 'None' option shall be included
-* @return an array of Strings or an empty array.
-*/
+   * Produce a list of action names
+   *
+   * @param fNone if <code>true</code> the 'None' option shall be included
+   * @return an array of Strings or an empty array.
+   */
   public String[] retrieveActionNames(boolean fNone) {
-    List<String> list = new ArrayList<String>();
+    List<String> list = new ArrayList<>();
     Actions actions = getProcessModel().getActionsEx();
     if (fNone) {
       list.add("");
@@ -2630,14 +2562,14 @@ public class WorkflowDesignerSessionController extends AbstractAdminComponentSes
   }
 
   /**
-* Produce a list of role names
-*
-* @param fNone if <code>true</code> the 'None' option shall be included
-* @param fDefault if <code>true</code> the 'default' option shall be included
-* @return an array of Strings or an empty array.
-*/
+   * Produce a list of role names
+   *
+   * @param fNone if <code>true</code> the 'None' option shall be included
+   * @param fDefault if <code>true</code> the 'default' option shall be included
+   * @return an array of Strings or an empty array.
+   */
   public String[] retrieveRoleNames(boolean fNone, boolean fDefault) {
-    List<String> list = new ArrayList<String>();
+    List<String> list = new ArrayList<>();
     Roles roles = getProcessModel().getRolesEx();
     if (fNone) {
       list.add("");
@@ -2655,13 +2587,13 @@ public class WorkflowDesignerSessionController extends AbstractAdminComponentSes
   }
 
   /**
-* Produce a list of state names
-*
-* @param fNone if <code>true</code> the 'None' option shall be included
-* @return an array of Strings or an empty array.
-*/
+   * Produce a list of state names
+   *
+   * @param fNone if <code>true</code> the 'None' option shall be included
+   * @return an array of Strings or an empty array.
+   */
   public String[] retrieveStateNames(boolean fNone) {
-    List<String> list = new ArrayList<String>();
+    List<String> list = new ArrayList<>();
     States states = getProcessModel().getStatesEx();
     if (fNone) {
       list.add("");
@@ -2676,13 +2608,13 @@ public class WorkflowDesignerSessionController extends AbstractAdminComponentSes
   }
 
   /**
-* Produce a list of participant names
-*
-* @param fNone if <code>true</code> the 'None' option shall be included
-* @return an array of Strings or an empty array.
-*/
+   * Produce a list of participant names
+   *
+   * @param fNone if <code>true</code> the 'None' option shall be included
+   * @return an array of Strings or an empty array.
+   */
   public String[] retrieveParticipantNames(boolean fNone) {
-    List<String> list = new ArrayList<String>();
+    List<String> list = new ArrayList<>();
     Participants participants = getProcessModel().getParticipantsEx();
     if (fNone) {
       list.add("");
@@ -2698,14 +2630,14 @@ public class WorkflowDesignerSessionController extends AbstractAdminComponentSes
   }
 
   /**
-* Produce a list of user info item names, optionally those where the type = 'user'
-*
-* @param fNone if <code>true</code> the 'None' option shall be included
-* @param fUsersOnly if <code>true</code> only the items of type 'user' shall be included
-* @return an array of Strings or an empty array.
-*/
+   * Produce a list of user info item names, optionally those where the type = 'user'
+   *
+   * @param fNone if <code>true</code> the 'None' option shall be included
+   * @param fUsersOnly if <code>true</code> only the items of type 'user' shall be included
+   * @return an array of Strings or an empty array.
+   */
   public String[] retrieveUserInfoItemNames(boolean fNone, boolean fUsersOnly) {
-    List<String> list = new ArrayList<String>();
+    List<String> list = new ArrayList<>();
     DataFolder userInfos = getProcessModel().getUserInfos();
     if (fNone) {
       list.add("");
@@ -2726,14 +2658,14 @@ public class WorkflowDesignerSessionController extends AbstractAdminComponentSes
   }
 
   /**
-* Produce a list of data folder item names, optionally those where the type = 'user'
-*
-* @param fNone if <code>true</code> the 'None' option shall be included
-* @param fUsersOnly if <code>true</code> only the items of type 'user' shall be included
-* @return an array of Strings or an empty array.
-*/
+   * Produce a list of data folder item names, optionally those where the type = 'user'
+   *
+   * @param fNone if <code>true</code> the 'None' option shall be included
+   * @param fUsersOnly if <code>true</code> only the items of type 'user' shall be included
+   * @return an array of Strings or an empty array.
+   */
   public String[] retrieveFolderItemNames(boolean fNone, boolean fUsersOnly) {
-    List<String> list = new ArrayList<String>();
+    List<String> list = new ArrayList<>();
     DataFolder dataFolder = getProcessModel().getDataFolder();
 
     if (fNone) {
@@ -2761,14 +2693,14 @@ public class WorkflowDesignerSessionController extends AbstractAdminComponentSes
   }
 
   /**
-* Produce a list of form names, only forms other than 'presentationForm' and 'printForm'
-*
-* @param fNone if <code>true</code> the 'None' option shall be included
-* @return an array of Strings or an empty array.
-*/
+   * Produce a list of form names, only forms other than 'presentationForm' and 'printForm'
+   *
+   * @param fNone if <code>true</code> the 'None' option shall be included
+   * @return an array of Strings or an empty array.
+   */
   public String[] retrieveFormNames(boolean fNone) {
     Forms forms = getProcessModel().getForms();
-    List<String> list = new ArrayList<String>();
+    List<String> list = new ArrayList<>();
     if (fNone) {
       list.add("");
     }
@@ -2790,15 +2722,18 @@ public class WorkflowDesignerSessionController extends AbstractAdminComponentSes
   /**
    * Generates component descriptor file in the appropriate directory, stores the new descriptor's
    * name to be able to access it later
+   *
    * @throws WorkflowDesignerException when something goes wrong
    */
   public void generateComponentDescriptor() throws WorkflowDesignerException {
-    SilverpeasTemplate template = SilverpeasTemplateFactory.createSilverpeasTemplateOnCore("workflow");
+    SilverpeasTemplate template = SilverpeasTemplateFactory.createSilverpeasTemplateOnCore(
+        "workflow");
     final String sureProcessModelFileName = processModelFileName.replace("\\", "/");
     template.setAttribute("processModelFileName", sureProcessModelFileName);
 
     final WAComponent waComponent = new WAComponent();
-    final LocalizedWAComponentRegistry localizedCmpRegistry = new LocalizedWAComponentRegistry(waComponent);
+    final LocalizedWAComponentRegistry localizedCmpRegistry =
+        new LocalizedWAComponentRegistry(waComponent);
     final List<LocalizedWAComponent> stLocalizedCmpLabels = new ArrayList<>();
     final List<LocalizedWAComponent> stLocalizedCmpDescriptions = new ArrayList<>();
     final Map<String, List<LocalizedProfile>> stLocalizedCmpProfiles = new HashMap<>();
@@ -2882,7 +2817,8 @@ public class WorkflowDesignerSessionController extends AbstractAdminComponentSes
     Optional.of(xmlComponentTemp.getParentFile())
         .filter(f -> !f.exists())
         .ifPresent(File::mkdirs);
-    try (final PrintWriter out = new PrintWriter(new FileWriter(xmlComponentTemp, Charsets.UTF_8))) {
+    try (final PrintWriter out =
+             new PrintWriter(new FileWriter(xmlComponentTemp, Charsets.UTF_8))) {
       out.print(template.applyFileTemplate("xmlComponent"));
     } catch (IOException e) {
       throw new WorkflowDesignerException(
@@ -2929,13 +2865,13 @@ public class WorkflowDesignerSessionController extends AbstractAdminComponentSes
   }
 
   /**
-* Finds the component that references the given process model
-*
-* @param strProcessModelFileName the relative path to the file containing the process model
-* description
-* @return the name of the component descriptor file name (without .XML ) or <code>null</code> if
-* no components reference the given model.
-*/
+   * Finds the component that references the given process model
+   *
+   * @param strProcessModelFileName the relative path to the file containing the process model
+   * description
+   * @return the name of the component descriptor file name (without .XML ) or <code>null</code> if
+   * no components reference the given model.
+   */
   private String findComponentDescriptor(String strProcessModelFileName) {
     Collection<WAComponent> waComponents = WAComponent.getAll();
     if (strProcessModelFileName != null) {
@@ -2957,16 +2893,16 @@ public class WorkflowDesignerSessionController extends AbstractAdminComponentSes
   }
 
   /**
-* Upload given process model in workflow repository.
-*
-* @param model process model file
-* @throws WorkflowDesignerException , WorkflowException
-*/
+   * Upload given process model in workflow repository.
+   *
+   * @param model process model file
+   * @throws WorkflowDesignerException , WorkflowException
+   */
   public void uploadProcessModel(FileItem model)
-      throws WorkflowDesignerException, WorkflowException {
+      throws WorkflowDesignerException {
     String name = model.getName();
     if (name != null) {
-      name = name.substring(name.lastIndexOf(File.separator) + 1, name.length());
+      name = name.substring(name.lastIndexOf(File.separator) + 1);
       name = replaceSpecialChars(name);
 
       ProcessModelManager manager = WorkflowHub.getProcessModelManager();

--- a/core-war/src/main/java/org/silverpeas/web/workflowdesigner/servlets/FunctionHandler.java
+++ b/core-war/src/main/java/org/silverpeas/web/workflowdesigner/servlets/FunctionHandler.java
@@ -43,7 +43,7 @@ public interface FunctionHandler {
    * @throws WorkflowDesignerException when something goes wrong
    * @throws WorkflowException when something goes wrong
    */
-  public String getDestination(String function,
+  String getDestination(String function,
       WorkflowDesignerSessionController workflowDesignerSC,
       HttpServletRequest request) throws WorkflowDesignerException,
       WorkflowException;

--- a/core-war/src/main/java/org/silverpeas/web/workflowdesigner/taglib/ProcessModelButtonPane.java
+++ b/core-war/src/main/java/org/silverpeas/web/workflowdesigner/taglib/ProcessModelButtonPane.java
@@ -23,20 +23,18 @@
  */
 package org.silverpeas.web.workflowdesigner.taglib;
 
-import java.io.IOException;
-
-import javax.servlet.jsp.JspException;
-import javax.servlet.jsp.tagext.TagSupport;
-
 import org.silverpeas.core.util.MultiSilverpeasBundle;
 import org.silverpeas.core.web.util.viewgenerator.html.GraphicElementFactory;
 import org.silverpeas.core.web.util.viewgenerator.html.buttonpanes.ButtonPane;
 import org.silverpeas.core.web.util.viewgenerator.html.buttons.Button;
 
+import javax.servlet.jsp.JspException;
+import java.io.IOException;
+
 /**
  * Class implementing the tag &lt;buttonPane&gt; from workflowEditor.tld
  */
-public class ProcessModelButtonPane extends TagSupport {
+public class ProcessModelButtonPane extends WorkflowTagSupport {
 
   private static final long serialVersionUID = 2771341684220021139L;
   private String strCancelAction;
@@ -55,10 +53,7 @@ public class ProcessModelButtonPane extends TagSupport {
     strCancelAction = cancelAction;
   }
 
-  /*
-   * (non-Javadoc)
-   * @see javax.servlet.jsp.tagext.TagSupport#doStartTag()
-   */
+  @Override
   public int doStartTag() throws JspException {
     GraphicElementFactory gef;
     MultiSilverpeasBundle resource;
@@ -71,9 +66,9 @@ public class ProcessModelButtonPane extends TagSupport {
     buttonPane = gef.getButtonPane();
     resource = (MultiSilverpeasBundle) pageContext.getRequest().getAttribute(
         "resources");
-    validateButton = (Button) gef.getFormButton(resource
+    validateButton = gef.getFormButton(resource
         .getString("GML.validate"), "javascript:sendData();", false);
-    cancelButton = (Button) gef.getFormButton(resource.getString("GML.cancel"),
+    cancelButton = gef.getFormButton(resource.getString("GML.cancel"),
         strCancelAction, false);
 
     buttonPane.addButton(validateButton);

--- a/core-war/src/main/java/org/silverpeas/web/workflowdesigner/taglib/ProcessModelTabs.java
+++ b/core-war/src/main/java/org/silverpeas/web/workflowdesigner/taglib/ProcessModelTabs.java
@@ -23,21 +23,29 @@
  */
 package org.silverpeas.web.workflowdesigner.taglib;
 
-import java.io.IOException;
-
-import javax.servlet.jsp.JspException;
-import javax.servlet.jsp.tagext.TagSupport;
-
 import org.silverpeas.core.util.MultiSilverpeasBundle;
 import org.silverpeas.core.web.util.viewgenerator.html.GraphicElementFactory;
 import org.silverpeas.core.web.util.viewgenerator.html.tabs.TabbedPane;
 
+import javax.servlet.jsp.JspException;
+import java.io.IOException;
+
 /**
  * Class implementing the tag &lt;processModelTabs&gt; from workflowEditor.tld
  */
-public class ProcessModelTabs extends TagSupport {
+public class ProcessModelTabs extends WorkflowTagSupport {
 
   private static final long serialVersionUID = 5607804796452218902L;
+  private static final String MODIFY_WORKFLOW = "ModifyWorkflow";
+  private static final String VIEW_PRESENTATION = "ViewPresentation";
+  private static final String VIEW_PARTICIPANTS = "ViewParticipants";
+  private static final String VIEW_STATES = "ViewStates";
+  private static final String VIEW_ACTIONS = "ViewActions";
+  private static final String VIEW_USER_INFOS = "ViewUserInfos";
+  private static final String VIEW_DATA_FOLDER = "ViewDataFolder";
+  private static final String VIEW_FORMS = "ViewForms";
+  private static final String VIEW_ROLES = "ViewRoles";
+
   private String strCurrentTab;
 
   /**
@@ -54,10 +62,7 @@ public class ProcessModelTabs extends TagSupport {
     strCurrentTab = currentTab;
   }
 
-  /*
-   * (non-Javadoc)
-   * @see javax.servlet.jsp.tagext.TagSupport#doStartTag()
-   */
+  @Override
   public int doStartTag() throws JspException {
     GraphicElementFactory gef;
     MultiSilverpeasBundle resource;
@@ -69,32 +74,32 @@ public class ProcessModelTabs extends TagSupport {
         "resources");
     tabbedPane = gef.getTabbedPane();
 
-    tabbedPane.addTab(resource.getString("GML.head"), "ModifyWorkflow"
-        .equals(strCurrentTab) ? "#" : "ModifyWorkflow", "ModifyWorkflow"
+    tabbedPane.addTab(resource.getString("GML.head"), MODIFY_WORKFLOW
+        .equals(strCurrentTab) ? "#" : MODIFY_WORKFLOW, MODIFY_WORKFLOW
         .equals(strCurrentTab));
-    tabbedPane.addTab(resource.getString("workflowDesigner.roles"), "ViewRoles"
-        .equals(strCurrentTab) ? "#" : "ViewRoles", "ViewRoles"
+    tabbedPane.addTab(resource.getString("workflowDesigner.roles"), VIEW_ROLES
+        .equals(strCurrentTab) ? "#" : VIEW_ROLES, VIEW_ROLES
         .equals(strCurrentTab));
     tabbedPane.addTab(resource.getString("workflowDesigner.presentation"),
-        "ViewPresentation".equals(strCurrentTab) ? "#" : "ViewPresentation",
-        "ViewPresentation".equals(strCurrentTab));
+        VIEW_PRESENTATION.equals(strCurrentTab) ? "#" : VIEW_PRESENTATION,
+        VIEW_PRESENTATION.equals(strCurrentTab));
     tabbedPane.addTab(resource.getString("workflowDesigner.participants"),
-        "ViewParticipants".equals(strCurrentTab) ? "#" : "ViewParticipants",
-        "ViewParticipants".equals(strCurrentTab));
+        VIEW_PARTICIPANTS.equals(strCurrentTab) ? "#" : VIEW_PARTICIPANTS,
+        VIEW_PARTICIPANTS.equals(strCurrentTab));
     tabbedPane.addTab(resource.getString("workflowDesigner.states"),
-        "ViewStates".equals(strCurrentTab) ? "#" : "ViewStates", "ViewStates"
+        VIEW_STATES.equals(strCurrentTab) ? "#" : VIEW_STATES, VIEW_STATES
         .equals(strCurrentTab));
     tabbedPane.addTab(resource.getString("workflowDesigner.actions"),
-        "ViewActions".equals(strCurrentTab) ? "#" : "ViewActions",
-        "ViewActions".equals(strCurrentTab));
+        VIEW_ACTIONS.equals(strCurrentTab) ? "#" : VIEW_ACTIONS,
+        VIEW_ACTIONS.equals(strCurrentTab));
     tabbedPane.addTab(resource.getString("workflowDesigner.userInfos"),
-        "ViewUserInfos".equals(strCurrentTab) ? "#" : "ViewUserInfos",
-        "ViewUserInfos".equals(strCurrentTab));
+        VIEW_USER_INFOS.equals(strCurrentTab) ? "#" : VIEW_USER_INFOS,
+        VIEW_USER_INFOS.equals(strCurrentTab));
     tabbedPane.addTab(resource.getString("workflowDesigner.dataFolder"),
-        "ViewDataFolder".equals(strCurrentTab) ? "#" : "ViewDataFolder",
-        "ViewDataFolder".equals(strCurrentTab));
-    tabbedPane.addTab(resource.getString("workflowDesigner.forms"), "ViewForms"
-        .equals(strCurrentTab) ? "#" : "ViewForms", "ViewForms"
+        VIEW_DATA_FOLDER.equals(strCurrentTab) ? "#" : VIEW_DATA_FOLDER,
+        VIEW_DATA_FOLDER.equals(strCurrentTab));
+    tabbedPane.addTab(resource.getString("workflowDesigner.forms"), VIEW_FORMS
+        .equals(strCurrentTab) ? "#" : VIEW_FORMS, VIEW_FORMS
         .equals(strCurrentTab));
 
     try {

--- a/core-war/src/main/java/org/silverpeas/web/workflowdesigner/taglib/WorkflowTagSupport.java
+++ b/core-war/src/main/java/org/silverpeas/web/workflowdesigner/taglib/WorkflowTagSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2000 - 2024 Silverpeas
+ * Copyright (C) 2000 - 2025 Silverpeas
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -21,23 +21,33 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-package org.silverpeas.core.workflow.api.model;
 
-import java.io.Serializable;
+package org.silverpeas.web.workflowdesigner.taglib;
+
+import org.silverpeas.core.util.MultiSilverpeasBundle;
+import org.silverpeas.core.web.util.viewgenerator.html.GraphicElementFactory;
+import org.silverpeas.core.web.util.viewgenerator.html.iconpanes.IconPane;
+
+import javax.servlet.jsp.tagext.TagSupport;
 
 /**
- * Interface describing a representation of the &lt;userInRole&gt; element of a Process Model.
+ * Common properties of all the tag defined for the workflow web pages.
+ *
+ * @author mmoquillon
  */
-public interface UserInRole extends Serializable {
+public abstract class WorkflowTagSupport extends TagSupport {
 
-  /**
-   * Get name of the role
-   */
-  String getRoleName();
-
-  /**
-   * Set name of the role
-   * @param roleName the name of the role
-   */
-  void setRoleName(String roleName);
+  protected IconPane addIconPane(GraphicElementFactory gef, MultiSilverpeasBundle resource,
+      String modifAction, String removalAction) {
+    var iconPane = gef.getIconPane();
+    var updateIcon = iconPane.addIcon();
+    var delIcon = iconPane.addIcon();
+    updateIcon.setProperties(resource.getIcon("workflowDesigner.smallUpdate"),
+        resource.getString("GML.modify"), modifAction);
+    delIcon.setProperties(resource.getIcon("workflowDesigner.smallDelete"),
+        resource.getString("GML.delete"), removalAction);
+    iconPane.setSpacing("30px");
+    return iconPane;
+  }
 }
+  

--- a/core-war/src/main/webapp/workflowDesigner/jsp/JavaScript/forms.js
+++ b/core-war/src/main/webapp/workflowDesigner/jsp/JavaScript/forms.js
@@ -1,5 +1,14 @@
-function confirmRemove(strURL, strQuestion) {
+function confirmRemove(action, params, strQuestion) {
   jQuery.popup.confirm(strQuestion, function() {
-    location.href = strURL;
+    let $div = jQuery('<div>', {id: 'Form-Removal'})
+    let $form = jQuery('<form>', {name: action, action: action, method: 'POST'}).appendTo($div);
+    for (let input in params) {
+      let $input = jQuery('<input>', {name: input, value: params[input], type: 'hidden'});
+      $form.append($input);
+    }
+    jQuery('body').append($div);
+    setTokens('#Form-Removal');
+    $form.submit();
+    $div.remove();
   });
 }

--- a/core-war/src/main/webapp/workflowDesigner/jsp/actions.jsp
+++ b/core-war/src/main/webapp/workflowDesigner/jsp/actions.jsp
@@ -25,7 +25,8 @@
 --%>
 <%@ page import="org.silverpeas.core.workflow.api.model.Actions" %>
 <%@ page import="org.silverpeas.core.workflow.api.model.Action" %>
-<%@ page import="org.silverpeas.core.util.WebEncodeHelper" %><%--
+<%@ page import="org.silverpeas.core.util.WebEncodeHelper" %>
+<%@ page import="java.nio.charset.StandardCharsets" %><%--
 
     Copyright (C) 2000 - 2024 Silverpeas
 
@@ -65,18 +66,16 @@ Actions actions = (Actions)request.getAttribute( "Actions" );
 ArrayPane  actionsPane = gef.getArrayPane("actionsList", strCurrentTab, request, session);
 %>
 
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<view:looknfeel/>
+<view:sp-page>
+<view:sp-head-part>
 <script type="text/javascript" src="<%=m_context%>/workflowDesigner/jsp/JavaScript/forms.js"></script>
 <script type="text/javascript">
 function sendData() {
     document.workflowHeaderForm.submit();
 }
 </script>
-</head>
-<body class="page_content_admin">
+</view:sp-head-part>
+<view:sp-body-part cssClass="page_content_admin">
 <%
 browseBar.setDomainName(resource.getString("workflowDesigner.toolName") );
 browseBar.setComponentName(resource.getString("workflowDesigner.actions") );
@@ -96,11 +95,11 @@ column.setSortable(false);
 if ( actions != null )
 {
     Action action;
-    Iterator   iterAction = actions.iterateAction();
+    Iterator<Action> iterAction = actions.iterateAction();
 
     while ( iterAction.hasNext() )
     {
-        action = (Action)iterAction.next();
+        action = iterAction.next();
         strActionName = action.getName();
         strModifyAction = "ModifyAction?action=" + strActionName;
         row    = actionsPane.addArrayLine();
@@ -110,8 +109,8 @@ if ( actions != null )
         delIcon = iconPane.addIcon();
         delIcon.setProperties(resource.getIcon("workflowDesigner.smallDelete"),
                               resource.getString("GML.delete"),
-                              "javascript:confirmRemove('RemoveAction?action="
-                              + URLEncoder.encode(strActionName, UTF8) + "', '"
+                              "javascript:confirmRemove('RemoveAction', {action: '"
+                              + URLEncoder.encode(strActionName, StandardCharsets.UTF_8) + "'}, '"
                               + resource.getString("workflowDesigner.confirmRemoveJS")
                               + " " + WebEncodeHelper.javaStringToJsString(strActionName) + " ?');" );
 
@@ -135,10 +134,14 @@ out.println(window.printBefore());
 <view:areaOfOperationOfCreation/>
 <!-- help -->
 <div class="inlineMessage">
-	<table border="0"><tr>
-		<td valign="absmiddle"><img border="0" src="<%=resource.getIcon("workflowDesigner.info") %>"/></td>
+	<table>
+        <tr><th></th></tr>
+        <tr>
+		<td class="absmiddle"><img alt="info"
+                                    src="<%=resource.getIcon("workflowDesigner.info") %>"/></td>
 		<td><%=resource.getString("workflowDesigner.help.actions") %></td>
-	</tr></table>
+	    </tr>
+    </table>
 </div>
 <br/>
 <%
@@ -151,5 +154,5 @@ out.println(actionsPane.print());
 <%
 out.println(window.printAfter());
 %>
-</body>
-</html>
+</view:sp-body-part>
+</view:sp-page>

--- a/core-war/src/main/webapp/workflowDesigner/jsp/check.jsp
+++ b/core-war/src/main/webapp/workflowDesigner/jsp/check.jsp
@@ -78,6 +78,7 @@ response.setDateHeader ("Expires",-1);          //prevents caching at the proxy 
 <%@ page import="org.silverpeas.core.web.util.viewgenerator.html.window.Window"%>
 <%@ page import="java.io.UnsupportedEncodingException"%>
 <%@ page import="java.net.URLEncoder"%>
+<%@ page import="java.nio.charset.StandardCharsets"%>
 
 
 <%@ page import="java.util.ArrayList"%>
@@ -117,8 +118,7 @@ ArrayCellRadio  cellRadio;
  String componentId = browseContext[3];
 %>
 
-<%! public static final String UTF8 = "UTF-8";
-
+<%!
     public void addContextualDesignation( OperationPane    operationPane,
                                           MultiSilverpeasBundle resource,
                                           String           strContext,
@@ -130,9 +130,9 @@ ArrayCellRadio  cellRadio;
             operationPane.addOperation(resource.getIcon("workflowDesigner.add"),
                                        resource.getString(strAddActionKey),
                                        "AddContextualDesignation?context="
-                                       + URLEncoder.encode( strContext, UTF8 )
+                                       + URLEncoder.encode( strContext, StandardCharsets.UTF_8 )
                                        + "&parentScreen="
-                                       + URLEncoder.encode( strParentScreen, UTF8 ) );
+                                       + URLEncoder.encode( strParentScreen, StandardCharsets.UTF_8 ) );
     }
 
     public void addItem( OperationPane    operationPane,
@@ -144,7 +144,7 @@ ArrayCellRadio  cellRadio;
         if ( operationPane != null )
             operationPane.addOperationOfCreation( resource.getIcon("workflowDesigner.add"),
                                         resource.getString( strAddActionKey ),
-                                        "AddItem?context=" + URLEncoder.encode( strContext, "UTF-8") );
+                                        "AddItem?context=" + URLEncoder.encode( strContext, StandardCharsets.UTF_8) );
     }
 
     public void addRelatedUser( OperationPane    operationPane,
@@ -155,6 +155,7 @@ ArrayCellRadio  cellRadio;
         if ( operationPane != null )
             operationPane.addOperation(resource.getIcon("workflowDesigner.add"),
                                        resource.getString("workflowDesigner.add.relatedUser"),
-                                       "AddRelatedUser?context=" + URLEncoder.encode( strContext, "UTF-8") );
+                                       "AddRelatedUser?context="
+                                               + URLEncoder.encode( strContext, StandardCharsets.UTF_8) );
     }
 %>

--- a/core-war/src/main/webapp/workflowDesigner/jsp/dataFolder.jsp
+++ b/core-war/src/main/webapp/workflowDesigner/jsp/dataFolder.jsp
@@ -34,18 +34,16 @@ String        strCurrentTab   = "ViewDataFolder",
 DataFolder    items = (DataFolder)request.getAttribute("Items");
 %>
 
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<view:looknfeel/>
+<view:sp-page>
+<view:sp-head-part>
 <script type="text/javascript" src="<%=m_context%>/workflowDesigner/jsp/JavaScript/forms.js"></script>
 <script type="text/javascript">
 function sendData() {
     document.workflowHeaderForm.submit();
 }
 </script>
-</head>
-<body class="page_content_admin">
+</view:sp-head-part>
+<view:sp-body-part cssClass="page_content_admin">
 <%
 browseBar.setDomainName(resource.getString("workflowDesigner.toolName"));
 browseBar.setComponentName(resource.getString("workflowDesigner.list.dataFolder"));
@@ -74,5 +72,5 @@ out.println(window.printBefore());
 <%
 out.println(window.printAfter());
 %>
-</body>
-</html>
+</view:sp-body-part>
+</view:sp-page>

--- a/core-war/src/main/webapp/workflowDesigner/jsp/editAction.jsp
+++ b/core-war/src/main/webapp/workflowDesigner/jsp/editAction.jsp
@@ -1,4 +1,4 @@
-<%--
+<%@ page import="java.nio.charset.StandardCharsets" %><%--
 
     Copyright (C) 2000 - 2024 Silverpeas
 
@@ -32,25 +32,24 @@
 <%
     Action          action = (Action)request.getAttribute("Action");
     String          strCancelAction = "ViewActions",
-                    strCurrentScreen = "ModifyAction?action=" + URLEncoder.encode( action.getName(), UTF8 ),
+                    strCurrentScreen = "ModifyAction?action=" + URLEncoder.encode( action.getName(), StandardCharsets.UTF_8 ),
                     strDescriptionContext = "actions/" + action.getName() + "/descriptions",
                     strLabelContext = "actions/" + action.getName() + "/labels",
-                    strAllowedContext = URLEncoder.encode( "actions/" + action.getName() + "/allowedUsers", UTF8),
+                    strAllowedContext = URLEncoder.encode( "actions/" + action.getName() + "/allowedUsers", StandardCharsets.UTF_8),
                     strEditConsequence,
                     strItem,
-                    strConsequenceContext = URLEncoder.encode( "actions/" + action.getName() + "/consequences", UTF8),
+                    strConsequenceContext = URLEncoder.encode( "actions/" + action.getName() + "/consequences", StandardCharsets.UTF_8),
                     strContextEncoded;
     ArrayPane       actionPane = gef.getArrayPane( "actionPane", strCurrentScreen, request, session ),
                     usersPane = gef.getArrayPane( "usersPane", strCurrentScreen, request, session ),
                     consequencesPane = gef.getArrayPane( "consequencesPane", strCurrentScreen, request, session );
     String[]        astrFormNames = (String[])request.getAttribute( "FormNames" ),
                     astrKindValues = (String[])request.getAttribute( "KindValues" );
-    boolean         fExistingAction = ( (Boolean)request.getAttribute( "IsExisitingAction" ) ).booleanValue();
+    boolean         fExistingAction = (Boolean) request.getAttribute("IsExisitingAction");
     StringBuffer    sb = new StringBuffer();
 %>
-<html>
-<head>
-<view:looknfeel withCheckFormScript="true"/>
+<view:sp-page>
+<view:sp-head-part withCheckFormScript="true">
 <script type="text/javascript" src="<%=m_context%>/workflowDesigner/jsp/JavaScript/forms.js"></script>
 <script type="text/javascript">
     function move(direction, iConsequence)
@@ -61,19 +60,19 @@
 
     function sendData()
     {
-        var errorMsg = "";
-        var errorNb = 0;
+      let errorMsg = "";
+      let errorNb = 0;
 
-        var actionName = document.actionForm.name.value;
-        var formName = document.actionForm.form.value;
+      const actionName = document.actionForm.name.value;
+      const formName = document.actionForm.form.value;
 
-        if ( isWhitespace(actionName) )
+      if ( isWhitespace(actionName) )
         {
             errorMsg+="  - '<%=resource.getString("GML.name")%>' <%=resource.getString("GML.MustBeFilled")%>\n";
             errorNb++;
         }
 
-        if (actionName.toLowerCase() == formName.toLowerCase()) {
+        if (actionName.toLowerCase() === formName.toLowerCase()) {
 		      errorMsg+="  - <%=resource.getString("workflowDesigner.action.js.different")%>\n";
             errorNb++;
         }
@@ -93,8 +92,8 @@
         }
     }
 </script>
-</head>
-<body class="page_content_admin">
+</view:sp-head-part>
+<view:sp-body-part cssClass="page_content_admin">
 <%
     browseBar.setDomainName(resource.getString("workflowDesigner.toolName"));
     browseBar.setComponentName(resource.getString("workflowDesigner.actions"), strCancelAction);
@@ -125,11 +124,10 @@
     cellText.setStyleSheet( "txtlibform" );
     row.addArrayCellText( "" );
 
-    for ( int i = 0; i < astrKindValues.length; i++ )
-    {
+    for (String astrKindValue : astrKindValues) {
         row = actionPane.addArrayLine();
-        row.addArrayCellRadio( "kind", astrKindValues[i], astrKindValues[i].equals( action.getKind() ) );
-        row.addArrayCellText( astrKindValues[i] );
+        row.addArrayCellRadio("kind", astrKindValue, astrKindValue.equals(action.getKind()));
+        row.addArrayCellText(astrKindValue);
     }
 
     // Allowed users
@@ -172,9 +170,9 @@
             // Create the remove link
             //
             sb.setLength(0);
-            sb.append( "javascript:confirmRemove('RemoveQualifiedUsers?context=" );
+            sb.append( "javascript:confirmRemove('RemoveQualifiedUsers', {context: '" );
             sb.append( strAllowedContext );
-            sb.append( "', '" );
+            sb.append( "'}, '" );
             sb.append( resource.getString("workflowDesigner.confirmRemoveJS") );
             sb.append( " " );
             sb.append( WebEncodeHelper.javaStringToJsString( resource.getString("workflowDesigner.allowedUsers") ) );
@@ -209,17 +207,17 @@
     if ( fExistingAction )
         operationPane.addOperation(resource.getIcon("workflowDesigner.add"),
             resource.getString("workflowDesigner.add.consequence"),
-            "AddConsequence?context=" + URLEncoder.encode( "actions/" + action.getName(), UTF8 ) );
+            "AddConsequence?context=" + URLEncoder.encode( "actions/" + action.getName(), StandardCharsets.UTF_8) );
 
     if ( action.getConsequences() != null )
     {
-        Consequence   consequence;
-        Iterator      iterConsequences = action.getConsequences().iterateConsequence();
+        Consequence consequence;
+        Iterator<Consequence> iterConsequences = action.getConsequences().iterateConsequence();
         int           idx = 0;
 
         while ( iterConsequences.hasNext() )
         {
-            consequence = (Consequence)iterConsequences.next();
+            consequence = iterConsequences.next();
             iconPane = gef.getIconPane();
             iconPane.setSpacing("30px");
             updateIcon = iconPane.addIcon();
@@ -234,16 +232,16 @@
             sb.append( action.getName() );
             sb.append( "/consequences/" );
             sb.append( idx );
-            strContextEncoded = URLEncoder.encode( sb.toString(), "UTF-8" );
+            strContextEncoded = URLEncoder.encode( sb.toString(), StandardCharsets.UTF_8);
 
             strEditConsequence = "ModifyConsequence?context=" + strContextEncoded;
 
             // Create the remove link
             //
             sb.setLength(0);
-            sb.append("javascript:confirmRemove('RemoveConsequence?context=" );
+            sb.append("javascript:confirmRemove('RemoveConsequence', {context: '" );
             sb.append( strContextEncoded );
-            sb.append( "', '" );
+            sb.append( "'}, '" );
             sb.append( resource.getString("workflowDesigner.confirmRemoveJS") );
             sb.append( " " );
             sb.append( WebEncodeHelper.javaStringToJsString( resource.getString("workflowDesigner.consequence") ) );
@@ -360,5 +358,5 @@
     out.println(frame.printAfter());
     out.println(window.printAfter());
 %>
-</body>
-</html>
+</view:sp-body-part>
+</view:sp-page>

--- a/core-war/src/main/webapp/workflowDesigner/jsp/editColumns.jsp
+++ b/core-war/src/main/webapp/workflowDesigner/jsp/editColumns.jsp
@@ -45,25 +45,22 @@ String          strCancelAction = "ViewPresentation";
 <script type="text/javascript">
 
     function sendData() {
-        var errorMsg = "";
-        var errorNb = 0;
-        var fChecked = false;
-        var i = 0;
-
-        for ( i = 0; i < document.columnsForm.column.length; i++ )
+      let errorMsg = "";
+      let errorNb = 0;
+      let fChecked = false;
+      for (let i = 0; document.columnsForm.column && i < document.columnsForm.column.length; i++ )
             fChecked = fChecked || document.columnsForm.column[i].checked;
 
-        var totalElementsChecked = <%=columns.getColumnList().size()%>;
-        if ( document.columnsForm.column != null )
-        {
-          for ( i = 0 ; i < document.columnsForm.elements.length ; i++ ) {
-            oElement = document.columnsForm.elements[i] ;
-            if ( oElement.tagName.toLowerCase( ) == "input" ) {
-              if ( oElement.type.toLowerCase( ) == "checkbox" )
+        const totalElementsChecked = <%=columns.getColumnList().size()%>;
+        if ( document.columnsForm.column != null ) {
+          for (let i = 0 ; i < document.columnsForm.elements.length ; i++ ) {
+            let oElement = document.columnsForm.elements[i] ;
+            if ( oElement.tagName.toLowerCase( ) === "input" ) {
+              if ( oElement.type.toLowerCase( ) === "checkbox" )
                    fChecked = fChecked || oElement.checked;
             }
           }
-          if (totalElementsChecked>i && !fChecked)
+          if (totalElementsChecked > i && !fChecked)
             fChecked = true;
         }
 
@@ -111,14 +108,13 @@ cellSelect.setSize( "1" );
 //Fill the 'columns' section
 // Prepare a list of column names, based on the dataFolder
 //
-for ( int i = 0; i < astrFolderItemNames.length; i++ )
-{
-    row = columnPane.addArrayLine();
-    row.addArrayCellCheckbox( "column",
-                              astrFolderItemNames[i],null,
-                              columns.getColumn( astrFolderItemNames[i] ) != null );
-    row.addArrayCellText( astrFolderItemNames[i] );
-}
+    for (String astrFolderItemName : astrFolderItemNames) {
+        row = columnPane.addArrayLine();
+        row.addArrayCellCheckbox("column",
+                astrFolderItemName, null,
+                columns.getColumn(astrFolderItemName) != null);
+        row.addArrayCellText(astrFolderItemName);
+    }
 
 out.println(window.printBefore());
 out.println(frame.printBefore());

--- a/core-war/src/main/webapp/workflowDesigner/jsp/editConsequence.jsp
+++ b/core-war/src/main/webapp/workflowDesigner/jsp/editConsequence.jsp
@@ -23,7 +23,8 @@
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 --%>
-<%@ page import="org.silverpeas.core.util.WebEncodeHelper" %><%--
+<%@ page import="org.silverpeas.core.util.WebEncodeHelper" %>
+<%@ page import="java.nio.charset.StandardCharsets" %><%--
 
     Copyright (C) 2000 - 2024 Silverpeas
 
@@ -59,8 +60,8 @@
     Consequence     consequence = (Consequence)request.getAttribute("Consequence");
     String          strParentScreen = (String)request.getAttribute( "parentScreen" ),
                     strContext = (String)request.getAttribute("context"),
-                    strNotifiedContext = URLEncoder.encode( strContext + "/notifiedUsers", UTF8 ),
-                    strCurrentScreen = "ModifyConsequence?context=" + URLEncoder.encode( strContext, UTF8 );
+                    strNotifiedContext = URLEncoder.encode( strContext + "/notifiedUsers", StandardCharsets.UTF_8 ),
+                    strCurrentScreen = "ModifyConsequence?context=" + URLEncoder.encode( strContext, StandardCharsets.UTF_8 );
     ArrayPane       consequencePane = gef.getArrayPane( "consequencePane", strCurrentScreen, request, session ),
                     usersPane = gef.getArrayPane( "usersPane", strCurrentScreen, request, session ),
                     setUnsetPane = gef.getArrayPane( "setUnsetPane", strCurrentScreen, request, session );
@@ -69,17 +70,16 @@
                     astrFolderItemValues = (String[])astrFolderItemNames.clone(),
                     astrOperatorNames = (String[])request.getAttribute( "Operators" ),
                     astrOperatorValues = (String[])astrOperatorNames.clone();
-    boolean         fExistingConsequence = ( (Boolean)request.getAttribute( "IsExisitingConsequence" ) ).booleanValue();
+    boolean         fExistingConsequence = (Boolean) request.getAttribute("IsExisitingConsequence");
     StringBuffer    sb = new StringBuffer();
 %>
-<HTML>
-<HEAD>
-<view:looknfeel withCheckFormScript="true"/>
+<view:sp-page>
+<view:sp-head-part withCheckFormScript="true">
 <script type="text/javascript" src="<%=m_context%>/workflowDesigner/jsp/JavaScript/forms.js"></script>
 <script language="javaScript">
     function activateCondition()
     {
-        if ( document.consequenceForm.item.options.selectedIndex == 0 )
+        if ( document.consequenceForm.item.options.selectedIndex === 0 )
         {
             // Clear and block operator & value
             //
@@ -101,12 +101,12 @@
 
     function sendData()
     {
-        var errorMsg = "";
-        var errorNb = 0;
+      let errorMsg = "";
+      let errorNb = 0;
 
-        if ( document.consequenceForm.item.options.selectedIndex != 0 )
+      if ( document.consequenceForm.item.options.selectedIndex !== 0 )
         {
-            if ( document.consequenceForm.operator.options.selectedIndex == 0 )
+            if ( document.consequenceForm.operator.options.selectedIndex === 0 )
             {
                 errorMsg+="  - '<%=resource.getString("workflowDesigner.operator")%>' <%=resource.getString("GML.MustBeFilled")%>\n";
                 errorNb++;
@@ -134,8 +134,8 @@
         }
     }
 </script>
-</HEAD>
-<BODY onLoad="activateCondition()" class="page_content_admin">
+</view:sp-head-part>
+<view:sp-body-part onLoad="activateCondition()" cssClass="page_content_admin">
 <%
     browseBar.setDomainName(resource.getString("workflowDesigner.toolName"));
     browseBar.setComponentName(resource.getString("workflowDesigner.consequences"), strParentScreen);
@@ -192,22 +192,21 @@
 
     // Print a list of state names, based on the 'states' element
     //
-    for ( int i = 0; i < astrStateValues.length; i ++ )
-    {
-        boolean  fSet = consequence.getTargetState( astrStateValues[i] ) != null,
-                 fUnSet = consequence.getUnsetState( astrStateValues[i] ) != null;
+    for (String astrStateValue : astrStateValues) {
+        boolean fSet = consequence.getTargetState(astrStateValue) != null,
+                fUnSet = consequence.getUnsetState(astrStateValue) != null;
 
         row = setUnsetPane.addArrayLine();
-        row.addArrayCellRadio( WebEncodeHelper.javaStringToHtmlString( "setUnset_" + astrStateValues[i] ),
-                               "",
-                               ! (fSet || fUnSet) );
-        row.addArrayCellRadio( WebEncodeHelper.javaStringToHtmlString( "setUnset_" + astrStateValues[i] ),
-                               "set",
-                               fSet );
-        row.addArrayCellRadio( WebEncodeHelper.javaStringToHtmlString( "setUnset_" + astrStateValues[i] ),
-                               "unset",
-                               fUnSet );
-        row.addArrayCellText( astrStateValues[i] );
+        row.addArrayCellRadio(WebEncodeHelper.javaStringToHtmlString("setUnset_" + astrStateValue),
+                "",
+                !(fSet || fUnSet));
+        row.addArrayCellRadio(WebEncodeHelper.javaStringToHtmlString("setUnset_" + astrStateValue),
+                "set",
+                fSet);
+        row.addArrayCellRadio(WebEncodeHelper.javaStringToHtmlString("setUnset_" + astrStateValue),
+                "unset",
+                fUnSet);
+        row.addArrayCellText(astrStateValue);
     }
 
     // Notified users
@@ -249,9 +248,9 @@
 	            // Create the remove link
 	            //
 	            sb.setLength(0);
-	            sb.append( "javascript:confirmRemove('RemoveQualifiedUsers?context=" );
+	            sb.append( "javascript:confirmRemove('RemoveQualifiedUsers', {context: '" );
 	            sb.append( indexedStrNotifiedContext );
-	            sb.append( "', '" );
+	            sb.append( "'}, '" );
 	            sb.append( resource.getString("workflowDesigner.confirmRemoveJS") );
 	            sb.append( " " );
 	            sb.append( WebEncodeHelper.javaStringToJsString( resource.getString("workflowDesigner.notifiedUsers") ) );
@@ -308,5 +307,5 @@
     out.println(frame.printAfter());
     out.println(window.printAfter());
 %>
-</BODY>
-</HTML>
+</view:sp-body-part>
+</view:sp-page>

--- a/core-war/src/main/webapp/workflowDesigner/jsp/editContextualDesignation.jsp
+++ b/core-war/src/main/webapp/workflowDesigner/jsp/editContextualDesignation.jsp
@@ -37,16 +37,15 @@
                              strEditorName = (String)request.getAttribute( "EditorName" ),
                              strContext = (String)request.getAttribute( "context" ); // context
 %>
-<html>
-<head>
-<view:looknfeel withCheckFormScript="true"/>
+<view:sp-page>
+<view:sp-head-part withCheckFormScript="true">
 <script language="javaScript">
     function sendData()
     {
-        var errorMsg = "";
-        var errorNb = 0;
+      let errorMsg = "";
+      let errorNb = 0;
 
-        if ( isWhitespace(document.designationForm.content.value) )
+      if ( isWhitespace(document.designationForm.content.value) )
         {
             errorMsg+="  - '<%=resource.getString("workflowDesigner.content")%>' <%=resource.getString("GML.MustBeFilled")%>\n";
             errorNb++;
@@ -67,8 +66,8 @@
         }
     }
 </script>
-</head>
-<body class="page_content_admin">
+</view:sp-head-part>
+<view:sp-body-part cssClass="page_content_admin">
 <%
     browseBar.setDomainName(resource.getString("workflowDesigner.toolName"));
     browseBar.setComponentName( resource.getString(strEditorName) );
@@ -140,5 +139,5 @@
     out.println(frame.printAfter());
     out.println(window.printAfter());
 %>
-</body>
-</html>
+</view:sp-body-part>
+</view:sp-page>

--- a/core-war/src/main/webapp/workflowDesigner/jsp/editForm.jsp
+++ b/core-war/src/main/webapp/workflowDesigner/jsp/editForm.jsp
@@ -1,4 +1,4 @@
-<%--
+<%@ page import="java.nio.charset.StandardCharsets" %><%--
 
     Copyright (C) 2000 - 2024 Silverpeas
 
@@ -35,7 +35,7 @@
                     strFormType = (String)request.getAttribute("type"),
                     strContext = (String)request.getAttribute("context"),
                     strInputContext = strContext + "/inputs",
-                    strCurrentScreen = "ModifyForm?context=" + URLEncoder.encode( strContext, UTF8 ),
+                    strCurrentScreen = "EditForm?context=" + URLEncoder.encode( strContext, StandardCharsets.UTF_8),
                     strTitleContext = strContext + "/titles",
                     strEditInput,
                     strInputContextEncoded,
@@ -43,19 +43,18 @@
     ArrayPane       formPane = gef.getArrayPane( "formPane", strCurrentScreen, request, session ),
                     inputsPane = gef.getArrayPane( "inputsPane", strCurrentScreen, request, session );
     String[]        astrRoleNames = (String[])request.getAttribute( "RoleNames" ),
-                    astrRoleValues = (String[])astrRoleNames.clone();
+                    astrRoleValues = astrRoleNames.clone();
     Input           input;
-    Iterator        iterInputs = form.iterateInput();
+    Iterator<Input> iterInputs = form.iterateInput();
     int             idx = 0;
-    boolean         fExistingForm = ( (Boolean)request.getAttribute( "IsExisitingForm" ) ).booleanValue();
-    StringBuffer    sb = new StringBuffer();
+    boolean         fExistingForm = (Boolean) request.getAttribute("IsExisitingForm");
+    StringBuilder sb = new StringBuilder();
 %>
 
-<HTML>
-<HEAD>
-<view:looknfeel withCheckFormScript="true"/>
-<script type="text/javascript" src="<%=m_context%>/workflowDesigner/jsp/JavaScript/forms.js"></script>
-<script language="javaScript">
+<view:sp-page>
+<view:sp-head-part withCheckFormScript="true">
+<script type="application/javascript" src="<%=m_context%>/workflowDesigner/jsp/JavaScript/forms.js"></script>
+<script type="application/javascript">
     function switchType()
     {
         // Which type of form is it?
@@ -89,10 +88,10 @@
 
     function sendData()
     {
-        var errorMsg = "";
-        var errorNb = 0;
+      let errorMsg = "";
+      let errorNb = 0;
 
-        // Which type of form is it?
+      // Which type of form is it?
         //
         if ( document.formForm.type[0].checked
              && isWhitespace( document.formForm.name.value ) )
@@ -126,8 +125,8 @@
         }
     }
 </script>
-</HEAD>
-<BODY onLoad="switchType()" class="page_content_admin">
+</view:sp-head-part>
+<view:sp-body-part onLoad="switchType()" cssClass="page_content_admin">
 <%
     browseBar.setDomainName(resource.getString("workflowDesigner.toolName"));
     browseBar.setComponentName(resource.getString("workflowDesigner.forms"));
@@ -191,40 +190,42 @@
     //Fill the 'inputs' section
     //
     inputsPane.setTitle(resource.getString("workflowDesigner.list.input"));
-    column = inputsPane.addArrayColumn(resource.getString("workflowDesigner.folderItem"));
-    column = inputsPane.addArrayColumn(resource.getString("workflowDesigner.value"));
-    column = inputsPane.addArrayColumn(resource.getString("workflowDesigner.readonly"));
-    column = inputsPane.addArrayColumn(resource.getString("workflowDesigner.displayerName"));
-    column = inputsPane.addArrayColumn(resource.getString("GML.requiredField"));
+    inputsPane.addArrayColumn(resource.getString("workflowDesigner.folderItem"));
+    inputsPane.addArrayColumn(resource.getString("workflowDesigner.value"));
+    inputsPane.addArrayColumn(resource.getString("workflowDesigner.readonly"));
+    inputsPane.addArrayColumn(resource.getString("workflowDesigner.displayerName"));
+    inputsPane.addArrayColumn(resource.getString("GML.requiredField"));
     column = inputsPane.addArrayColumn(resource.getString("GML.operations"));
     column.setSortable(false);
 
     if ( fExistingForm )
         operationPane.addOperation(resource.getIcon("workflowDesigner.add"),
             resource.getString("workflowDesigner.add.input"),
-            "AddInput?context=" + URLEncoder.encode(strInputContext, UTF8) );
+            "AddInput?context=" + URLEncoder.encode(strInputContext, StandardCharsets.UTF_8) );
 
     while ( iterInputs.hasNext() )
     {
-        input = (Input)iterInputs.next();
+        input = iterInputs.next();
         iconPane = gef.getIconPane();
         iconPane.setSpacing("30px");
         updateIcon = iconPane.addIcon();
         delIcon = iconPane.addIcon();
 
         strItemName = input.getItem() == null ? "" : input.getItem().getName();
-        strInputContextEncoded = URLEncoder.encode( strInputContext + "[" + Integer.toString( idx ) + "]", UTF8 );
+        strInputContextEncoded = URLEncoder.encode( strInputContext + "[" + idx + "]", StandardCharsets.UTF_8 );
         strEditInput = "ModifyInput?context=" + strInputContextEncoded;
 
         // Create the remove link
         //
         sb.setLength(0);
-        sb.append("javascript:confirmRemove('RemoveInput?context=" );
+        sb.append("javascript:confirmRemove('RemoveInput', {context: '" );
         sb.append( strInputContextEncoded );
-        sb.append( "', '" );
+        sb.append( "'}, '" );
         sb.append( resource.getString("workflowDesigner.confirmRemoveJS") );
         sb.append( " " );
         sb.append( WebEncodeHelper.javaStringToJsString( resource.getString("workflowDesigner.input") ) );
+        sb.append(" ");
+        sb.append(strItemName);
         sb.append( " ?');" );
 
         row = inputsPane.addArrayLine();
@@ -293,5 +294,5 @@
     out.println(frame.printAfter());
     out.println(window.printAfter());
 %>
-</BODY>
-</HTML>
+</view:sp-body-part>
+</view:sp-page>

--- a/core-war/src/main/webapp/workflowDesigner/jsp/editInput.jsp
+++ b/core-war/src/main/webapp/workflowDesigner/jsp/editInput.jsp
@@ -24,6 +24,7 @@
 
 --%>
 <%@ page import="java.util.Map" %>
+<%@ page import="java.nio.charset.StandardCharsets" %>
 <%--
 
     Copyright (C) 2000 - 2024 Silverpeas
@@ -60,10 +61,10 @@
     Input           input = (Input)request.getAttribute("Input");
     String          strCancelAction = (String)request.getAttribute("parentScreen"),
                     strContext = (String)request.getAttribute("context"),
-                    strCurrentScreen = "ModifyInput?context=" + URLEncoder.encode( strContext, UTF8 ),
+                    strCurrentScreen = "ModifyInput?context=" + URLEncoder.encode( strContext, StandardCharsets.UTF_8 ),
                     strLabelContext = strContext + "/labels";
     ArrayPane       inputPane = gef.getArrayPane( "inputPane", strCurrentScreen, request, session );
-    boolean         fExistingInput = ( (Boolean)request.getAttribute( "IsExisitingInput" ) ).booleanValue();
+    boolean         fExistingInput = (Boolean) request.getAttribute("IsExisitingInput");
     List<Item>      folderItems = (List<Item>) request.getAttribute("FolderItems");
     List<String>    folderItemNames = new ArrayList<>();
     folderItemNames.add(resource.getString("GML.none"));
@@ -72,17 +73,16 @@
     }
     Map<String, List<String>> typesAndDisplayers = (Map<String, List<String>>) request.getAttribute("TypesAndDisplayers");
 %>
-<HTML>
-<HEAD>
-<view:looknfeel withCheckFormScript="true"/>
-<script type="text/javascript" src="<%=m_context%>/workflowDesigner/jsp/JavaScript/forms.js"></script>
-<script language="javaScript">
+<view:sp-page>
+<view:sp-head-part withCheckFormScript="true">
+<script type="application/javascript" src="<%=m_context%>/workflowDesigner/jsp/JavaScript/forms.js"></script>
+<script type="application/javascript">
     function sendData()
     {
-        var errorMsg = "";
-        var errorNb = 0;
+      let errorMsg = "";
+      let errorNb = 0;
 
-        if ( document.inputForm.item.options.selectedIndex == 0
+      if ( document.inputForm.item.options.selectedIndex === 0
              && isWhitespace(document.inputForm.value.value) )
         {
             errorMsg+="  - '<%=resource.getString("workflowDesigner.folderItem")%>'"
@@ -107,33 +107,33 @@
         }
     }
 
-    var items = [];
+    const items = [];
     <% for (Item item : folderItems) {%>
     items["<%=item.getName()%>"] = "<%=item.getType()%>";
     <% } %>
 
-    var displayers = [];
+    const displayers = [];
     <% for (String type : typesAndDisplayers.keySet()) {
-       String displayers = "";
+       StringBuilder displayers = new StringBuilder();
        for (String displayer : typesAndDisplayers.get(type)) {
-        if (!displayers.isEmpty()) {
-          displayers += ",";
+        if (displayers.length() > 0) {
+          displayers.append(",");
         }
-        displayers += "\""+displayer+"\"";
+        displayers.append("\"").append(displayer).append("\"");
        }
        %>
       displayers["<%=type%>"] = [<%=displayers%>];
     <% } %>
 
     function changeDisplayersList() {
-      var itemName = $("select[name='item']").val();
-      var itemType = items[itemName];
-      var itemDisplayers = displayers[itemType];
+      const itemName = $("select[name='item']").val();
+      const itemType = items[itemName];
+      const itemDisplayers = displayers[itemType];
 
-      var displayerSelect = $("select[name='displayerName']");
+      const displayerSelect = $("select[name='displayerName']");
       displayerSelect.empty();
-      var options = '';
-      for (var j = 0; j < itemDisplayers.length; j++){
+      let options = '';
+      for (let j = 0; j < itemDisplayers.length; j++){
         options += "<option value='" +itemDisplayers[j]+ "'>" +itemDisplayers[j]+ "</option>";
       }
       displayerSelect.html(options);
@@ -155,8 +155,8 @@
     });
 
 </script>
-</HEAD>
-<BODY class="page_content_admin">
+</view:sp-head-part>
+<view:sp-body-part cssClass="page_content_admin">
 <%
     browseBar.setDomainName(resource.getString("workflowDesigner.toolName"));
     browseBar.setComponentName(resource.getString("workflowDesigner.editor.form"), strCancelAction );
@@ -237,5 +237,5 @@
     out.println(frame.printAfter());
     out.println(window.printAfter());
 %>
-</BODY>
-</HTML>
+</view:sp-body-part>
+</view:sp-page>

--- a/core-war/src/main/webapp/workflowDesigner/jsp/editItem.jsp
+++ b/core-war/src/main/webapp/workflowDesigner/jsp/editItem.jsp
@@ -1,4 +1,4 @@
-<%--
+<%@ page import="java.nio.charset.StandardCharsets" %><%--
 
     Copyright (C) 2000 - 2024 Silverpeas
 
@@ -33,8 +33,8 @@
     Item            item = (Item)request.getAttribute("Item");
     String          strCancelAction = (String)request.getAttribute("parentScreen"),
                     strContext = (String)request.getAttribute("context"),
-                    strParameterContext = URLEncoder.encode( strContext + "/parameters", UTF8 ),
-                    strCurrentScreen = "ModifyItem?context=" + URLEncoder.encode( strContext, UTF8 ),
+                    strParameterContext = URLEncoder.encode( strContext + "/parameters", StandardCharsets.UTF_8 ),
+                    strCurrentScreen = "ModifyItem?context=" + URLEncoder.encode( strContext, StandardCharsets.UTF_8 ),
                     strDescriptionContext = strContext + "/descriptions",
                     strLabelContext = strContext + "/labels",
                     strEditParameter,
@@ -46,21 +46,20 @@
                     astrTypeValues = (String[])request.getAttribute( "TypeValues" ),
                     astrTypeNames = astrTypeValues.clone();
     Parameter       parameter;
-    Iterator        iterParameters = item.iterateParameter();
-    boolean         fExistingItem = ( (Boolean)request.getAttribute( "IsExisitingItem" ) ).booleanValue();
-    StringBuffer    sb = new StringBuffer();
+    Iterator<Parameter> iterParameters = item.iterateParameter();
+    boolean         fExistingItem = (Boolean) request.getAttribute("IsExisitingItem");
+    StringBuilder sb = new StringBuilder();
 %>
-<HTML>
-<HEAD>
-<view:looknfeel withCheckFormScript="true"/>
+<view:sp-page>
+<view:sp-head-part withCheckFormScript="true">
 <script type="text/javascript" src="<%=m_context%>/workflowDesigner/jsp/JavaScript/forms.js"></script>
 <script language="javaScript">
     function sendData()
     {
-        var errorMsg = "";
-        var errorNb = 0;
+      let errorMsg = "";
+      let errorNb = 0;
 
-        if ( isWhitespace(document.itemForm.name.value) )
+      if ( isWhitespace(document.itemForm.name.value) )
         {
             errorMsg+="  - '<%=resource.getString("GML.name")%>' <%=resource.getString("GML.MustBeFilled")%>\n";
             errorNb++;
@@ -81,8 +80,8 @@
         }
     }
 </script>
-</HEAD>
-<BODY class="page_content_admin">
+</view:sp-head-part>
+<view:sp-body-part cssClass="page_content_admin">
 <%
     browseBar.setDomainName(resource.getString("workflowDesigner.toolName"));
     browseBar.setComponentName(resource.getString("workflowDesigner.editor.item") );
@@ -154,21 +153,23 @@
 
     while ( iterParameters.hasNext() )
     {
-        parameter = (Parameter)iterParameters.next();
+        parameter = iterParameters.next();
         iconPane = gef.getIconPane();
         iconPane.setSpacing("30px");
         updateIcon = iconPane.addIcon();
         delIcon = iconPane.addIcon();
-        strParameterName = "&name=" + URLEncoder.encode( parameter.getName(), UTF8 );
-        strEditParameter = "ModifyParameter?context=" + strParameterContext + strParameterName;
+        strParameterName = URLEncoder.encode( parameter.getName(), StandardCharsets.UTF_8 );
+        strEditParameter = "ModifyParameter?context=" + strParameterContext +
+                "&name=" + strParameterName;
 
         // Create the remove link
         //
         sb.setLength(0);
-        sb.append("javascript:confirmRemove('RemoveParameter?context=" );
+        sb.append("javascript:confirmRemove('RemoveParameter', {context: '" );
         sb.append( strParameterContext );
+        sb.append("', name: '");
         sb.append( strParameterName );
-        sb.append( "', '" );
+        sb.append( "'}, '" );
         sb.append( resource.getString("workflowDesigner.confirmRemoveJS") );
         sb.append( " " );
         sb.append( WebEncodeHelper.javaStringToJsString( parameter.getName() ) );
@@ -250,5 +251,5 @@
     out.println(frame.printAfter());
     out.println(window.printAfter());
 %>
-</BODY>
-</HTML>
+</view:sp-body-part>
+</view:sp-page>

--- a/core-war/src/main/webapp/workflowDesigner/jsp/editParameter.jsp
+++ b/core-war/src/main/webapp/workflowDesigner/jsp/editParameter.jsp
@@ -1,4 +1,4 @@
-<%--
+<%@ page import="java.nio.charset.StandardCharsets" %><%--
 
     Copyright (C) 2000 - 2024 Silverpeas
 
@@ -33,8 +33,8 @@
     Parameter       parameter = (Parameter)request.getAttribute("Parameter");
     String          strCancelAction = (String)request.getAttribute("parentScreen"),
                     strContext = (String)request.getAttribute("context"),
-                    strCurrentScreen = "ModifyParameter?context=" + URLEncoder.encode(strContext, UTF8)
-                                       + "parameter=" + URLEncoder.encode(parameter.getName(), UTF8);
+                    strCurrentScreen = "ModifyParameter?context=" + URLEncoder.encode(strContext, StandardCharsets.UTF_8)
+                                       + "parameter=" + URLEncoder.encode(parameter.getName(), StandardCharsets.UTF_8);
     ArrayPane       parameterPane = gef.getArrayPane( "parameterName", strCurrentScreen, request, session );
 %>
 <HTML>

--- a/core-war/src/main/webapp/workflowDesigner/jsp/editParticipant.jsp
+++ b/core-war/src/main/webapp/workflowDesigner/jsp/editParticipant.jsp
@@ -41,17 +41,16 @@
     boolean         fExistingParticipant = ( (Boolean)request.getAttribute( "IsExisitingParticipant" ) ).booleanValue();
 %>
 
-<HTML>
-<HEAD>
-  <view:looknfeel withCheckFormScript="true"/>
+<view:sp-page>
+<view:sp-head-part withCheckFormScript="true">
 <script type="text/javascript" src="<%=m_context%>/workflowDesigner/jsp/JavaScript/forms.js"></script>
 <script language="javaScript">
     function sendData()
     {
-        var errorMsg = "";
-        var errorNb = 0;
+      let errorMsg = "";
+      let errorNb = 0;
 
-        if ( isWhitespace(document.participantForm.name.value) )
+      if ( isWhitespace(document.participantForm.name.value) )
         {
             errorMsg+="  - '<%=resource.getString("GML.name")%>' <%=resource.getString("GML.MustBeFilled")%>\n";
             errorNb++;
@@ -72,8 +71,8 @@
         }
     }
 </script>
-</HEAD>
-<BODY class="page_content_admin">
+</view:sp-head-part>
+<view:sp-body-part cssClass="page_content_admin">
 <%
     browseBar.setDomainName(resource.getString("workflowDesigner.toolName"));
     browseBar.setComponentName(resource.getString("workflowDesigner.participants"), strCancelAction);
@@ -152,5 +151,5 @@
     out.println(frame.printAfter());
     out.println(window.printAfter());
 %>
-</BODY>
-</HTML>
+</view:sp-body-part>
+</view:sp-page>

--- a/core-war/src/main/webapp/workflowDesigner/jsp/editQualifiedUsers.jsp
+++ b/core-war/src/main/webapp/workflowDesigner/jsp/editQualifiedUsers.jsp
@@ -28,6 +28,7 @@
 <%@ include file="check.jsp" %>
 <%@ taglib uri="http://www.silverpeas.com/tld/viewGenerator" prefix="view"%>
 <%@ taglib prefix="designer" uri="/WEB-INF/workflowEditor.tld" %>
+<%@ taglib prefix="vies" uri="http://www.silverpeas.com/tld/viewGenerator" %>
 <%
     QualifiedUsers           qualifiedUsers = (QualifiedUsers)request.getAttribute( "QualifiedUsers" );
     Boolean                  fDisplayRoleSelector = (Boolean)request.getAttribute( "RoleSelector" ),
@@ -43,24 +44,22 @@
                              inRolePane = gef.getArrayPane( "inRolePane", "", request, session );
 %>
 
-<html>
-<head>
-<view:looknfeel withCheckFormScript="true"/>
+<view:sp-page>
+<view:sp-head-part withCheckFormScript="true">
 <script type="text/javascript" src="<%=m_context%>/workflowDesigner/jsp/JavaScript/forms.js"></script>
 <script type="text/javascript">
     function sendData()
     {
-        var errorMsg = '';
-        var errorNb = 0;
-        var result;
-        var fExistingQualifiedUser = <%=fExistingQualifiedUser.toString()%>;
-        var fUserInRoleVisible = true;
-        var fMessageVisible = <%=fNotifiedUser.toString()%>;
-        var fRelatedUserDefined = <%=Boolean.toString( qualifiedUsers.iterateRelatedUser().hasNext() )%>;
-        var fUserInRoleDefined = false;
-        var i = 0;
+      let errorMsg = '';
+      let errorNb = 0;
+      let fExistingQualifiedUser = <%=fExistingQualifiedUser.toString()%>;
+      const fUserInRoleVisible = true;
+      let fMessageVisible = <%=fNotifiedUser.toString()%>;
+      let fRelatedUserDefined = <%=Boolean.toString( qualifiedUsers.iterateRelatedUser().hasNext())%>;
+      let fUserInRoleDefined = false;
+      let i = 0;
 
-        // Verify only for an existing (not new object)
+      // Verify only for an existing (not new object)
         //
         if ( fExistingQualifiedUser )
         {
@@ -112,18 +111,18 @@
         }
     }
 </script>
-</head>
-<body class="page_content_admin">
+</view:sp-head-part>
+<view:sp-body-part cssClass="page_content_admin">
 <%
     browseBar.setDomainName(resource.getString("workflowDesigner.toolName"));
     browseBar.setComponentName( resource.getString(strEditorName) );
 
-    if ( fExistingQualifiedUser.booleanValue() )
+    if (fExistingQualifiedUser)
         addRelatedUser( operationPane, resource, strContext );
 
     // Role - display for workingUsers and InterestedUsers, omit for AllowedUsers and Notified users
     //
-    if ( fDisplayRoleSelector.booleanValue() )
+    if (fDisplayRoleSelector)
     {
         headerPane.setTitle(resource.getString(strEditorName));
         row = headerPane.addArrayLine();
@@ -138,7 +137,7 @@
 
     // add a row with the message to the header pane
     //
-    if ( fNotifiedUser.booleanValue() )
+    if (fNotifiedUser)
     {
         row = headerPane.addArrayLine();
         cellText = row.addArrayCellText( resource.getString("workflowDesigner.message") );
@@ -180,13 +179,13 @@
     out.println("<table border=\"0\"><tr>");
     out.println("<td valign=\"absmiddle\"><img border=\"0\" src=\""+resource.getIcon("workflowDesigner.info")+"\"></td>");
 
-    if ( fNotifiedUser.booleanValue() )
+    if (fNotifiedUser)
     {
         out.println("<td>"+resource.getString("workflowDesigner.help.notifiedUsers")+"</td>");
     }
     else  // allowed, interested or working users
     {
-        if ( fDisplayRoleSelector.booleanValue() ) // interested or working users
+        if (fDisplayRoleSelector) // interested or working users
             out.println("<td>"+resource.getString("workflowDesigner.help.interestedOrWorkingUsers")+"</td>");
         else                                       // allowed users
             out.println("<td>"+resource.getString("workflowDesigner.help.allowedUsers")+"</td>");
@@ -202,7 +201,7 @@
     <input type="hidden" name="role_original" value="<%=qualifiedUsers.getRole()%> "/>
     <input type="hidden" name="context" value="<%=strContext%>" />
 <%
-    if ( fDisplayRoleSelector.booleanValue() || fNotifiedUser.booleanValue() ) {
+    if (fDisplayRoleSelector || fNotifiedUser) {
         out.println( headerPane.print() );
     }
 
@@ -223,5 +222,5 @@
     out.println(frame.printAfter());
     out.println(window.printAfter());
 %>
-</body>
-</html>
+</view:sp-body-part>
+</view:sp-page>

--- a/core-war/src/main/webapp/workflowDesigner/jsp/editRelatedUser.jsp
+++ b/core-war/src/main/webapp/workflowDesigner/jsp/editRelatedUser.jsp
@@ -48,21 +48,20 @@
                                              ? ""
                                              : relatedUser.getFolderItem().getName();
 %>
-<HTML>
-<HEAD>
-<view:looknfeel withCheckFormScript="true"/>
+<view:sp-page>
+<view:sp-head-part withCheckFormScript="true">
 <script language="javaScript">
     function sendData()
     {
-        var errorMsg = "";
-        var errorNb = 0;
+      let errorMsg = "";
+      let errorNb = 0;
 
-        // Just one of the fields should be filled
+      // Just one of the fields should be filled
         //
-        if ( ( document.relatedUserForm.participant.options.selectedIndex == 0
-               && document.relatedUserForm.folderItem.options.selectedIndex == 0 )
-              || ( document.relatedUserForm.participant.options.selectedIndex != 0
-                   && document.relatedUserForm.folderItem.options.selectedIndex != 0 ) )
+        if ( ( document.relatedUserForm.participant.options.selectedIndex === 0
+               && document.relatedUserForm.folderItem.options.selectedIndex === 0 )
+              || ( document.relatedUserForm.participant.options.selectedIndex !== 0
+                   && document.relatedUserForm.folderItem.options.selectedIndex !== 0 ) )
         {
             errorMsg+=" - <%=resource.getString("workflowDesigner.Either")%>"
                       + " '<%=resource.getString("workflowDesigner.participant")%>'"
@@ -87,8 +86,8 @@
         }
     }
 </script>
-</HEAD>
-<BODY class="page_content_admin">
+</view:sp-head-part>
+<view:sp-body-part cssClass="page_content_admin">
 <%
     browseBar.setDomainName(resource.getString("workflowDesigner.toolName"));
     browseBar.setComponentName( resource.getString("workflowDesigner.editor.relatedUser") );
@@ -170,5 +169,5 @@
     out.println(frame.printAfter());
     out.println(window.printAfter());
 %>
-</BODY>
-</HTML>
+</view:sp-body-part>
+</view:sp-page>

--- a/core-war/src/main/webapp/workflowDesigner/jsp/editRole.jsp
+++ b/core-war/src/main/webapp/workflowDesigner/jsp/editRole.jsp
@@ -36,19 +36,18 @@
                     strDescriptionContext = "roles/" + role.getName() + "/descriptions",
                     strLabelContext = "roles/" + role.getName() + "/labels";
     ArrayPane       rolePane = gef.getArrayPane( "roleName", strCurrentScreen, request, session );
-    boolean         fExistingRole = ( (Boolean)request.getAttribute( "IsExisitingRole" ) ).booleanValue();
+    boolean         fExistingRole = (Boolean) request.getAttribute("IsExisitingRole");
 %>
-<HTML>
-<HEAD>
-<view:looknfeel withCheckFormScript="true"/>
+<view:sp-page>
+<view:sp-head-part withCheckFormScript="true">
 <script type="text/javascript" src="<%=m_context%>/workflowDesigner/jsp/JavaScript/forms.js"></script>
 <script language="javaScript">
     function sendData()
     {
-        var errorMsg = "";
-        var errorNb = 0;
+      let errorMsg = "";
+      let errorNb = 0;
 
-        if ( isWhitespace(document.roleForm.name.value) )
+      if ( isWhitespace(document.roleForm.name.value) )
         {
             errorMsg+="  - '<%=resource.getString("GML.name")%>' <%=resource.getString("GML.MustBeFilled")%>\n";
             errorNb++;
@@ -69,8 +68,8 @@
         }
     }
 </script>
-</HEAD>
-<BODY  class="page_content_admin">
+</view:sp-head-part>
+<view:sp-body-part  cssClass="page_content_admin">
 <%
     browseBar.setDomainName(resource.getString("workflowDesigner.toolName"));
     browseBar.setComponentName(resource.getString("workflowDesigner.roles"), strCancelAction);
@@ -139,5 +138,5 @@
     out.println(frame.printAfter());
     out.println(window.printAfter());
 %>
-</BODY>
-</HTML>
+</view:sp-body-part>
+</view:sp-page>

--- a/core-war/src/main/webapp/workflowDesigner/jsp/editState.jsp
+++ b/core-war/src/main/webapp/workflowDesigner/jsp/editState.jsp
@@ -1,4 +1,4 @@
-<%--
+<%@ page import="java.nio.charset.StandardCharsets" %><%--
 
     Copyright (C) 2000 - 2024 Silverpeas
 
@@ -37,25 +37,24 @@
                     strDescriptionContext = "states/" + state.getName() + "/descriptions",
                     strLabelContext = "states/" + state.getName() + "/labels",
                     strActivityContext = "states/" + state.getName() + "/activities",
-                    strWorkingContext = URLEncoder.encode( "states/" + state.getName() + "/workingUsers", UTF8 ),
-                    strInterestedContext = URLEncoder.encode( "states/" + state.getName() + "/interestedUsers", UTF8 );
+                    strWorkingContext = URLEncoder.encode( "states/" + state.getName() + "/workingUsers", StandardCharsets.UTF_8 ),
+                    strInterestedContext = URLEncoder.encode( "states/" + state.getName() + "/interestedUsers", StandardCharsets.UTF_8 );
     ArrayPane       statePane = gef.getArrayPane( "statePane", strCurrentScreen, request, session ),
                     usersPane = gef.getArrayPane( "usersPane", strCurrentScreen, request, session ),
                     allowedActionsPane = gef.getArrayPane( "allowedActionsPane", strCurrentScreen, request, session );
     String[]        astrActionNames = (String[])request.getAttribute( "ActionNames" ),
                     astrActionValues = (String[])astrActionNames.clone();
     Action          timeoutAction = state.getTimeoutAction();
-    boolean         fExistingState = ( (Boolean)request.getAttribute( "IsExisitingState" ) ).booleanValue();
+    boolean         fExistingState = (Boolean) request.getAttribute("IsExisitingState");
     StringBuffer    sb = new StringBuffer();
 %>
-<HTML>
-<HEAD>
-<view:looknfeel withCheckFormScript="true"/>
+<view:sp-page>
+<view:sp-head-part withCheckFormScript="true">
 <script type="text/javascript" src="<%=m_context%>/workflowDesigner/jsp/JavaScript/forms.js"></script>
 <script language="javaScript">
     function activateTimeout()
     {
-        if ( document.stateForm.timeoutAction.options.selectedIndex == 0 )
+        if ( document.stateForm.timeoutAction.options.selectedIndex === 0 )
         {
             // Clear and block timeout interval & notify admin
             //
@@ -78,10 +77,10 @@
 
     function sendData()
     {
-        var errorMsg = "";
-        var errorNb = 0;
+      let errorMsg = "";
+      let errorNb = 0;
 
-        if ( isWhitespace(document.stateForm.name.value) )
+      if ( isWhitespace(document.stateForm.name.value) )
         {
             errorMsg+="  - '<%=resource.getString("GML.name")%>' <%=resource.getString("GML.MustBeFilled")%>\n";
             errorNb++;
@@ -89,7 +88,7 @@
 
         // If timeout action has been specified then an integer value must be given for timeout interval
         //
-        if ( document.stateForm.timeoutAction.options.selectedIndex != 0
+        if ( document.stateForm.timeoutAction.options.selectedIndex !== 0
              && ( isEmpty(document.stateForm.timeoutInterval.value)
                   || !isInteger(document.stateForm.timeoutInterval.value) ) )
         {
@@ -115,11 +114,10 @@
                            + errorMsg;
                 jQuery.popup.error(errorMsg);
         }
-        return result;
     }
 </script>
-</HEAD>
-<BODY onLoad="activateTimeout()"  class="page_content_admin">
+</view:sp-head-part>
+<view:sp-body-part onLoad="activateTimeout()"  cssClass="page_content_admin">
 <%
     browseBar.setDomainName(resource.getString("workflowDesigner.toolName"));
     browseBar.setComponentName(resource.getString("workflowDesigner.states"), strCancelAction);
@@ -209,9 +207,9 @@
             // Create the remove link
             //
             sb.setLength(0);
-            sb.append( "javascript:confirmRemove('RemoveQualifiedUsers?context=" );
+            sb.append( "javascript:confirmRemove('RemoveQualifiedUsers', {context: '" );
             sb.append( strWorkingContext );
-            sb.append( "', '" );
+            sb.append( "'}, '" );
             sb.append( resource.getString("workflowDesigner.confirmRemoveJS") );
             sb.append( " " );
             sb.append( WebEncodeHelper.javaStringToJsString( resource.getString("workflowDesigner.workingUsers") ) );
@@ -256,9 +254,9 @@
             // Create the remove link
             //
             sb.setLength(0);
-            sb.append( "javascript:confirmRemove('RemoveQualifiedUsers?context=" );
+            sb.append( "javascript:confirmRemove('RemoveQualifiedUsers', {context: '" );
             sb.append( strInterestedContext );
-            sb.append( "', '" );
+            sb.append( "'}, '" );
             sb.append( resource.getString("workflowDesigner.confirmRemoveJS") );
             sb.append( " " );
             sb.append( WebEncodeHelper.javaStringToJsString( resource.getString("workflowDesigner.interestedUsers") ) );
@@ -373,5 +371,5 @@
     out.println(frame.printAfter());
     out.println(window.printAfter());
 %>
-</BODY>
-</HTML>
+</view:sp-body-part>
+</view:sp-page>

--- a/core-war/src/main/webapp/workflowDesigner/jsp/errorpageMain.jsp
+++ b/core-war/src/main/webapp/workflowDesigner/jsp/errorpageMain.jsp
@@ -26,7 +26,7 @@
 <%@page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 <%@ taglib uri="http://www.silverpeas.com/tld/viewGenerator" prefix="view"%>
 <%
-    if (response.isCommitted() == false)
+    if (!response.isCommitted())
         response.resetBuffer();
 %>
 <%--
@@ -53,22 +53,22 @@
     if ( exception instanceof SilverpeasException )
         detailedString = ( (SilverpeasException)exception ).getExtraInfos();
 %>
-<HTML>
-<HEAD>
+<view:sp-page>
+<view:sp-head-part>
 <TITLE><%= generalMessage.getString("GML.popupTitle")%></TITLE>
-<view:looknfeel/>
-</HEAD>
+</view:sp-head-part>
 
-<BODY marginwidth=5 marginheight=5 leftmargin=5 topmargin=5>
+<view:sp-body-part>
 <%
 					out.println(window.printBefore());
 					out.println(frame.printBefore());
 %>
-<CENTER>
-<table CELLPADDING=0 CELLSPACING=2 BORDER=0 WIDTH="98%" CLASS=intfdcolor>
+<div class="center">
+<table class="intfdcolor">
+    <tr><th></th></tr>
 	<tr>
-		<td CLASS=intfdcolor4 NOWRAP>
-			<center>
+		<td class="intfdcolor4 nowrap">
+			<div class="center">
 				<br>
 				<span class="txtnav">
 					<% if (exStr != null)
@@ -83,7 +83,7 @@
                        }
                     %>
 				</span>
-			</center>
+			</div>
 			<br>
 		</td>
 	</tr>
@@ -95,10 +95,10 @@
           buttonPane.addButton((Button) gef.getFormButton(generalMessage.getString("GML.back"), "javascript:history.go(-1);", false));
           out.println(buttonPane.print());
 %>
-</CENTER>
+</div>
 <%
                 out.println(frame.printAfter());
                 out.println(window.printAfter());
 %>
-</BODY>
-</HTML>
+</view:sp-body-part>
+</view:sp-page>

--- a/core-war/src/main/webapp/workflowDesigner/jsp/forms.jsp
+++ b/core-war/src/main/webapp/workflowDesigner/jsp/forms.jsp
@@ -1,4 +1,4 @@
-<%--
+<%@ page import="java.nio.charset.StandardCharsets" %><%--
 
     Copyright (C) 2000 - 2024 Silverpeas
 
@@ -38,18 +38,16 @@ Forms      forms = (Forms)request.getAttribute( "Forms" );
 ArrayPane  formsPane = gef.getArrayPane("formsList", strCurrentTab, request, session);
 %>
 
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<view:looknfeel/>
+<view:sp-page>
+<view:sp-head-part>
 <script type="text/javascript" src="<%=m_context%>/workflowDesigner/jsp/JavaScript/forms.js"></script>
 <script type="text/javascript">
 function sendData() {
     document.workflowHeaderForm.submit();
 }
 </script>
-</head>
-<body class="page_content_admin">
+</view:sp-head-part>
+<view:sp-body-part cssClass="page_content_admin">
 <%
 browseBar.setDomainName(resource.getString("workflowDesigner.toolName") );
 browseBar.setComponentName(resource.getString("workflowDesigner.forms") );
@@ -69,15 +67,15 @@ column.setSortable( false );
 
 if ( forms != null )
 {
-    Form       form;
-    Iterator   iterForm = forms.iterateForm();
+    Form form;
+    Iterator<Form> iterForm = forms.iterateForm();
 
     while ( iterForm.hasNext() )
     {
-        form = (Form)iterForm.next();
+        form = iterForm.next();
         strRoleName = form.getRole() == null ? "" : form.getRole();
-        strContextEncoded = URLEncoder.encode( "forms[" + form.getName() + "," + strRoleName + "]", UTF8);
-        strEditForm = "ModifyForm?context=" + strContextEncoded;
+        strContextEncoded = URLEncoder.encode( "forms[" + form.getName() + "," + strRoleName + "]", StandardCharsets.UTF_8);
+        strEditForm = "EditForm?context=" + strContextEncoded;
         row    = formsPane.addArrayLine();
         iconPane = gef.getIconPane();
         iconPane.setSpacing("30px");
@@ -85,11 +83,11 @@ if ( forms != null )
         delIcon = iconPane.addIcon();
         delIcon.setProperties(resource.getIcon("workflowDesigner.smallDelete"),
                               resource.getString("GML.delete"),
-                              "javascript:confirmRemove('RemoveForm?context="
-                              + strContextEncoded + "', '"
+                              "javascript:confirmRemove('RemoveForm', {" +
+                                      "context: '" + strContextEncoded + "'}, '"
                               + resource.getString("workflowDesigner.confirmRemoveJS") + " "
                               + WebEncodeHelper.javaStringToJsString( form.getName() + " " + strRoleName )
-                              + " ?');" );
+                              + " ?');");
         updateIcon.setProperties(resource.getIcon("workflowDesigner.smallUpdate"),
                                  resource.getString("GML.modify"),
                                  strEditForm );
@@ -110,8 +108,11 @@ out.println(window.printBefore());
 <view:areaOfOperationOfCreation/>
 <!-- help -->
 <div class="inlineMessage">
-	<table border="0"><tr>
-		<td valign="absmiddle"><img border="0" src="<%=resource.getIcon("workflowDesigner.info") %>"/></td>
+	<table>
+        <tr><th></th></tr>
+        <tr>
+		<td class="absmiddle"><img alt="info"
+                                   src="<%=resource.getIcon("workflowDesigner.info") %>"/></td>
 		<td><%=resource.getString("workflowDesigner.help.forms") %></td>
 	</tr></table>
 </div>
@@ -126,5 +127,5 @@ out.println(formsPane.print());
 <%
 out.println(window.printAfter());
 %>
-</body>
-</html>
+</view:sp-body-part>
+</view:sp-page>

--- a/core-war/src/main/webapp/workflowDesigner/jsp/importWorkflow.jsp
+++ b/core-war/src/main/webapp/workflowDesigner/jsp/importWorkflow.jsp
@@ -29,20 +29,19 @@
 <%@ taglib uri="http://www.silverpeas.com/tld/viewGenerator" prefix="view"%>
 <%@ taglib prefix="designer" uri="/WEB-INF/workflowEditor.tld" %>
 
-<HTML>
-<HEAD>
-<view:looknfeel withCheckFormScript="true"/>
+<view:sp-page>
+<view:sp-head-part withCheckFormScript="true">
 <script type="text/javascript" src="<%=m_context%>/workflowDesigner/jsp/JavaScript/forms.js"></script>
 
 <script language="javascript">
 
 	function sendData()
 	{
-	var errorMsg = "";
-	var errorNb = 0;
-	var xmlFile = stripInitialWhitespace(document.importWorkflowForm.xmlFile.value);
+      let errorMsg = "";
+      let errorNb = 0;
+      const xmlFile = stripInitialWhitespace(document.importWorkflowForm.xmlFile.value);
 
-	if (xmlFile == "")
+      if (!xmlFile || xmlFile === "")
 	{
 		errorMsg+="  - '<%=resource.getString("workflowDesigner.import.filename")%>' <%=resource.getString("GML.MustBeFilled")%>\n";
 		errorNb++;
@@ -64,8 +63,8 @@
 	}
 
 </script>
-</HEAD>
-<BODY>
+</view:sp-head-part>
+<view:sp-body-part>
 <%
 	browseBar.setDomainName(resource.getString("workflowDesigner.toolName") );
 	browseBar.setComponentName(resource.getString("workflowDesigner.importWorkflow"), "#" );
@@ -86,7 +85,8 @@
     out.println(board.printBefore());
 %>
 	<FORM NAME="importWorkflowForm" METHOD="POST" ACTION="DoImportWorkflow" enctype="multipart/form-data">
-		<table cellpadding=5 cellspacing=2 border=0 width="98%" >
+		<table>
+            <tr><th></th></tr>
 			<tr>
 				<td class="txtlibform"><%=resource.getString("workflowDesigner.import.filename")%> :</td>
 				<td><input type="file" name="xmlFile" size="30"></td>
@@ -102,5 +102,5 @@
     out.println(frame.printAfter());
     out.println(window.printAfter());
 %>
-</BODY>
-</HTML>
+</view:sp-body-part>
+</view:sp-page>

--- a/core-war/src/main/webapp/workflowDesigner/jsp/participants.jsp
+++ b/core-war/src/main/webapp/workflowDesigner/jsp/participants.jsp
@@ -1,4 +1,4 @@
-<%--
+<%@ page import="java.nio.charset.StandardCharsets" %><%--
 
     Copyright (C) 2000 - 2024 Silverpeas
 
@@ -32,23 +32,21 @@
 String       strCurrentTab = "ViewParticipants",
              strParticipantName;
 Participants participants = (Participants)request.getAttribute( "Participants" );
-Iterator     iterParticipant;
+Iterator<Participant>     iterParticipant;
 ArrayPane    arrayPane = gef.getArrayPane("participantList", strCurrentTab, request, session);
 Participant  participant;
 %>
 
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<view:looknfeel/>
+<view:sp-page>
+<view:sp-head-part>
 <script type="text/javascript" src="<%=m_context%>/workflowDesigner/jsp/JavaScript/forms.js"></script>
 <script type="text/javascript">
 function sendData() {
     document.workflowHeaderForm.submit();
 }
 </script>
-</head>
-<body class="page_content_admin">
+</view:sp-head-part>
+<view:sp-body-part cssClass="page_content_admin">
 <%
 browseBar.setDomainName(resource.getString("workflowDesigner.toolName"));
 browseBar.setComponentName(resource.getString("workflowDesigner.participants") );
@@ -70,7 +68,7 @@ if ( participants != null )
 
     while ( iterParticipant.hasNext() )
     {
-        participant = (Participant)iterParticipant.next();
+        participant = iterParticipant.next();
         strParticipantName = participant.getName();
         row    = arrayPane.addArrayLine();
         iconPane = gef.getIconPane();
@@ -79,8 +77,9 @@ if ( participants != null )
         delIcon = iconPane.addIcon();
         delIcon.setProperties(resource.getIcon("workflowDesigner.smallDelete"),
                               resource.getString("GML.delete"),
-                              "javascript:confirmRemove('RemoveParticipant?participant="
-                              + URLEncoder.encode(strParticipantName, UTF8) + "', '"
+                              "javascript:confirmRemove('RemoveParticipant', {participant: '"
+                              + URLEncoder.encode(strParticipantName, StandardCharsets.UTF_8) +
+                                      "'}, '"
                               + resource.getString("workflowDesigner.confirmRemoveJS") + " "
                               + WebEncodeHelper.javaStringToJsString( strParticipantName ) + " ?');" );
         updateIcon.setProperties(resource.getIcon("workflowDesigner.smallUpdate"),
@@ -103,8 +102,11 @@ out.println(window.printBefore());
 <view:areaOfOperationOfCreation/>
 <!-- help -->
 <div class="inlineMessage">
-	<table border="0"><tr>
-		<td valign="absmiddle"><img border="0" src="<%=resource.getIcon("workflowDesigner.info") %>"/></td>
+	<table>
+        <tr><th></th></tr>
+        <tr>
+		<td class="absmiddle"><img alt="info"
+                                    src="<%=resource.getIcon("workflowDesigner.info") %>"/></td>
 		<td><%=resource.getString("workflowDesigner.help.participants") %></td>
 	</tr></table>
 </div>
@@ -119,5 +121,5 @@ out.println(arrayPane.print());
 <%
 out.println(window.printAfter());
 %>
-</body>
-</html>
+</view:sp-body-part>
+</view:sp-page>

--- a/core-war/src/main/webapp/workflowDesigner/jsp/presentation.jsp
+++ b/core-war/src/main/webapp/workflowDesigner/jsp/presentation.jsp
@@ -1,4 +1,4 @@
-<%--
+<%@ page import="java.nio.charset.StandardCharsets" %><%--
 
     Copyright (C) 2000 - 2024 Silverpeas
 
@@ -29,25 +29,23 @@
 <%@ taglib prefix="designer" uri="/WEB-INF/workflowEditor.tld" %>
 <%@ taglib uri="http://www.silverpeas.com/tld/viewGenerator" prefix="view"%>
 
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<view:looknfeel/>
+<view:sp-page>
+<view:sp-head-part>
 <script type="text/javascript" src="<%=m_context%>/workflowDesigner/jsp/JavaScript/forms.js"></script>
 <script type="text/javascript">
 function sendData() {
     document.workflowHeaderForm.submit();
 }
 </script>
-</head>
-<body class="page_content_admin">
+</view:sp-head-part>
+<view:sp-body-part cssClass="page_content_admin">
 <%
-String          strColumnList,
-                strCurrentTab   = "ViewPresentation";
-ArrayPane       columnPane = gef.getArrayPane("columnsList", strCurrentTab, request, session);
+StringBuilder strColumnList;
+    String strCurrentTab   = "ViewPresentation";
+    ArrayPane       columnPane = gef.getArrayPane("columnsList", strCurrentTab, request, session);
 Presentation    presentation = (Presentation)request.getAttribute( "Presentation" );
-Iterator        iterColumns = presentation.iterateColumns(),
-                iterColumn;
+Iterator<Columns> iterColumns = presentation.iterateColumns();
+Iterator<Column> iterColumn;
 
 browseBar.setDomainName(resource.getString("workflowDesigner.toolName"));
 browseBar.setComponentName(resource.getString("workflowDesigner.presentationTab"));
@@ -68,7 +66,7 @@ column.setSortable(false);
 //
 while ( iterColumns.hasNext() )
 {
-    Columns columns = (Columns)iterColumns.next();
+    Columns columns = iterColumns.next();
 
     row = columnPane.addArrayLine();
     iconPane = gef.getIconPane();
@@ -80,27 +78,27 @@ while ( iterColumns.hasNext() )
                              "ModifyColumns?columns=" + columns.getRoleName() );
     delIcon.setProperties(resource.getIcon("workflowDesigner.smallDelete"),
                           resource.getString("GML.delete"),
-                          "javascript:confirmRemove('RemoveColumns?columns="
-                          + URLEncoder.encode(columns.getRoleName(), UTF8) + "', '"
+                          "javascript:confirmRemove('RemoveColumns', {columns: '"
+                          + URLEncoder.encode(columns.getRoleName(), StandardCharsets.UTF_8) + "'}, '"
                           + resource.getString("workflowDesigner.confirmRemoveJS") + " "
                           + WebEncodeHelper.javaStringToJsString( columns.getRoleName() ) + " ?');" );
     iconPane.setSpacing("30px");
 
-    // Build a comma-separated list of refrenced items to put in the 'column list' column
+    // Build a comma-separated list of referenced items to put in the 'column list' column
     //
-    strColumnList = "";
+    strColumnList = new StringBuilder();
     iterColumn = columns.iterateColumn();
 
     while ( iterColumn.hasNext() )
     {
-        if ( strColumnList.length() > 0 )
-            strColumnList += ", ";
+        if (strColumnList.length() > 0)
+            strColumnList.append(", ");
 
-        strColumnList += ((Column)iterColumn.next()).getItem().getName();
+        strColumnList.append(iterColumn.next().getItem().getName());
     }
 
     row.addArrayCellLink( columns.getRoleName(), "ModifyColumns?columns=" + columns.getRoleName() );
-    row.addArrayCellLink( strColumnList, "ModifyColumns?columns=" + columns.getRoleName() );
+    row.addArrayCellLink(strColumnList.toString(), "ModifyColumns?columns=" + columns.getRoleName() );
     row.addArrayCellIconPane(iconPane);
 }
 
@@ -111,8 +109,11 @@ out.println(window.printBefore());
 <view:areaOfOperationOfCreation/>
 <!-- help -->
 <div class="inlineMessage">
-	<table border="0"><tr>
-		<td valign="absmiddle"><img border="0" src="<%=resource.getIcon("workflowDesigner.info") %>"/></td>
+	<table>
+        <tr><th></th></tr>
+        <tr>
+		<td class="absmiddle"><img alt="info"
+                                    src="<%=resource.getIcon("workflowDesigner.info") %>"/></td>
 		<td><%=resource.getString("workflowDesigner.help.presentation") %></td>
 	</tr></table>
 </div>
@@ -134,5 +135,5 @@ out.println( columnPane.print() );
 <%
 out.println(window.printAfter());
 %>
-</body>
-</html>
+</view:sp-body-part>
+</view:sp-page>

--- a/core-war/src/main/webapp/workflowDesigner/jsp/roles.jsp
+++ b/core-war/src/main/webapp/workflowDesigner/jsp/roles.jsp
@@ -1,4 +1,4 @@
-<%--
+<%@ page import="java.nio.charset.StandardCharsets" %><%--
 
     Copyright (C) 2000 - 2024 Silverpeas
 
@@ -36,10 +36,8 @@ Roles      roles = (Roles)request.getAttribute( "Roles" );
 ArrayPane  rolesPane = gef.getArrayPane("rolesList", strCurrentTab, request, session);
 %>
 
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<view:looknfeel/>
+<view:sp-page>
+<view:sp-head-part>
 <script type="text/javascript" src="<%=m_context%>/workflowDesigner/jsp/JavaScript/forms.js"></script>
 <script type="text/javascript">
     function sendData()
@@ -47,8 +45,8 @@ ArrayPane  rolesPane = gef.getArrayPane("rolesList", strCurrentTab, request, ses
         document.workflowHeaderForm.submit();
     }
 </script>
-</head>
-<body class="page_content_admin">
+</view:sp-head-part>
+<view:sp-body-part cssClass="page_content_admin">
 <%
 browseBar.setDomainName(resource.getString("workflowDesigner.toolName") );
 browseBar.setComponentName(resource.getString("workflowDesigner.roles") );
@@ -65,11 +63,11 @@ column.setSortable(false);
 
 if ( roles != null )
 {
-    Iterator   iterRole = roles.iterateRole();
+    Iterator<Role> iterRole = roles.iterateRole();
 
     while ( iterRole.hasNext() )
     {
-        strRoleName = ( (Role)iterRole.next() ).getName();
+        strRoleName = iterRole.next().getName();
 	row    = rolesPane.addArrayLine();
 	iconPane = gef.getIconPane();
 	iconPane.setSpacing("30px");
@@ -77,16 +75,17 @@ if ( roles != null )
 	delIcon = iconPane.addIcon();
 	delIcon.setProperties(resource.getIcon("workflowDesigner.smallDelete"),
 	                      resource.getString("GML.delete"),
-	                      "javascript:confirmRemove('RemoveRole?role="
-                                                        + URLEncoder.encode(strRoleName, UTF8) + "', '"
+	                      "javascript:confirmRemove('RemoveRole', {role: '"
+                                                        + URLEncoder.encode(strRoleName, StandardCharsets.UTF_8) +
+								  "'}, '"
                                                         + resource.getString("workflowDesigner.confirmRemoveJS")
                                                         + " " + WebEncodeHelper.javaStringToJsString( strRoleName ) + " ?');" );
 	updateIcon.setProperties(resource.getIcon("workflowDesigner.smallUpdate"),
 	                         resource.getString("GML.modify"),
-	                         "ModifyRole?role=" + URLEncoder.encode(strRoleName, UTF8) );
+	                         "ModifyRole?role=" + URLEncoder.encode(strRoleName, StandardCharsets.UTF_8) );
 
 
-	row.addArrayCellLink( strRoleName, "ModifyRole?role=" + URLEncoder.encode(strRoleName, UTF8) );
+	row.addArrayCellLink( strRoleName, "ModifyRole?role=" + URLEncoder.encode(strRoleName, StandardCharsets.UTF_8) );
 	row.addArrayCellIconPane(iconPane);
     }
 }
@@ -98,8 +97,11 @@ out.println(window.printBefore());
 <view:areaOfOperationOfCreation/>
 <!-- help -->
 <div class="inlineMessage">
-	<table border="0"><tr>
-		<td valign="absmiddle"><img border="0" src="<%=resource.getIcon("workflowDesigner.info") %>"/></td>
+	<table>
+		<tr><th></th></tr>
+		<tr>
+		<td class="absmiddle"><img alt="info"
+									src="<%=resource.getIcon("workflowDesigner.info") %>"/></td>
 		<td><%=resource.getString("workflowDesigner.help.roles") %></td>
 	</tr></table>
 </div>
@@ -114,5 +116,5 @@ out.println(rolesPane.print());
 <%
 out.println(window.printAfter());
 %>
-</body>
-</html>
+</view:sp-body-part>
+</view:sp-page>

--- a/core-war/src/main/webapp/workflowDesigner/jsp/states.jsp
+++ b/core-war/src/main/webapp/workflowDesigner/jsp/states.jsp
@@ -1,4 +1,4 @@
-<%--
+<%@ page import="java.nio.charset.StandardCharsets" %><%--
 
     Copyright (C) 2000 - 2024 Silverpeas
 
@@ -35,18 +35,16 @@ States      states = (States)request.getAttribute( "States" );
 ArrayPane   arrayPane = gef.getArrayPane("stateList", strCurrentTab, request, session);
 State       state;
 %>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<view:looknfeel/>
+<view:sp-page>
+<view:sp-head-part>
 <script type="text/javascript" src="<%=m_context%>/workflowDesigner/jsp/JavaScript/forms.js"></script>
 <script type="text/javascript">
 function sendData() {
     document.workflowHeaderForm.submit();
 }
 </script>
-</head>
-<body class="page_content_admin">
+</view:sp-head-part>
+<view:sp-body-part cssClass="page_content_admin">
 <%
 browseBar.setDomainName(resource.getString("workflowDesigner.toolName"));
 browseBar.setComponentName(resource.getString("workflowDesigner.states") );
@@ -64,13 +62,13 @@ column.setSortable(false);
 
 if ( states != null )
 {
-    Iterator    iterState = states.iterateState();
+    Iterator<State> iterState = states.iterateState();
 
     while ( iterState.hasNext() )
     {
         Action timeoutAction;
 
-        state = (State)iterState.next();
+        state = iterState.next();
         strStateName = state.getName();
         timeoutAction = state.getTimeoutAction();
 
@@ -81,8 +79,8 @@ if ( states != null )
         delIcon = iconPane.addIcon();
         delIcon.setProperties(resource.getIcon("workflowDesigner.smallDelete"),
                               resource.getString("GML.delete"),
-                              "javascript:confirmRemove('RemoveState?state="
-                              + URLEncoder.encode(strStateName, UTF8) + "', '"
+                              "javascript:confirmRemove('RemoveState', {state: '"
+                              + URLEncoder.encode(strStateName, StandardCharsets.UTF_8) + "'}, '"
                               + resource.getString("workflowDesigner.confirmRemoveJS") + " "
                               + WebEncodeHelper.javaStringToJsString( strStateName ) + " ?');" );
         updateIcon.setProperties(resource.getIcon("workflowDesigner.smallUpdate"),
@@ -105,8 +103,11 @@ out.println(window.printBefore());
 <view:areaOfOperationOfCreation/>
 <!-- help -->
 <div class="inlineMessage">
-	<table border="0"><tr>
-		<td valign="absmiddle"><img border="0" src="<%=resource.getIcon("workflowDesigner.info") %>"/></td>
+	<table>
+        <tr><th></th></tr>
+        <tr>
+		<td class="absmiddle"><img alt="info"
+                                    src="<%=resource.getIcon("workflowDesigner.info") %>"/></td>
 		<td><%=resource.getString("workflowDesigner.help.states") %></td>
 	</tr></table>
 </div>
@@ -121,5 +122,5 @@ out.println(arrayPane.print());
 <%
 out.println(window.printAfter());
 %>
-</body>
-</html>
+</view:sp-body-part>
+</view:sp-page>

--- a/core-war/src/main/webapp/workflowDesigner/jsp/userInfos.jsp
+++ b/core-war/src/main/webapp/workflowDesigner/jsp/userInfos.jsp
@@ -35,18 +35,16 @@ String        strCurrentTab   = "ViewUserInfos",
 DataFolder    items = (DataFolder)request.getAttribute("Items");
 %>
 
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<view:looknfeel/>
+<view:sp-page>
+<view:sp-head-part>
 <script type="text/javascript" src="<%=m_context%>/workflowDesigner/jsp/JavaScript/forms.js"></script>
 <script type="text/javascript">
 function sendData() {
     document.workflowHeaderForm.submit();
 }
 </script>
-</head>
-<body class="page_content_admin">
+</view:sp-head-part>
+<view:sp-body-part cssClass="page_content_admin">
 <%
 browseBar.setDomainName(resource.getString("workflowDesigner.toolName"));
 browseBar.setComponentName(resource.getString("workflowDesigner.userInfos"));
@@ -60,8 +58,11 @@ out.println(window.printBefore());
 <view:areaOfOperationOfCreation/>
 <!-- help -->
 <div class="inlineMessage">
-	<table border="0"><tr>
-		<td valign="absmiddle"><img border="0" src="<%=resource.getIcon("workflowDesigner.info") %>"/></td>
+	<table>
+		<tr><th></th></tr>
+		<tr>
+		<td class="absmiddle"><img alt="info"
+									src="<%=resource.getIcon("workflowDesigner.info") %>"/></td>
 		<td><%=resource.getString("workflowDesigner.help.userInfos") %></td>
 	</tr></table>
 </div>
@@ -75,5 +76,5 @@ out.println(window.printBefore());
 <%
 out.println(window.printAfter());
 %>
-</body>
-</html>
+</view:sp-body-part>
+</view:sp-page>

--- a/core-war/src/main/webapp/workflowDesigner/jsp/welcome.jsp
+++ b/core-war/src/main/webapp/workflowDesigner/jsp/welcome.jsp
@@ -23,7 +23,8 @@
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 --%>
-<%@ page import="org.silverpeas.core.util.WebEncodeHelper" %><%--
+<%@ page import="org.silverpeas.core.util.WebEncodeHelper" %>
+<%@ page import="java.nio.charset.StandardCharsets" %><%--
 
     Copyright (C) 2000 - 2024 Silverpeas
 
@@ -54,20 +55,18 @@
 <%@ taglib uri="http://www.silverpeas.com/tld/viewGenerator" prefix="view"%>
 <%@ include file="check.jsp" %>
 <%
-Iterator  workflows = ((List) request.getAttribute("ProcessFileNames")).iterator();
+Iterator<String>  workflows = ((List<String>) request.getAttribute("ProcessFileNames")).iterator();
 ArrayPane arrayPane;
 String    strProcessFileName,
           strProcessFileNameURLEncoded,
           strProcessFileNameJSEncoded;
 %>
 
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<view:looknfeel/>
+<view:sp-page>
+<view:sp-head-part>
 <script type="text/javascript" src="<%=m_context%>/workflowDesigner/jsp/JavaScript/forms.js"></script>
-</head>
-<body class="page_content_admin">
+</view:sp-head-part>
+<view:sp-body-part cssClass="page_content_admin">
 <%
 browseBar.setDomainName(resource.getString("workflowDesigner.toolName"));
 browseBar.setComponentName(resource.getString("workflowDesigner.list.workflow"));
@@ -88,8 +87,8 @@ column.setSortable( false );
 
 while ( workflows.hasNext() )
 {
-	strProcessFileName = (String) workflows.next();
-    strProcessFileNameURLEncoded = URLEncoder.encode( strProcessFileName, UTF8);
+	strProcessFileName = workflows.next();
+    strProcessFileNameURLEncoded = URLEncoder.encode( strProcessFileName, StandardCharsets.UTF_8);
     strProcessFileNameJSEncoded = WebEncodeHelper.javaStringToJsString( strProcessFileName );
 
     row       = arrayPane.addArrayLine();
@@ -106,9 +105,9 @@ while ( workflows.hasNext() )
                               + strProcessFileNameURLEncoded );
 	delIcon.setProperties(resource.getIcon("workflowDesigner.smallDelete"),
 	                      resource.getString("GML.delete"),
-                          "javascript:confirmRemove('RemoveWorkflow?ProcessFileName="
-                          + URLEncoder.encode( strProcessFileNameJSEncoded, UTF8)
-                          + "', '"
+                          "javascript:confirmRemove('RemoveWorkflow', {ProcessFileName: '"
+                          + URLEncoder.encode( strProcessFileNameJSEncoded, StandardCharsets.UTF_8)
+                          + "'}, '"
                           + resource.getString("workflowDesigner.confirmRemoveJS") + " "
                           + strProcessFileNameJSEncoded + " ?');" );
 	iconPane.setSpacing("30px");
@@ -131,5 +130,5 @@ out.println(arrayPane.print());
 <%
 out.println(window.printAfter());
 %>
-</body>
-</html>
+</view:sp-body-part>
+</view:sp-page>

--- a/core-war/src/main/webapp/workflowDesigner/jsp/workflow.jsp
+++ b/core-war/src/main/webapp/workflowDesigner/jsp/workflow.jsp
@@ -138,12 +138,15 @@
 <view:frame>
 <!-- help -->
 <div class="inlineMessage">
-	<table border="0"><tr>
-		<td valign="absmiddle"><img border="0" src="<%=resource.getIcon("workflowDesigner.info") %>"/></td>
+	<table>
+      <tr><th></th></tr>
+      <tr>
+		<td class="absmiddle"><img alt="info"
+                                    src="<%=resource.getIcon("workflowDesigner.info") %>"/></td>
 		<td><%=resource.getString("workflowDesigner.help.workflowHeader") %></td>
 	</tr></table>
 </div>
-<br clear="all"/>
+<br />
 <form name="workflowHeaderForm" action="UpdateWorkflow" method="post">
   <%
     out.println(processPane.print());

--- a/core-web/src/main/java/org/silverpeas/core/web/filter/MessageFilter.java
+++ b/core-web/src/main/java/org/silverpeas/core/web/filter/MessageFilter.java
@@ -73,7 +73,8 @@ public class MessageFilter implements Filter {
         chain.doFilter(request, response);
       } finally {
         // Remove message container if no message registered
-        if (MessageManager.getMessageContainer(registredKey).getMessages().isEmpty()) {
+        var container = MessageManager.getMessageContainer(registredKey);
+        if (container != null && container.getMessages().isEmpty() ) {
           MessageManager.clear(registredKey);
           httpResponse.setHeader(HTTP_MESSAGEKEY, null);
         }

--- a/core-web/src/main/java/org/silverpeas/core/web/mvc/route/AdminComponentRequestRouter.java
+++ b/core-web/src/main/java/org/silverpeas/core/web/mvc/route/AdminComponentRequestRouter.java
@@ -70,8 +70,7 @@ public abstract class AdminComponentRequestRouter<T extends AbstractAdminCompone
         ofNullable(request.getAttribute("javax.servlet.jsp.jspException"))
             .filter(ForbiddenRuntimeException.class::isInstance)
             .map(ForbiddenRuntimeException.class::cast)
-            .stream()
-            .forEach(forbidden::set);
+            .ifPresent(forbidden::set);
       }
     } catch (final ForbiddenRuntimeException e) {
       forbidden.set(e);


### PR DESCRIPTION
In the WorkflowDesigner the side-effect operations are done by sending HTTP GET requests. Such requests require to have the session token to be specified in order to protect any CRSF attempts. But, in the case of removal, the request is performed directly by an explicit relocation (document.location) instead of using a simple anchor. In this situation, there is no session token set automatically. And, if the URL to which the relocation is performed contains some specific keywords (like creat for example), then the massive web shield forbiddes such relocation attempt without any anti-CRSF token. So, the fix was to replace the relocation mechanism by one in which a form is dynamically generated for the removal with as HTTP method POST.

By the way, I discovered by testing the fix the workflow  designer wasn't designer to create a workflow from scratch but to edit existing ones. Besides that, I discovered also some hidden bugs. So I took the opportunity to clean up this mess up to a given level (in order to avoid to rewrite all the designer or to take too much time in this effort).