### PR TITLE
Fix bug #15362 - CSS adjustement

### DIFF
--- a/core-war/src/main/webapp/util/styleSheets/silverpeas-main.css
+++ b/core-war/src/main/webapp/util/styleSheets/silverpeas-main.css
@@ -5506,8 +5506,11 @@ ul.tagit li.tagit-choice a.tagit-close {
 .ui-dialog .champ-ui-dialog .document-template-input,
 .ui-dialog .champ-ui-dialog input[type=text],
 .ui-dialog .champ-ui-dialog input[type=file],
+.ui-dialog input[type="text"] ,
+.ui-dialog input[type="file"] ,
+.ui-dialog  textarea,
 .ui-dialog .champ-ui-dialog textarea {
-  width: 90%;
+  width: calc(100% - 2em) !important;
 }
 
 .ui-dialog .filedset-ui-dialog legend {


### PR DESCRIPTION
Some input balises have an attribute size that impacting the presentation making it exceeding from the modal dialog.

So I choose to force (important) the width of all input( (text & file)  et textarea